### PR TITLE
Add .env.example documenting all env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,64 @@
+# OpenPraxis environment variables
+#
+# Copy this file to .env and fill in values as needed. None are required for
+# local operation — config.yaml defaults cover everything. Env vars override
+# config.yaml when set.
+#
+# Source of truth: internal/config/config.go (applyEnvOverrides) and
+# internal/web/handlers_chat.go (provider key lookup).
+
+# -----------------------------------------------------------------------------
+# Server / node overrides (optional — defaults in config.yaml)
+# -----------------------------------------------------------------------------
+
+# Display name for this peer on the dashboard and in sync messages.
+# Default: OS hostname.
+OPENPRAXIS_NODE_NAME=
+
+# HTTP dashboard bind host. Default: 127.0.0.1
+OPENPRAXIS_HOST=
+
+# HTTP dashboard port. Default: 8765
+OPENPRAXIS_PORT=
+
+# Automerge peer-sync bind host. Default: 0.0.0.0
+OPENPRAXIS_SYNC_HOST=
+
+# Automerge peer-sync port. Default: 8766
+OPENPRAXIS_SYNC_PORT=
+
+# Data directory for SQLite databases and peer state. Default: ~/.openpraxis/data
+OPENPRAXIS_DATA_DIR=
+
+# Default project tag applied to new memories/manifests when none is specified.
+# Default: basename of the current working directory.
+OPENPRAXIS_DEFAULT_PROJECT=
+
+# Set to "false" to suppress auto-opening the dashboard in a browser on `serve`.
+# Default: true
+OPENPRAXIS_OPEN_BROWSER=
+
+# -----------------------------------------------------------------------------
+# Embedding provider (Ollama — used for semantic memory search)
+# -----------------------------------------------------------------------------
+
+# Ollama HTTP endpoint. Default: http://localhost:11434
+OPENPRAXIS_OLLAMA_URL=
+
+# Embedding model name. Default: nomic-embed-text (768 dims)
+OPENPRAXIS_EMBEDDING_MODEL=
+
+# -----------------------------------------------------------------------------
+# Chat provider API keys (only needed for the dashboard chat feature)
+# -----------------------------------------------------------------------------
+# These can also be stored directly in config.yaml under chat.providers.*.api_key,
+# but env vars are preferred. Leave blank to disable a provider.
+
+# Anthropic (Claude) — https://console.anthropic.com/settings/keys
+ANTHROPIC_API_KEY=
+
+# Google (Gemini) — https://aistudio.google.com/apikey
+GOOGLE_API_KEY=
+
+# OpenAI (GPT) — https://platform.openai.com/api-keys
+OPENAI_API_KEY=


### PR DESCRIPTION
## Summary
- Adds `.env.example` at the repo root documenting every env var the codebase reads
- Covers the 10 `OPENPRAXIS_*` overrides in `internal/config/config.go` (applyEnvOverrides) plus the three chat provider keys (`ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `OPENAI_API_KEY`) consumed via `ChatProviderKeyConfig.EnvKey()` and `internal/web/handlers_chat.go`
- All values left blank — `.env` itself stays gitignored; this is the pre-announcement blocker for making the repo public

## Test plan
- [ ] `git check-ignore .env.example` returns nothing (confirmed locally — the `!` on `.env` stops at the filename, and there is no rule hiding `.env.example`)
- [ ] Spot-check that every `os.Getenv` / provider env name in the codebase appears in the file
- [ ] Copy to `.env`, populate one `ANTHROPIC_API_KEY`, run `./openpraxis serve`, confirm dashboard chat picks up the key

🤖 Generated with [Claude Code](https://claude.com/claude-code)