### PR TITLE
Add GitHub Actions CI workflow (build + vet + test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - sandbox
+      - dev
+  pull_request:
+    branches:
+      - main
+      - sandbox
+      - dev
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    name: build + vet + test (linux/amd64)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: go build
+        env:
+          CGO_ENABLED: '1'
+        run: go build -trimpath ./...
+
+      - name: go vet
+        env:
+          CGO_ENABLED: '1'
+        run: go vet ./...
+
+      - name: go test
+        env:
+          CGO_ENABLED: '1'
+        run: go test ./...


### PR DESCRIPTION
## Summary
- New `.github/workflows/ci.yml` runs `go build`, `go vet`, `go test` on every push / PR against `main`, `sandbox`, `dev`.
- Go version pinned via `actions/setup-go@v5` with `go-version-file: go.mod` (currently 1.25.5).
- `CGO_ENABLED=1` for sqlite-vec; `ubuntu-latest` has `gcc` out of the box.
- `.github/workflows/release.yml` intentionally left untouched (task -8a1).

## Test plan
- [ ] CI job passes on this PR (build + vet + test green)
- [ ] Future pushes to `main`, `sandbox`, `dev` trigger the workflow
- [ ] Release workflow still builds tagged releases without interference

Closes task 019d9716-980.

🤖 Generated with [Claude Code](https://claude.com/claude-code)