### PR TITLE
Add settings table schema + Go model scaffolding

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -16,6 +16,7 @@ import (
 	"github.com/k8nstantin/OpenPraxis/internal/marker"
 	"github.com/k8nstantin/OpenPraxis/internal/memory"
 	"github.com/k8nstantin/OpenPraxis/internal/product"
+	"github.com/k8nstantin/OpenPraxis/internal/settings"
 	"github.com/k8nstantin/OpenPraxis/internal/task"
 	"github.com/k8nstantin/OpenPraxis/internal/watcher"
 )
@@ -95,6 +96,10 @@ func New(cfg *config.Config) (*Node, error) {
 	watcherStore, err := watcher.NewStore(index.DB())
 	if err != nil {
 		return nil, fmt.Errorf("init watcher store: %w", err)
+	}
+
+	if err := settings.InitSchema(index.DB()); err != nil {
+		return nil, fmt.Errorf("init settings schema: %w", err)
 	}
 
 	embedder := embedding.NewEngine(cfg.Embedding.OllamaURL, cfg.Embedding.Model, cfg.Embedding.Dimension)

--- a/internal/settings/model.go
+++ b/internal/settings/model.go
@@ -1,0 +1,29 @@
+// Package settings implements the hierarchical knob system.
+// Values are resolved at run time through task → manifest → product → system.
+package settings
+
+import "time"
+
+type ScopeType string
+
+const (
+	ScopeSystem   ScopeType = "system"
+	ScopeProduct  ScopeType = "product"
+	ScopeManifest ScopeType = "manifest"
+	ScopeTask     ScopeType = "task"
+)
+
+type Entry struct {
+	ScopeType ScopeType `json:"scope_type"`
+	ScopeID   string    `json:"scope_id"`
+	Key       string    `json:"key"`
+	Value     string    `json:"value"` // JSON-encoded
+	UpdatedAt time.Time `json:"updated_at"`
+	UpdatedBy string    `json:"updated_by,omitempty"`
+}
+
+type Scope struct {
+	ProductID  string
+	ManifestID string
+	TaskID     string
+}

--- a/internal/settings/schema.go
+++ b/internal/settings/schema.go
@@ -1,0 +1,34 @@
+package settings
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// InitSchema creates the settings table and its index on the given DB.
+// Safe to call repeatedly; uses IF NOT EXISTS semantics.
+//
+// The caller is responsible for opening the DB with WAL mode and
+// busy_timeout=5000 (see visceral rule #10 — SQLite must always use
+// WAL + busy_timeout=5000 on every db.Open).
+func InitSchema(db *sql.DB) error {
+	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS settings (
+		scope_type TEXT NOT NULL CHECK (scope_type IN ('system','product','manifest','task')),
+		scope_id   TEXT NOT NULL,
+		key        TEXT NOT NULL,
+		value      TEXT NOT NULL,
+		updated_at INTEGER NOT NULL,
+		updated_by TEXT NOT NULL DEFAULT '',
+		PRIMARY KEY (scope_type, scope_id, key)
+	) WITHOUT ROWID`)
+	if err != nil {
+		return fmt.Errorf("create settings table: %w", err)
+	}
+
+	_, err = db.Exec(`CREATE INDEX IF NOT EXISTS idx_settings_scope ON settings(scope_type, scope_id)`)
+	if err != nil {
+		return fmt.Errorf("create settings scope index: %w", err)
+	}
+
+	return nil
+}

--- a/internal/settings/schema_test.go
+++ b/internal/settings/schema_test.go
@@ -1,0 +1,151 @@
+package settings
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// openTestDB opens a fresh sqlite DB in t.TempDir() using the project's
+// standard WAL + busy_timeout pragmas, applies the settings schema, and
+// returns the handle. The DB is closed automatically on test cleanup.
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "settings.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		t.Fatalf("set WAL: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
+		t.Fatalf("set busy_timeout: %v", err)
+	}
+
+	if err := InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	return db
+}
+
+func TestSchema_CreatesSettingsTable(t *testing.T) {
+	db := openTestDB(t)
+
+	var name string
+	err := db.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name='settings'`,
+	).Scan(&name)
+	if err != nil {
+		t.Fatalf("lookup settings table: %v", err)
+	}
+	if name != "settings" {
+		t.Fatalf("expected settings table, got %q", name)
+	}
+
+	// Verify the expected columns exist and carry the expected not-null flag.
+	type col struct {
+		name    string
+		notnull int
+	}
+	want := map[string]int{
+		"scope_type": 1,
+		"scope_id":   1,
+		"key":        1,
+		"value":      1,
+		"updated_at": 1,
+		"updated_by": 1,
+	}
+	rows, err := db.Query(`PRAGMA table_info(settings)`)
+	if err != nil {
+		t.Fatalf("pragma table_info: %v", err)
+	}
+	defer rows.Close()
+	got := make(map[string]int)
+	for rows.Next() {
+		var (
+			cid        int
+			name, typ  string
+			notnull, _ int
+			dfltValue  sql.NullString
+			pk         int
+		)
+		if err := rows.Scan(&cid, &name, &typ, &notnull, &dfltValue, &pk); err != nil {
+			t.Fatalf("scan table_info: %v", err)
+		}
+		got[name] = notnull
+	}
+	for k, v := range want {
+		if g, ok := got[k]; !ok {
+			t.Errorf("missing column %q", k)
+		} else if g != v {
+			t.Errorf("column %q notnull=%d, want %d", k, g, v)
+		}
+	}
+
+	// Re-running InitSchema must be idempotent.
+	if err := InitSchema(db); err != nil {
+		t.Fatalf("InitSchema second call: %v", err)
+	}
+}
+
+func TestSchema_PrimaryKeyEnforced(t *testing.T) {
+	db := openTestDB(t)
+
+	_, err := db.Exec(
+		`INSERT INTO settings (scope_type, scope_id, key, value, updated_at, updated_by) VALUES (?, ?, ?, ?, ?, ?)`,
+		"product", "p1", "max_turns", "10", 1000, "tester",
+	)
+	if err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+
+	_, err = db.Exec(
+		`INSERT INTO settings (scope_type, scope_id, key, value, updated_at, updated_by) VALUES (?, ?, ?, ?, ?, ?)`,
+		"product", "p1", "max_turns", "20", 2000, "tester",
+	)
+	if err == nil {
+		t.Fatal("expected duplicate primary key insert to fail, got nil error")
+	}
+}
+
+func TestSchema_ScopeTypeCheckConstraint(t *testing.T) {
+	db := openTestDB(t)
+
+	for _, valid := range []string{"system", "product", "manifest", "task"} {
+		_, err := db.Exec(
+			`INSERT INTO settings (scope_type, scope_id, key, value, updated_at, updated_by) VALUES (?, ?, ?, ?, ?, ?)`,
+			valid, "id-"+valid, "k", "\"v\"", 1, "",
+		)
+		if err != nil {
+			t.Errorf("valid scope_type %q rejected: %v", valid, err)
+		}
+	}
+
+	_, err := db.Exec(
+		`INSERT INTO settings (scope_type, scope_id, key, value, updated_at, updated_by) VALUES (?, ?, ?, ?, ?, ?)`,
+		"invalid-scope", "x", "k", "\"v\"", 1, "",
+	)
+	if err == nil {
+		t.Fatal("expected CHECK constraint to reject invalid scope_type, got nil error")
+	}
+}
+
+func TestSchema_IndexPresent(t *testing.T) {
+	db := openTestDB(t)
+
+	var name string
+	err := db.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='index' AND name='idx_settings_scope'`,
+	).Scan(&name)
+	if err != nil {
+		t.Fatalf("lookup idx_settings_scope: %v", err)
+	}
+	if name != "idx_settings_scope" {
+		t.Fatalf("expected idx_settings_scope, got %q", name)
+	}
+}


### PR DESCRIPTION
## Summary
- New `settings` table: `(scope_type, scope_id, key)` primary key, CHECK constraint on `scope_type`, `(scope_type, scope_id)` index. `WITHOUT ROWID` for compact storage; `updated_by` defaults to `''`.
- `internal/settings/model.go` with `ScopeType`, `Entry`, `Scope` types — the surface the rest of M1 builds on.
- `internal/settings/schema.go` exposes `InitSchema(db)`, wired into `node.New` so every shared-DB process applies it on startup. Idempotent.
- 4 schema tests (`TestSchema_CreatesSettingsTable`, `TestSchema_PrimaryKeyEnforced`, `TestSchema_ScopeTypeCheckConstraint`, `TestSchema_IndexPresent`) using `t.TempDir()` + WAL + `busy_timeout=5000` per visceral rule #10.

## Out of scope (follow-ups in M1)
- Store CRUD — M1-T2
- Knob catalog + defaults — M1-T3
- Resolver walk — M1-T4

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` — 4 new tests pass, no regressions
- [ ] Fresh DB: schema applies clean on first startup
- [ ] Existing DB: `InitSchema` is additive, no regression

Refs #34, manifest `019d9b70-452`, product `019d9b6f-343`, task M1-T1 of 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)