### PR TITLE
Fix watcher build gate false positives

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -186,6 +186,8 @@ var serveCmd = &cobra.Command{
 			// Watcher hook: audit completed tasks
 			if event == "task_completed" {
 				go func() {
+					// Wait for agent's final git push / PR creation to complete
+					time.Sleep(5 * time.Second)
 					taskID := data["task_id"]
 					status := data["status"]
 					t, err := n.Tasks.Get(taskID)

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -216,11 +216,7 @@ func (w *Watcher) RunBuildGate() BuildResult {
 	}
 
 	cmd := exec.Command(parts[0], parts[1:]...)
-	cmd.Dir = filepath.Dir(w.repoDir)
-	// Try the agent-shared-memory directory specifically
-	if strings.Contains(w.repoDir, "agent-shared-memory") {
-		cmd.Dir = w.repoDir
-	}
+	cmd.Dir = w.repoDir
 
 	out, err := cmd.CombinedOutput()
 	output := string(out)


### PR DESCRIPTION
## Summary
- Build gate used `filepath.Dir(repoDir)` which went one directory up from the repo, causing `go build ./...` to fail with "directory prefix . does not contain main module"
- Removed dead `agent-shared-memory` path hack (repo renamed to openloom)
- Added 5-second delay before watcher audit fires, giving agent's `git push` and `gh pr create` time to complete

## Root Cause
Task `019d8fce-36d` (Split app.js into modules) was marked failed despite having 1 commit, 21 files changed, pushed branch, and open PR. The build gate ran from the parent directory instead of the repo.

## Test plan
- [ ] Rebuild OpenLoom, restart serve
- [ ] Run a task and verify watcher audit passes when commits exist
- [ ] Verify build gate runs from correct directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)