### PR TITLE
Suppress unknown-field suffix in version output

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -20,6 +20,14 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information",
 	Run: func(cmd *cobra.Command, args []string) {
+		// Suppress the "(commit: unknown, built: unknown)" suffix for
+		// `go install`-built binaries: their Version string is a pseudo
+		// version that already encodes both timestamp and commit, and
+		// vcs.revision/vcs.time aren't available from the module proxy.
+		if GitCommit == "unknown" && BuildDate == "unknown" {
+			fmt.Printf("openpraxis %s\n", Version)
+			return
+		}
 		fmt.Printf("openpraxis %s (commit: %s, built: %s)\n", Version, GitCommit, BuildDate)
 	},
 }


### PR DESCRIPTION
## Summary
Follow-up to #20. When built via \`go install\` from the module proxy, \`vcs.revision\` and \`vcs.time\` aren't available — only the pseudo-version. Print just the Version in that case, since the pseudo-version already encodes both commit SHA and timestamp.

## Test plan
- [x] \`go build\` (local git tree) → full format with real commit/built values
- [x] Pseudo-version path → \`openpraxis v0.1.1-0.20260416215506-3a0253c0e68b\`
- [x] Release ldflags path → values win, full format unchanged