### PR TITLE
Extract reusable renderTree() replacing 6 copy-pasted tree implementations

### DIFF
--- a/internal/web/ui/tree.js
+++ b/internal/web/ui/tree.js
@@ -1,23 +1,25 @@
 // OpenLoom — Reusable tree expand/collapse component
+// Provides renderTree() for multi-level collapsible tree UI.
 // Replaces 6+ duplicate toggle implementations across views.
 
 (function(OL) {
   'use strict';
+
+  var esc = OL.esc;
 
   // Wire expand/collapse toggles for a tree level.
   // container: parent DOM element
   // attrName:  full data attribute name, e.g. "data-amn-peer"
   //
   // Expects HTML structure:
-  //   <div ... data-amn-peer="0"> <span class="tree-arrow">▼</span> ... </div>
+  //   <div ... data-amn-peer="0"> <span class="tree-arrow">...</span> ... </div>
   //   <div ... data-amn-peer-children="0"> ... </div>
   //
   // Clicking the header toggles display of the children container
-  // and flips the arrow between ▼ (expanded) and ▶ (collapsed).
+  // and flips the arrow between down and right.
   OL.wireTreeToggles = function(container, attrName) {
     container.querySelectorAll('[' + attrName + ']').forEach(function(node) {
       node.addEventListener('click', function(e) {
-        // Don't toggle if user clicked a button inside the header
         if (e.target.closest('button')) return;
         var idx = node.getAttribute(attrName);
         var children = container.querySelector('[' + attrName + '-children="' + idx + '"]');
@@ -27,43 +29,165 @@
         var hidden = children.style.display === 'none';
         children.style.display = hidden ? '' : 'none';
         arrow.innerHTML = hidden ? '\u25BC' : '\u25B6';
+        node.setAttribute('aria-expanded', String(hidden));
       });
     });
   };
 
-  // Render a standard peer-level tree with expand/collapse.
-  // peerGroups: array of { peer_id, count, ... }
-  // options:
-  //   prefix:          data-attribute prefix (e.g. "mem" → data-mem-peer)
-  //   renderChildren:  function(peerGroup, peerIndex) → HTML string for peer's children
-  //   emptyMessage:    message when no peer groups (optional)
-  OL.renderPeerTree = function(container, peerGroups, options) {
-    var esc = OL.esc;
-    var prefix = options.prefix;
+  // Render a multi-level collapsible tree.
+  //
+  // container: DOM element to render into
+  // data:      array of top-level items
+  // config: {
+  //   prefix:       string  — unique data-attribute prefix for this tree
+  //   emptyMessage: string  — shown when data is empty
+  //   levels: [{
+  //     label:         fn(item, idx) -> string  — display text (pre-escaped)
+  //     count:         fn(item) -> number|string — count badge value
+  //     children:      fn(item) -> array         — items for next level
+  //     renderContent: fn(item, key) -> string   — overrides children+leaf rendering
+  //     dotColor:      fn(item) -> string | string — CSS class for status-dot
+  //     dotStyle:      string                    — inline style for the dot
+  //     expanded:      boolean                   — default expanded (L0: true, others: false)
+  //     indent:        number                    — padding-left px (default: 0 for L0, 24 for others)
+  //     extra:         fn(item, idx) -> string   — extra HTML in header after label
+  //     nodeAttrs:     fn(item) -> string         — extra attributes on the header div
+  //     onClick:       fn(node, childrenEl, nowExpanded, item) — post-toggle callback
+  //   }],
+  //   renderLeaf:   fn(item, parentKey) -> string — HTML for bottom-level items
+  //   leafSelector: string  — CSS selector for clickable leaf items
+  //   onLeafClick:  fn(el, event) — click handler for leaf items
+  //   afterRender:  fn(container) — post-render hook
+  // }
+  OL.renderTree = function(container, data, config) {
+    var levels = config.levels || [];
+    var prefix = config.prefix || ('t' + Math.random().toString(36).substr(2, 4));
 
-    if (!peerGroups || !peerGroups.length) {
-      container.innerHTML = '<div class="empty-state">' + (options.emptyMessage || 'No data') + '</div>';
+    if (!data || !data.length) {
+      container.innerHTML = '<div class="empty-state">' + (config.emptyMessage || 'No data') + '</div>';
       return;
     }
 
-    var html = '';
-    for (var pi = 0; pi < peerGroups.length; pi++) {
-      var pg = peerGroups[pi];
-      html += '<div class="tree-node peer-header clickable" data-' + prefix + '-peer="' + pi + '">';
-      html += '<span class="tree-arrow">\u25BC</span>';
-      html += '<span class="status-dot green"></span>';
-      html += '<span>' + esc(pg.peer_id) + '</span>';
-      html += '<span class="count">' + pg.count + '</span>';
-      html += '</div>';
-      html += '<div class="peer-children" data-' + prefix + '-peer-children="' + pi + '">';
-      html += options.renderChildren(pg, pi);
-      html += '</div>';
+    // Store items keyed by level attr + key for onClick callbacks
+    var _items = {};
+
+    function buildLevel(items, levelIdx, parentKey) {
+      if (levelIdx >= levels.length) {
+        if (config.renderLeaf) {
+          var h = '';
+          for (var i = 0; i < items.length; i++) {
+            h += config.renderLeaf(items[i], parentKey);
+          }
+          return h;
+        }
+        return '';
+      }
+
+      var level = levels[levelIdx];
+      var expanded = levelIdx === 0 ? (level.expanded !== false) : (level.expanded === true);
+      var indent = level.indent != null ? level.indent : (levelIdx > 0 ? 24 : 0);
+      var attrBase = prefix + '-l' + levelIdx;
+      var html = '';
+
+      for (var i = 0; i < items.length; i++) {
+        var item = items[i];
+        var key = parentKey !== '' ? (parentKey + '-' + i) : String(i);
+
+        _items[attrBase + ':' + key] = item;
+
+        var labelStr = typeof level.label === 'function' ? level.label(item, i) : '';
+        var countVal = typeof level.count === 'function' ? level.count(item) : undefined;
+        var dot = typeof level.dotColor === 'function' ? level.dotColor(item) : (level.dotColor !== undefined ? level.dotColor : 'green');
+        var extraStr = typeof level.extra === 'function' ? level.extra(item, i) : '';
+        var nodeAttrs = typeof level.nodeAttrs === 'function' ? ' ' + level.nodeAttrs(item) : '';
+        var arrow = expanded ? '\u25BC' : '\u25B6';
+
+        // Header
+        html += '<div class="tree-node' + (levelIdx === 0 ? ' peer-header' : '') + ' clickable"';
+        html += ' data-' + attrBase + '="' + key + '"';
+        html += nodeAttrs;
+        html += ' role="button" tabindex="0" aria-expanded="' + expanded + '"';
+        if (indent > 0) html += ' style="padding-left:' + indent + 'px"';
+        html += '>';
+        html += '<span class="tree-arrow">' + arrow + '</span>';
+        if (dot) {
+          html += '<span class="status-dot ' + dot + '"';
+          if (level.dotStyle) html += ' style="' + level.dotStyle + '"';
+          html += '></span>';
+        }
+        if (labelStr) html += '<span>' + labelStr + '</span>';
+        if (extraStr) html += extraStr;
+        if (countVal !== undefined && countVal !== '') html += '<span class="count">' + countVal + '</span>';
+        html += '</div>';
+
+        // Children container
+        html += '<div';
+        if (levelIdx === 0) html += ' class="peer-children"';
+        html += ' data-' + attrBase + '-children="' + key + '"';
+        if (!expanded) html += ' style="display:none"';
+        html += '>';
+
+        if (typeof level.renderContent === 'function') {
+          html += level.renderContent(item, key);
+        } else {
+          var children = typeof level.children === 'function' ? level.children(item) : [];
+          html += buildLevel(children, levelIdx + 1, key);
+        }
+
+        html += '</div>';
+      }
+
+      return html;
     }
 
-    container.innerHTML = html;
-    OL.wireTreeToggles(container, 'data-' + prefix + '-peer');
+    container.innerHTML = buildLevel(data, 0, '');
 
-    if (options.afterRender) options.afterRender(container);
+    // Wire toggle + onClick for each level
+    for (var li = 0; li < levels.length; li++) {
+      (function(levelIdx, level) {
+        var attrName = 'data-' + prefix + '-l' + levelIdx;
+        container.querySelectorAll('[' + attrName + ']').forEach(function(node) {
+          function handleToggle(e) {
+            if (e.target.closest('button')) return;
+            var key = node.getAttribute(attrName);
+            var childrenEl = container.querySelector('[' + attrName + '-children="' + key + '"]');
+            if (!childrenEl) return;
+            var arrow = node.querySelector('.tree-arrow');
+
+            var wasHidden = childrenEl.style.display === 'none';
+            childrenEl.style.display = wasHidden ? '' : 'none';
+            if (arrow) arrow.innerHTML = wasHidden ? '\u25BC' : '\u25B6';
+            node.setAttribute('aria-expanded', String(wasHidden));
+
+            if (level.onClick) {
+              var item = _items[prefix + '-l' + levelIdx + ':' + key];
+              level.onClick(node, childrenEl, wasHidden, item);
+            }
+          }
+
+          node.addEventListener('click', handleToggle);
+          node.addEventListener('keydown', function(e) {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              handleToggle(e);
+            }
+          });
+        });
+      })(li, levels[li]);
+    }
+
+    // Wire leaf click handlers
+    if (config.onLeafClick) {
+      var selector = config.leafSelector || '.tree-leaf';
+      container.querySelectorAll(selector).forEach(function(el) {
+        el.addEventListener('click', function(e) {
+          e.stopPropagation();
+          config.onLeafClick(el, e);
+        });
+      });
+    }
+
+    if (config.afterRender) config.afterRender(container);
   };
 
 })(window.OL);

--- a/internal/web/ui/views/compliance.js
+++ b/internal/web/ui/views/compliance.js
@@ -2,67 +2,60 @@
   'use strict';
   var fetchJSON = OL.fetchJSON, esc = OL.esc, formatTime = OL.formatTime;
 
+  function wireActionLinks(container) {
+    container.querySelectorAll('.action-link').forEach(function(link) {
+      link.addEventListener('click', function() {
+        OL.switchView('actions');
+        setTimeout(function() { OL.loadActionDetail(link.dataset.aid); }, 300);
+      });
+    });
+  }
+
   // --- Delusions ---
   OL.loadDelusions = async function() {
-    const el = document.getElementById('delusion-list');
+    var el = document.getElementById('delusion-list');
     try {
-      const peerGroups = await fetchJSON('/api/delusions/by-peer');
-      if (!peerGroups || !peerGroups.length) {
-        el.innerHTML = '<div class="empty-state">No delusions detected. Agents are following their manifests.</div>';
-        return;
-      }
-      let html = '';
-      for (let pi = 0; pi < peerGroups.length; pi++) {
-        const pg = peerGroups[pi];
-        html += `<div class="tree-node peer-header clickable" data-del-peer="${pi}">
-          <span class="tree-arrow">&#x25BC;</span>
-          <span class="status-dot green"></span>
-          <span>${esc(pg.peer_id)}</span>
-          <span class="count">${pg.count}</span>
-        </div>`;
-        html += `<div class="peer-children" data-del-peer-children="${pi}">`;
-        for (const d of pg.delusions) {
-          const sid = d.session_id ? d.session_id.substring(0, 12) : '';
-          const simPercent = Math.round(d.score * 100);
-          const statusClass = d.status === 'confirmed' ? 'confirmed' : d.status === 'dismissed' ? 'dismissed' : 'flagged';
+      var peerGroups = await fetchJSON('/api/delusions/by-peer');
 
-          html += `<div class="amnesia-item ${statusClass}">
-            <div class="amnesia-header">
-              <span class="amnesia-score medium">${simPercent}% relevant</span>
-              <span class="badge type">${esc(d.tool_name)}</span>
-              ${d.action_id ? `<span class="badge scope action-link" style="cursor:pointer;font-size:10px" data-aid="${esc(d.action_id)}">view action</span>` : ''}
-              <span class="amnesia-status-label">${esc(d.status)}</span>
-              <span style="color:var(--text-muted);font-size:11px;margin-left:auto">${formatTime(d.created_at)}</span>
-            </div>
-            <div class="amnesia-session">
-              <span style="color:var(--text-muted);font-size:12px">Session:</span>
-              <span class="session-uuid">${esc(sid)}</span>
-            </div>
-            <div class="amnesia-rule">
-              <span style="color:var(--yellow);font-weight:500">Manifest [${esc(d.manifest_marker)}]:</span> ${esc(d.manifest_title)}
-            </div>
-            <div style="font-size:12px;color:var(--text-secondary);margin-bottom:6px">${esc(d.reason)}</div>
-            <div class="amnesia-action">
-              <span style="color:var(--text-muted)">Action:</span> ${esc(d.tool_input)}
-            </div>
-            ${d.status === 'flagged' ? `<div class="amnesia-actions">
-              <button class="btn-confirm" onclick="window._delusionAction(${d.id},'confirm')">Confirm Off-Spec</button>
-              <button class="btn-dismiss" onclick="window._delusionAction(${d.id},'dismiss')">Dismiss</button>
-            </div>` : ''}
-          </div>`;
-        }
-        html += `</div>`;
-      }
-      el.innerHTML = html;
+      OL.renderTree(el, peerGroups, {
+        prefix: 'del',
+        emptyMessage: 'No delusions detected. Agents are following their manifests.',
+        levels: [{
+          label: function(pg) { return esc(pg.peer_id); },
+          count: function(pg) { return pg.count; },
+          children: function(pg) { return pg.delusions; },
+        }],
+        renderLeaf: function(d) {
+          var sid = d.session_id ? d.session_id.substring(0, 12) : '';
+          var simPercent = Math.round(d.score * 100);
+          var statusClass = d.status === 'confirmed' ? 'confirmed' : d.status === 'dismissed' ? 'dismissed' : 'flagged';
 
-      OL.wireTreeToggles(el, 'data-del-peer');
-
-      // Action cross-links
-      el.querySelectorAll('.action-link').forEach(link => {
-        link.addEventListener('click', () => {
-          OL.switchView('actions');
-          setTimeout(() => OL.loadActionDetail(link.dataset.aid), 300);
-        });
+          return '<div class="amnesia-item ' + statusClass + '">' +
+            '<div class="amnesia-header">' +
+              '<span class="amnesia-score medium">' + simPercent + '% relevant</span>' +
+              '<span class="badge type">' + esc(d.tool_name) + '</span>' +
+              (d.action_id ? '<span class="badge scope action-link" style="cursor:pointer;font-size:10px" data-aid="' + esc(d.action_id) + '">view action</span>' : '') +
+              '<span class="amnesia-status-label">' + esc(d.status) + '</span>' +
+              '<span style="color:var(--text-muted);font-size:11px;margin-left:auto">' + formatTime(d.created_at) + '</span>' +
+            '</div>' +
+            '<div class="amnesia-session">' +
+              '<span style="color:var(--text-muted);font-size:12px">Session:</span>' +
+              '<span class="session-uuid">' + esc(sid) + '</span>' +
+            '</div>' +
+            '<div class="amnesia-rule">' +
+              '<span style="color:var(--yellow);font-weight:500">Manifest [' + esc(d.manifest_marker) + ']:</span> ' + esc(d.manifest_title) +
+            '</div>' +
+            '<div style="font-size:12px;color:var(--text-secondary);margin-bottom:6px">' + esc(d.reason) + '</div>' +
+            '<div class="amnesia-action">' +
+              '<span style="color:var(--text-muted)">Action:</span> ' + esc(d.tool_input) +
+            '</div>' +
+            (d.status === 'flagged' ? '<div class="amnesia-actions">' +
+              '<button class="btn-confirm" onclick="window._delusionAction(' + d.id + ',\'confirm\')">Confirm Off-Spec</button>' +
+              '<button class="btn-dismiss" onclick="window._delusionAction(' + d.id + ',\'dismiss\')">Dismiss</button>' +
+            '</div>' : '') +
+          '</div>';
+        },
+        afterRender: function(container) { wireActionLinks(container); },
       });
     } catch (e) {
       console.error('Load delusions failed:', e);
@@ -76,8 +69,8 @@
 
   OL.updateDelusionCount = async function() {
     try {
-      const events = await fetchJSON('/api/delusions?status=flagged');
-      const badge = document.getElementById('delusion-badge');
+      var events = await fetchJSON('/api/delusions?status=flagged');
+      var badge = document.getElementById('delusion-badge');
       if (events && events.length > 0) {
         badge.textContent = events.length;
         badge.style.display = '';
@@ -89,91 +82,79 @@
 
   // --- Amnesia ---
   OL.loadAmnesia = async function() {
-    const el = document.getElementById('amnesia-list');
+    var el = document.getElementById('amnesia-list');
     try {
-      const peerGroups = await fetchJSON('/api/amnesia/by-peer');
-      if (!peerGroups || !peerGroups.length) {
-        el.innerHTML = '<div class="empty-state">No amnesia events</div>';
-        return;
-      }
-      let html = '';
-      for (let pi = 0; pi < peerGroups.length; pi++) {
-        const pg = peerGroups[pi];
-        html += `<div class="tree-node peer-header clickable" data-amn-peer="${pi}">
-          <span class="tree-arrow">&#x25BC;</span>
-          <span class="status-dot green"></span>
-          <span>${esc(pg.peer_id)}</span>
-          <span class="count">${pg.count}</span>
-        </div>`;
-        html += `<div class="peer-children" data-amn-peer-children="${pi}">`;
+      var peerGroups = await fetchJSON('/api/amnesia/by-peer');
 
-        // Group events by session
-        const sessionMap = {};
-        const sessionOrder = [];
-        for (const a of pg.events) {
-          const sid = a.session_id || 'unknown';
+      // Transform: group events by session within each peer
+      var treeData = (peerGroups || []).map(function(pg) {
+        var sessionMap = {};
+        var sessionOrder = [];
+        for (var i = 0; i < pg.events.length; i++) {
+          var a = pg.events[i];
+          var sid = a.session_id || 'unknown';
           if (!sessionMap[sid]) {
-            sessionMap[sid] = [];
+            sessionMap[sid] = { sid: sid, events: [], taskId: '' };
             sessionOrder.push(sid);
           }
-          sessionMap[sid].push(a);
+          sessionMap[sid].events.push(a);
+          if (!sessionMap[sid].taskId && a.task_id) sessionMap[sid].taskId = a.task_id;
         }
+        return {
+          peer_id: pg.peer_id,
+          count: pg.count,
+          sessions: sessionOrder.map(function(s) { return sessionMap[s]; }),
+        };
+      });
 
-        for (let si = 0; si < sessionOrder.length; si++) {
-          const sid = sessionOrder[si];
-          const sessionEvents = sessionMap[sid];
-          const shortSid = sid.length > 12 ? sid.substring(0, 12) : sid;
-          const taskId = sessionEvents[0].task_id;
-          const shortTask = taskId ? taskId.substring(0, 8) : '';
-
-          html += `<div class="tree-node clickable" style="padding-left:24px" data-amn-session="${pi}-${si}">
-            <span class="tree-arrow">&#x25B6;</span>
-            <span class="session-uuid">${esc(shortSid)}</span>
-            ${shortTask ? `<span class="badge scope" style="font-size:10px">${esc(shortTask)}</span>` : ''}
-            <span class="count">${sessionEvents.length}</span>
-          </div>`;
-          html += `<div style="display:none" data-amn-session-children="${pi}-${si}">`;
-
-          for (const a of sessionEvents) {
-            const scorePercent = Math.round(a.score * 100);
-            const scoreClass = scorePercent >= 80 ? 'high' : scorePercent >= 60 ? 'medium' : 'low';
-            const statusClass = a.status === 'confirmed' ? 'confirmed' : a.status === 'dismissed' ? 'dismissed' : 'flagged';
-
-            html += `<div class="amnesia-item ${statusClass}" style="margin-left:24px">
-              <div class="amnesia-header">
-                <span class="amnesia-score ${scoreClass}">${scorePercent}%</span>
-                <span class="badge type">${esc(a.tool_name)}</span>
-                ${a.action_id ? `<span class="badge scope action-link" style="cursor:pointer;font-size:10px" data-aid="${esc(a.action_id)}">view action</span>` : ''}
-                <span class="amnesia-status-label">${esc(a.status)}</span>
-                <span style="color:var(--text-muted);font-size:11px;margin-left:auto">${formatTime(a.created_at)}</span>
-              </div>
-              <div class="amnesia-rule">
-                <span style="color:var(--red);font-weight:500">Rule [${esc(a.rule_marker)}]:</span> ${esc(a.rule_text)}
-              </div>
-              <div class="amnesia-action">
-                <span style="color:var(--text-muted)">Action:</span> ${esc(a.tool_input)}
-              </div>
-              ${a.status === 'flagged' ? `<div class="amnesia-actions">
-                <button class="btn-confirm" onclick="window._amnesiaAction(${a.id},'confirm')">Confirm Violation</button>
-                <button class="btn-dismiss" onclick="window._amnesiaAction(${a.id},'dismiss')">Dismiss</button>
-              </div>` : ''}
-            </div>`;
+      OL.renderTree(el, treeData, {
+        prefix: 'amn',
+        emptyMessage: 'No amnesia events',
+        levels: [
+          {
+            label: function(pg) { return esc(pg.peer_id); },
+            count: function(pg) { return pg.count; },
+            children: function(pg) { return pg.sessions; },
+          },
+          {
+            dotColor: '',
+            expanded: false,
+            extra: function(sg) {
+              var shortSid = sg.sid.length > 12 ? sg.sid.substring(0, 12) : sg.sid;
+              var shortTask = sg.taskId ? sg.taskId.substring(0, 8) : '';
+              return '<span class="session-uuid">' + esc(shortSid) + '</span>' +
+                (shortTask ? '<span class="badge scope" style="font-size:10px">' + esc(shortTask) + '</span>' : '');
+            },
+            count: function(sg) { return sg.events.length; },
+            children: function(sg) { return sg.events; },
           }
-          html += `</div>`;
-        }
-        html += `</div>`;
-      }
-      el.innerHTML = html;
+        ],
+        renderLeaf: function(a) {
+          var scorePercent = Math.round(a.score * 100);
+          var scoreClass = scorePercent >= 80 ? 'high' : scorePercent >= 60 ? 'medium' : 'low';
+          var statusClass = a.status === 'confirmed' ? 'confirmed' : a.status === 'dismissed' ? 'dismissed' : 'flagged';
 
-      OL.wireTreeToggles(el, 'data-amn-peer');
-      OL.wireTreeToggles(el, 'data-amn-session');
-
-      // Action cross-links
-      el.querySelectorAll('.action-link').forEach(link => {
-        link.addEventListener('click', () => {
-          OL.switchView('actions');
-          setTimeout(() => OL.loadActionDetail(link.dataset.aid), 300);
-        });
+          return '<div class="amnesia-item ' + statusClass + '" style="margin-left:24px">' +
+            '<div class="amnesia-header">' +
+              '<span class="amnesia-score ' + scoreClass + '">' + scorePercent + '%</span>' +
+              '<span class="badge type">' + esc(a.tool_name) + '</span>' +
+              (a.action_id ? '<span class="badge scope action-link" style="cursor:pointer;font-size:10px" data-aid="' + esc(a.action_id) + '">view action</span>' : '') +
+              '<span class="amnesia-status-label">' + esc(a.status) + '</span>' +
+              '<span style="color:var(--text-muted);font-size:11px;margin-left:auto">' + formatTime(a.created_at) + '</span>' +
+            '</div>' +
+            '<div class="amnesia-rule">' +
+              '<span style="color:var(--red);font-weight:500">Rule [' + esc(a.rule_marker) + ']:</span> ' + esc(a.rule_text) +
+            '</div>' +
+            '<div class="amnesia-action">' +
+              '<span style="color:var(--text-muted)">Action:</span> ' + esc(a.tool_input) +
+            '</div>' +
+            (a.status === 'flagged' ? '<div class="amnesia-actions">' +
+              '<button class="btn-confirm" onclick="window._amnesiaAction(' + a.id + ',\'confirm\')">Confirm Violation</button>' +
+              '<button class="btn-dismiss" onclick="window._amnesiaAction(' + a.id + ',\'dismiss\')">Dismiss</button>' +
+            '</div>' : '') +
+          '</div>';
+        },
+        afterRender: function(container) { wireActionLinks(container); },
       });
     } catch (e) {
       console.error('Load amnesia failed:', e);
@@ -187,8 +168,8 @@
 
   OL.updateAmnesiaCount = async function() {
     try {
-      const events = await fetchJSON('/api/amnesia?status=flagged');
-      const badge = document.getElementById('amnesia-badge');
+      var events = await fetchJSON('/api/amnesia?status=flagged');
+      var badge = document.getElementById('amnesia-badge');
       if (events && events.length > 0) {
         badge.textContent = events.length;
         badge.style.display = '';
@@ -200,56 +181,47 @@
 
   // --- Visceral ---
   OL.loadVisceral = async function() {
-    const el = document.getElementById('visceral-rules');
-    const input = document.getElementById('visceral-input');
-    const btn = document.getElementById('visceral-add-btn');
+    var el = document.getElementById('visceral-rules');
+    var input = document.getElementById('visceral-input');
+    var btn = document.getElementById('visceral-add-btn');
 
-    btn.onclick = async () => {
-      const rule = input.value.trim();
+    btn.onclick = async function() {
+      var rule = input.value.trim();
       if (!rule) return;
       await fetch('/api/visceral', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({rule})
+        body: JSON.stringify({rule: rule})
       });
       input.value = '';
       OL.loadVisceral();
     };
-    input.onkeypress = (e) => { if (e.key === 'Enter') btn.click(); };
+    input.onkeypress = function(e) { if (e.key === 'Enter') btn.click(); };
 
     try {
-      const peerGroups = await fetchJSON('/api/visceral/by-peer');
-      if (!peerGroups || !peerGroups.length) {
-        el.innerHTML = '<div class="empty-state">No visceral rules set yet. Add rules that every agent must follow.</div>';
-        return;
-      }
-      let html = '';
-      let ruleNum = 0;
-      for (let pi = 0; pi < peerGroups.length; pi++) {
-        const pg = peerGroups[pi];
-        html += `<div class="tree-node peer-header clickable" data-visc-peer="${pi}">
-          <span class="tree-arrow">&#x25BC;</span>
-          <span class="status-dot green"></span>
-          <span>${esc(pg.peer_id)}</span>
-          <span class="count">${pg.count}</span>
-        </div>`;
-        html += `<div class="peer-children" data-visc-peer-children="${pi}">`;
-        for (const r of pg.rules) {
-          ruleNum++;
-          html += `<div class="visceral-rule" style="padding-left:24px">
-            <span class="visceral-num">${ruleNum}</span>
-            <span class="session-uuid">${esc(r.marker)}</span>
-            <span class="visceral-text">${esc(r.text)}</span>
-            <span style="color:var(--text-muted);font-size:11px">${esc(r.source || '')}</span>
-            <button class="btn-copy" onclick="window._copy('recall memory ${esc(r.marker)}')" title="Copy reference">&#x2398;</button>
-            <button class="visceral-delete" onclick="window._deleteVisceral('${esc(r.id)}')" title="Remove rule">&times;</button>
-          </div>`;
-        }
-        html += `</div>`;
-      }
-      el.innerHTML = html;
+      var peerGroups = await fetchJSON('/api/visceral/by-peer');
+      var ruleNum = 0;
 
-      OL.wireTreeToggles(el, 'data-visc-peer');
+      OL.renderTree(el, peerGroups, {
+        prefix: 'visc',
+        emptyMessage: 'No visceral rules set yet. Add rules that every agent must follow.',
+        levels: [{
+          label: function(pg) { return esc(pg.peer_id); },
+          count: function(pg) { return pg.count; },
+          children: function(pg) { return pg.rules; },
+        }],
+        renderLeaf: function(r) {
+          ruleNum++;
+          return '<div class="visceral-rule" style="padding-left:24px">' +
+            '<span class="visceral-num">' + ruleNum + '</span>' +
+            '<span class="session-uuid">' + esc(r.marker) + '</span>' +
+            '<span class="visceral-text">' + esc(r.text) + '</span>' +
+            '<span style="color:var(--text-muted);font-size:11px">' + esc(r.source || '') + '</span>' +
+            '<button class="btn-copy" onclick="window._copy(\'recall memory ' + esc(r.marker) + '\')" title="Copy reference">&#x2398;</button>' +
+            '<button class="visceral-delete" onclick="window._deleteVisceral(\'' + esc(r.id) + '\')" title="Remove rule">&times;</button>' +
+          '</div>';
+        },
+      });
     } catch (e) {
       console.error('Load visceral failed:', e);
     }

--- a/internal/web/ui/views/manifests.js
+++ b/internal/web/ui/views/manifests.js
@@ -11,127 +11,78 @@
     searchInput.onkeypress = (e) => { if (e.key === 'Enter') searchManifests(searchInput.value); };
 
     try {
-      const [peerGroups, products] = await Promise.all([
+      var results = await Promise.all([
         fetchJSON('/api/manifests/by-peer'),
         fetchJSON('/api/products'),
       ]);
-      if (!peerGroups || !peerGroups.length) {
-        el.innerHTML = '<div class="empty-state">No manifests yet</div>';
-        return;
-      }
+      var peerGroups = results[0];
+      var products = results[1];
 
       // Build product lookup
-      const prodMap = {};
-      for (const p of (products || [])) {
-        prodMap[p.id] = p;
+      var prodMap = {};
+      for (var pi = 0; pi < (products || []).length; pi++) {
+        prodMap[products[pi].id] = products[pi];
       }
 
-      // Peer -> Product -> Manifests (mirrors tasks: Peer -> Manifest -> Tasks)
-      let html = '';
-      for (let pi = 0; pi < peerGroups.length; pi++) {
-        const pg = peerGroups[pi];
-
-        // Peer header (L1)
-        html += `<div class="tree-node peer-header clickable" data-mfst-peer="${pi}">
-          <span class="tree-arrow">&#x25BC;</span>
-          <span class="status-dot green"></span>
-          <span>${esc(pg.peer_id)}</span>
-          <span class="count">${pg.count}</span>
-        </div>`;
-        html += `<div class="peer-children" data-mfst-peer-children="${pi}">`;
-
-        // Group manifests by product
-        const byProduct = {};
-        const productOrder = [];
-        for (const m of pg.manifests) {
-          const pid = (m.project_id && prodMap[m.project_id]) ? m.project_id : '__unassigned__';
+      // Transform: group manifests by product within each peer
+      var treeData = (peerGroups || []).map(function(pg) {
+        var byProduct = {};
+        var productOrder = [];
+        for (var i = 0; i < pg.manifests.length; i++) {
+          var m = pg.manifests[i];
+          var pid = (m.project_id && prodMap[m.project_id]) ? m.project_id : '__unassigned__';
           if (!byProduct[pid]) {
-            byProduct[pid] = [];
+            byProduct[pid] = { pid: pid, prod: prodMap[pid] || null, items: [] };
             productOrder.push(pid);
           }
-          byProduct[pid].push(m);
+          byProduct[pid].items.push(m);
         }
-
-        // Product headers (L2)
-        for (let pri = 0; pri < productOrder.length; pri++) {
-          const pid = productOrder[pri];
-          const items = byProduct[pid];
-          const prod = prodMap[pid];
-          const prodTitle = prod ? prod.title : 'Unassigned';
-          const prodMarker = prod ? prod.marker : '';
-          const dotColor = prod ? 'green' : '';
-
-          html += `<div class="tree-node clickable" style="padding-left:24px" data-mfst-prod="${pi}-${pri}">
-            <span class="tree-arrow">&#x25B6;</span>
-            ${dotColor ? `<span class="status-dot ${dotColor}"></span>` : ''}
-            <span>${esc(prodTitle)}</span>
-            ${prodMarker ? `<span class="session-uuid">${esc(prodMarker)}</span>` : ''}
-            <span class="count">${items.length}</span>
-          </div>`;
-          html += `<div style="display:none" data-mfst-prod-children="${pi}-${pri}">`;
-
-          // Manifest items (L3)
-          for (const m of items) {
-            const statusClass = m.status === 'open' ? 'confirmed' : m.status === 'closed' ? 'flagged' : 'dismissed';
-            const metaParts = [];
-            if (m.total_tasks > 0) metaParts.push(`${m.total_tasks} tasks`);
-            if (m.total_turns > 0) metaParts.push(`${m.total_turns} turns`);
-            if (m.total_cost > 0) metaParts.push(`$${m.total_cost.toFixed(2)}`);
-
-            html += `<div class="amnesia-item ${statusClass} clickable" data-id="${esc(m.id)}" style="margin-left:24px;cursor:pointer">
-              <div class="amnesia-header">
-                <span class="amnesia-status-label">${esc(m.status)}</span>
-                <span class="session-uuid">${esc(m.marker)}</span>
-                ${metaParts.length ? `<span style="font-size:11px;color:var(--text-muted)">${metaParts.join(' &middot; ')}</span>` : ''}
-                <span style="color:var(--text-muted);font-size:11px;margin-left:auto">${formatTime(m.updated_at || '')}</span>
-              </div>
-              <div class="amnesia-rule">${esc(m.title)}</div>
-            </div>`;
-          }
-          html += `</div>`;
-        }
-        html += `</div>`;
-      }
-      el.innerHTML = html;
-
-      // Peer toggle (L1)
-      el.querySelectorAll('[data-mfst-peer]').forEach(node => {
-        node.addEventListener('click', () => {
-          const idx = node.dataset.mfstPeer;
-          const children = el.querySelector(`[data-mfst-peer-children="${idx}"]`);
-          const arrow = node.querySelector('.tree-arrow');
-          if (children.style.display === 'none') {
-            children.style.display = '';
-            arrow.innerHTML = '&#x25BC;';
-          } else {
-            children.style.display = 'none';
-            arrow.innerHTML = '&#x25B6;';
-          }
-        });
+        return {
+          peer_id: pg.peer_id,
+          count: pg.count,
+          productGroups: productOrder.map(function(p) { return byProduct[p]; }),
+        };
       });
 
-      // Product toggle (L2)
-      el.querySelectorAll('[data-mfst-prod]').forEach(node => {
-        node.addEventListener('click', () => {
-          const idx = node.dataset.mfstProd;
-          const children = el.querySelector(`[data-mfst-prod-children="${idx}"]`);
-          const arrow = node.querySelector('.tree-arrow');
-          if (children.style.display === 'none') {
-            children.style.display = '';
-            arrow.innerHTML = '&#x25BC;';
-          } else {
-            children.style.display = 'none';
-            arrow.innerHTML = '&#x25B6;';
+      OL.renderTree(el, treeData, {
+        prefix: 'mfst',
+        emptyMessage: 'No manifests yet',
+        levels: [
+          {
+            label: function(pg) { return esc(pg.peer_id); },
+            count: function(pg) { return pg.count; },
+            children: function(pg) { return pg.productGroups; },
+          },
+          {
+            label: function(grp) { return esc(grp.prod ? grp.prod.title : 'Unassigned'); },
+            extra: function(grp) {
+              return grp.prod && grp.prod.marker ? '<span class="session-uuid">' + esc(grp.prod.marker) + '</span>' : '';
+            },
+            count: function(grp) { return grp.items.length; },
+            children: function(grp) { return grp.items; },
+            dotColor: function(grp) { return grp.prod ? 'green' : ''; },
+            expanded: false,
           }
-        });
-      });
+        ],
+        renderLeaf: function(m) {
+          var statusClass = m.status === 'open' ? 'confirmed' : m.status === 'closed' ? 'flagged' : 'dismissed';
+          var metaParts = [];
+          if (m.total_tasks > 0) metaParts.push(m.total_tasks + ' tasks');
+          if (m.total_turns > 0) metaParts.push(m.total_turns + ' turns');
+          if (m.total_cost > 0) metaParts.push('$' + m.total_cost.toFixed(2));
 
-      // Manifest clicks (L3)
-      el.querySelectorAll('.amnesia-item.clickable').forEach(item => {
-        item.addEventListener('click', (e) => {
-          e.stopPropagation();
-          window._loadManifest(item.dataset.id);
-        });
+          return '<div class="amnesia-item ' + statusClass + ' clickable tree-leaf" data-id="' + esc(m.id) + '" style="margin-left:24px;cursor:pointer">' +
+            '<div class="amnesia-header">' +
+              '<span class="amnesia-status-label">' + esc(m.status) + '</span>' +
+              '<span class="session-uuid">' + esc(m.marker) + '</span>' +
+              (metaParts.length ? '<span style="font-size:11px;color:var(--text-muted)">' + metaParts.join(' &middot; ') + '</span>' : '') +
+              '<span style="color:var(--text-muted);font-size:11px;margin-left:auto">' + formatTime(m.updated_at || '') + '</span>' +
+            '</div>' +
+            '<div class="amnesia-rule">' + esc(m.title) + '</div>' +
+          '</div>';
+        },
+        leafSelector: '.tree-leaf',
+        onLeafClick: function(item) { window._loadManifest(item.dataset.id); },
       });
     } catch (e) {
       console.error('Load manifests failed:', e);

--- a/internal/web/ui/views/memories.js
+++ b/internal/web/ui/views/memories.js
@@ -4,54 +4,40 @@
 
   OL.loadMemoryPeerTree = async function() {
     try {
-      const peerGroups = await fetchJSON('/api/memories/by-peer');
-      const el = document.getElementById('memory-peer-tree');
-      if (!peerGroups || !peerGroups.length) {
-        el.innerHTML = '<div class="empty-state">No peers</div>';
-        return;
-      }
-      let html = '';
-      for (let pi = 0; pi < peerGroups.length; pi++) {
-        const pg = peerGroups[pi];
-        html += `<div class="tree-node peer-header clickable" data-peer="${pi}">
-          <span class="tree-arrow">&#x25BC;</span>
-          <span class="status-dot green"></span>
-          <span>${esc(pg.peer_id)}</span>
-          <span class="count">${pg.count}</span>
-        </div>`;
-        html += `<div class="peer-children" data-peer-children="${pi}">`;
-        for (let si = 0; si < pg.sessions.length; si++) {
-          const sg = pg.sessions[si];
-          html += `<div class="tree-node session-header clickable" data-session="${pi}-${si}">
-            <span class="tree-arrow" style="font-size:10px">&#x25BC;</span>
-            <span class="status-dot green" style="width:6px;height:6px"></span>
-            <span>${esc(sg.session)}</span>
-            <span class="count">${sg.count}</span>
-          </div>`;
-          html += `<div class="session-children" data-session-children="${pi}-${si}">`;
-          for (const m of sg.memories) {
-            html += `<div class="tree-node peer-leaf clickable" data-memory-id="${esc(m.id)}">
-              <span class="session-uuid">${esc(m.marker)}</span>
-              <span style="font-size:12px;color:var(--text-primary);flex:1">${esc(m.l0.length > 50 ? m.l0.substring(0,50) + '...' : m.l0)}</span>
-              <button class="btn-copy-sm" onclick="event.stopPropagation();window._copy('recall memory ${esc(m.marker)}')" title="Copy ref">&#x2398;</button>
-            </div>`;
+      var peerGroups = await fetchJSON('/api/memories/by-peer');
+      var el = document.getElementById('memory-peer-tree');
+
+      OL.renderTree(el, peerGroups, {
+        prefix: 'mem',
+        emptyMessage: 'No peers',
+        levels: [
+          {
+            label: function(pg) { return esc(pg.peer_id); },
+            count: function(pg) { return pg.count; },
+            children: function(pg) { return pg.sessions; },
+          },
+          {
+            label: function(sg) { return esc(sg.session); },
+            count: function(sg) { return sg.count; },
+            children: function(sg) { return sg.memories; },
+            dotColor: 'green',
+            dotStyle: 'width:6px;height:6px',
+            expanded: true,
           }
-          html += `</div>`;
-        }
-        html += `</div>`;
-      }
-      el.innerHTML = html;
-
-      OL.wireTreeToggles(el, 'data-peer');
-      OL.wireTreeToggles(el, 'data-session');
-
-      // Memory leaf clicks
-      el.querySelectorAll('.tree-node.peer-leaf').forEach(node => {
-        node.addEventListener('click', () => {
-          el.querySelectorAll('.tree-node').forEach(n => n.classList.remove('active'));
+        ],
+        renderLeaf: function(m) {
+          return '<div class="tree-node peer-leaf clickable tree-leaf" data-memory-id="' + esc(m.id) + '">' +
+            '<span class="session-uuid">' + esc(m.marker) + '</span>' +
+            '<span style="font-size:12px;color:var(--text-primary);flex:1">' + esc(m.l0.length > 50 ? m.l0.substring(0, 50) + '...' : m.l0) + '</span>' +
+            '<button class="btn-copy-sm" onclick="event.stopPropagation();window._copy(\'recall memory ' + esc(m.marker) + '\')" title="Copy ref">&#x2398;</button>' +
+          '</div>';
+        },
+        leafSelector: '.tree-leaf',
+        onLeafClick: function(node) {
+          el.querySelectorAll('.tree-node').forEach(function(n) { n.classList.remove('active'); });
           node.classList.add('active');
           OL.loadMemoryPeerDetail(node.dataset.memoryId);
-        });
+        },
       });
     } catch (e) {
       console.error('Load peer memories failed:', e);

--- a/internal/web/ui/views/products.js
+++ b/internal/web/ui/views/products.js
@@ -3,92 +3,62 @@
   var fetchJSON = OL.fetchJSON, esc = OL.esc, formatTime = OL.formatTime;
 
   OL.loadProducts = async function() {
-    const el = document.getElementById('products-list');
+    var el = document.getElementById('products-list');
     try {
-      const peerGroups = await fetchJSON('/api/products/by-peer');
-      let html = `<div style="padding:8px 0;margin-bottom:8px"><button class="btn-search" id="btn-new-product" style="font-size:12px;padding:6px 16px">+ New Product</button></div>`;
-      if (!peerGroups || !peerGroups.length) {
-        el.innerHTML = html + '<div class="empty-state" style="padding:16px">No products yet. Create one to group your manifests.</div>';
-        el.querySelector('#btn-new-product').addEventListener('click', () => window._createProduct());
-        return;
-      }
+      var peerGroups = await fetchJSON('/api/products/by-peer');
 
-      // Peer -> Product -> Manifests (mirrors amnesia: Peer -> Session -> Violations)
-      for (let pi = 0; pi < peerGroups.length; pi++) {
-        const pg = peerGroups[pi];
-
-        // Peer header (L1)
-        html += `<div class="tree-node peer-header clickable" data-prod-peer="${pi}">
-          <span class="tree-arrow">&#x25BC;</span>
-          <span class="status-dot green"></span>
-          <span>${esc(pg.peer_id)}</span>
-          <span class="count">${pg.count}</span>
-        </div>`;
-        html += `<div class="peer-children" data-prod-peer-children="${pi}">`;
-
-        // Product headers (L2) -- same as amnesia sessions
-        for (let pri = 0; pri < pg.products.length; pri++) {
-          const p = pg.products[pri];
-          const dotColor = p.status === 'open' ? 'green' : p.status === 'closed' ? 'red' : p.status === 'archive' ? 'red' : 'yellow';
-          const metaParts = [];
-          if (p.total_tasks > 0) metaParts.push(`${p.total_tasks} tasks`);
-          if (p.total_turns > 0) metaParts.push(`${p.total_turns} turns`);
-          if (p.total_cost > 0) metaParts.push(`$${p.total_cost.toFixed(2)}`);
-
-          html += `<div class="tree-node clickable" style="padding-left:24px" data-prod-item="${pi}-${pri}" data-product-id="${esc(p.id)}">
-            <span class="tree-arrow">&#x25B6;</span>
-            <span class="status-dot ${dotColor}"></span>
-            <span>${esc(p.title)}</span>
-            <span class="session-uuid">${esc(p.marker)}</span>
-            ${p.total_manifests > 0 ? `<span class="count">${p.total_manifests}</span>` : ''}
-          </div>`;
-          html += `<div style="display:none" data-prod-item-children="${pi}-${pri}">`;
-
-          // Manifest placeholder -- loaded on expand
-          html += `<div class="prod-manifests-placeholder" data-prod-manifests-for="${esc(p.id)}" style="margin-left:24px">
-            <div style="padding:8px 12px;color:var(--text-muted);font-size:12px">
-              ${metaParts.length ? metaParts.join(' &middot; ') : ''}
-              ${p.total_manifests > 0 ? '<div style="margin-top:4px;font-style:italic">Loading manifests...</div>' : '<div style="margin-top:4px;font-style:italic">No manifests linked</div>'}
-            </div>
-          </div>`;
-          html += `</div>`;
-        }
-        html += `</div>`;
-      }
-      el.innerHTML = html;
-
-      // Peer toggle (L1)
-      OL.wireTreeToggles(el, 'data-prod-peer');
-
-      // Product toggle (L2) -- expand loads manifests, click also opens detail
-      el.querySelectorAll('[data-prod-item]').forEach(node => {
-        node.addEventListener('click', () => {
-          const idx = node.dataset.prodItem;
-          const productId = node.dataset.productId;
-          const children = el.querySelector(`[data-prod-item-children="${idx}"]`);
-          const arrow = node.querySelector('.tree-arrow');
-
-          // Load detail panel
-          OL.loadProductDetail(productId);
-
-          if (children.style.display === 'none') {
-            children.style.display = '';
-            arrow.innerHTML = '&#x25BC;';
-            // Lazy-load manifests on first expand
-            const placeholder = children.querySelector('.prod-manifests-placeholder');
-            if (placeholder) {
-              loadProductManifests(productId, placeholder);
-            }
-          } else {
-            children.style.display = 'none';
-            arrow.innerHTML = '&#x25B6;';
+      OL.renderTree(el, peerGroups, {
+        prefix: 'prod',
+        emptyMessage: 'No products yet. Create one to group your manifests.',
+        levels: [
+          {
+            label: function(pg) { return esc(pg.peer_id); },
+            count: function(pg) { return pg.count; },
+            children: function(pg) { return pg.products; },
+          },
+          {
+            label: function(p) { return esc(p.title); },
+            extra: function(p) {
+              return '<span class="session-uuid">' + esc(p.marker) + '</span>' +
+                (p.total_manifests > 0 ? '<span class="count">' + p.total_manifests + '</span>' : '');
+            },
+            dotColor: function(p) {
+              return p.status === 'open' ? 'green' : p.status === 'closed' ? 'red' : p.status === 'archive' ? 'red' : 'yellow';
+            },
+            expanded: false,
+            nodeAttrs: function(p) { return 'data-product-id="' + esc(p.id) + '"'; },
+            renderContent: function(p) {
+              var metaParts = [];
+              if (p.total_tasks > 0) metaParts.push(p.total_tasks + ' tasks');
+              if (p.total_turns > 0) metaParts.push(p.total_turns + ' turns');
+              if (p.total_cost > 0) metaParts.push('$' + p.total_cost.toFixed(2));
+              return '<div class="prod-manifests-placeholder" data-prod-manifests-for="' + esc(p.id) + '" style="margin-left:24px">' +
+                '<div style="padding:8px 12px;color:var(--text-muted);font-size:12px">' +
+                  (metaParts.length ? metaParts.join(' &middot; ') : '') +
+                  (p.total_manifests > 0 ? '<div style="margin-top:4px;font-style:italic">Loading manifests...</div>' : '<div style="margin-top:4px;font-style:italic">No manifests linked</div>') +
+                '</div>' +
+              '</div>';
+            },
+            onClick: function(node, childrenEl, nowExpanded, p) {
+              OL.loadProductDetail(p.id);
+              if (nowExpanded) {
+                var placeholder = childrenEl.querySelector('.prod-manifests-placeholder');
+                if (placeholder) loadProductManifests(p.id, placeholder);
+              }
+            },
           }
-        });
+        ],
+        afterRender: function(container) {
+          container.insertAdjacentHTML('afterbegin', '<div style="padding:8px 0;margin-bottom:8px"><button class="btn-search" id="btn-new-product" style="font-size:12px;padding:6px 16px">+ New Product</button></div>');
+          container.querySelector('#btn-new-product').addEventListener('click', function() { window._createProduct(); });
+        },
       });
 
-      // New product button
-      const newBtn = el.querySelector('#btn-new-product');
-      if (newBtn) newBtn.addEventListener('click', () => window._createProduct());
+      // Handle empty case — still need new product button
+      if (!peerGroups || !peerGroups.length) {
+        el.insertAdjacentHTML('afterbegin', '<div style="padding:8px 0;margin-bottom:8px"><button class="btn-search" id="btn-new-product" style="font-size:12px;padding:6px 16px">+ New Product</button></div>');
+        el.querySelector('#btn-new-product').addEventListener('click', function() { window._createProduct(); });
+      }
     } catch (e) {
       console.error('Load products failed:', e);
     }

--- a/internal/web/ui/views/tasks.js
+++ b/internal/web/ui/views/tasks.js
@@ -75,121 +75,71 @@
 
     newBtn.onclick = () => OL.showTaskCreateForm();
 
-    const statusColors = {running:'green',paused:'yellow',scheduled:'yellow',waiting:'yellow',pending:'',completed:'green',max_turns:'yellow',failed:'red',cancelled:''};
+    var statusColors = {running:'green',paused:'yellow',scheduled:'yellow',waiting:'yellow',pending:'',completed:'green',max_turns:'yellow',failed:'red',cancelled:''};
 
     try {
-      const peerGroups = await fetchJSON('/api/tasks/by-peer');
-      if (!peerGroups || !peerGroups.length) {
-        el.innerHTML = '<div class="empty-state" style="padding:16px">No tasks yet</div>';
-        return;
-      }
+      var peerGroups = await fetchJSON('/api/tasks/by-peer');
 
-      // Peer → Manifest → Tasks (mirrors amnesia: Peer → Session → Violations)
-      let html = '';
-      for (let pi = 0; pi < peerGroups.length; pi++) {
-        const pg = peerGroups[pi];
-        const totalTasks = pg.manifests.reduce((sum, mg) => sum + mg.tasks.length, 0);
-
-        // Peer header (L1)
-        html += `<div class="tree-node peer-header clickable" data-task-peer="${pi}">
-          <span class="tree-arrow">&#x25BC;</span>
-          <span class="status-dot green"></span>
-          <span>${esc(pg.peer_id)}</span>
-          <span class="count">${totalTasks}</span>
-        </div>`;
-        html += `<div class="peer-children" data-task-peer-children="${pi}">`;
-
-        // Manifest headers (L2) — same as amnesia sessions
-        for (let mi = 0; mi < pg.manifests.length; mi++) {
-          const mg = pg.manifests[mi];
-          if (!mg.tasks.length) continue;
-
-          // Pick dot color from most active task status
-          const hasRunning = mg.tasks.some(t => t.status === 'running');
-          const hasFailed = mg.tasks.some(t => t.status === 'failed');
-          const hasScheduled = mg.tasks.some(t => t.status === 'scheduled' || t.status === 'waiting');
-          const dotColor = hasRunning ? 'green' : hasFailed ? 'red' : hasScheduled ? 'yellow' : 'green';
-
-          html += `<div class="tree-node clickable" style="padding-left:24px" data-task-manifest="${pi}-${mi}">
-            <span class="tree-arrow">&#x25B6;</span>
-            <span class="status-dot ${dotColor}"></span>
-            <span>${esc(mg.manifest_title || 'Standalone')}</span>
-            <span class="session-uuid">${esc(mg.manifest_marker || '')}</span>
-            <span class="count">${mg.tasks.length}</span>
-          </div>`;
-          html += `<div style="display:none" data-task-manifest-children="${pi}-${mi}">`;
-
-          // Task items (L3) — same as amnesia violations
-          for (const t of mg.tasks) {
-            const sColor = statusColors[t.status] || '';
-            const statusClass = t.status === 'completed' ? 'confirmed' : t.status === 'failed' ? 'flagged' : t.status === 'running' ? 'confirmed' : 'dismissed';
-            const metaParts = [];
-            if (t.run_count > 0) metaParts.push(`${t.run_count} runs`);
-            if (t.total_turns > 0) metaParts.push(`${t.total_turns} turns`);
-            if (t.total_cost > 0) metaParts.push(`$${t.total_cost.toFixed(2)}`);
-            metaParts.push(t.schedule);
-
-            html += `<div class="amnesia-item ${statusClass} clickable" data-id="${esc(t.id)}" style="margin-left:24px;cursor:pointer">
-              <div class="amnesia-header">
-                ${t.status === 'running' ? '<span class="status-dot green status-pulse"></span>' : `<span class="status-dot ${sColor}"></span>`}
-                <span class="amnesia-status-label">${esc(t.status)}</span>
-                <span class="session-uuid">${esc(t.marker)}</span>
-                <span class="badge type">${esc(t.schedule)}</span>
-                ${t.depends_on ? '<span class="badge scope">dep</span>' : ''}
-                <span style="color:var(--text-muted);font-size:11px;margin-left:auto">${formatTime(t.updated_at || t.created_at)}</span>
-              </div>
-              <div class="amnesia-rule">${esc(t.title)}</div>
-              <div class="amnesia-action">
-                ${metaParts.join(' &middot; ')}
-              </div>
-            </div>`;
-          }
-          html += `</div>`;
-        }
-        html += `</div>`;
-      }
-      el.innerHTML = html;
-
-      // Peer toggle (L1)
-      el.querySelectorAll('[data-task-peer]').forEach(node => {
-        node.addEventListener('click', () => {
-          const idx = node.dataset.taskPeer;
-          const children = el.querySelector(`[data-task-peer-children="${idx}"]`);
-          const arrow = node.querySelector('.tree-arrow');
-          if (children.style.display === 'none') {
-            children.style.display = '';
-            arrow.innerHTML = '&#x25BC;';
-          } else {
-            children.style.display = 'none';
-            arrow.innerHTML = '&#x25B6;';
-          }
-        });
+      // Filter out empty manifests before passing to renderTree
+      var treeData = (peerGroups || []).map(function(pg) {
+        return {
+          peer_id: pg.peer_id,
+          manifests: pg.manifests.filter(function(mg) { return mg.tasks.length > 0; }),
+          totalTasks: pg.manifests.reduce(function(sum, mg) { return sum + mg.tasks.length; }, 0),
+        };
       });
 
-      // Manifest toggle (L2)
-      el.querySelectorAll('[data-task-manifest]').forEach(node => {
-        node.addEventListener('click', () => {
-          const idx = node.dataset.taskManifest;
-          const children = el.querySelector(`[data-task-manifest-children="${idx}"]`);
-          const arrow = node.querySelector('.tree-arrow');
-          if (children.style.display === 'none') {
-            children.style.display = '';
-            arrow.innerHTML = '&#x25BC;';
-          } else {
-            children.style.display = 'none';
-            arrow.innerHTML = '&#x25B6;';
+      OL.renderTree(el, treeData, {
+        prefix: 'task',
+        emptyMessage: 'No tasks yet',
+        levels: [
+          {
+            label: function(pg) { return esc(pg.peer_id); },
+            count: function(pg) { return pg.totalTasks; },
+            children: function(pg) { return pg.manifests; },
+          },
+          {
+            label: function(mg) { return esc(mg.manifest_title || 'Standalone'); },
+            extra: function(mg) { return '<span class="session-uuid">' + esc(mg.manifest_marker || '') + '</span>'; },
+            count: function(mg) { return mg.tasks.length; },
+            children: function(mg) { return mg.tasks; },
+            dotColor: function(mg) {
+              var hasRunning = mg.tasks.some(function(t) { return t.status === 'running'; });
+              var hasFailed = mg.tasks.some(function(t) { return t.status === 'failed'; });
+              var hasScheduled = mg.tasks.some(function(t) { return t.status === 'scheduled' || t.status === 'waiting'; });
+              return hasRunning ? 'green' : hasFailed ? 'red' : hasScheduled ? 'yellow' : 'green';
+            },
+            expanded: false,
           }
-        });
-      });
+        ],
+        renderLeaf: function(t) {
+          var sColor = statusColors[t.status] || '';
+          var statusClass = t.status === 'completed' ? 'confirmed' : t.status === 'failed' ? 'flagged' : t.status === 'running' ? 'confirmed' : 'dismissed';
+          var metaParts = [];
+          if (t.run_count > 0) metaParts.push(t.run_count + ' runs');
+          if (t.total_turns > 0) metaParts.push(t.total_turns + ' turns');
+          if (t.total_cost > 0) metaParts.push('$' + t.total_cost.toFixed(2));
+          metaParts.push(t.schedule);
 
-      // Task clicks (L3)
-      el.querySelectorAll('.amnesia-item.clickable').forEach(item => {
-        item.addEventListener('click', (e) => {
-          e.stopPropagation();
-          el.querySelectorAll('.amnesia-item').forEach(i => i.classList.remove('active'));
+          return '<div class="amnesia-item ' + statusClass + ' clickable tree-leaf" data-id="' + esc(t.id) + '" style="margin-left:24px;cursor:pointer">' +
+            '<div class="amnesia-header">' +
+              (t.status === 'running' ? '<span class="status-dot green status-pulse"></span>' : '<span class="status-dot ' + sColor + '"></span>') +
+              '<span class="amnesia-status-label">' + esc(t.status) + '</span>' +
+              '<span class="session-uuid">' + esc(t.marker) + '</span>' +
+              '<span class="badge type">' + esc(t.schedule) + '</span>' +
+              (t.depends_on ? '<span class="badge scope">dep</span>' : '') +
+              '<span style="color:var(--text-muted);font-size:11px;margin-left:auto">' + formatTime(t.updated_at || t.created_at) + '</span>' +
+            '</div>' +
+            '<div class="amnesia-rule">' + esc(t.title) + '</div>' +
+            '<div class="amnesia-action">' + metaParts.join(' &middot; ') + '</div>' +
+          '</div>';
+        },
+        leafSelector: '.tree-leaf',
+        onLeafClick: function(item) {
+          el.querySelectorAll('.amnesia-item').forEach(function(i) { i.classList.remove('active'); });
           item.classList.add('active');
           OL.loadTaskDetail(item.dataset.id);
-        });
+        },
       });
     } catch (e) {
       console.error('Load tasks failed:', e);

--- a/internal/web/ui/views/watcher.js
+++ b/internal/web/ui/views/watcher.js
@@ -40,10 +40,6 @@
 
       // Audit list — Peer -> Task -> Audits
       var listEl = document.getElementById('watcher-list');
-      if (!audits || !audits.length) {
-        listEl.innerHTML = '<div class="empty-state">No audits yet &mdash; audits are created automatically when tasks complete</div>';
-        return;
-      }
 
       function gateIcon(passed) {
         return passed ? '<span style="color:var(--green)">&#x2713;</span>' : '<span style="color:var(--red)">&#x2717;</span>';
@@ -52,7 +48,7 @@
       // Group: peer -> task -> audits
       var peerMap = {};
       var peerOrder = [];
-      for (var ai = 0; ai < audits.length; ai++) {
+      for (var ai = 0; ai < (audits || []).length; ai++) {
         var a = audits[ai];
         var pid = a.source_node || 'unknown';
         var tid = a.task_id || 'unknown';
@@ -69,75 +65,61 @@
         peer.count++;
       }
 
-      var html = '';
-      for (var pi = 0; pi < peerOrder.length; pi++) {
-        var pId = peerOrder[pi];
-        var pg = peerMap[pId];
+      // Transform into array for renderTree
+      var treeData = peerOrder.map(function(pid) {
+        var pg = peerMap[pid];
+        return {
+          peer_id: pid,
+          count: pg.count,
+          taskGroups: pg.taskOrder.map(function(tid) { return pg.tasks[tid]; }),
+        };
+      });
 
-        // Peer header (L1)
-        html += '<div class="tree-node peer-header clickable" data-wt-peer="' + pi + '">' +
-          '<span class="tree-arrow">&#x25BC;</span>' +
-          '<span class="status-dot green"></span>' +
-          '<span>' + esc(pId) + '</span>' +
-          '<span class="count">' + pg.count + '</span>' +
-        '</div>';
-        html += '<div class="peer-children" data-wt-peer-children="' + pi + '">';
-
-        // Task headers (L2)
-        for (var ti = 0; ti < pg.taskOrder.length; ti++) {
-          var tId = pg.taskOrder[ti];
-          var tg = pg.tasks[tId];
-          var latestStatus = tg.audits[0].status;
-          var dotColor = latestStatus === 'passed' ? 'green' : latestStatus === 'failed' ? 'red' : 'yellow';
-
-          html += '<div class="tree-node clickable" style="padding-left:24px" data-wt-task="' + pi + '-' + ti + '">' +
-            '<span class="tree-arrow">&#x25B6;</span>' +
-            '<span class="status-dot ' + dotColor + '"></span>' +
-            '<span>' + esc(tg.title) + '</span>' +
-            '<span class="session-uuid">' + esc(tg.marker) + '</span>' +
-            '<span class="count">' + tg.audits.length + '</span>' +
-          '</div>';
-          html += '<div style="display:none" data-wt-task-children="' + pi + '-' + ti + '">';
-
-          // Audit items (L3)
-          for (var aui = 0; aui < tg.audits.length; aui++) {
-            var au = tg.audits[aui];
-            var statusClass = au.status === 'passed' ? 'confirmed' : au.status === 'failed' ? 'flagged' : 'dismissed';
-            var downgraded = au.original_status !== au.final_status;
-
-            html += '<div class="amnesia-item ' + statusClass + ' clickable" data-id="' + esc(au.id) + '" style="margin-left:24px;cursor:pointer">' +
-              '<div class="amnesia-header">' +
-                '<span class="amnesia-status-label">' + esc(au.status) + '</span>' +
-                '<span class="badge type">Git ' + gateIcon(au.git_passed) + '</span>' +
-                '<span class="badge type">Build ' + gateIcon(au.build_passed) + '</span>' +
-                '<span class="badge type">Manifest ' + gateIcon(au.manifest_passed) + ' ' + (au.manifest_score > 0 ? Math.round(au.manifest_score * 100) + '%' : '') + '</span>' +
-                (downgraded ? '<span class="badge type" style="color:var(--red);font-weight:600">DOWNGRADED</span>' : '') +
-                '<span style="color:var(--text-muted);font-size:11px;margin-left:auto">' + formatTime(au.audited_at) + '</span>' +
-              '</div>' +
-              '<div class="amnesia-rule">' +
-                '<span style="color:var(--text-muted)">Manifest:</span> ' + esc(au.manifest_title || 'none') +
-              '</div>' +
-              '<div class="amnesia-action">' +
-                '<span style="color:var(--text-muted)">Actions:</span> ' + au.action_count +
-                (au.cost_usd > 0 ? '<span style="margin-left:12px;color:var(--text-muted)">Cost:</span> $' + au.cost_usd.toFixed(2) : '') +
-              '</div>' +
-            '</div>';
+      OL.renderTree(listEl, treeData, {
+        prefix: 'wt',
+        emptyMessage: 'No audits yet &mdash; audits are created automatically when tasks complete',
+        levels: [
+          {
+            label: function(pg) { return esc(pg.peer_id); },
+            count: function(pg) { return pg.count; },
+            children: function(pg) { return pg.taskGroups; },
+          },
+          {
+            label: function(tg) { return esc(tg.title); },
+            extra: function(tg) { return '<span class="session-uuid">' + esc(tg.marker) + '</span>'; },
+            count: function(tg) { return tg.audits.length; },
+            children: function(tg) { return tg.audits; },
+            dotColor: function(tg) {
+              var s = tg.audits[0].status;
+              return s === 'passed' ? 'green' : s === 'failed' ? 'red' : 'yellow';
+            },
+            expanded: false,
           }
-          html += '</div>';
-        }
-        html += '</div>';
-      }
-      listEl.innerHTML = html;
+        ],
+        renderLeaf: function(au) {
+          var statusClass = au.status === 'passed' ? 'confirmed' : au.status === 'failed' ? 'flagged' : 'dismissed';
+          var downgraded = au.original_status !== au.final_status;
 
-      // Peer toggle (L1)
-      OL.wireTreeToggles(listEl, 'data-wt-peer', 'data-wt-peer-children');
-
-      // Task toggle (L2)
-      OL.wireTreeToggles(listEl, 'data-wt-task', 'data-wt-task-children');
-
-      // Click handlers for detail view (L3)
-      listEl.querySelectorAll('.amnesia-item.clickable').forEach(function(item) {
-        item.addEventListener('click', function() { OL.loadWatcherDetail(item.dataset.id); });
+          return '<div class="amnesia-item ' + statusClass + ' clickable tree-leaf" data-id="' + esc(au.id) + '" style="margin-left:24px;cursor:pointer">' +
+            '<div class="amnesia-header">' +
+              '<span class="amnesia-status-label">' + esc(au.status) + '</span>' +
+              '<span class="badge type">Git ' + gateIcon(au.git_passed) + '</span>' +
+              '<span class="badge type">Build ' + gateIcon(au.build_passed) + '</span>' +
+              '<span class="badge type">Manifest ' + gateIcon(au.manifest_passed) + ' ' + (au.manifest_score > 0 ? Math.round(au.manifest_score * 100) + '%' : '') + '</span>' +
+              (downgraded ? '<span class="badge type" style="color:var(--red);font-weight:600">DOWNGRADED</span>' : '') +
+              '<span style="color:var(--text-muted);font-size:11px;margin-left:auto">' + formatTime(au.audited_at) + '</span>' +
+            '</div>' +
+            '<div class="amnesia-rule">' +
+              '<span style="color:var(--text-muted)">Manifest:</span> ' + esc(au.manifest_title || 'none') +
+            '</div>' +
+            '<div class="amnesia-action">' +
+              '<span style="color:var(--text-muted)">Actions:</span> ' + au.action_count +
+              (au.cost_usd > 0 ? '<span style="margin-left:12px;color:var(--text-muted)">Cost:</span> $' + au.cost_usd.toFixed(2) : '') +
+            '</div>' +
+          '</div>';
+        },
+        leafSelector: '.tree-leaf',
+        onLeafClick: function(el) { OL.loadWatcherDetail(el.dataset.id); },
       });
 
     } catch(e) {


### PR DESCRIPTION
## Summary

- Added `OL.renderTree(container, data, config)` to `tree.js` — a single, configurable multi-level collapsible tree renderer supporting arbitrary nesting depth, custom leaf rendering, lazy-loaded content, and post-toggle callbacks
- Refactored 8 tree instances across 6 view files (memories, amnesia, delusions, visceral, watcher, products, manifests, tasks) to use the shared component
- Added basic a11y: `role="button"`, `tabindex="0"`, `aria-expanded`, and keyboard Enter/Space support on all tree nodes
- Net reduction of 65 lines despite adding the reusable component

## Test plan

- [ ] Verify each dashboard view renders its tree correctly (expand/collapse, correct labels, counts, dot colors)
- [ ] Verify leaf item clicks navigate to detail views (memory detail, manifest detail, task detail, watcher audit detail)
- [ ] Verify products view lazy-loads manifests on first expand
- [ ] Verify keyboard navigation (Tab to tree nodes, Enter/Space to toggle)
- [ ] Verify aria-expanded updates on toggle
- [ ] Build passes: `make build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)