### PR TITLE
Add CODE_OF_CONDUCT, SECURITY policy, and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+<!--
+Thanks for opening a PR! Please fill in the sections below.
+See CONTRIBUTING.md for the full contributor guide.
+-->
+
+## Summary
+
+<!-- 1-3 bullets describing what changed and why. -->
+
+-
+-
+
+## Test plan
+
+<!-- How did you verify this change? Commands, screenshots for UI, etc. -->
+
+- [ ] `make test` passes locally
+- [ ] Manually exercised the change (describe how):
+
+## Checklist
+
+- [ ] Branch is topic-specific (not reused across tasks)
+- [ ] One logical change per PR
+- [ ] Updated docs (`README.md`, `CLAUDE.md`, `CONTRIBUTING.md`) if behavior changed
+- [ ] SQLite access uses WAL + `busy_timeout=5000` if this touches a new DB open
+- [ ] Operational data (metrics, costs, run history) persists to SQLite, not memory only
+
+## Related issues
+
+<!-- Closes #123, Refs #456 -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+# Code of Conduct
+
+OpenPraxis is an open project and we want it to be a welcoming place for
+everyone who wants to participate, regardless of background or experience
+level.
+
+## Expected behavior
+
+- Be respectful and patient with other contributors.
+- Assume good intent. Ask questions before assuming the worst.
+- Give constructive feedback focused on the work, not the person.
+- Accept constructive feedback gracefully.
+- Prefer clear, direct communication over sarcasm.
+
+## Unacceptable behavior
+
+Behavior that makes the project unpleasant or unsafe for others is not
+welcome. Maintainers will address reports at their discretion, up to and
+including removing contributions and banning repeat offenders from the
+project.
+
+## Scope
+
+This code applies in all project spaces — issues, pull requests, discussions,
+commits, and any other venue where you are representing OpenPraxis.
+
+## Reporting
+
+If you experience or witness behavior that violates this code, please email
+**constantin@dedomena.io**. Reports will be handled confidentially. Please
+include:
+
+- What happened and where (link to the issue, PR, or channel if applicable).
+- Who was involved.
+- Any supporting context.
+
+Maintainers will acknowledge reports within a reasonable time and follow up
+with the reporter.
+
+## Attribution
+
+This code is inspired by the
+[Contributor Covenant](https://www.contributor-covenant.org/), adapted for a
+small project. For a more detailed reference, see the Contributor Covenant
+2.1 text at that link.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security Policy
+
+## Supported versions
+
+OpenPraxis is pre-1.0 software under active development. Security fixes are
+applied to the `main` branch and included in the next tagged release. Older
+tagged releases do not receive backports.
+
+| Version  | Supported |
+|----------|-----------|
+| `main`   | yes       |
+| tagged releases | only the most recent |
+
+## Reporting a vulnerability
+
+Please **do not open a public GitHub issue** for security vulnerabilities.
+
+Email disclosures to: **constantin@dedomena.io**
+
+Include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce (proof-of-concept welcome, but not required).
+- The affected OpenPraxis version (`./openpraxis version`) and environment.
+- Your contact information and whether you would like public credit after the
+  fix ships.
+
+You should receive an acknowledgement within **72 hours**. A fix timeline
+depends on severity — expect a patch within **30 days** for high-severity
+issues, longer for lower-severity or complex ones. You will be kept informed
+as the fix is developed.
+
+### Coordinated disclosure
+
+Please give the maintainer a reasonable window to ship a fix before publishing
+details. Once a patch is released, a security advisory will be published on
+the GitHub repository and credit given to the reporter (unless anonymity is
+requested).
+
+## Scope
+
+In scope:
+
+- The `openpraxis` binary (`serve`, `mcp`, and any other subcommands).
+- The HTTP dashboard and WebSocket endpoints served on port `8765`.
+- The MCP server (stdio and HTTP transports) and its tool handlers.
+- The Claude Code hooks installed by `internal/setup/agents.go`.
+- The SQLite data store under `~/.openpraxis/data/`.
+
+Out of scope:
+
+- Vulnerabilities in upstream dependencies — please report those to the
+  respective projects. If an upstream issue materially affects OpenPraxis,
+  feel free to forward the advisory so we can track a bump.
+- Social engineering of maintainers or contributors.
+- Denial-of-service via resource exhaustion on a single local node
+  (OpenPraxis is designed as a single-user local tool).
+
+## Out-of-band hardening tips for operators
+
+- OpenPraxis stores conversation transcripts, tool outputs, and API keys in
+  the local SQLite DB. Treat `~/.openpraxis/data/` as sensitive.
+- The dashboard binds to `127.0.0.1:8765` by default. Do not expose it to
+  untrusted networks without an authenticating reverse proxy.
+- MCP stdio transport inherits the parent process environment — keep provider
+  API keys out of shell history and committed config.


### PR DESCRIPTION
## Summary

- **CODE_OF_CONDUCT.md** — short, generic conduct policy with reporting address (`constantin@dedomena.io`). Points to Contributor Covenant 2.1 for a more detailed reference.
- **SECURITY.md** — private vulnerability disclosure process, scope, and acknowledgement/fix timelines. Fills the gap where `CONTRIBUTING.md:225` said "email the maintainer" without listing an address.
- **.github/pull_request_template.md** — auto-populates the Summary / Test plan format required by `CONTRIBUTING.md`, plus a checklist covering the branch-per-task and SQLite WAL visceral rules.

## Test plan

- [x] Files render correctly on GitHub (markdown preview)
- [ ] Opening a new PR on this repo auto-fills the template
- [ ] A security reporter finds `SECURITY.md` via the repo's Security tab

No code changes, so no build/test impact.