### PR TITLE
Implement settings Resolver with task→manifest→product→system inheritance walk

### DIFF
--- a/internal/settings/resolver.go
+++ b/internal/settings/resolver.go
@@ -1,0 +1,369 @@
+package settings
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// TaskLookup resolves a task's manifest id. Kept as a minimal interface so
+// internal/settings can stay import-cycle-free vs internal/task — concrete
+// adapters live in internal/task and are wired by the runner (M4).
+type TaskLookup interface {
+	GetTaskForSettings(ctx context.Context, taskID string) (TaskRec, error)
+}
+
+// ManifestLookup resolves a manifest's product id. Minimal interface vs
+// internal/manifest for the same import-cycle reason as TaskLookup.
+type ManifestLookup interface {
+	GetManifestForSettings(ctx context.Context, manifestID string) (ManifestRec, error)
+}
+
+// TaskRec is the minimum task info the resolver needs. ManifestID may be ""
+// for tasks that exist outside any manifest — in that case the walk skips
+// straight from task scope to system scope.
+type TaskRec struct {
+	ID         string
+	ManifestID string
+}
+
+// ManifestRec is the minimum manifest info the resolver needs. ProductID may
+// be "" for orphan manifests; the walk then skips the product tier.
+type ManifestRec struct {
+	ID        string
+	ProductID string
+}
+
+// Resolved is the output of Resolve — typed value plus provenance so callers
+// (UI, audit logs, "where did this value come from?" tooltips) can show why a
+// knob has the value it does.
+type Resolved struct {
+	Key      string      `json:"key"`
+	Value    interface{} `json:"value"`     // typed per KnobDef.Type
+	Source   ScopeType   `json:"source"`    // task | manifest | product | system
+	SourceID string      `json:"source_id"` // entity id, or "" for system
+}
+
+// ErrResolveLookupFailed wraps errors returned by the TaskLookup or
+// ManifestLookup adapters when scope normalization needs them. Callers can
+// distinguish "the task does not exist" (lookup error) from "no entry was
+// stored at this scope" (sql.ErrNoRows — handled internally as fallthrough).
+var ErrResolveLookupFailed = errors.New("settings: resolve lookup failed")
+
+// ErrResolveDecodeFailed wraps decode errors. Should never fire in practice
+// because the catalog validates on Set, but we surface it as a sentinel so
+// production callers can alert rather than panic on a corrupted row.
+var ErrResolveDecodeFailed = errors.New("settings: resolve decode failed")
+
+// Resolver walks task → manifest → product → system for any knob.
+//
+// The Resolver is read-only: it never writes to settings or invokes the
+// lookups for any side effect. Construct a new Resolver per request if your
+// store/lookup wiring is request-scoped; otherwise share one — the type holds
+// no per-call state.
+type Resolver struct {
+	store     *Store
+	tasks     TaskLookup
+	manifests ManifestLookup
+}
+
+// NewResolver constructs a Resolver. Caller owns lifecycle of store + lookups.
+// Either lookup may be nil if the caller guarantees the corresponding scope
+// id will already be set on every Scope passed in (e.g. background jobs that
+// know all three IDs upfront). If a lookup is required and nil, NormalizeScope
+// returns an error.
+func NewResolver(store *Store, tasks TaskLookup, manifests ManifestLookup) *Resolver {
+	return &Resolver{store: store, tasks: tasks, manifests: manifests}
+}
+
+// Resolve returns the effective value for one knob at the given scope.
+// Resolution order (first hit wins): task → manifest → product → system.
+//
+// Missing entries at any scope (sql.ErrNoRows) are not errors; they are the
+// normal "try the next scope up" path. The only hard errors are:
+//   - unknown key (ErrUnknownKey)
+//   - decode failure on a stored value (ErrResolveDecodeFailed)
+//   - lookup failure during scope normalization (ErrResolveLookupFailed)
+//   - underlying DB errors (wrapped)
+//
+// Resolve normalizes the scope as it walks, so a Scope with only TaskID set
+// is the canonical caller input.
+func (r *Resolver) Resolve(ctx context.Context, scope Scope, key string) (Resolved, error) {
+	knob, ok := KnobByKey(key)
+	if !ok {
+		return Resolved{}, fmt.Errorf("%w: %q", ErrUnknownKey, key)
+	}
+
+	if scope.TaskID != "" {
+		hit, err := r.tryScope(ctx, ScopeTask, scope.TaskID, knob)
+		if err != nil {
+			return Resolved{}, err
+		}
+		if hit != nil {
+			return *hit, nil
+		}
+	}
+
+	if scope.ManifestID == "" && scope.TaskID != "" && r.tasks != nil {
+		rec, err := r.tasks.GetTaskForSettings(ctx, scope.TaskID)
+		if err != nil {
+			return Resolved{}, fmt.Errorf("%w: task %q: %v", ErrResolveLookupFailed, scope.TaskID, err)
+		}
+		scope.ManifestID = rec.ManifestID
+	}
+
+	if scope.ManifestID != "" {
+		hit, err := r.tryScope(ctx, ScopeManifest, scope.ManifestID, knob)
+		if err != nil {
+			return Resolved{}, err
+		}
+		if hit != nil {
+			return *hit, nil
+		}
+	}
+
+	if scope.ProductID == "" && scope.ManifestID != "" && r.manifests != nil {
+		rec, err := r.manifests.GetManifestForSettings(ctx, scope.ManifestID)
+		if err != nil {
+			return Resolved{}, fmt.Errorf("%w: manifest %q: %v", ErrResolveLookupFailed, scope.ManifestID, err)
+		}
+		scope.ProductID = rec.ProductID
+	}
+
+	if scope.ProductID != "" {
+		hit, err := r.tryScope(ctx, ScopeProduct, scope.ProductID, knob)
+		if err != nil {
+			return Resolved{}, err
+		}
+		if hit != nil {
+			return *hit, nil
+		}
+	}
+
+	def, _ := SystemDefault(key) // ok already verified via KnobByKey above
+	return Resolved{Key: key, Value: def, Source: ScopeSystem, SourceID: ""}, nil
+}
+
+// ResolveAll returns the effective value for every knob in the catalog at
+// the given scope. The implementation issues at most three DB queries
+// (one per non-system scope tier) regardless of catalog size — important
+// because UI screens render the whole knob grid on every page load.
+//
+// Design choice C from the task spec: snapshot each tier with one
+// store.ListScope call, build per-tier maps, then iterate the catalog and
+// consult the maps in inheritance order. O(N) in catalog size, with a fixed
+// query budget.
+func (r *Resolver) ResolveAll(ctx context.Context, scope Scope) (map[string]Resolved, error) {
+	normalized, err := r.NormalizeScope(ctx, scope)
+	if err != nil {
+		return nil, err
+	}
+
+	taskMap, err := r.snapshotScope(ctx, ScopeTask, normalized.TaskID)
+	if err != nil {
+		return nil, err
+	}
+	manifestMap, err := r.snapshotScope(ctx, ScopeManifest, normalized.ManifestID)
+	if err != nil {
+		return nil, err
+	}
+	productMap, err := r.snapshotScope(ctx, ScopeProduct, normalized.ProductID)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]Resolved, len(Catalog()))
+	for _, knob := range Catalog() {
+		resolved, err := r.pickFromMaps(knob, normalized, taskMap, manifestMap, productMap)
+		if err != nil {
+			return nil, err
+		}
+		out[knob.Key] = resolved
+	}
+	return out, nil
+}
+
+// NormalizeScope fills in ManifestID + ProductID from the TaskID, if either
+// is missing. A Scope with only TaskID set is the canonical caller input;
+// the walk transparently promotes to manifest + product via the lookups.
+//
+// NormalizeScope respects caller overrides: if ManifestID or ProductID is
+// already set on the input scope, it is left as-is. This lets callers pin a
+// scope to a specific manifest even when the task technically belongs to a
+// different one (used by previews, "what-if" queries).
+func (r *Resolver) NormalizeScope(ctx context.Context, scope Scope) (Scope, error) {
+	if scope.TaskID != "" && scope.ManifestID == "" {
+		if r.tasks == nil {
+			return scope, fmt.Errorf("%w: task lookup is nil but TaskID=%q needs promotion", ErrResolveLookupFailed, scope.TaskID)
+		}
+		rec, err := r.tasks.GetTaskForSettings(ctx, scope.TaskID)
+		if err != nil {
+			return scope, fmt.Errorf("%w: task %q: %v", ErrResolveLookupFailed, scope.TaskID, err)
+		}
+		scope.ManifestID = rec.ManifestID
+	}
+
+	if scope.ManifestID != "" && scope.ProductID == "" {
+		if r.manifests == nil {
+			return scope, fmt.Errorf("%w: manifest lookup is nil but ManifestID=%q needs promotion", ErrResolveLookupFailed, scope.ManifestID)
+		}
+		rec, err := r.manifests.GetManifestForSettings(ctx, scope.ManifestID)
+		if err != nil {
+			return scope, fmt.Errorf("%w: manifest %q: %v", ErrResolveLookupFailed, scope.ManifestID, err)
+		}
+		scope.ProductID = rec.ProductID
+	}
+
+	return scope, nil
+}
+
+// tryScope reads the explicit entry for (scopeType, scopeID, knob.Key). On a
+// hit it decodes and wraps in a Resolved; on sql.ErrNoRows it returns nil so
+// the caller falls through to the next scope tier.
+func (r *Resolver) tryScope(ctx context.Context, scopeType ScopeType, scopeID string, knob KnobDef) (*Resolved, error) {
+	entry, err := r.store.Get(ctx, scopeType, scopeID, knob.Key)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("settings: resolve %s scope %q key %q: %w", scopeType, scopeID, knob.Key, err)
+	}
+	value, err := decodeValue(knob, entry.Value)
+	if err != nil {
+		return nil, err
+	}
+	return &Resolved{Key: knob.Key, Value: value, Source: scopeType, SourceID: scopeID}, nil
+}
+
+// snapshotScope reads every entry at one scope tier in a single query, keyed
+// by knob name for O(1) lookup. Returns an empty (non-nil) map when scopeID
+// is "" so the caller can index without nil-checks.
+func (r *Resolver) snapshotScope(ctx context.Context, scopeType ScopeType, scopeID string) (map[string]Entry, error) {
+	if scopeID == "" {
+		return map[string]Entry{}, nil
+	}
+	entries, err := r.store.ListScope(ctx, scopeType, scopeID)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]Entry, len(entries))
+	for _, e := range entries {
+		out[e.Key] = e
+	}
+	return out, nil
+}
+
+// pickFromMaps walks the inheritance chain in memory using the per-tier maps
+// produced by snapshotScope. Mirrors Resolve's order but without re-querying.
+func (r *Resolver) pickFromMaps(
+	knob KnobDef,
+	scope Scope,
+	taskMap, manifestMap, productMap map[string]Entry,
+) (Resolved, error) {
+	tiers := []struct {
+		scopeType ScopeType
+		scopeID   string
+		entries   map[string]Entry
+	}{
+		{ScopeTask, scope.TaskID, taskMap},
+		{ScopeManifest, scope.ManifestID, manifestMap},
+		{ScopeProduct, scope.ProductID, productMap},
+	}
+	for _, t := range tiers {
+		if t.scopeID == "" {
+			continue
+		}
+		entry, ok := t.entries[knob.Key]
+		if !ok {
+			continue
+		}
+		value, err := decodeValue(knob, entry.Value)
+		if err != nil {
+			return Resolved{}, err
+		}
+		return Resolved{Key: knob.Key, Value: value, Source: t.scopeType, SourceID: t.scopeID}, nil
+	}
+
+	def, _ := SystemDefault(knob.Key)
+	return Resolved{Key: knob.Key, Value: def, Source: ScopeSystem, SourceID: ""}, nil
+}
+
+// decodeValue dispatches on KnobType to produce a typed Go value from the
+// stored JSON-encoded string. Catalog.ValidateValue runs on Set, so decode
+// failures here indicate either DB corruption or a knob whose type changed
+// after rows were already written — both warrant a hard error.
+func decodeValue(knob KnobDef, jsonValue string) (interface{}, error) {
+	switch knob.Type {
+	case KnobInt:
+		return decodeInt(knob, jsonValue)
+	case KnobFloat:
+		return decodeFloat(knob, jsonValue)
+	case KnobString:
+		return decodeString(knob, jsonValue)
+	case KnobEnum:
+		return decodeEnum(knob, jsonValue)
+	case KnobMultiselect:
+		return decodeMultiselect(knob, jsonValue)
+	default:
+		return nil, fmt.Errorf("%w: knob %q has unsupported type %q", ErrResolveDecodeFailed, knob.Key, knob.Type)
+	}
+}
+
+// decodeInt reads a JSON number and casts to int64. Go's encoding/json
+// surfaces all numbers as float64 by default; we round-trip through int64 so
+// downstream consumers get a stable integral type rather than a float that
+// might quietly lose precision past 2^53.
+func decodeInt(knob KnobDef, jsonValue string) (interface{}, error) {
+	var n float64
+	if err := json.Unmarshal([]byte(jsonValue), &n); err != nil {
+		return nil, fmt.Errorf("%w: knob %q expects int, raw=%q: %v", ErrResolveDecodeFailed, knob.Key, jsonValue, err)
+	}
+	return int64(n), nil
+}
+
+func decodeFloat(knob KnobDef, jsonValue string) (interface{}, error) {
+	var n float64
+	if err := json.Unmarshal([]byte(jsonValue), &n); err != nil {
+		return nil, fmt.Errorf("%w: knob %q expects float, raw=%q: %v", ErrResolveDecodeFailed, knob.Key, jsonValue, err)
+	}
+	return n, nil
+}
+
+func decodeString(knob KnobDef, jsonValue string) (interface{}, error) {
+	var s string
+	if err := json.Unmarshal([]byte(jsonValue), &s); err != nil {
+		return nil, fmt.Errorf("%w: knob %q expects string, raw=%q: %v", ErrResolveDecodeFailed, knob.Key, jsonValue, err)
+	}
+	return s, nil
+}
+
+// decodeEnum decodes the same shape as a string but is a separate function so
+// future enum-specific normalization (case-folding, alias resolution) has a
+// dedicated home.
+func decodeEnum(knob KnobDef, jsonValue string) (interface{}, error) {
+	var s string
+	if err := json.Unmarshal([]byte(jsonValue), &s); err != nil {
+		return nil, fmt.Errorf("%w: knob %q expects enum string, raw=%q: %v", ErrResolveDecodeFailed, knob.Key, jsonValue, err)
+	}
+	return s, nil
+}
+
+// decodeMultiselect decodes a JSON array of strings into []string. We accept
+// the [] interface{} round-trip so empty arrays don't surprise callers.
+func decodeMultiselect(knob KnobDef, jsonValue string) (interface{}, error) {
+	var raw []interface{}
+	if err := json.Unmarshal([]byte(jsonValue), &raw); err != nil {
+		return nil, fmt.Errorf("%w: knob %q expects array, raw=%q: %v", ErrResolveDecodeFailed, knob.Key, jsonValue, err)
+	}
+	out := make([]string, 0, len(raw))
+	for i, item := range raw {
+		s, ok := item.(string)
+		if !ok {
+			return nil, fmt.Errorf("%w: knob %q[%d] expects string, got %T", ErrResolveDecodeFailed, knob.Key, i, item)
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}

--- a/internal/settings/resolver_test.go
+++ b/internal/settings/resolver_test.go
@@ -1,0 +1,527 @@
+package settings
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	sqlite3 "github.com/mattn/go-sqlite3"
+)
+
+// Fake lookups —————————————————————————————————————————————————————————————
+
+type fakeTaskLookup struct {
+	tasks map[string]TaskRec
+	err   error
+}
+
+func (f *fakeTaskLookup) GetTaskForSettings(_ context.Context, taskID string) (TaskRec, error) {
+	if f.err != nil {
+		return TaskRec{}, f.err
+	}
+	rec, ok := f.tasks[taskID]
+	if !ok {
+		return TaskRec{}, fmt.Errorf("fake task lookup: task %q not found", taskID)
+	}
+	return rec, nil
+}
+
+type fakeManifestLookup struct {
+	manifests map[string]ManifestRec
+	err       error
+}
+
+func (f *fakeManifestLookup) GetManifestForSettings(_ context.Context, manifestID string) (ManifestRec, error) {
+	if f.err != nil {
+		return ManifestRec{}, f.err
+	}
+	rec, ok := f.manifests[manifestID]
+	if !ok {
+		return ManifestRec{}, fmt.Errorf("fake manifest lookup: manifest %q not found", manifestID)
+	}
+	return rec, nil
+}
+
+// Test helper ——————————————————————————————————————————————————————————————
+
+// openResolverTestDB mirrors openStoreTestDB from store_test.go but also wires
+// a Resolver with fake lookups that map a single (task → manifest → product)
+// chain. Tests that need different lookup behavior can mutate the returned
+// fake maps before calling the resolver.
+func openResolverTestDB(t *testing.T) (*Resolver, *Store, *fakeTaskLookup, *fakeManifestLookup) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "settings.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=on")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		t.Fatalf("set WAL: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
+		t.Fatalf("set busy_timeout: %v", err)
+	}
+
+	if err := InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+
+	store := NewStore(db)
+	tasks := &fakeTaskLookup{tasks: map[string]TaskRec{
+		"t1": {ID: "t1", ManifestID: "m1"},
+	}}
+	manifests := &fakeManifestLookup{manifests: map[string]ManifestRec{
+		"m1": {ID: "m1", ProductID: "p1"},
+	}}
+	r := NewResolver(store, tasks, manifests)
+	return r, store, tasks, manifests
+}
+
+// Resolve tests ————————————————————————————————————————————————————————————
+
+func TestResolver_Resolve_UnknownKey_ReturnsErrUnknownKey(t *testing.T) {
+	r, _, _, _ := openResolverTestDB(t)
+	_, err := r.Resolve(context.Background(), Scope{TaskID: "t1"}, "no_such_knob")
+	if !errors.Is(err, ErrUnknownKey) {
+		t.Fatalf("expected ErrUnknownKey, got %v", err)
+	}
+}
+
+func TestResolver_Resolve_TaskLevelWins(t *testing.T) {
+	r, store, _, _ := openResolverTestDB(t)
+	ctx := context.Background()
+
+	mustSet(t, store, ScopeProduct, "p1", "max_turns", "10")
+	mustSet(t, store, ScopeManifest, "m1", "max_turns", "20")
+	mustSet(t, store, ScopeTask, "t1", "max_turns", "30")
+
+	got, err := r.Resolve(ctx, Scope{TaskID: "t1", ManifestID: "m1", ProductID: "p1"}, "max_turns")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Source != ScopeTask || got.SourceID != "t1" {
+		t.Errorf("source = %s/%s, want task/t1", got.Source, got.SourceID)
+	}
+	if got.Value.(int64) != 30 {
+		t.Errorf("value = %v, want 30", got.Value)
+	}
+}
+
+func TestResolver_Resolve_FallsThroughToManifest(t *testing.T) {
+	r, store, _, _ := openResolverTestDB(t)
+	ctx := context.Background()
+
+	mustSet(t, store, ScopeProduct, "p1", "max_turns", "10")
+	mustSet(t, store, ScopeManifest, "m1", "max_turns", "20")
+	// no task-scope entry
+
+	got, err := r.Resolve(ctx, Scope{TaskID: "t1", ManifestID: "m1", ProductID: "p1"}, "max_turns")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Source != ScopeManifest || got.SourceID != "m1" {
+		t.Errorf("source = %s/%s, want manifest/m1", got.Source, got.SourceID)
+	}
+	if got.Value.(int64) != 20 {
+		t.Errorf("value = %v, want 20", got.Value)
+	}
+}
+
+func TestResolver_Resolve_FallsThroughToProduct(t *testing.T) {
+	r, store, _, _ := openResolverTestDB(t)
+	ctx := context.Background()
+
+	mustSet(t, store, ScopeProduct, "p1", "max_turns", "10")
+	// no manifest- or task-scope entry
+
+	got, err := r.Resolve(ctx, Scope{TaskID: "t1", ManifestID: "m1", ProductID: "p1"}, "max_turns")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Source != ScopeProduct || got.SourceID != "p1" {
+		t.Errorf("source = %s/%s, want product/p1", got.Source, got.SourceID)
+	}
+	if got.Value.(int64) != 10 {
+		t.Errorf("value = %v, want 10", got.Value)
+	}
+}
+
+func TestResolver_Resolve_FallsThroughToSystem(t *testing.T) {
+	r, _, _, _ := openResolverTestDB(t)
+	ctx := context.Background()
+
+	got, err := r.Resolve(ctx, Scope{TaskID: "t1", ManifestID: "m1", ProductID: "p1"}, "max_turns")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Source != ScopeSystem || got.SourceID != "" {
+		t.Errorf("source = %s/%s, want system/<empty>", got.Source, got.SourceID)
+	}
+	// system default for max_turns is 3 per Catalog (catalog.go); cast to int.
+	wantSystem, _ := SystemDefault("max_turns")
+	if got.Value != wantSystem {
+		t.Errorf("value = %v, want system default %v", got.Value, wantSystem)
+	}
+}
+
+func TestResolver_Resolve_ReturnsCorrectProvenance(t *testing.T) {
+	r, store, _, _ := openResolverTestDB(t)
+	ctx := context.Background()
+
+	mustSet(t, store, ScopeProduct, "p1", "max_turns", "10")
+	mustSet(t, store, ScopeManifest, "m1", "max_turns", "20")
+
+	cases := []struct {
+		name       string
+		scope      Scope
+		wantSource ScopeType
+		wantID     string
+	}{
+		{
+			name:       "no task scope, manifest wins over product",
+			scope:      Scope{TaskID: "t1", ManifestID: "m1", ProductID: "p1"},
+			wantSource: ScopeManifest, wantID: "m1",
+		},
+		{
+			name:       "no manifest scope override, manifest wins over product (manifest is set)",
+			scope:      Scope{TaskID: "t1", ManifestID: "m1", ProductID: "p1"},
+			wantSource: ScopeManifest, wantID: "m1",
+		},
+		{
+			name:       "only product scope set explicitly (skips empty task/manifest IDs)",
+			scope:      Scope{ProductID: "p1"},
+			wantSource: ScopeProduct, wantID: "p1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := r.Resolve(ctx, tc.scope, "max_turns")
+			if err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			if got.Source != tc.wantSource || got.SourceID != tc.wantID {
+				t.Errorf("source = %s/%s, want %s/%s", got.Source, got.SourceID, tc.wantSource, tc.wantID)
+			}
+		})
+	}
+}
+
+// Typed-decoding tests ——————————————————————————————————————————————————————
+
+func TestResolver_Resolve_TypedDecoding_IntKnob(t *testing.T) {
+	r, store, _, _ := openResolverTestDB(t)
+	ctx := context.Background()
+	mustSet(t, store, ScopeTask, "t1", "max_turns", "42")
+
+	got, err := r.Resolve(ctx, Scope{TaskID: "t1"}, "max_turns")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	v, ok := got.Value.(int64)
+	if !ok {
+		t.Fatalf("value type = %T, want int64", got.Value)
+	}
+	if v != 42 {
+		t.Errorf("value = %d, want 42", v)
+	}
+}
+
+func TestResolver_Resolve_TypedDecoding_FloatKnob(t *testing.T) {
+	r, store, _, _ := openResolverTestDB(t)
+	ctx := context.Background()
+	mustSet(t, store, ScopeTask, "t1", "temperature", "0.7")
+
+	got, err := r.Resolve(ctx, Scope{TaskID: "t1"}, "temperature")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	v, ok := got.Value.(float64)
+	if !ok {
+		t.Fatalf("value type = %T, want float64", got.Value)
+	}
+	if v != 0.7 {
+		t.Errorf("value = %v, want 0.7", v)
+	}
+}
+
+func TestResolver_Resolve_TypedDecoding_EnumKnob(t *testing.T) {
+	r, store, _, _ := openResolverTestDB(t)
+	ctx := context.Background()
+	mustSet(t, store, ScopeTask, "t1", "reasoning_effort", `"high"`)
+
+	got, err := r.Resolve(ctx, Scope{TaskID: "t1"}, "reasoning_effort")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	v, ok := got.Value.(string)
+	if !ok {
+		t.Fatalf("value type = %T, want string", got.Value)
+	}
+	if v != "high" {
+		t.Errorf("value = %q, want %q", v, "high")
+	}
+}
+
+func TestResolver_Resolve_TypedDecoding_MultiselectKnob(t *testing.T) {
+	r, store, _, _ := openResolverTestDB(t)
+	ctx := context.Background()
+	mustSet(t, store, ScopeTask, "t1", "allowed_tools", `["Bash","Read"]`)
+
+	got, err := r.Resolve(ctx, Scope{TaskID: "t1"}, "allowed_tools")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	v, ok := got.Value.([]string)
+	if !ok {
+		t.Fatalf("value type = %T, want []string", got.Value)
+	}
+	if len(v) != 2 || v[0] != "Bash" || v[1] != "Read" {
+		t.Errorf("value = %v, want [Bash Read]", v)
+	}
+}
+
+func TestResolver_Resolve_TypedDecoding_StringKnob(t *testing.T) {
+	r, store, _, _ := openResolverTestDB(t)
+	ctx := context.Background()
+	mustSet(t, store, ScopeTask, "t1", "default_model", `"gpt-5"`)
+
+	got, err := r.Resolve(ctx, Scope{TaskID: "t1"}, "default_model")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	v, ok := got.Value.(string)
+	if !ok {
+		t.Fatalf("value type = %T, want string", got.Value)
+	}
+	if v != "gpt-5" {
+		t.Errorf("value = %q, want %q", v, "gpt-5")
+	}
+}
+
+// ResolveAll tests ——————————————————————————————————————————————————————————
+
+func TestResolver_ResolveAll_IncludesEveryCatalogKnob(t *testing.T) {
+	r, _, _, _ := openResolverTestDB(t)
+	ctx := context.Background()
+
+	out, err := r.ResolveAll(ctx, Scope{TaskID: "t1", ManifestID: "m1", ProductID: "p1"})
+	if err != nil {
+		t.Fatalf("ResolveAll: %v", err)
+	}
+	if len(out) != len(Catalog()) {
+		t.Fatalf("ResolveAll returned %d entries, want %d", len(out), len(Catalog()))
+	}
+	for _, knob := range Catalog() {
+		got, ok := out[knob.Key]
+		if !ok {
+			t.Errorf("key %q missing from ResolveAll output", knob.Key)
+			continue
+		}
+		if got.Source != ScopeSystem {
+			t.Errorf("key %q source = %s, want system (no overrides set)", knob.Key, got.Source)
+		}
+	}
+}
+
+func TestResolver_ResolveAll_ThreeQueriesRegardlessOfCatalogSize(t *testing.T) {
+	store, counter := openCountingResolverDB(t)
+	tasks := &fakeTaskLookup{tasks: map[string]TaskRec{
+		"t1": {ID: "t1", ManifestID: "m1"},
+	}}
+	manifests := &fakeManifestLookup{manifests: map[string]ManifestRec{
+		"m1": {ID: "m1", ProductID: "p1"},
+	}}
+	r := NewResolver(store, tasks, manifests)
+	ctx := context.Background()
+
+	// Pre-populate every tier with one entry so ResolveAll has reason to
+	// query at every scope. Setup queries are intentionally NOT zeroed yet —
+	// we reset the counter immediately before the call we want to measure.
+	mustSet(t, store, ScopeProduct, "p1", "max_turns", "10")
+	mustSet(t, store, ScopeManifest, "m1", "temperature", "0.5")
+	mustSet(t, store, ScopeTask, "t1", "default_model", `"gpt-5"`)
+
+	counter.Store(0)
+	if _, err := r.ResolveAll(ctx, Scope{TaskID: "t1", ManifestID: "m1", ProductID: "p1"}); err != nil {
+		t.Fatalf("ResolveAll: %v", err)
+	}
+	if got := counter.Load(); got != 3 {
+		t.Fatalf("ResolveAll issued %d DB queries, want exactly 3 (one per non-system tier)", got)
+	}
+}
+
+func TestResolver_ResolveAll_MixedProvenance(t *testing.T) {
+	r, store, _, _ := openResolverTestDB(t)
+	ctx := context.Background()
+
+	mustSet(t, store, ScopeTask, "t1", "max_turns", "30")
+	mustSet(t, store, ScopeManifest, "m1", "temperature", "0.9")
+	mustSet(t, store, ScopeProduct, "p1", "default_model", `"claude-sonnet-4-6"`)
+
+	out, err := r.ResolveAll(ctx, Scope{TaskID: "t1", ManifestID: "m1", ProductID: "p1"})
+	if err != nil {
+		t.Fatalf("ResolveAll: %v", err)
+	}
+
+	cases := []struct {
+		key        string
+		wantSource ScopeType
+		wantID     string
+	}{
+		{"max_turns", ScopeTask, "t1"},
+		{"temperature", ScopeManifest, "m1"},
+		{"default_model", ScopeProduct, "p1"},
+		{"daily_budget_usd", ScopeSystem, ""},
+		{"approval_mode", ScopeSystem, ""},
+	}
+	for _, tc := range cases {
+		got := out[tc.key]
+		if got.Source != tc.wantSource || got.SourceID != tc.wantID {
+			t.Errorf("%s source = %s/%s, want %s/%s",
+				tc.key, got.Source, got.SourceID, tc.wantSource, tc.wantID)
+		}
+	}
+}
+
+// NormalizeScope tests ——————————————————————————————————————————————————————
+
+func TestResolver_NormalizeScope_FillsManifestFromTaskID(t *testing.T) {
+	r, _, _, _ := openResolverTestDB(t)
+	got, err := r.NormalizeScope(context.Background(), Scope{TaskID: "t1"})
+	if err != nil {
+		t.Fatalf("NormalizeScope: %v", err)
+	}
+	if got.ManifestID != "m1" {
+		t.Errorf("ManifestID = %q, want m1", got.ManifestID)
+	}
+	if got.ProductID != "p1" {
+		t.Errorf("ProductID = %q, want p1 (chained promotion)", got.ProductID)
+	}
+}
+
+func TestResolver_NormalizeScope_FillsProductFromManifestID(t *testing.T) {
+	r, _, _, _ := openResolverTestDB(t)
+	got, err := r.NormalizeScope(context.Background(), Scope{ManifestID: "m1"})
+	if err != nil {
+		t.Fatalf("NormalizeScope: %v", err)
+	}
+	if got.ProductID != "p1" {
+		t.Errorf("ProductID = %q, want p1", got.ProductID)
+	}
+	if got.TaskID != "" {
+		t.Errorf("TaskID = %q, want unchanged empty", got.TaskID)
+	}
+}
+
+func TestResolver_NormalizeScope_RespectsExplicitOverrides(t *testing.T) {
+	r, _, _, _ := openResolverTestDB(t)
+	in := Scope{TaskID: "t1", ManifestID: "different-m", ProductID: "different-p"}
+	got, err := r.NormalizeScope(context.Background(), in)
+	if err != nil {
+		t.Fatalf("NormalizeScope: %v", err)
+	}
+	if got.ManifestID != "different-m" {
+		t.Errorf("ManifestID overwritten: got %q, want %q", got.ManifestID, "different-m")
+	}
+	if got.ProductID != "different-p" {
+		t.Errorf("ProductID overwritten: got %q, want %q", got.ProductID, "different-p")
+	}
+}
+
+func TestResolver_NormalizeScope_LookupError_PropagatesUpward(t *testing.T) {
+	r, _, tasks, _ := openResolverTestDB(t)
+	tasks.err = errors.New("boom")
+
+	_, err := r.NormalizeScope(context.Background(), Scope{TaskID: "t1"})
+	if !errors.Is(err, ErrResolveLookupFailed) {
+		t.Fatalf("expected ErrResolveLookupFailed, got %v", err)
+	}
+}
+
+// Helpers ——————————————————————————————————————————————————————————————————
+
+func mustSet(t *testing.T, s *Store, scope ScopeType, id, key, value string) {
+	t.Helper()
+	if err := s.Set(context.Background(), scope, id, key, value, "test"); err != nil {
+		t.Fatalf("Set %s/%s/%s: %v", scope, id, key, err)
+	}
+}
+
+// Counting driver wrapper ———————————————————————————————————————————————————
+//
+// Used only by TestResolver_ResolveAll_ThreeQueriesRegardlessOfCatalogSize
+// to guard the "≤3 DB queries per ResolveAll" performance contract. The
+// wrapper counts driver.Conn.Prepare(Context) calls — database/sql funnels
+// every QueryContext / ExecContext through Prepare when the conn does NOT
+// implement the QueryerContext / ExecerContext fast-paths, which is the
+// case here because we deliberately omit those methods on countingConn.
+
+var (
+	countingDriverOnce sync.Once
+	countingCounter    atomic.Int64
+)
+
+func openCountingResolverDB(t *testing.T) (*Store, *atomic.Int64) {
+	t.Helper()
+	countingDriverOnce.Do(func() {
+		sql.Register("sqlite3_settings_counting", &countingDriver{inner: &sqlite3.SQLiteDriver{}})
+	})
+
+	dbPath := filepath.Join(t.TempDir(), "settings.db")
+	db, err := sql.Open("sqlite3_settings_counting",
+		dbPath+"?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=on")
+	if err != nil {
+		t.Fatalf("open counting db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		t.Fatalf("set WAL: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
+		t.Fatalf("set busy_timeout: %v", err)
+	}
+	if err := InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+
+	return NewStore(db), &countingCounter
+}
+
+type countingDriver struct{ inner driver.Driver }
+
+func (d *countingDriver) Open(name string) (driver.Conn, error) {
+	c, err := d.inner.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &countingConn{inner: c}, nil
+}
+
+type countingConn struct {
+	inner driver.Conn
+}
+
+func (c *countingConn) Prepare(query string) (driver.Stmt, error) {
+	countingCounter.Add(1)
+	return c.inner.Prepare(query)
+}
+
+func (c *countingConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	countingCounter.Add(1)
+	if cp, ok := c.inner.(driver.ConnPrepareContext); ok {
+		return cp.PrepareContext(ctx, query)
+	}
+	return c.inner.Prepare(query)
+}
+
+func (c *countingConn) Begin() (driver.Tx, error) { return c.inner.Begin()}
+func (c *countingConn) Close() error              { return c.inner.Close() }


### PR DESCRIPTION
## Summary
- `Resolver.Resolve` + `ResolveAll` + `NormalizeScope` with typed provenance per knob
- `TaskLookup` / `ManifestLookup` minimal interfaces avoid an import cycle vs `internal/task` and `internal/manifest`; concrete adapters live in those packages (M4 will wire them)
- `ResolveAll` issues at most 3 DB queries regardless of catalog size (one `ListScope` per non-system tier), proven by a guard test using a wrapping `sql/driver` that counts `Prepare` calls
- 18 named tests covering provenance, typed decoding for all 5 KnobTypes, mixed-tier resolution, scope normalization, and lookup-error propagation

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./internal/settings/...` — clean
- [x] `go test -race ./internal/settings/...` — all green (T1 + T2 + T3 + T4)
- [x] `make test` — all green
- [x] Query-count guard test ensures `ResolveAll` does not explode N×catalog
- [x] T1 + T2 + T3 untouched (`schema.go`, `model.go`, `store.go`, `catalog.go`, `node.go`)

Closes M1 of #34. Refs manifest 019d9b70-452, product 019d9b6f-343, task M1-T4 of 14. Builds on PR #36, #37, #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)