### PR TITLE
Fill version from runtime/debug.ReadBuildInfo when ldflags absent

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,11 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
 
-// Set via ldflags at build time
+// Defaults. The release build overrides these via ldflags; for `go install`
+// and plain `go build`, fillFromBuildInfo() populates them from the module
+// metadata Go embeds in every binary since 1.18.
 var (
 	Version   = "dev"
 	GitCommit = "unknown"
@@ -21,6 +24,36 @@ var versionCmd = &cobra.Command{
 	},
 }
 
+// fillFromBuildInfo replaces any default value with data from
+// runtime/debug.ReadBuildInfo. ldflags-injected values are left alone because
+// they no longer equal their defaults.
+func fillFromBuildInfo() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	if Version == "dev" && info.Main.Version != "" && info.Main.Version != "(devel)" {
+		Version = info.Main.Version
+	}
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			if GitCommit == "unknown" && s.Value != "" {
+				commit := s.Value
+				if len(commit) > 7 {
+					commit = commit[:7]
+				}
+				GitCommit = commit
+			}
+		case "vcs.time":
+			if BuildDate == "unknown" && s.Value != "" {
+				BuildDate = s.Value
+			}
+		}
+	}
+}
+
 func init() {
+	fillFromBuildInfo()
 	rootCmd.AddCommand(versionCmd)
 }


### PR DESCRIPTION
## Summary
- \`go install github.com/k8nstantin/OpenPraxis@v0.1.0\` currently produces \`openpraxis dev (commit: unknown, built: unknown)\` because \`go install\` doesn't run the release workflow's ldflags.
- Add \`fillFromBuildInfo()\` that backfills \`Version\`, \`GitCommit\`, \`BuildDate\` from \`runtime/debug.ReadBuildInfo\` during package init.
- ldflags still win (the checks only replace defaults), so release archives are unchanged.

## Test plan
- [x] \`go build\` without ldflags → \`openpraxis v0.1.0+dirty (commit: 5da66cd, built: 2026-04-16T21:47:51Z)\`
- [x] \`go build\` with goreleaser-style ldflags → ldflags values win, BuildInfo skipped
- [ ] \`go install github.com/k8nstantin/OpenPraxis@<commit>\` on merged main → shows real version info