### PR TITLE
Add settings knob catalog with 12 v1 definitions + validator

### DIFF
--- a/internal/settings/catalog.go
+++ b/internal/settings/catalog.go
@@ -1,0 +1,185 @@
+package settings
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// KnobType identifies the declared value shape for a knob. The Store layer
+// stores values as opaque JSON-encoded strings; the catalog owns type/range
+// validation on the way in and decode on the way out.
+type KnobType string
+
+const (
+	KnobInt         KnobType = "int"
+	KnobFloat       KnobType = "float"
+	KnobString      KnobType = "string"
+	KnobEnum        KnobType = "enum"
+	KnobMultiselect KnobType = "multiselect"
+)
+
+// KnobDef describes one knob in the v1 catalog. Slider fields are optional
+// and used only by numeric knobs for UI hinting; EnumValues constrains enums.
+// Default is the system-tier value returned when no explicit entry exists at
+// task / manifest / product scope.
+type KnobDef struct {
+	Key         string      `json:"key"`
+	Type        KnobType    `json:"type"`
+	SliderMin   *float64    `json:"slider_min,omitempty"`
+	SliderMax   *float64    `json:"slider_max,omitempty"`
+	SliderStep  *float64    `json:"slider_step,omitempty"`
+	EnumValues  []string    `json:"enum_values,omitempty"`
+	Default     interface{} `json:"default"`
+	Description string      `json:"description"`
+	Unit        string      `json:"unit,omitempty"`
+}
+
+// Sentinel errors surfaced by ValidateValue. Callers should use errors.Is for
+// matching. M2's API write layer imports these names — do not rename.
+var (
+	ErrUnknownKey     = errors.New("settings: unknown key")
+	ErrTypeMismatch   = errors.New("settings: value type mismatch")
+	ErrEnumOutOfRange = errors.New("settings: enum value not in allowed list")
+)
+
+// Catalog returns all v1 knobs in stable order. Order matches the issue #34
+// v1 table so UIs that render in catalog order stay deterministic.
+func Catalog() []KnobDef {
+	return []KnobDef{
+		{Key: "max_parallel", Type: KnobInt, SliderMin: f(1), SliderMax: f(100), SliderStep: f(1), Default: 3, Description: "Max tasks this product runs concurrently"},
+		{Key: "max_turns", Type: KnobInt, SliderMin: f(10), SliderMax: f(10000), SliderStep: f(10), Default: 50, Description: "Agent turn ceiling per task run"},
+		{Key: "max_cost_usd", Type: KnobFloat, SliderMin: f(0.01), SliderMax: f(1000), SliderStep: f(0.01), Default: 10.0, Unit: "USD", Description: "Max cost per single task run"},
+		{Key: "daily_budget_usd", Type: KnobFloat, SliderMin: f(1), SliderMax: f(10000), SliderStep: f(1), Default: 100.0, Unit: "USD", Description: "Per-product daily budget; clamped by visceral rule"},
+		{Key: "timeout_minutes", Type: KnobInt, SliderMin: f(1), SliderMax: f(1440), SliderStep: f(1), Default: 30, Unit: "minutes", Description: "Max wall time per task run"},
+		{Key: "temperature", Type: KnobFloat, SliderMin: f(0), SliderMax: f(2), SliderStep: f(0.05), Default: 0.2, Description: "LLM sampling temperature"},
+		{Key: "reasoning_effort", Type: KnobEnum, EnumValues: []string{"minimal", "low", "medium", "high"}, Default: "medium", Description: "Thinking budget for reasoning models"},
+		{Key: "default_agent", Type: KnobEnum, EnumValues: []string{"claude-code", "codex", "cursor", "windsurf"}, Default: "claude-code", Description: "Agent runtime"},
+		{Key: "default_model", Type: KnobString, Default: "", Description: "Model ID (agent-dependent)"},
+		{Key: "retry_on_failure", Type: KnobInt, SliderMin: f(0), SliderMax: f(10), SliderStep: f(1), Default: 0, Description: "Auto-retry count"},
+		{Key: "approval_mode", Type: KnobEnum, EnumValues: []string{"auto", "manual", "on-failure"}, Default: "auto", Description: "Codex approval mode"},
+		{Key: "allowed_tools", Type: KnobMultiselect, Default: []string{"Bash", "Read", "Write", "Edit", "Glob", "Grep"}, Description: "Tool allowlist for agent"},
+	}
+}
+
+// KnobByKey returns the catalog entry for a key and whether it was found.
+// Linear scan over the 12-item catalog is cheap and avoids init-order traps.
+func KnobByKey(key string) (KnobDef, bool) {
+	for _, k := range Catalog() {
+		if k.Key == key {
+			return k, true
+		}
+	}
+	return KnobDef{}, false
+}
+
+// SystemDefault returns the built-in system-tier default for a key.
+// Equivalent to KnobByKey(key).Default with a presence flag.
+func SystemDefault(key string) (interface{}, bool) {
+	k, ok := KnobByKey(key)
+	if !ok {
+		return nil, false
+	}
+	return k.Default, true
+}
+
+// ValidateValue checks a JSON-encoded value against the knob's declared type.
+// Returns (warnings, hardError). Warnings are soft — callers should surface
+// them to the user but never block the save (the user explicitly chose no
+// hard caps on slider values). Hard errors (unknown key, type mismatch,
+// unknown enum member, bad JSON) always block.
+//
+// Visceral-rule clamping (e.g. daily_budget_usd ≤ 100) is NOT applied here;
+// that belongs in M2's API write layer so catalog-level validation stays
+// purely type/shape-focused.
+func ValidateValue(key, jsonValue string) (warnings []string, hardError error) {
+	knob, ok := KnobByKey(key)
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownKey, key)
+	}
+
+	var decoded interface{}
+	if err := json.Unmarshal([]byte(jsonValue), &decoded); err != nil {
+		return nil, fmt.Errorf("%w: %q is not valid JSON: %v", ErrTypeMismatch, jsonValue, err)
+	}
+
+	switch knob.Type {
+	case KnobInt:
+		return validateInt(knob, decoded)
+	case KnobFloat:
+		return validateFloat(knob, decoded)
+	case KnobString:
+		return validateString(knob, decoded)
+	case KnobEnum:
+		return validateEnum(knob, decoded)
+	case KnobMultiselect:
+		return validateMultiselect(knob, decoded)
+	default:
+		return nil, fmt.Errorf("%w: knob %q has unsupported type %q", ErrTypeMismatch, key, knob.Type)
+	}
+}
+
+func validateInt(knob KnobDef, decoded interface{}) ([]string, error) {
+	n, ok := decoded.(float64)
+	if !ok {
+		return nil, fmt.Errorf("%w: %q expects int, got %T", ErrTypeMismatch, knob.Key, decoded)
+	}
+	if n != float64(int64(n)) {
+		return nil, fmt.Errorf("%w: %q expects whole number, got %v", ErrTypeMismatch, knob.Key, n)
+	}
+	return sliderWarnings(knob, n), nil
+}
+
+func validateFloat(knob KnobDef, decoded interface{}) ([]string, error) {
+	n, ok := decoded.(float64)
+	if !ok {
+		return nil, fmt.Errorf("%w: %q expects float, got %T", ErrTypeMismatch, knob.Key, decoded)
+	}
+	return sliderWarnings(knob, n), nil
+}
+
+func validateString(knob KnobDef, decoded interface{}) ([]string, error) {
+	if _, ok := decoded.(string); !ok {
+		return nil, fmt.Errorf("%w: %q expects string, got %T", ErrTypeMismatch, knob.Key, decoded)
+	}
+	return nil, nil
+}
+
+func validateEnum(knob KnobDef, decoded interface{}) ([]string, error) {
+	s, ok := decoded.(string)
+	if !ok {
+		return nil, fmt.Errorf("%w: %q expects string, got %T", ErrTypeMismatch, knob.Key, decoded)
+	}
+	for _, allowed := range knob.EnumValues {
+		if s == allowed {
+			return nil, nil
+		}
+	}
+	return nil, fmt.Errorf("%w: %q not in %v (key %q)", ErrEnumOutOfRange, s, knob.EnumValues, knob.Key)
+}
+
+func validateMultiselect(knob KnobDef, decoded interface{}) ([]string, error) {
+	arr, ok := decoded.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("%w: %q expects array, got %T", ErrTypeMismatch, knob.Key, decoded)
+	}
+	for i, item := range arr {
+		if _, ok := item.(string); !ok {
+			return nil, fmt.Errorf("%w: %q[%d] expects string, got %T", ErrTypeMismatch, knob.Key, i, item)
+		}
+	}
+	return nil, nil
+}
+
+func sliderWarnings(knob KnobDef, n float64) []string {
+	var warnings []string
+	if knob.SliderMax != nil && n > *knob.SliderMax {
+		warnings = append(warnings, fmt.Sprintf("%s=%v exceeds typical slider max of %v", knob.Key, n, *knob.SliderMax))
+	}
+	if knob.SliderMin != nil && n < *knob.SliderMin {
+		warnings = append(warnings, fmt.Sprintf("%s=%v below typical slider min of %v", knob.Key, n, *knob.SliderMin))
+	}
+	return warnings
+}
+
+func f(v float64) *float64 { return &v }

--- a/internal/settings/catalog_test.go
+++ b/internal/settings/catalog_test.go
@@ -1,0 +1,231 @@
+package settings
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCatalog_HasExactly12Knobs(t *testing.T) {
+	got := len(Catalog())
+	if got != 12 {
+		t.Fatalf("Catalog() returned %d knobs, want 12", got)
+	}
+}
+
+func TestCatalog_EveryKnobHasDescription(t *testing.T) {
+	for _, k := range Catalog() {
+		if k.Description == "" {
+			t.Errorf("knob %q has empty Description", k.Key)
+		}
+	}
+}
+
+func TestCatalog_AllSliderKnobsHaveMinMaxStep(t *testing.T) {
+	for _, k := range Catalog() {
+		if k.Type != KnobInt && k.Type != KnobFloat {
+			continue
+		}
+		if k.SliderMin == nil || k.SliderMax == nil || k.SliderStep == nil {
+			t.Errorf("numeric knob %q missing slider fields: min=%v max=%v step=%v",
+				k.Key, k.SliderMin, k.SliderMax, k.SliderStep)
+			continue
+		}
+		if *k.SliderMax <= *k.SliderMin {
+			t.Errorf("knob %q: slider_max (%v) must be greater than slider_min (%v)",
+				k.Key, *k.SliderMax, *k.SliderMin)
+		}
+		if *k.SliderStep <= 0 {
+			t.Errorf("knob %q: slider_step (%v) must be positive", k.Key, *k.SliderStep)
+		}
+	}
+}
+
+func TestCatalog_AllEnumKnobsHaveEnumValues(t *testing.T) {
+	for _, k := range Catalog() {
+		if k.Type != KnobEnum {
+			continue
+		}
+		if len(k.EnumValues) == 0 {
+			t.Errorf("enum knob %q has no EnumValues", k.Key)
+		}
+	}
+}
+
+func TestKnobByKey_ReturnsEntry(t *testing.T) {
+	got, ok := KnobByKey("max_parallel")
+	if !ok {
+		t.Fatalf("KnobByKey(%q) returned ok=false", "max_parallel")
+	}
+	if got.Key != "max_parallel" {
+		t.Errorf("KnobByKey returned key %q, want %q", got.Key, "max_parallel")
+	}
+	if got.Type != KnobInt {
+		t.Errorf("KnobByKey returned type %q, want %q", got.Type, KnobInt)
+	}
+}
+
+func TestKnobByKey_ReturnsFalseForUnknown(t *testing.T) {
+	if _, ok := KnobByKey("does_not_exist"); ok {
+		t.Fatalf("KnobByKey(%q) returned ok=true, want false", "does_not_exist")
+	}
+}
+
+func TestSystemDefault_EveryKnobHasDefault(t *testing.T) {
+	for _, k := range Catalog() {
+		got, ok := SystemDefault(k.Key)
+		if !ok {
+			t.Errorf("SystemDefault(%q) returned ok=false", k.Key)
+			continue
+		}
+		if got == nil && k.Type != KnobString {
+			t.Errorf("SystemDefault(%q) returned nil", k.Key)
+		}
+	}
+}
+
+func TestSystemDefault_TypesMatchKnobType(t *testing.T) {
+	for _, k := range Catalog() {
+		def, ok := SystemDefault(k.Key)
+		if !ok {
+			t.Fatalf("SystemDefault(%q) missing", k.Key)
+		}
+		switch k.Type {
+		case KnobInt:
+			if _, ok := def.(int); !ok {
+				t.Errorf("knob %q: int default is %T, want int", k.Key, def)
+			}
+		case KnobFloat:
+			if _, ok := def.(float64); !ok {
+				t.Errorf("knob %q: float default is %T, want float64", k.Key, def)
+			}
+		case KnobString, KnobEnum:
+			if _, ok := def.(string); !ok {
+				t.Errorf("knob %q: %s default is %T, want string", k.Key, k.Type, def)
+			}
+		case KnobMultiselect:
+			if _, ok := def.([]string); !ok {
+				t.Errorf("knob %q: multiselect default is %T, want []string", k.Key, def)
+			}
+		}
+	}
+}
+
+func TestValidateValue_RejectsUnknownKey(t *testing.T) {
+	_, err := ValidateValue("no_such_key", "1")
+	if !errors.Is(err, ErrUnknownKey) {
+		t.Fatalf("got err %v, want ErrUnknownKey", err)
+	}
+}
+
+func TestValidateValue_RejectsInvalidJSON(t *testing.T) {
+	_, err := ValidateValue("max_turns", "not-json")
+	if !errors.Is(err, ErrTypeMismatch) {
+		t.Fatalf("got err %v, want ErrTypeMismatch", err)
+	}
+}
+
+func TestValidateValue_IntKnob_AcceptsWholeNumber(t *testing.T) {
+	warnings, err := ValidateValue("max_turns", "100")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+}
+
+func TestValidateValue_IntKnob_RejectsFractional(t *testing.T) {
+	_, err := ValidateValue("max_turns", "3.5")
+	if !errors.Is(err, ErrTypeMismatch) {
+		t.Fatalf("got err %v, want ErrTypeMismatch", err)
+	}
+}
+
+func TestValidateValue_FloatKnob_AcceptsAny(t *testing.T) {
+	if _, err := ValidateValue("temperature", "0.7"); err != nil {
+		t.Errorf("unexpected error for 0.7: %v", err)
+	}
+	if _, err := ValidateValue("temperature", "1"); err != nil {
+		t.Errorf("unexpected error for whole 1: %v", err)
+	}
+}
+
+func TestValidateValue_StringKnob_AcceptsString(t *testing.T) {
+	warnings, err := ValidateValue("default_model", `"gpt-5"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+}
+
+func TestValidateValue_EnumKnob_AcceptsKnownValue(t *testing.T) {
+	if _, err := ValidateValue("reasoning_effort", `"high"`); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if _, err := ValidateValue("default_agent", `"codex"`); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if _, err := ValidateValue("approval_mode", `"on-failure"`); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateValue_EnumKnob_RejectsUnknownValue(t *testing.T) {
+	_, err := ValidateValue("reasoning_effort", `"turbo"`)
+	if !errors.Is(err, ErrEnumOutOfRange) {
+		t.Fatalf("got err %v, want ErrEnumOutOfRange", err)
+	}
+}
+
+func TestValidateValue_MultiselectKnob_AcceptsStringArray(t *testing.T) {
+	warnings, err := ValidateValue("allowed_tools", `["Bash","Read"]`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+}
+
+func TestValidateValue_MultiselectKnob_RejectsMixedTypes(t *testing.T) {
+	_, err := ValidateValue("allowed_tools", `["Bash", 7]`)
+	if !errors.Is(err, ErrTypeMismatch) {
+		t.Fatalf("got err %v, want ErrTypeMismatch", err)
+	}
+}
+
+func TestValidateValue_SliderOverMax_ReturnsWarningNotError(t *testing.T) {
+	warnings, err := ValidateValue("max_parallel", "500")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Fatalf("expected a warning for value above slider max, got none")
+	}
+}
+
+func TestValidateValue_SliderUnderMin_ReturnsWarningNotError(t *testing.T) {
+	warnings, err := ValidateValue("timeout_minutes", "0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Fatalf("expected a warning for value below slider min, got none")
+	}
+}
+
+func TestValidateValue_TypeMismatch_ErrorsIsTypeMismatch(t *testing.T) {
+	_, err := ValidateValue("max_turns", `"not-an-int"`)
+	if !errors.Is(err, ErrTypeMismatch) {
+		t.Fatalf("got err %v, want ErrTypeMismatch", err)
+	}
+}
+
+func TestValidateValue_UnknownEnum_ErrorsIsEnumOutOfRange(t *testing.T) {
+	_, err := ValidateValue("default_agent", `"emacs"`)
+	if !errors.Is(err, ErrEnumOutOfRange) {
+		t.Fatalf("got err %v, want ErrEnumOutOfRange", err)
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/settings/catalog.go` — `KnobDef`, `Catalog()`, `KnobByKey`, `SystemDefault`, `ValidateValue`
- 12 knobs matching issue #34 v1 spec exactly (keys, types, defaults, enum values, slider ranges)
- Sentinel errors: `ErrUnknownKey`, `ErrTypeMismatch`, `ErrEnumOutOfRange` — `errors.Is` works
- Soft warnings (no hard error) for out-of-range slider values — user explicitly asked for no hard caps
- Visceral-rule clamping intentionally deferred to M2's API write layer so this stays a pure type/shape validator
- Per-type sub-validators extracted (`validateInt/Float/String/Enum/Multiselect`) following T2's DRY pattern

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] 22 new tests in `catalog_test.go` — every knob, every type, every failure mode (unknown key, invalid JSON, fractional int, unknown enum, mixed multiselect, slider-over/under, `errors.Is` checks)
- [x] T1 schema tests (4) + T2 store tests (10) still pass — `internal/node/node.go`, `schema.go`, `model.go`, `store.go` untouched
- [x] `make test` — all green

Refs #34, manifest 019d9b70-452, task M1-T3 of 14. Builds on PR #36 and #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)