### PR TITLE
Replace window._* globals with OL.* module-scoped functions

### DIFF
--- a/internal/web/ui/api.js
+++ b/internal/web/ui/api.js
@@ -82,7 +82,7 @@ window.OL = {};
     return model;
   };
 
-  window._copy = OL.copy = function(text) {
+  OL.copy = function(text) {
     navigator.clipboard.writeText(text).then(function() {
       var toast = document.createElement('div');
       toast.className = 'copy-toast';

--- a/internal/web/ui/app.js
+++ b/internal/web/ui/app.js
@@ -72,7 +72,6 @@
     if (view === 'chat') OL.loadChat();
     if (view === 'settings') OL.loadSettings();
   }
-  window.switchView = switchView;
   OL.switchView = switchView;
 
   // --- Theme ---
@@ -204,11 +203,5 @@
     }
   }
   OL.refreshAll = refreshAll;
-
-  // Expose switchView to global for inline onclick handlers
-  window.switchView = switchView;
-
-  // Expose loadTaskDetail globally for inline onclick in HTML strings
-  window.loadTaskDetail = function(id) { OL.loadTaskDetail(id); };
 
 })(window.OL);

--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -122,19 +122,19 @@
         </div>
 
         <div class="metrics-grid" style="grid-template-columns:repeat(4,1fr)">
-          <div class="metric-card metric-card-primary" id="metric-running-card" style="cursor:pointer" onclick="switchView('tasks')">
+          <div class="metric-card metric-card-primary" id="metric-running-card" style="cursor:pointer" onclick="OL.switchView('tasks')">
             <div class="metric-value" id="metric-running" style="color:var(--green)">0</div>
             <div class="metric-label">running</div>
           </div>
-          <div class="metric-card metric-card-primary" style="cursor:pointer" onclick="switchView('tasks')">
+          <div class="metric-card metric-card-primary" style="cursor:pointer" onclick="OL.switchView('tasks')">
             <div class="metric-value" id="metric-turns-today">-</div>
             <div class="metric-label">turns today</div>
           </div>
-          <div class="metric-card metric-card-primary" id="metric-cost-card" style="cursor:pointer" onclick="switchView('cost-history')">
+          <div class="metric-card metric-card-primary" id="metric-cost-card" style="cursor:pointer" onclick="OL.switchView('cost-history')">
             <div class="metric-value" id="metric-cost-today">-</div>
             <div class="metric-label" id="metric-cost-label">cost today</div>
           </div>
-          <div class="metric-card metric-card-primary" style="cursor:pointer" onclick="switchView('tasks')">
+          <div class="metric-card metric-card-primary" style="cursor:pointer" onclick="OL.switchView('tasks')">
             <div class="metric-value" id="metric-tasks-total">-</div>
             <div class="metric-label">tasks</div>
           </div>
@@ -323,7 +323,7 @@
         <div class="panel" id="tasks-running-panel" style="display:none;margin-bottom:16px;border-left:3px solid var(--green)">
           <div class="panel-header" style="background:rgba(0,217,126,0.05)">
             Running Now
-            <button class="btn-confirm" onclick="window._emergencyStopAll()" style="margin-left:auto;font-size:11px;padding:4px 12px">Emergency Stop All</button>
+            <button class="btn-confirm" onclick="OL.emergencyStopAll()" style="margin-left:auto;font-size:11px;padding:4px 12px">Emergency Stop All</button>
           </div>
           <div class="panel-body" id="tasks-running-list"></div>
         </div>

--- a/internal/web/ui/views/actions.js
+++ b/internal/web/ui/views/actions.js
@@ -99,7 +99,7 @@
       bodyEl.querySelectorAll('.conv-nav').forEach(el => {
         OL.onView(el, 'click', () => {
           OL.switchView('conversations');
-          setTimeout(() => window._loadConv(el.dataset.convId), 300);
+          setTimeout(() => OL.loadConv(el.dataset.convId), 300);
         });
       });
 

--- a/internal/web/ui/views/activity.js
+++ b/internal/web/ui/views/activity.js
@@ -58,7 +58,7 @@
           var id = item.dataset.activityId;
           if (type === 'conversation') {
             OL.switchView('conversations');
-            setTimeout(function() { window._loadConv(id); }, 300);
+            setTimeout(function() { OL.loadConv(id); }, 300);
           } else if (type === 'memory') {
             OL.switchView('memories');
             setTimeout(function() { OL.loadMemoryPeerDetail(id); }, 300);

--- a/internal/web/ui/views/compliance.js
+++ b/internal/web/ui/views/compliance.js
@@ -50,8 +50,8 @@
               '<span style="color:var(--text-muted)">Action:</span> ' + esc(d.tool_input) +
             '</div>' +
             (d.status === 'flagged' ? '<div class="amnesia-actions">' +
-              '<button class="btn-confirm" onclick="window._delusionAction(' + d.id + ',\'confirm\')">Confirm Off-Spec</button>' +
-              '<button class="btn-dismiss" onclick="window._delusionAction(' + d.id + ',\'dismiss\')">Dismiss</button>' +
+              '<button class="btn-confirm" onclick="OL.delusionAction(' + d.id + ',\'confirm\')">Confirm Off-Spec</button>' +
+              '<button class="btn-dismiss" onclick="OL.delusionAction(' + d.id + ',\'dismiss\')">Dismiss</button>' +
             '</div>' : '') +
           '</div>';
         },
@@ -62,7 +62,7 @@
     }
   };
 
-  window._delusionAction = async function(id, action) {
+  OL.delusionAction = async function(id, action) {
     await fetch('/api/delusions/' + id + '/' + action, {method: 'POST'});
     OL.loadDelusions();
   };
@@ -149,8 +149,8 @@
               '<span style="color:var(--text-muted)">Action:</span> ' + esc(a.tool_input) +
             '</div>' +
             (a.status === 'flagged' ? '<div class="amnesia-actions">' +
-              '<button class="btn-confirm" onclick="window._amnesiaAction(' + a.id + ',\'confirm\')">Confirm Violation</button>' +
-              '<button class="btn-dismiss" onclick="window._amnesiaAction(' + a.id + ',\'dismiss\')">Dismiss</button>' +
+              '<button class="btn-confirm" onclick="OL.amnesiaAction(' + a.id + ',\'confirm\')">Confirm Violation</button>' +
+              '<button class="btn-dismiss" onclick="OL.amnesiaAction(' + a.id + ',\'dismiss\')">Dismiss</button>' +
             '</div>' : '') +
           '</div>';
         },
@@ -161,7 +161,7 @@
     }
   };
 
-  window._amnesiaAction = async function(id, action) {
+  OL.amnesiaAction = async function(id, action) {
     await fetch('/api/amnesia/' + id + '/' + action, {method: 'POST'});
     OL.loadAmnesia();
   };
@@ -217,8 +217,8 @@
             '<span class="session-uuid">' + esc(r.marker) + '</span>' +
             '<span class="visceral-text">' + esc(r.text) + '</span>' +
             '<span style="color:var(--text-muted);font-size:11px">' + esc(r.source || '') + '</span>' +
-            '<button class="btn-copy" onclick="window._copy(\'recall memory ' + esc(r.marker) + '\')" title="Copy reference">&#x2398;</button>' +
-            '<button class="visceral-delete" onclick="window._deleteVisceral(\'' + esc(r.id) + '\')" title="Remove rule">&times;</button>' +
+            '<button class="btn-copy" onclick="OL.copy(\'recall memory ' + esc(r.marker) + '\')" title="Copy reference">&#x2398;</button>' +
+            '<button class="visceral-delete" onclick="OL.deleteVisceral(\'' + esc(r.id) + '\')" title="Remove rule">&times;</button>' +
           '</div>';
         },
       });
@@ -227,7 +227,7 @@
     }
   };
 
-  window._deleteVisceral = async function(id) {
+  OL.deleteVisceral = async function(id) {
     if (!confirm('Remove this visceral rule?')) return;
     await fetch('/api/visceral/' + id, {method: 'DELETE'});
     OL.loadVisceral();

--- a/internal/web/ui/views/conversations.js
+++ b/internal/web/ui/views/conversations.js
@@ -67,7 +67,7 @@
         OL.onView(item, 'click', function() {
           el.querySelectorAll('.conv-item').forEach(function(i) { i.classList.remove('active'); });
           item.classList.add('active');
-          window._loadConv(item.dataset.id);
+          OL.loadConv(item.dataset.id);
         });
       });
     } catch (e) {
@@ -94,13 +94,13 @@
       OL.onView(item, 'click', function() {
         el.querySelectorAll('.conv-item').forEach(function(i) { i.classList.remove('active'); });
         item.classList.add('active');
-        window._loadConv(item.dataset.id);
+        OL.loadConv(item.dataset.id);
       });
     });
   }
 
   // Expose to onclick
-  window._loadConv = async function(id) {
+  OL.loadConv = async function(id) {
     // Highlight active
     document.querySelectorAll('.conv-item').forEach(function(i) { i.classList.remove('active'); });
     var active = document.querySelector('.conv-item[data-id="' + id + '"]');
@@ -119,7 +119,7 @@
     var bodyEl = document.getElementById('conv-detail');
 
     var convRef = conv.id ? conv.id.substring(0, 12) : '';
-    titleEl.innerHTML = esc(conv.title || 'Conversation') + ' <button class="btn-copy" onclick="window._copy(\'recall conversation ' + convRef + '\')" title="Copy reference">&#x2398;</button>';
+    titleEl.innerHTML = esc(conv.title || 'Conversation') + ' <button class="btn-copy" onclick="OL.copy(\'recall conversation ' + convRef + '\')" title="Copy reference">&#x2398;</button>';
 
     // Fetch linked actions
     var actionsHtml = '';
@@ -156,7 +156,7 @@
         '<div class="conv-turn-header">' +
           '<span class="conv-turn-role">' + esc(label) + '</span>' +
           '<span class="conv-turn-index">#' + (i + 1) + '</span>' +
-          '<button class="btn-copy" onclick="window._copy(\'recall conversation ' + convRef + ' turn ' + (i + 1) + ': ' + esc(t.content.substring(0, 80)).replace(/'/g, '') + '\')" title="Copy this turn">&#x2398;</button>' +
+          '<button class="btn-copy" onclick="OL.copy(\'recall conversation ' + convRef + ' turn ' + (i + 1) + ': ' + esc(t.content.substring(0, 80)).replace(/'/g, '') + '\')" title="Copy this turn">&#x2398;</button>' +
         '</div>' +
         '<div class="conv-turn-content">' + esc(t.content) + '</div>' +
       '</div>';

--- a/internal/web/ui/views/cost.js
+++ b/internal/web/ui/views/cost.js
@@ -108,7 +108,7 @@
           var h = maxCost > 0 ? Math.max(2, Math.round((d.cost / maxCost) * 100)) : 2;
           var overBudget = budget > 0 && d.cost >= budget;
           var color = overBudget ? 'var(--red)' : (budget > 0 && d.cost >= budget * 0.8) ? 'var(--yellow)' : 'var(--green)';
-          chartHtml += '<div title="' + d.period + ': $' + d.cost.toFixed(2) + '" style="width:' + barWidth + 'px;height:' + h + 'px;background:' + color + ';border-radius:2px 2px 0 0;flex-shrink:0;opacity:' + (d.cost === 0 ? '0.2' : '0.8') + ';cursor:' + (_costPeriod === 'day' ? 'pointer' : 'default') + '" ' + (_costPeriod === 'day' ? 'onclick="loadCostDrillDown(\'' + d.period + '\')"' : '') + '></div>';
+          chartHtml += '<div title="' + d.period + ': $' + d.cost.toFixed(2) + '" style="width:' + barWidth + 'px;height:' + h + 'px;background:' + color + ';border-radius:2px 2px 0 0;flex-shrink:0;opacity:' + (d.cost === 0 ? '0.2' : '0.8') + ';cursor:' + (_costPeriod === 'day' ? 'pointer' : 'default') + '" ' + (_costPeriod === 'day' ? 'onclick="OL.loadCostDrillDown(\'' + d.period + '\')"' : '') + '></div>';
         }
         chartHtml += '</div>';
         chartEl.innerHTML = chartHtml;
@@ -143,7 +143,7 @@
         totalTurns += d.turns;
         totalTasks += d.tasks;
         totalRuns += (d.runs || 0);
-        html += '<tr class="top-task-row" style="' + rowBg + ';' + (clickable ? 'cursor:pointer' : '') + '" ' + (clickable ? 'onclick="loadCostDrillDown(\'' + d.period + '\')"' : '') + '>' +
+        html += '<tr class="top-task-row" style="' + rowBg + ';' + (clickable ? 'cursor:pointer' : '') + '" ' + (clickable ? 'onclick="OL.loadCostDrillDown(\'' + d.period + '\')"' : '') + '>' +
           '<td style="padding:6px 12px;font-family:var(--font-mono);font-size:12px;color:var(--accent)">' + d.period + (isToday ? ' <span style="font-size:10px;color:var(--green)">(today)</span>' : '') + '</td>' +
           '<td style="padding:6px 12px;text-align:right;font-family:var(--font-mono);font-size:12px">' + d.tasks + '</td>' +
           '<td style="padding:6px 12px;text-align:right;font-family:var(--font-mono);font-size:12px">' + (d.runs || d.tasks) + '</td>' +
@@ -172,7 +172,7 @@
   };
 
   // Drill-down: show individual tasks for a specific date, grouped by agent
-  window.loadCostDrillDown = async function(date) {
+  OL.loadCostDrillDown = async function(date) {
     var tableEl = document.getElementById('cost-history-table');
     var chartEl = document.getElementById('cost-chart');
     var banner = document.getElementById('cost-drilldown-banner');

--- a/internal/web/ui/views/ideas.js
+++ b/internal/web/ui/views/ideas.js
@@ -59,21 +59,21 @@
       OL.wireTreeToggles(el, 'data-idea-peer');
 
       el.querySelectorAll('.manifest-item').forEach(function(item) {
-        OL.onView(item, 'click', function() { window._loadIdea(item.dataset.id); });
+        OL.onView(item, 'click', function() { OL.loadIdea(item.dataset.id); });
       });
 
       if (_pendingIdeaId) {
         var id = _pendingIdeaId;
         _pendingIdeaId = null;
         var match = allIdeas.find(function(i) { return i.id.startsWith(id) || i.marker === id; });
-        if (match) window._loadIdea(match.id);
+        if (match) OL.loadIdea(match.id);
       }
     } catch (e) {
       console.error('Load ideas failed:', e);
     }
   };
 
-  window._loadIdea = async function(id) {
+  OL.loadIdea = async function(id) {
     document.querySelectorAll('#ideas-list .manifest-item').forEach(function(i) { i.classList.remove('active'); });
     var active = document.querySelector('#ideas-list .manifest-item[data-id="' + id + '"]');
     if (active) active.classList.add('active');
@@ -112,7 +112,7 @@
             '<span class="amnesia-score ' + prioClass + '">' + esc(idea.priority) + '</span>' +
             '<span class="badge">' + esc(idea.status) + '</span>' +
             '<span style="font-size:12px;color:var(--text-muted)">by ' + esc(idea.author) + '</span>' +
-            '<button class="btn-copy" onclick="window._copy(\'get idea ' + idea.marker + '\')" title="Copy ref">&#x2398;</button>' +
+            '<button class="btn-copy" onclick="OL.copy(\'get idea ' + idea.marker + '\')" title="Copy ref">&#x2398;</button>' +
           '</div>' +
           (idea.description ? '<div style="font-size:14px;color:var(--text-primary);margin:12px 0;line-height:1.5">' + esc(idea.description) + '</div>' : '') +
           linkedHtml +
@@ -121,7 +121,7 @@
           '</div>' +
           '<div style="margin-top:12px;display:flex;gap:8px">' +
             '<button class="btn-search promote-idea-btn" style="font-size:12px;padding:6px 14px">Create Manifest from Idea</button>' +
-            '<button class="btn-dismiss" onclick="window._archiveIdea(\'' + esc(idea.id) + '\')">Archive</button>' +
+            '<button class="btn-dismiss" onclick="OL.archiveIdea(\'' + esc(idea.id) + '\')">Archive</button>' +
           '</div>' +
         '</div>';
 
@@ -129,13 +129,13 @@
       bodyEl.querySelectorAll('.manifest-link').forEach(function(el) {
         OL.onView(el, 'click', function() {
           OL.switchView('manifests');
-          setTimeout(function() { window._loadManifest(el.dataset.mid); }, 300);
+          setTimeout(function() { OL.loadManifest(el.dataset.mid); }, 300);
         });
       });
 
       // Promote idea to manifest
       OL.onView(bodyEl.querySelector('.promote-idea-btn'), 'click', function() {
-        window._promoteToManifest(
+        OL.promoteToManifest(
           idea.title,
           idea.description || '',
           '# ' + idea.title + '\n\n' + (idea.description || '') + '\n\nPromoted from idea [' + idea.marker + ']\nPriority: ' + idea.priority + '\nStatus: ' + idea.status
@@ -147,12 +147,12 @@
   };
 
   // Navigate from manifest → specific idea
-  window._goToIdea = function(marker) {
+  OL.goToIdea = function(marker) {
     _pendingIdeaId = marker;
     OL.switchView('ideas');
   };
 
-  window._archiveIdea = async function(id) {
+  OL.archiveIdea = async function(id) {
     var idea = await fetchJSON('/api/ideas/' + id);
     if (idea) {
       await fetchJSON('/api/ideas/' + id, { method: 'PUT', headers: {'Content-Type':'application/json'}, body: JSON.stringify({status: 'archive'}) });

--- a/internal/web/ui/views/manifests.js
+++ b/internal/web/ui/views/manifests.js
@@ -82,7 +82,7 @@
           '</div>';
         },
         leafSelector: '.tree-leaf',
-        onLeafClick: function(item) { window._loadManifest(item.dataset.id); },
+        onLeafClick: function(item) { OL.loadManifest(item.dataset.id); },
       });
     } catch (e) {
       console.error('Load manifests failed:', e);
@@ -113,12 +113,12 @@
     el.innerHTML = manifests.map(m => {
       const statusClass = m.status === 'open' ? 'scope' : m.status === 'closed' ? 'type' : m.status === 'archive' ? 'type' : '';
       const jira = (m.jira_refs || []).join(', ');
-      return `<div class="manifest-item clickable" data-id="${esc(m.id)}" onclick="window._loadManifest('${esc(m.id)}')">
+      return `<div class="manifest-item clickable" data-id="${esc(m.id)}" onclick="OL.loadManifest('${esc(m.id)}')">
         <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">
           <span class="session-uuid">${esc(m.marker)}</span>
           <span class="badge ${statusClass}">${esc(m.status)}</span>
           <span style="font-size:11px;color:var(--text-muted)">v${m.version}</span>
-          <button class="btn-copy-sm" onclick="event.stopPropagation();window._copy('get manifest ${esc(m.marker)}')" title="Copy ref">&#x2398;</button>
+          <button class="btn-copy-sm" onclick="event.stopPropagation();OL.copy('get manifest ${esc(m.marker)}')" title="Copy ref">&#x2398;</button>
         </div>
         <div class="manifest-item-title">${esc(m.title)}</div>
         <div style="font-size:12px;color:var(--text-secondary)">${esc(m.description)}</div>
@@ -128,7 +128,7 @@
   }
 
   // Promote idea or memory to manifest -- opens manifest detail panel with creation form pre-filled
-  window._promoteToManifest = async function(title, description, content) {
+  OL.promoteToManifest = async function(title, description, content) {
     OL.switchView('manifests');
 
     // Fetch products for the dropdown
@@ -212,12 +212,12 @@
         const m = await resp.json();
         bodyEl.querySelector('#pm-status-msg').textContent = 'Created!';
         OL.loadManifests();
-        setTimeout(() => window._loadManifest(m.id), 500);
+        setTimeout(() => OL.loadManifest(m.id), 500);
       };
     }, 300);
   };
 
-  window._loadManifest = async function(id) {
+  OL.loadManifest = async function(id) {
     document.querySelectorAll('.manifest-item').forEach(i => i.classList.remove('active'));
     const active = document.querySelector(`.manifest-item[data-id="${id}"]`);
     if (active) active.classList.add('active');
@@ -232,7 +232,7 @@
       const jira = (m.jira_refs || []).map(r => `<a href="https://gryphonnetworks.atlassian.net/browse/${r}" target="_blank" style="color:var(--accent)">${esc(r)}</a>`).join(', ');
       const tags = (m.tags || []).map(t => `<span class="badge tag">${esc(t)}</span>`).join(' ');
 
-      titleEl.innerHTML = `<span id="manifest-edit-title" class="manifest-editable" style="cursor:pointer;border-radius:4px;padding:2px 4px" title="Click to edit title">${esc(m.title)}</span> <button class="btn-copy" onclick="window._copy('get manifest ${esc(m.marker)}')" title="Copy ref">&#x2398;</button>`;
+      titleEl.innerHTML = `<span id="manifest-edit-title" class="manifest-editable" style="cursor:pointer;border-radius:4px;padding:2px 4px" title="Click to edit title">${esc(m.title)}</span> <button class="btn-copy" onclick="OL.copy('get manifest ${esc(m.marker)}')" title="Copy ref">&#x2398;</button>`;
 
       // Fetch linked product for breadcrumb
       let product = null;
@@ -326,7 +326,7 @@
           <!-- BREADCRUMB -->
           <div style="font-size:11px;color:var(--text-muted);margin-bottom:8px;font-family:var(--font-mono)">
             <span style="cursor:pointer;color:var(--accent)" onclick="OL.switchView('${product ? 'products' : 'manifests'}')">${esc(m.source_node ? m.source_node.substring(0,12) : 'node')}</span>
-            ${product ? `<span style="opacity:0.4"> → </span><span style="cursor:pointer;color:var(--accent)" onclick="OL.switchView('products');setTimeout(()=>window._loadProduct('${esc(product.id)}'),300)">${esc(product.marker)} ${esc(product.title)}</span>` : ''}
+            ${product ? `<span style="opacity:0.4"> → </span><span style="cursor:pointer;color:var(--accent)" onclick="OL.switchView('products');setTimeout(()=>OL.loadProduct('${esc(product.id)}'),300)">${esc(product.marker)} ${esc(product.title)}</span>` : ''}
             <span style="opacity:0.4"> → </span>
             <span style="color:var(--text-primary)">${esc(m.marker)} ${esc(m.title)}</span>
           </div>
@@ -373,7 +373,7 @@
 
       // Bind idea navigation links
       bodyEl.querySelectorAll('.idea-nav').forEach(el => {
-        OL.onView(el, 'click', () => window._goToIdea(el.dataset.iid));
+        OL.onView(el, 'click', () => OL.goToIdea(el.dataset.iid));
       });
 
       // Bind task navigation links
@@ -395,7 +395,7 @@
               headers: {'Content-Type': 'application/json'},
               body: JSON.stringify({status: newStatus})
             });
-            window._loadManifest(m.id);
+            OL.loadManifest(m.id);
             OL.loadManifests();
           } catch(e) {
             console.error('Update manifest status failed:', e);
@@ -425,10 +425,10 @@
               });
               OL.loadManifests();
             }
-            window._loadManifest(m.id);
+            OL.loadManifest(m.id);
           };
           OL.onView(input, 'blur', save);
-          OL.onView(input, 'keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); save(); } if (e.key === 'Escape') window._loadManifest(m.id); });
+          OL.onView(input, 'keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); save(); } if (e.key === 'Escape') OL.loadManifest(m.id); });
         });
       }
 
@@ -454,10 +454,10 @@
               });
               OL.loadManifests();
             }
-            window._loadManifest(m.id);
+            OL.loadManifest(m.id);
           };
           OL.onView(input, 'blur', save);
-          OL.onView(input, 'keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); save(); } if (e.key === 'Escape') window._loadManifest(m.id); });
+          OL.onView(input, 'keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); save(); } if (e.key === 'Escape') OL.loadManifest(m.id); });
         });
       }
 
@@ -485,10 +485,10 @@
               });
               OL.loadManifests();
             }
-            window._loadManifest(m.id);
+            OL.loadManifest(m.id);
           };
           OL.onView(sel, 'change', save);
-          OL.onView(sel, 'blur', () => window._loadManifest(m.id));
+          OL.onView(sel, 'blur', () => OL.loadManifest(m.id));
         });
       }
 
@@ -515,7 +515,7 @@
             body: JSON.stringify({content: val})
           });
           OL.loadManifests();
-          window._loadManifest(m.id);
+          OL.loadManifest(m.id);
         });
       }
 
@@ -539,10 +539,10 @@
     }
   };
 
-  window._archiveManifest = async function(id) {
+  OL.archiveManifest = async function(id) {
     await fetchJSON('/api/manifests/' + id, { method: 'PUT', headers: {'Content-Type':'application/json'}, body: JSON.stringify({status: 'archive'}) });
     OL.loadManifests();
-    window._loadManifest(id);
+    OL.loadManifest(id);
   };
 
 })(window.OL);

--- a/internal/web/ui/views/markers.js
+++ b/internal/web/ui/views/markers.js
@@ -20,19 +20,19 @@
         '<div class="marker-message">' + esc(m.message) + '</div>' +
         '<div class="marker-target">' + esc(m.target_path || m.target_id) + '</div>' +
         '<div class="marker-actions">' +
-          '<button onclick="window._markerDone(\'' + esc(m.id) + '\')">Done</button>' +
-          '<button onclick="window._markerSeen(\'' + esc(m.id) + '\')">Seen</button>' +
+          '<button onclick="OL.markerDone(\'' + esc(m.id) + '\')">Done</button>' +
+          '<button onclick="OL.markerSeen(\'' + esc(m.id) + '\')">Seen</button>' +
         '</div>' +
       '</div>';
     }).join('');
   };
 
-  window._markerDone = async function(id) {
+  OL.markerDone = async function(id) {
     await fetch('/api/markers/' + id + '/done', {method: 'POST'});
     OL.refreshAll();
   };
 
-  window._markerSeen = async function(id) {
+  OL.markerSeen = async function(id) {
     await fetch('/api/markers/' + id + '/seen', {method: 'POST'});
     OL.refreshAll();
   };

--- a/internal/web/ui/views/memories.js
+++ b/internal/web/ui/views/memories.js
@@ -29,7 +29,7 @@
           return '<div class="tree-node peer-leaf clickable tree-leaf" data-memory-id="' + esc(m.id) + '">' +
             '<span class="session-uuid">' + esc(m.marker) + '</span>' +
             '<span style="font-size:12px;color:var(--text-primary);flex:1">' + esc(m.l0.length > 50 ? m.l0.substring(0, 50) + '...' : m.l0) + '</span>' +
-            '<button class="btn-copy-sm" onclick="event.stopPropagation();window._copy(\'recall memory ' + esc(m.marker) + '\')" title="Copy ref">&#x2398;</button>' +
+            '<button class="btn-copy-sm" onclick="event.stopPropagation();OL.copy(\'recall memory ' + esc(m.marker) + '\')" title="Copy ref">&#x2398;</button>' +
           '</div>';
         },
         leafSelector: '.tree-leaf',
@@ -66,7 +66,7 @@
         <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px">
           <span class="session-uuid" style="font-size:14px">${esc(marker)}</span>
           <span style="font-family:var(--font-mono);font-size:12px;color:var(--accent);flex:1">${esc(mem.path)}</span>
-          <button class="btn-copy" onclick="window._copy('recall memory ${marker}')" title="Copy reference">&#x2398;</button>
+          <button class="btn-copy" onclick="OL.copy('recall memory ${marker}')" title="Copy reference">&#x2398;</button>
         </div>
         <div class="memory-meta">
           <span class="badge type">${esc(mem.type || 'insight')}</span>
@@ -92,13 +92,13 @@
         <div style="margin-top:8px;font-family:var(--font-mono);font-size:10px;color:var(--text-muted)">ID: ${esc(mem.id)}</div>
         <div style="margin-top:12px;display:flex;gap:8px">
           <button class="btn-search" id="mem-promote-btn" style="font-size:12px;padding:6px 14px">Create Manifest from Memory</button>
-          <button class="btn-dismiss" onclick="window._archiveMemory('${esc(mem.id)}')" style="font-size:12px;padding:6px 14px">Archive</button>
+          <button class="btn-dismiss" onclick="OL.archiveMemory('${esc(mem.id)}')" style="font-size:12px;padding:6px 14px">Archive</button>
         </div>
       </div>
     `;
 
     OL.onView(detail.querySelector('#mem-promote-btn'), 'click', () => {
-      window._promoteToManifest(
+      OL.promoteToManifest(
         tierContent.l0,
         tierContent.l1,
         tierContent.l2
@@ -114,7 +114,7 @@
     });
   }
 
-  window._archiveMemory = async function(id) {
+  OL.archiveMemory = async function(id) {
     // Memories don't have a status field — soft delete via API
     await fetch('/api/memories/' + id, {method: 'DELETE'});
     document.getElementById('memory-peer-detail').innerHTML = '<div class="empty-state">Archived</div>';

--- a/internal/web/ui/views/overview.js
+++ b/internal/web/ui/views/overview.js
@@ -280,9 +280,9 @@
             '<span style="font-size:12px;color:var(--text-muted)">' + rt.actions + ' actions</span>' +
             '<span style="font-size:12px;color:' + (rt.paused ? 'var(--yellow)' : 'var(--green)') + ';font-weight:500">' + (rt.paused ? 'PAUSED' : mins + 'm ' + secs + 's') + '</span>' +
             (rt.paused
-              ? '<button class="btn-search" onclick="event.stopPropagation();window._resumeTask(\'' + esc(rt.task_id) + '\')" style="font-size:11px;padding:3px 10px">Resume</button>'
-              : '<button class="btn-search" onclick="event.stopPropagation();window._pauseTask(\'' + esc(rt.task_id) + '\')" style="font-size:11px;padding:3px 10px;background:var(--yellow);color:var(--bg-primary)">Pause</button>') +
-            '<button class="btn-confirm" onclick="event.stopPropagation();window._killTask(\'' + esc(rt.task_id) + '\')" style="font-size:11px;padding:3px 10px">Stop</button>' +
+              ? '<button class="btn-search" onclick="event.stopPropagation();OL.resumeTask(\'' + esc(rt.task_id) + '\')" style="font-size:11px;padding:3px 10px">Resume</button>'
+              : '<button class="btn-search" onclick="event.stopPropagation();OL.pauseTask(\'' + esc(rt.task_id) + '\')" style="font-size:11px;padding:3px 10px;background:var(--yellow);color:var(--bg-primary)">Pause</button>') +
+            '<button class="btn-confirm" onclick="event.stopPropagation();OL.killTask(\'' + esc(rt.task_id) + '\')" style="font-size:11px;padding:3px 10px">Stop</button>' +
           '</div>';
         }).join('');
 
@@ -297,7 +297,7 @@
     } catch (e) {}
   };
 
-  window._killTask = async function(id) {
+  OL.killTask = async function(id) {
     if (!confirm('Stop this running task?')) return;
     await fetch('/api/tasks/' + id + '/kill', {method: 'POST'});
     OL.loadRunningTasks();
@@ -305,21 +305,21 @@
     OL.loadTasks();
   };
 
-  window._pauseTask = async function(id) {
+  OL.pauseTask = async function(id) {
     await fetch('/api/tasks/' + id + '/pause', {method: 'POST'});
     OL.loadRunningTasks();
     OL.loadTaskDetail(id);
     OL.loadTasks();
   };
 
-  window._resumeTask = async function(id) {
+  OL.resumeTask = async function(id) {
     await fetch('/api/tasks/' + id + '/resume', {method: 'POST'});
     OL.loadRunningTasks();
     OL.loadTaskDetail(id);
     OL.loadTasks();
   };
 
-  window._emergencyStopAll = async function() {
+  OL.emergencyStopAll = async function() {
     if (!confirm('EMERGENCY STOP — Kill ALL running tasks?')) return;
     try {
       var tasks = await fetchJSON('/api/tasks/running');
@@ -336,7 +336,7 @@
   document.addEventListener('DOMContentLoaded', function() {
     var btn1 = document.getElementById('emergency-stop-btn');
     var btn2 = document.getElementById('activity-emergency-stop');
-    if (btn1) btn1.onclick = window._emergencyStopAll;
-    if (btn2) btn2.onclick = window._emergencyStopAll;
+    if (btn1) btn1.onclick = OL.emergencyStopAll;
+    if (btn2) btn2.onclick = OL.emergencyStopAll;
   });
 })(window.OL);

--- a/internal/web/ui/views/products.js
+++ b/internal/web/ui/views/products.js
@@ -50,14 +50,14 @@
         ],
         afterRender: function(container) {
           container.insertAdjacentHTML('afterbegin', '<div style="padding:8px 0;margin-bottom:8px"><button class="btn-search" id="btn-new-product" style="font-size:12px;padding:6px 16px">+ New Product</button></div>');
-          OL.onView(container.querySelector('#btn-new-product'), 'click', function() { window._createProduct(); });
+          OL.onView(container.querySelector('#btn-new-product'), 'click', function() { OL.createProduct(); });
         },
       });
 
       // Handle empty case — still need new product button
       if (!peerGroups || !peerGroups.length) {
         el.insertAdjacentHTML('afterbegin', '<div style="padding:8px 0;margin-bottom:8px"><button class="btn-search" id="btn-new-product" style="font-size:12px;padding:6px 16px">+ New Product</button></div>');
-        OL.onView(el.querySelector('#btn-new-product'), 'click', function() { window._createProduct(); });
+        OL.onView(el.querySelector('#btn-new-product'), 'click', function() { OL.createProduct(); });
       }
     } catch (e) {
       console.error('Load products failed:', e);
@@ -74,7 +74,7 @@
       let html = '';
       for (const m of manifests) {
         const statusClass = m.status === 'open' ? 'confirmed' : m.status === 'closed' ? 'flagged' : 'dismissed';
-        html += `<div class="amnesia-item ${statusClass}" style="cursor:pointer" onclick="OL.switchView('manifests');setTimeout(()=>window._loadManifest&&window._loadManifest('${esc(m.id)}'),300)">
+        html += `<div class="amnesia-item ${statusClass}" style="cursor:pointer" onclick="OL.switchView('manifests');setTimeout(()=>OL.loadManifest&&OL.loadManifest('${esc(m.id)}'),300)">
           <div class="amnesia-header">
             <span class="amnesia-status-label">${esc(m.status)}</span>
             <span class="session-uuid">${esc(m.marker)}</span>
@@ -90,7 +90,7 @@
   }
 
   // Create product dialog
-  window._createProduct = function() {
+  OL.createProduct = function() {
     const titleEl = document.getElementById('product-detail-title');
     const bodyEl = document.getElementById('product-detail');
     titleEl.textContent = 'New Product';
@@ -156,7 +156,7 @@
             if (m.total_turns > 0) mCostParts.push(`${m.total_turns} turns`);
             if (m.total_cost > 0) mCostParts.push(`<span style="color:var(--green)">$${m.total_cost.toFixed(2)}</span>`);
             return `<div class="manifest-item" style="border-bottom:1px solid var(--border);padding:10px 12px;display:flex;align-items:center">
-              <div style="flex:1;cursor:pointer" onclick="OL.switchView('manifests');setTimeout(()=>window._loadManifest('${esc(m.id)}'),300)">
+              <div style="flex:1;cursor:pointer" onclick="OL.switchView('manifests');setTimeout(()=>OL.loadManifest('${esc(m.id)}'),300)">
                 <div style="display:flex;align-items:center;gap:8px">
                   <span class="session-uuid" style="font-size:11px">${esc(m.marker)}</span>
                   <span class="badge ${mStatusClass}" style="font-size:10px">${esc(m.status)}</span>
@@ -164,7 +164,7 @@
                 </div>
                 <div style="font-size:13px;color:var(--text-primary);margin-top:4px">${esc(m.title)}</div>
               </div>
-              <button class="btn-dismiss" style="font-size:10px;padding:2px 8px;flex-shrink:0" onclick="event.stopPropagation();window._unlinkManifestFromProduct('${esc(m.id)}','${esc(p.id)}')" title="Remove from product">&#x2715;</button>
+              <button class="btn-dismiss" style="font-size:10px;padding:2px 8px;flex-shrink:0" onclick="event.stopPropagation();OL.unlinkManifestFromProduct('${esc(m.id)}','${esc(p.id)}')" title="Remove from product">&#x2715;</button>
             </div>`;
           }).join('');
           manifestsHtml = `<div style="margin-top:16px;padding-top:12px;border-top:1px solid var(--border)">
@@ -195,13 +195,13 @@
                 </div>
                 <div style="font-size:13px;color:var(--text-primary);margin-top:2px">${esc(i.title)}</div>
               </div>
-              <button class="btn-dismiss" style="font-size:10px;padding:2px 8px;flex-shrink:0" onclick="event.stopPropagation();window._unlinkIdeaFromProduct('${esc(i.id)}','${esc(p.id)}')" title="Remove from product">&#x2715;</button>
+              <button class="btn-dismiss" style="font-size:10px;padding:2px 8px;flex-shrink:0" onclick="event.stopPropagation();OL.unlinkIdeaFromProduct('${esc(i.id)}','${esc(p.id)}')" title="Remove from product">&#x2715;</button>
             </div>`;
           }).join('');
           ideasHtml = `<div style="margin-top:16px;padding-top:12px;border-top:1px solid var(--border)">
             <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
               <span style="font-size:13px;color:var(--text-primary);font-weight:600">Linked Ideas <span style="font-weight:400;font-size:12px;color:var(--text-muted)">(${ideas.length})</span></span>
-              <button class="btn-search" style="font-size:11px;padding:2px 10px" onclick="window._linkIdeaToProduct('${esc(p.id)}')">+ Link Idea</button>
+              <button class="btn-search" style="font-size:11px;padding:2px 10px" onclick="OL.linkIdeaToProduct('${esc(p.id)}')">+ Link Idea</button>
             </div>
             <div style="border:1px solid var(--border);border-radius:4px;overflow:hidden">${ideaRows}</div>
           </div>`;
@@ -209,7 +209,7 @@
           ideasHtml = `<div style="margin-top:16px;padding-top:12px;border-top:1px solid var(--border)">
             <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
               <span style="font-size:13px;color:var(--text-primary);font-weight:600">Linked Ideas</span>
-              <button class="btn-search" style="font-size:11px;padding:2px 10px" onclick="window._linkIdeaToProduct('${esc(p.id)}')">+ Link Idea</button>
+              <button class="btn-search" style="font-size:11px;padding:2px 10px" onclick="OL.linkIdeaToProduct('${esc(p.id)}')">+ Link Idea</button>
             </div>
             <div style="font-size:12px;color:var(--text-muted);padding:12px;border:1px dashed var(--border);border-radius:4px;text-align:center">No ideas linked yet</div>
           </div>`;
@@ -229,7 +229,7 @@
             <span class="session-uuid" style="font-size:14px">${esc(p.marker)}</span>
             <span class="badge ${statusClass}">${esc(p.status)}</span>
             ${tags}
-            <button class="btn-copy" onclick="window._copy('get product ${esc(p.marker)}')" title="Copy ref">&#x2398;</button>
+            <button class="btn-copy" onclick="OL.copy('get product ${esc(p.marker)}')" title="Copy ref">&#x2398;</button>
           </div>
           <!-- METRICS BAR -->
           <div style="display:flex;gap:12px;font-size:12px;color:var(--text-muted);margin-bottom:12px;align-items:center;flex-wrap:wrap;padding:8px 12px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;font-family:var(--font-mono)">
@@ -243,18 +243,18 @@
           </div>
           <!-- CONTROLS -->
           <div style="display:flex;gap:8px;margin-bottom:12px;flex-wrap:wrap">
-            <button class="btn-search" style="font-size:11px;padding:4px 12px" onclick="window._editProduct('${esc(p.id)}')">&#9998; Edit</button>
-            <button class="btn-search" style="font-size:11px;padding:4px 12px;background:var(--bg-input)" onclick="window._linkManifestToProduct('${esc(p.id)}')">+ Link Manifest</button>
+            <button class="btn-search" style="font-size:11px;padding:4px 12px" onclick="OL.editProduct('${esc(p.id)}')">&#9998; Edit</button>
+            <button class="btn-search" style="font-size:11px;padding:4px 12px;background:var(--bg-input)" onclick="OL.linkManifestToProduct('${esc(p.id)}')">+ Link Manifest</button>
             ${['draft','open','closed','archive'].map(s => {
               const active = p.status === s;
               const color = s === 'open' ? 'var(--green)' : s === 'closed' ? 'var(--text-muted)' : s === 'archive' ? 'var(--red)' : 'var(--yellow)';
-              return '<button class="product-status-btn" data-status="' + s + '" style="padding:4px 12px;font-size:11px;font-weight:600;text-transform:uppercase;border-radius:4px;cursor:pointer;border:1px solid ' + color + ';background:' + (active ? color : 'transparent') + ';color:' + (active ? 'var(--bg-primary)' : color) + ';opacity:' + (active ? '1' : '0.7') + '" onclick="window._updateProductStatus(\'' + esc(p.id) + '\',\'' + s + '\')">' + s + '</button>';
+              return '<button class="product-status-btn" data-status="' + s + '" style="padding:4px 12px;font-size:11px;font-weight:600;text-transform:uppercase;border-radius:4px;cursor:pointer;border:1px solid ' + color + ';background:' + (active ? color : 'transparent') + ';color:' + (active ? 'var(--bg-primary)' : color) + ';opacity:' + (active ? '1' : '0.7') + '" onclick="OL.updateProductStatus(\'' + esc(p.id) + '\',\'' + s + '\')">' + s + '</button>';
             }).join('')}
           </div>
           ${p.description ? `<div style="font-size:13px;color:var(--text-secondary);line-height:1.6;margin-bottom:12px;white-space:pre-wrap">${esc(p.description)}</div>` : ''}
           <!-- DIAGRAM BUTTON -->
           <div style="margin-bottom:12px">
-            <button class="btn-search" style="font-size:12px;padding:6px 16px" onclick="window._showProductDiagram('${esc(p.id)}','${esc(p.title)}')">&#x25C8; Product DAG</button>
+            <button class="btn-search" style="font-size:12px;padding:6px 16px" onclick="OL.showProductDiagram('${esc(p.id)}','${esc(p.title)}')">&#x25C8; Product DAG</button>
           </div>
           ${manifestsHtml}
           ${ideasHtml}
@@ -265,10 +265,10 @@
     }
   };
 
-  window._loadProduct = OL.loadProductDetail;
+  OL.loadProduct = OL.loadProductDetail;
 
   // --- Cytoscape Directed Acyclic Graph Diagram (Full Page) ---
-  window._showProductDiagram = function(productId, productTitle) {
+  OL.showProductDiagram = function(productId, productTitle) {
     // Create full-page overlay
     let overlay = document.getElementById('product-diagram-overlay');
     if (overlay) overlay.remove();
@@ -490,7 +490,7 @@
           setTimeout(() => OL.loadProductDetail(d.id), 300);
         } else if (d.type === 'manifest') {
           OL.switchView('manifests');
-          setTimeout(() => window._loadManifest(d.id), 300);
+          setTimeout(() => OL.loadManifest(d.id), 300);
         } else if (d.type === 'task') {
           OL.switchView('tasks');
           setTimeout(() => OL.loadTaskDetail(d.id), 300);
@@ -504,7 +504,7 @@
   }
 
   // Product CRUD actions
-  window._editProduct = function(id) {
+  OL.editProduct = function(id) {
     const titleEl = document.getElementById('product-detail-title');
     const bodyEl = document.getElementById('product-detail');
     fetchJSON('/api/products/' + id).then(p => {
@@ -541,7 +541,7 @@
     });
   };
 
-  window._updateProductStatus = async function(id, status) {
+  OL.updateProductStatus = async function(id, status) {
     await fetchJSON('/api/products/' + id, { method: 'PUT', headers: {'Content-Type':'application/json'}, body: JSON.stringify({status}) });
     OL.loadProducts();
     OL.loadProductDetail(id);
@@ -549,7 +549,7 @@
 
   // _deleteProduct removed -- use status toggle to archive instead
 
-  window._linkManifestToProduct = async function(productId) {
+  OL.linkManifestToProduct = async function(productId) {
     // Fetch all manifests not yet linked to this product
     const allManifests = await fetchJSON('/api/manifests');
     const unlinked = (allManifests || []).filter(m => m.project_id !== productId);
@@ -583,13 +583,13 @@
     });
   };
 
-  window._unlinkManifestFromProduct = async function(manifestId, productId) {
+  OL.unlinkManifestFromProduct = async function(manifestId, productId) {
     await fetchJSON('/api/manifests/' + manifestId, { method: 'PUT', headers: {'Content-Type':'application/json'}, body: JSON.stringify({project_id: ''}) });
     OL.loadProducts();
     OL.loadProductDetail(productId);
   };
 
-  window._linkIdeaToProduct = async function(productId) {
+  OL.linkIdeaToProduct = async function(productId) {
     const allIdeas = await fetchJSON('/api/ideas');
     const unlinked = (allIdeas || []).filter(i => i.project_id !== productId);
     if (!unlinked.length) { alert('No ideas available to link'); return; }
@@ -625,7 +625,7 @@
     });
   };
 
-  window._unlinkIdeaFromProduct = async function(ideaId, productId) {
+  OL.unlinkIdeaFromProduct = async function(ideaId, productId) {
     const idea = await fetchJSON('/api/ideas/' + ideaId);
     if (idea) {
       await fetchJSON('/api/ideas/' + ideaId, { method: 'PUT', headers: {'Content-Type':'application/json'}, body: JSON.stringify({project_id: '', title: idea.title, description: idea.description, status: idea.status, priority: idea.priority}) });

--- a/internal/web/ui/views/settings.js
+++ b/internal/web/ui/views/settings.js
@@ -234,11 +234,11 @@
       if (a.installed && a.connected) {
         statusClass = 'connected';
         statusText = 'Connected';
-        button = `<button class="btn-disconnect" onclick="window._disconnectAgent('${esc(a.id)}')">Disconnect</button>`;
+        button = `<button class="btn-disconnect" onclick="OL.disconnectAgent('${esc(a.id)}')">Disconnect</button>`;
       } else if (a.installed && !a.connected) {
         statusClass = 'disconnected';
         statusText = 'Not connected';
-        button = `<button class="btn-connect" onclick="window._connectAgent('${esc(a.id)}')">Connect</button>`;
+        button = `<button class="btn-connect" onclick="OL.connectAgent('${esc(a.id)}')">Connect</button>`;
       } else {
         statusText = 'Not installed';
       }
@@ -257,12 +257,12 @@
     }).join('');
   }
 
-  window._connectAgent = async function(id) {
+  OL.connectAgent = async function(id) {
     await fetch('/api/settings/agents/' + id + '/connect', {method: 'POST'});
     OL.loadSettings();
   };
 
-  window._disconnectAgent = async function(id) {
+  OL.disconnectAgent = async function(id) {
     await fetch('/api/settings/agents/' + id + '/disconnect', {method: 'POST'});
     OL.loadSettings();
   };

--- a/internal/web/ui/views/tasks.js
+++ b/internal/web/ui/views/tasks.js
@@ -269,8 +269,8 @@
           <!-- BREADCRUMB -->
           <div style="font-size:11px;color:var(--text-muted);margin-bottom:8px;font-family:var(--font-mono)">
             <span style="cursor:pointer;color:var(--accent)" onclick="OL.switchView('${taskProduct ? 'products' : 'tasks'}')">${esc(t.source_node ? t.source_node.substring(0,12) : 'node')}</span>
-            ${taskProduct ? `<span style="opacity:0.4"> → </span><span style="cursor:pointer;color:var(--accent)" onclick="OL.switchView('products');setTimeout(()=>window._loadProduct('${esc(taskProduct.id)}'),300)">${esc(taskProduct.marker)} ${esc(taskProduct.title)}</span>` : ''}
-            ${t.manifest_id ? `<span style="opacity:0.4"> → </span><span style="cursor:pointer;color:var(--accent)" onclick="OL.switchView('manifests');setTimeout(()=>window._loadManifest('${esc(t.manifest_id)}'),300)">${esc(taskManifest ? taskManifest.marker + ' ' + taskManifest.title : t.manifest_id.substring(0,12))}</span>` : ''}
+            ${taskProduct ? `<span style="opacity:0.4"> → </span><span style="cursor:pointer;color:var(--accent)" onclick="OL.switchView('products');setTimeout(()=>OL.loadProduct('${esc(taskProduct.id)}'),300)">${esc(taskProduct.marker)} ${esc(taskProduct.title)}</span>` : ''}
+            ${t.manifest_id ? `<span style="opacity:0.4"> → </span><span style="cursor:pointer;color:var(--accent)" onclick="OL.switchView('manifests');setTimeout(()=>OL.loadManifest('${esc(t.manifest_id)}'),300)">${esc(taskManifest ? taskManifest.marker + ' ' + taskManifest.title : t.manifest_id.substring(0,12))}</span>` : ''}
             <span style="opacity:0.4"> → </span>
             <span style="color:var(--text-primary)">${esc(t.marker)} ${esc(t.title)}</span>
           </div>
@@ -291,7 +291,7 @@
             <span>Branch: <strong style="color:var(--text-primary)">openloom/${esc(t.marker)}</strong></span>
             ${t.manifest_id ? `<span>Manifest: <span class="manifest-nav" style="cursor:pointer;color:var(--accent);text-decoration:underline;font-weight:600" data-mid="${esc(t.manifest_id)}">${esc(t.manifest_id.substring(0,12))} &#x2192;</span></span>` : '<span>standalone</span>'}
             <span style="opacity:0.3">|</span>
-            <span style="display:flex;align-items:center;gap:6px">Max turns: <input type="range" id="task-max-turns" value="${t.max_turns || 100}" min="10" max="500" step="10" style="width:100px;accent-color:var(--accent);cursor:pointer" oninput="document.getElementById('task-max-turns-val').textContent=this.value" onchange="window._updateMaxTurns('${esc(t.id)}',this.value)" /><strong id="task-max-turns-val" style="color:var(--text-primary);min-width:28px">${t.max_turns || 100}</strong></span>
+            <span style="display:flex;align-items:center;gap:6px">Max turns: <input type="range" id="task-max-turns" value="${t.max_turns || 100}" min="10" max="500" step="10" style="width:100px;accent-color:var(--accent);cursor:pointer" oninput="document.getElementById('task-max-turns-val').textContent=this.value" onchange="OL.updateMaxTurns('${esc(t.id)}',this.value)" /><strong id="task-max-turns-val" style="color:var(--text-primary);min-width:28px">${t.max_turns || 100}</strong></span>
             ${t.last_run_at ? `<span style="opacity:0.3">|</span><span>Last: ${new Date(t.last_run_at).toLocaleString()}</span>` : ''}
             <span>Created: ${new Date(t.created_at).toLocaleString()}</span>
           </div>
@@ -300,29 +300,29 @@
           <div style="margin-bottom:16px;padding:12px;border:1px solid var(--border);border-radius:8px;background:var(--bg-secondary)">
             <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:${isRunningOrPaused ? '0' : '12'}px">
               ${t.status === 'pending' || t.status === 'waiting' ? `
-                <button class="btn-search" onclick="window._taskStart('${esc(t.id)}')">&#9654; Start Now</button>
-                <button class="btn-search" style="background:var(--bg-input)" onclick="window._rescheduleTask('${esc(t.id)}')">&#128260; Reschedule</button>
-                <button class="btn-dismiss" onclick="window._taskArchive('${esc(t.id)}')">Archive</button>
+                <button class="btn-search" onclick="OL.taskStart('${esc(t.id)}')">&#9654; Start Now</button>
+                <button class="btn-search" style="background:var(--bg-input)" onclick="OL.rescheduleTask('${esc(t.id)}')">&#128260; Reschedule</button>
+                <button class="btn-dismiss" onclick="OL.taskArchive('${esc(t.id)}')">Archive</button>
               ` : ''}
               ${t.status === 'scheduled' ? `
-                <button class="btn-search" onclick="window._taskStart('${esc(t.id)}')">&#9654; Start Now</button>
-                <button class="btn-dismiss" onclick="window._taskAction('${esc(t.id)}','cancel')">&#10005; Cancel</button>
-                <button class="btn-search" style="background:var(--bg-input)" onclick="window._rescheduleTask('${esc(t.id)}')">&#128260; Reschedule</button>
-                <button class="btn-dismiss" onclick="window._taskArchive('${esc(t.id)}')">Archive</button>
+                <button class="btn-search" onclick="OL.taskStart('${esc(t.id)}')">&#9654; Start Now</button>
+                <button class="btn-dismiss" onclick="OL.taskAction('${esc(t.id)}','cancel')">&#10005; Cancel</button>
+                <button class="btn-search" style="background:var(--bg-input)" onclick="OL.rescheduleTask('${esc(t.id)}')">&#128260; Reschedule</button>
+                <button class="btn-dismiss" onclick="OL.taskArchive('${esc(t.id)}')">Archive</button>
               ` : ''}
               ${t.status === 'running' ? `
-                <button class="btn-search" style="background:var(--yellow);color:var(--bg-primary)" onclick="window._pauseTask('${esc(t.id)}')">&#9208; Pause</button>
-                <button class="btn-confirm" onclick="window._killTask('${esc(t.id)}')">&#9209; Stop</button>
+                <button class="btn-search" style="background:var(--yellow);color:var(--bg-primary)" onclick="OL.pauseTask('${esc(t.id)}')">&#9208; Pause</button>
+                <button class="btn-confirm" onclick="OL.killTask('${esc(t.id)}')">&#9209; Stop</button>
               ` : ''}
               ${t.status === 'paused' ? `
-                <button class="btn-search" onclick="window._resumeTask('${esc(t.id)}')">&#9654; Resume</button>
-                <button class="btn-search" style="background:var(--accent)" onclick="window._editInstructions('${esc(t.id)}')">&#9998; Edit Instructions</button>
-                <button class="btn-confirm" onclick="window._killTask('${esc(t.id)}')">&#9209; Stop</button>
+                <button class="btn-search" onclick="OL.resumeTask('${esc(t.id)}')">&#9654; Resume</button>
+                <button class="btn-search" style="background:var(--accent)" onclick="OL.editInstructions('${esc(t.id)}')">&#9998; Edit Instructions</button>
+                <button class="btn-confirm" onclick="OL.killTask('${esc(t.id)}')">&#9209; Stop</button>
               ` : ''}
               ${t.status === 'completed' || t.status === 'failed' || t.status === 'cancelled' ? `
-                <button class="btn-search" onclick="window._taskStart('${esc(t.id)}')">&#128260; Restart</button>
-                <button class="btn-search" style="background:var(--bg-input)" onclick="window._rescheduleTask('${esc(t.id)}')">&#128260; Reschedule</button>
-                <button class="btn-dismiss" onclick="window._taskArchive('${esc(t.id)}')">Archive</button>
+                <button class="btn-search" onclick="OL.taskStart('${esc(t.id)}')">&#128260; Restart</button>
+                <button class="btn-search" style="background:var(--bg-input)" onclick="OL.rescheduleTask('${esc(t.id)}')">&#128260; Reschedule</button>
+                <button class="btn-dismiss" onclick="OL.taskArchive('${esc(t.id)}')">Archive</button>
               ` : ''}
             </div>
 
@@ -346,25 +346,25 @@
 
               <!-- One-shot options -->
               <div id="task-sched-oneshot" style="display:${isOneShot ? 'flex' : 'none'};gap:6px;align-items:center;flex-wrap:wrap;margin-bottom:8px">
-                <button class="btn-search" style="font-size:11px;padding:4px 10px;${scheduleSelectVal==='once'?'border:2px solid var(--accent)':''}" onclick="window._quickSchedule('${esc(t.id)}','once')">Now</button>
-                <button class="btn-search" style="font-size:11px;padding:4px 10px;background:var(--bg-input);${scheduleSelectVal==='in:5m'?'border:2px solid var(--accent)':''}" onclick="window._quickSchedule('${esc(t.id)}','in:5m')">In 5m</button>
-                <button class="btn-search" style="font-size:11px;padding:4px 10px;background:var(--bg-input);${scheduleSelectVal==='in:15m'?'border:2px solid var(--accent)':''}" onclick="window._quickSchedule('${esc(t.id)}','in:15m')">In 15m</button>
-                <button class="btn-search" style="font-size:11px;padding:4px 10px;background:var(--bg-input);${scheduleSelectVal==='in:30m'?'border:2px solid var(--accent)':''}" onclick="window._quickSchedule('${esc(t.id)}','in:30m')">In 30m</button>
-                <button class="btn-search" style="font-size:11px;padding:4px 10px;background:var(--bg-input);${scheduleSelectVal==='in:1h'?'border:2px solid var(--accent)':''}" onclick="window._quickSchedule('${esc(t.id)}','in:1h')">In 1h</button>
+                <button class="btn-search" style="font-size:11px;padding:4px 10px;${scheduleSelectVal==='once'?'border:2px solid var(--accent)':''}" onclick="OL.quickSchedule('${esc(t.id)}','once')">Now</button>
+                <button class="btn-search" style="font-size:11px;padding:4px 10px;background:var(--bg-input);${scheduleSelectVal==='in:5m'?'border:2px solid var(--accent)':''}" onclick="OL.quickSchedule('${esc(t.id)}','in:5m')">In 5m</button>
+                <button class="btn-search" style="font-size:11px;padding:4px 10px;background:var(--bg-input);${scheduleSelectVal==='in:15m'?'border:2px solid var(--accent)':''}" onclick="OL.quickSchedule('${esc(t.id)}','in:15m')">In 15m</button>
+                <button class="btn-search" style="font-size:11px;padding:4px 10px;background:var(--bg-input);${scheduleSelectVal==='in:30m'?'border:2px solid var(--accent)':''}" onclick="OL.quickSchedule('${esc(t.id)}','in:30m')">In 30m</button>
+                <button class="btn-search" style="font-size:11px;padding:4px 10px;background:var(--bg-input);${scheduleSelectVal==='in:1h'?'border:2px solid var(--accent)':''}" onclick="OL.quickSchedule('${esc(t.id)}','in:1h')">In 1h</button>
                 <span style="font-size:11px;color:var(--text-muted)">At:</span>
                 <input type="datetime-local" id="task-sched-at-picker" class="conv-search" style="font-size:11px;padding:4px" value="${t.next_run_at ? new Date(t.next_run_at).toISOString().slice(0,16) : ''}" />
-                <button class="btn-search" style="font-size:11px;padding:4px 10px" onclick="window._scheduleAt('${esc(t.id)}')">Set</button>
+                <button class="btn-search" style="font-size:11px;padding:4px 10px" onclick="OL.scheduleAt('${esc(t.id)}')">Set</button>
               </div>
 
               <!-- Recurring options -->
               <div id="task-sched-recurring" style="display:${!isOneShot ? 'flex' : 'none'};gap:6px;align-items:center;flex-wrap:wrap;margin-bottom:8px">
                 <span style="font-size:11px;color:var(--text-muted)">Every:</span>
-                <button class="btn-search" style="font-size:11px;padding:4px 10px;${t.schedule==='5m'?'border:2px solid var(--green)':''}" onclick="window._quickSchedule('${esc(t.id)}','5m')">5m</button>
-                <button class="btn-search" style="font-size:11px;padding:4px 10px;${t.schedule==='15m'?'border:2px solid var(--green)':''}" onclick="window._quickSchedule('${esc(t.id)}','15m')">15m</button>
-                <button class="btn-search" style="font-size:11px;padding:4px 10px;${t.schedule==='30m'?'border:2px solid var(--green)':''}" onclick="window._quickSchedule('${esc(t.id)}','30m')">30m</button>
-                <button class="btn-search" style="font-size:11px;padding:4px 10px;${t.schedule==='1h'?'border:2px solid var(--green)':''}" onclick="window._quickSchedule('${esc(t.id)}','1h')">1h</button>
-                <button class="btn-search" style="font-size:11px;padding:4px 10px;${t.schedule==='6h'?'border:2px solid var(--green)':''}" onclick="window._quickSchedule('${esc(t.id)}','6h')">6h</button>
-                <button class="btn-search" style="font-size:11px;padding:4px 10px;${t.schedule==='24h'?'border:2px solid var(--green)':''}" onclick="window._quickSchedule('${esc(t.id)}','24h')">24h</button>
+                <button class="btn-search" style="font-size:11px;padding:4px 10px;${t.schedule==='5m'?'border:2px solid var(--green)':''}" onclick="OL.quickSchedule('${esc(t.id)}','5m')">5m</button>
+                <button class="btn-search" style="font-size:11px;padding:4px 10px;${t.schedule==='15m'?'border:2px solid var(--green)':''}" onclick="OL.quickSchedule('${esc(t.id)}','15m')">15m</button>
+                <button class="btn-search" style="font-size:11px;padding:4px 10px;${t.schedule==='30m'?'border:2px solid var(--green)':''}" onclick="OL.quickSchedule('${esc(t.id)}','30m')">30m</button>
+                <button class="btn-search" style="font-size:11px;padding:4px 10px;${t.schedule==='1h'?'border:2px solid var(--green)':''}" onclick="OL.quickSchedule('${esc(t.id)}','1h')">1h</button>
+                <button class="btn-search" style="font-size:11px;padding:4px 10px;${t.schedule==='6h'?'border:2px solid var(--green)':''}" onclick="OL.quickSchedule('${esc(t.id)}','6h')">6h</button>
+                <button class="btn-search" style="font-size:11px;padding:4px 10px;${t.schedule==='24h'?'border:2px solid var(--green)':''}" onclick="OL.quickSchedule('${esc(t.id)}','24h')">24h</button>
               </div>
 
               ${t.next_run_at ? `<div style="font-size:12px;color:var(--text-muted)">Next run: <strong style="color:var(--text-primary)">${new Date(t.next_run_at).toLocaleString()}</strong></div>` : ''}
@@ -387,8 +387,8 @@
               <input type="text" id="task-dep-search" class="conv-search" placeholder="Search tasks to set dependency..." style="font-size:12px;flex:1;min-width:180px;padding:6px 10px" />
               <select id="task-dep-select" class="conv-filter" style="font-size:12px;padding:6px 8px;max-width:320px;display:none">
               </select>
-              <button id="task-dep-set-btn" class="btn-search" style="font-size:11px;padding:4px 12px;display:none" onclick="window._setDependency('${esc(t.id)}')">Set</button>
-              ${t.depends_on ? `<button class="btn-dismiss" style="font-size:11px;padding:4px 12px" onclick="window._removeDependency('${esc(t.id)}')">Remove</button>` : ''}
+              <button id="task-dep-set-btn" class="btn-search" style="font-size:11px;padding:4px 12px;display:none" onclick="OL.setDependency('${esc(t.id)}')">Set</button>
+              ${t.depends_on ? `<button class="btn-dismiss" style="font-size:11px;padding:4px 12px" onclick="OL.removeDependency('${esc(t.id)}')">Remove</button>` : ''}
             </div>
           </div>
 
@@ -396,7 +396,7 @@
           <div id="task-instructions-section" style="margin-bottom:12px">
             <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">
               <span style="font-size:12px;font-weight:600;color:var(--text-primary)">Instructions</span>
-              <button id="task-instructions-edit-btn" class="btn-search" style="font-size:11px;padding:2px 10px" onclick="window._editInstructions('${esc(t.id)}')">${t.description ? 'Edit' : 'Add Instructions'}</button>
+              <button id="task-instructions-edit-btn" class="btn-search" style="font-size:11px;padding:2px 10px" onclick="OL.editInstructions('${esc(t.id)}')">${t.description ? 'Edit' : 'Add Instructions'}</button>
             </div>
             <div id="task-instructions-display">
               ${t.description
@@ -406,8 +406,8 @@
             <div id="task-instructions-editor" style="display:none">
               <textarea id="task-instructions-textarea" style="width:100%;min-height:300px;padding:12px;font-size:13px;line-height:1.5;font-family:var(--font-mono);resize:both;border:1px solid var(--accent);border-radius:6px;background:var(--bg-secondary);color:var(--text-primary);box-sizing:border-box">${esc(t.description || '')}</textarea>
               <div style="display:flex;gap:8px;margin-top:8px">
-                <button class="btn-search" style="padding:4px 14px;font-size:12px" onclick="window._saveInstructions('${esc(t.id)}')">Save</button>
-                <button class="btn-dismiss" style="padding:4px 14px;font-size:12px" onclick="window._cancelEditInstructions()">Cancel</button>
+                <button class="btn-search" style="padding:4px 14px;font-size:12px" onclick="OL.saveInstructions('${esc(t.id)}')">Save</button>
+                <button class="btn-dismiss" style="padding:4px 14px;font-size:12px" onclick="OL.cancelEditInstructions()">Cancel</button>
               </div>
             </div>
           </div>
@@ -464,7 +464,7 @@
         }).catch(() => {});
         OL.onView(el, 'click', () => {
           OL.switchView('manifests');
-          setTimeout(() => window._loadManifest(mid), 300);
+          setTimeout(() => OL.loadManifest(mid), 300);
         });
       });
 
@@ -763,7 +763,7 @@
 
   // Window globals for onclick handlers
 
-  window._setDependency = async function(taskId) {
+  OL.setDependency = async function(taskId) {
     const sel = document.getElementById('task-dep-select');
     if (!sel || !sel.value) return;
     await fetch('/api/tasks/' + taskId + '/dependency', {
@@ -775,7 +775,7 @@
     OL.loadTasks();
   };
 
-  window._removeDependency = async function(taskId) {
+  OL.removeDependency = async function(taskId) {
     await fetch('/api/tasks/' + taskId + '/dependency', {
       method: 'PUT',
       headers: {'Content-Type': 'application/json'},
@@ -785,14 +785,14 @@
     OL.loadTasks();
   };
 
-  window._taskAction = async function(id, action) {
+  OL.taskAction = async function(id, action) {
     await fetch('/api/tasks/' + id + '/' + action, {method: 'POST'});
     OL.loadTaskDetail(id);
     OL.loadTasks();
   };
 
   // Re-run now (uses existing schedule)
-  window._updateMaxTurns = async function(id, val) {
+  OL.updateMaxTurns = async function(id, val) {
     const maxTurns = parseInt(val);
     if (!maxTurns || maxTurns < 1) return;
     await fetch('/api/tasks/' + id, {
@@ -802,7 +802,7 @@
     });
   };
 
-  window._taskStart = async function(id) {
+  OL.taskStart = async function(id) {
     await fetch('/api/tasks/' + id + '/start', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
@@ -813,7 +813,7 @@
   };
 
   // Quick schedule — one click reschedule to a preset
-  window._quickSchedule = async function(id, schedule) {
+  OL.quickSchedule = async function(id, schedule) {
     await fetch('/api/tasks/' + id + '/reschedule', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
@@ -824,7 +824,7 @@
   };
 
   // Schedule at a specific datetime from the picker
-  window._scheduleAt = async function(id) {
+  OL.scheduleAt = async function(id) {
     const dt = document.getElementById('task-sched-at-picker');
     if (!dt || !dt.value) { alert('Pick a date/time first'); return; }
     const schedule = 'at:' + new Date(dt.value).toISOString();
@@ -838,7 +838,7 @@
   };
 
   // Reschedule — called from the Reschedule button in control bar
-  window._rescheduleTask = async function(id) {
+  OL.rescheduleTask = async function(id) {
     // Just scroll to the schedule section — it's always visible
     const schedSection = document.querySelector('#task-sched-oneshot, #task-sched-recurring');
     if (schedSection) {
@@ -849,7 +849,7 @@
   };
 
   // Edit instructions — toggle editor view
-  window._editInstructions = function(id) {
+  OL.editInstructions = function(id) {
     const display = document.getElementById('task-instructions-display');
     const editor = document.getElementById('task-instructions-editor');
     const btn = document.getElementById('task-instructions-edit-btn');
@@ -866,7 +866,7 @@
   };
 
   // Save instructions via PATCH
-  window._saveInstructions = async function(id) {
+  OL.saveInstructions = async function(id) {
     const ta = document.getElementById('task-instructions-textarea');
     if (!ta) return;
     await fetch('/api/tasks/' + id, {
@@ -878,7 +878,7 @@
   };
 
   // Cancel edit — revert to display view
-  window._cancelEditInstructions = function() {
+  OL.cancelEditInstructions = function() {
     const display = document.getElementById('task-instructions-display');
     const editor = document.getElementById('task-instructions-editor');
     const btn = document.getElementById('task-instructions-edit-btn');
@@ -887,7 +887,7 @@
     if (btn) btn.style.display = '';
   };
 
-  window._taskArchive = async function(id) {
+  OL.taskArchive = async function(id) {
     await fetch('/api/tasks/' + id + '/cancel', {method: 'POST'});
     OL.loadTasks();
     OL.loadTaskDetail(id);

--- a/internal/web/ui/views/watcher.js
+++ b/internal/web/ui/views/watcher.js
@@ -238,7 +238,7 @@
             '<span style="cursor:pointer;color:var(--accent)" onclick="OL.switchView(\'tasks\');setTimeout(function(){OL.loadTaskDetail(\'' + esc(a.task_id) + '\')},300)">' + esc(a.task_marker) + ' ' + esc(a.task_title) + '</span>' +
             (a.manifest_id ?
               '<span style="opacity:0.4"> &rarr; </span>' +
-              '<span style="cursor:pointer;color:var(--accent)" onclick="OL.switchView(\'manifests\');setTimeout(function(){window._loadManifest(\'' + esc(a.manifest_id) + '\')},300)">' + esc(a.manifest_title || a.manifest_id.substring(0,12)) + '</span>'
+              '<span style="cursor:pointer;color:var(--accent)" onclick="OL.switchView(\'manifests\');setTimeout(function(){OL.loadManifest(\'' + esc(a.manifest_id) + '\')},300)">' + esc(a.manifest_title || a.manifest_id.substring(0,12)) + '</span>'
             : '') +
             '<span style="opacity:0.4"> &rarr; </span>' +
             '<span style="color:var(--text-primary)">Audit</span>' +
@@ -252,7 +252,7 @@
             '<div>' +
               '<span style="color:var(--text-muted)">Manifest:</span> ' +
               (a.manifest_id ?
-                '<span style="cursor:pointer;color:var(--accent);text-decoration:underline" onclick="OL.switchView(\'manifests\');setTimeout(function(){window._loadManifest(\'' + esc(a.manifest_id) + '\')},300)">' + esc(a.manifest_title || a.manifest_id.substring(0,12)) + '</span>'
+                '<span style="cursor:pointer;color:var(--accent);text-decoration:underline" onclick="OL.switchView(\'manifests\');setTimeout(function(){OL.loadManifest(\'' + esc(a.manifest_id) + '\')},300)">' + esc(a.manifest_title || a.manifest_id.substring(0,12)) + '</span>'
               : '<span style="opacity:0.5">standalone</span>') +
             '</div>' +
             '<div>' +
@@ -308,8 +308,8 @@
   OL.updateWatcherBadge();
 
   // Listen for watcher events via WebSocket
-  if (window._wsListeners) {
-    window._wsListeners.push(function(event) {
+  if (OL._wsListeners) {
+    OL._wsListeners.push(function(event) {
       if (event.type === 'watcher_audit') {
         OL.updateWatcherBadge();
         if (OL.currentView && OL.currentView() === 'watcher') OL.loadWatcher();

--- a/tools/replace_window_globals.py
+++ b/tools/replace_window_globals.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Replace window._* globals with OL.* namespace functions in the dashboard UI.
+
+This script performs the following transformations:
+1. window._functionName = ... -> OL.functionName = ...
+2. window._functionName(...) -> OL.functionName(...)
+3. window._functionName && window._functionName(...) -> OL.functionName && OL.functionName(...)
+4. Special handling for _copy (already on OL), _wsListeners, _loadProduct
+
+Usage: python3 tools/replace_window_globals.py [--dry-run]
+"""
+
+import os
+import re
+import sys
+
+UI_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                      'internal', 'web', 'ui')
+
+# All window._* globals to migrate, mapping old name -> new OL name
+# Drop the underscore prefix since OL namespace makes it unnecessary
+RENAMES = {
+    '_amnesiaAction': 'amnesiaAction',
+    '_archiveIdea': 'archiveIdea',
+    '_archiveManifest': 'archiveManifest',
+    '_archiveMemory': 'archiveMemory',
+    '_cancelEditInstructions': 'cancelEditInstructions',
+    '_connectAgent': 'connectAgent',
+    '_copy': 'copy',  # Already exists as OL.copy — just remove window._copy refs
+    '_createProduct': 'createProduct',
+    '_deleteVisceral': 'deleteVisceral',
+    '_delusionAction': 'delusionAction',
+    '_disconnectAgent': 'disconnectAgent',
+    '_editInstructions': 'editInstructions',
+    '_editProduct': 'editProduct',
+    '_emergencyStopAll': 'emergencyStopAll',
+    '_goToIdea': 'goToIdea',
+    '_killTask': 'killTask',
+    '_linkIdeaToProduct': 'linkIdeaToProduct',
+    '_linkManifestToProduct': 'linkManifestToProduct',
+    '_loadConv': 'loadConv',
+    '_loadIdea': 'loadIdea',
+    '_loadManifest': 'loadManifest',
+    '_loadProduct': 'loadProduct',  # Currently alias: window._loadProduct = OL.loadProductDetail
+    '_markerDone': 'markerDone',
+    '_markerSeen': 'markerSeen',
+    '_pauseTask': 'pauseTask',
+    '_promoteToManifest': 'promoteToManifest',
+    '_quickSchedule': 'quickSchedule',
+    '_removeDependency': 'removeDependency',
+    '_rescheduleTask': 'rescheduleTask',
+    '_resumeTask': 'resumeTask',
+    '_saveInstructions': 'saveInstructions',
+    '_scheduleAt': 'scheduleAt',
+    '_setDependency': 'setDependency',
+    '_showProductDiagram': 'showProductDiagram',
+    '_taskAction': 'taskAction',
+    '_taskArchive': 'taskArchive',
+    '_taskStart': 'taskStart',
+    '_unlinkIdeaFromProduct': 'unlinkIdeaFromProduct',
+    '_unlinkManifestFromProduct': 'unlinkManifestFromProduct',
+    '_updateMaxTurns': 'updateMaxTurns',
+    '_updateProductStatus': 'updateProductStatus',
+}
+
+
+def process_file(filepath, dry_run=False):
+    """Process a single file, replacing window._* with OL.* references."""
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    original = content
+    changes = []
+
+    # Special case 1: window._copy = OL.copy = function(text) {
+    # -> Just OL.copy = function(text) {  (remove the window._copy = part)
+    old = 'window._copy = OL.copy = function(text) {'
+    new = 'OL.copy = function(text) {'
+    if old in content:
+        content = content.replace(old, new)
+        changes.append(f'  Removed dual-assign: window._copy = OL.copy -> OL.copy')
+
+    # Special case 2: window._loadProduct = OL.loadProductDetail;
+    # -> OL.loadProduct = OL.loadProductDetail;
+    old = 'window._loadProduct = OL.loadProductDetail;'
+    new = 'OL.loadProduct = OL.loadProductDetail;'
+    if old in content:
+        content = content.replace(old, new)
+        changes.append(f'  Alias: window._loadProduct -> OL.loadProduct')
+
+    # Special case 3: window._wsListeners
+    # This is a data array, not a function — keep it on OL namespace
+    content = content.replace('window._wsListeners', 'OL._wsListeners')
+    if 'OL._wsListeners' in content and 'window._wsListeners' in original:
+        changes.append(f'  Renamed: window._wsListeners -> OL._wsListeners')
+
+    # Now handle all function definitions and references
+    for old_name, new_name in RENAMES.items():
+        # Skip _copy — already handled above
+        if old_name == '_copy':
+            # Still need to replace remaining window._copy(...) call references
+            # Pattern: window._copy( -> OL.copy(
+            pattern = r'window\._copy\('
+            replacement = 'OL.copy('
+            if re.search(pattern, content):
+                count = len(re.findall(pattern, content))
+                content = re.sub(pattern, replacement, content)
+                changes.append(f'  Refs: window._copy( -> OL.copy( [{count}x]')
+            continue
+
+        if old_name == '_loadProduct':
+            # Already handled the definition alias above
+            # Handle remaining references: window._loadProduct(...)
+            pattern = r'window\._loadProduct\b'
+            replacement = 'OL.loadProduct'
+            if re.search(pattern, content):
+                count = len(re.findall(pattern, content))
+                content = re.sub(pattern, replacement, content)
+                changes.append(f'  Refs: window._loadProduct -> OL.loadProduct [{count}x]')
+            continue
+
+        # Replace definitions: window._name = function/async function
+        # Pattern: window._oldName = (async )?function
+        def_pattern = rf'window\.{re.escape(old_name)}\s*='
+        def_replacement = f'OL.{new_name} ='
+        if re.search(def_pattern, content):
+            count = len(re.findall(def_pattern, content))
+            content = re.sub(def_pattern, def_replacement, content)
+            changes.append(f'  Def: window.{old_name} -> OL.{new_name} [{count}x]')
+
+        # Replace call references: window._oldName(
+        ref_pattern = rf'window\.{re.escape(old_name)}\('
+        ref_replacement = f'OL.{new_name}('
+        if re.search(ref_pattern, content):
+            count = len(re.findall(ref_pattern, content))
+            content = re.sub(ref_pattern, ref_replacement, content)
+            changes.append(f'  Call: window.{old_name}( -> OL.{new_name}( [{count}x]')
+
+        # Replace guarded references: window._oldName&&window._oldName(
+        # Already caught by the above patterns
+
+        # Replace bare references (e.g. btn.onclick = window._emergencyStopAll)
+        bare_pattern = rf'window\.{re.escape(old_name)}\b(?!\()'
+        bare_replacement = f'OL.{new_name}'
+        if re.search(bare_pattern, content):
+            count = len(re.findall(bare_pattern, content))
+            content = re.sub(bare_pattern, bare_replacement, content)
+            changes.append(f'  Bare: window.{old_name} -> OL.{new_name} [{count}x]')
+
+    if content != original:
+        rel = os.path.relpath(filepath, UI_DIR)
+        print(f'\n{rel}: {len(changes)} change(s)')
+        for c in changes:
+            print(c)
+
+        if not dry_run:
+            with open(filepath, 'w') as f:
+                f.write(content)
+            print(f'  -> Written')
+        else:
+            print(f'  -> [dry-run] Not written')
+        return True
+
+    return False
+
+
+def main():
+    dry_run = '--dry-run' in sys.argv
+
+    if dry_run:
+        print('=== DRY RUN MODE ===\n')
+
+    files_changed = 0
+
+    # Process all JS files and HTML files
+    for root, dirs, files in os.walk(UI_DIR):
+        for fname in sorted(files):
+            if fname.endswith(('.js', '.html')):
+                fpath = os.path.join(root, fname)
+                if process_file(fpath, dry_run):
+                    files_changed += 1
+
+    print(f'\n{"=" * 40}')
+    print(f'Files changed: {files_changed}')
+
+    # Verify no remaining window._ references (except OL._switchLifecycle, OL._activeLifecycleView)
+    print('\nRemaining window._ references:')
+    remaining = 0
+    for root, dirs, files in os.walk(UI_DIR):
+        for fname in sorted(files):
+            if fname.endswith(('.js', '.html')):
+                fpath = os.path.join(root, fname)
+                with open(fpath, 'r') as f:
+                    for i, line in enumerate(f, 1):
+                        # Look for window._ but not OL._ (which is fine)
+                        if 'window._' in line:
+                            rel = os.path.relpath(fpath, UI_DIR)
+                            print(f'  {rel}:{i}: {line.strip()}')
+                            remaining += 1
+
+    if remaining:
+        print(f'\nWARNING: {remaining} remaining window._ reference(s)')
+    else:
+        print('  None — all clean!')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Migrates all 134 `window._*` global function definitions and inline `onclick` references to the `OL.*` namespace across 17 UI files
- Removes legacy `window.switchView`, `window.loadTaskDetail`, and `window.loadCostDrillDown` globals — all inline handlers now use `OL.*` directly
- Eliminates the dual-assign pattern (`window._copy = OL.copy = ...`) in favor of single `OL.copy` definition
- Includes reusable Python migration tool at `tools/replace_window_globals.py` for future namespace refactoring

## Details
**Before:** 134 `window._*` globals created implicit dependencies between modules, making the code untestable and prone to naming collisions.

**After:** All functions live on the `OL` namespace object. Inline `onclick` handlers reference `OL.functionName()` instead of `window._functionName()`. Zero `window._*` references remain.

## Test plan
- [x] Build passes (`make build`)
- [x] Tests pass (`make test`)
- [x] Zero remaining `window._*` references verified by migration script
- [ ] Manual smoke test: navigate all dashboard tabs, verify onclick handlers work (task controls, markers, product CRUD, manifest editing, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)