### PR TITLE
Add MCP settings tools: catalog, get, set, resolve + visceral cap enforcement

### DIFF
--- a/internal/manifest/settings_adapter.go
+++ b/internal/manifest/settings_adapter.go
@@ -1,0 +1,33 @@
+package manifest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/k8nstantin/OpenPraxis/internal/settings"
+)
+
+// SettingsAdapter implements settings.ManifestLookup for the settings resolver.
+// Like its task counterpart it lives outside internal/settings to preserve the
+// import-cycle boundary — the resolver only references the minimal interface
+// declared in internal/settings/resolver.go.
+type SettingsAdapter struct {
+	Store *Store
+}
+
+// GetManifestForSettings returns the product id for a manifest, or an error
+// if the manifest cannot be found. The resolver uses this to promote a
+// manifest-scoped lookup to its parent product scope during inheritance walks.
+func (a *SettingsAdapter) GetManifestForSettings(_ context.Context, manifestID string) (settings.ManifestRec, error) {
+	if a == nil || a.Store == nil {
+		return settings.ManifestRec{}, fmt.Errorf("manifest settings adapter: store is nil")
+	}
+	m, err := a.Store.Get(manifestID)
+	if err != nil {
+		return settings.ManifestRec{}, fmt.Errorf("manifest settings adapter: get %q: %w", manifestID, err)
+	}
+	if m == nil {
+		return settings.ManifestRec{}, fmt.Errorf("manifest settings adapter: manifest %q not found", manifestID)
+	}
+	return settings.ManifestRec{ID: m.ID, ProductID: m.ProjectID}, nil
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -124,6 +124,7 @@ These behaviors are automatic. Never mention OpenPraxis to the user unless they 
 	s.registerIdeaTools()
 	s.registerLinkTools()
 	s.registerTaskTools()
+	s.registerSettingsTools()
 
 	s.http = mcpserver.NewStreamableHTTPServer(s.mcp,
 		mcpserver.WithSessionIdleTTL(2*time.Hour),

--- a/internal/mcp/tools_settings.go
+++ b/internal/mcp/tools_settings.go
@@ -1,0 +1,317 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/k8nstantin/OpenPraxis/internal/settings"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+// visceralRuleLoader returns the text of every active visceral rule. The MCP
+// layer calls this before writing settings that carry a visceral-backed cap
+// (e.g. daily_budget_usd is capped by rule #8). The indirection keeps the
+// core settings handlers testable without an index/memory store.
+type visceralRuleLoader func(ctx context.Context) ([]string, error)
+
+// visceralBudgetRe extracts a numeric ceiling from a rule text like
+// "daily budget = $100" or "cap is 100 USD". First capture group is the value.
+var visceralBudgetRe = regexp.MustCompile(`\$?([0-9]+(?:\.[0-9]+)?)`)
+
+// visceralCapFor reports the numeric ceiling enforced by active visceral rules
+// for a given knob key, if any. v1 hardcodes one mapping: daily_budget_usd →
+// the first rule whose text contains "daily budget". Extend here as new caps
+// are added. Returns (cap, true) when a cap applies; (0, false) otherwise.
+func visceralCapFor(key string, rules []string) (float64, bool) {
+	switch key {
+	case "daily_budget_usd":
+		for _, rule := range rules {
+			if !strings.Contains(strings.ToLower(rule), "daily budget") {
+				continue
+			}
+			m := visceralBudgetRe.FindStringSubmatch(rule)
+			if len(m) < 2 {
+				continue
+			}
+			v, err := strconv.ParseFloat(m[1], 64)
+			if err != nil {
+				continue
+			}
+			return v, true
+		}
+	}
+	return 0, false
+}
+
+func (s *Server) registerSettingsTools() {
+	s.mcp.AddTool(
+		mcplib.NewTool("settings_catalog",
+			mcplib.WithDescription("Return the catalog of v1 knob definitions (type, range, default, enum values). UIs use this to render the settings grid."),
+		),
+		s.handleSettingsCatalog,
+	)
+
+	s.mcp.AddTool(
+		mcplib.NewTool("settings_get",
+			mcplib.WithDescription("Return explicit settings at a single scope (product, manifest, or task). No inheritance walk — see settings_resolve for that."),
+			mcplib.WithString("scope_type", mcplib.Required(), mcplib.Description("Scope tier: 'product', 'manifest', or 'task'")),
+			mcplib.WithString("scope_id", mcplib.Required(), mcplib.Description("Scope entity id")),
+		),
+		s.handleSettingsGet,
+	)
+
+	s.mcp.AddTool(
+		mcplib.NewTool("settings_set",
+			mcplib.WithDescription("Write an explicit setting at a single scope. Value must be a JSON-encoded string (e.g. '10' for int, '\"auto\"' for enum). Returns soft warnings but does not block the save; visceral-rule caps (e.g. daily_budget_usd ≤ $100) and catalog type mismatches hard-block."),
+			mcplib.WithString("scope_type", mcplib.Required(), mcplib.Description("Scope tier: 'product', 'manifest', or 'task'")),
+			mcplib.WithString("scope_id", mcplib.Required(), mcplib.Description("Scope entity id")),
+			mcplib.WithString("key", mcplib.Required(), mcplib.Description("Knob key (must be in settings_catalog)")),
+			mcplib.WithString("value", mcplib.Required(), mcplib.Description("JSON-encoded value matching the knob's type")),
+		),
+		s.handleSettingsSet,
+	)
+
+	s.mcp.AddTool(
+		mcplib.NewTool("settings_resolve",
+			mcplib.WithDescription("Return the effective value for every knob at task scope, walking task → manifest → product → system. Each entry includes provenance (source tier + source id)."),
+			mcplib.WithString("task_id", mcplib.Required(), mcplib.Description("Task id to resolve for")),
+		),
+		s.handleSettingsResolve,
+	)
+}
+
+// -------- handlers -----------------------------------------------------------
+
+func (s *Server) handleSettingsCatalog(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	return jsonOrError(doSettingsCatalog())
+}
+
+func (s *Server) handleSettingsGet(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := args(req)
+	out, err := doSettingsGet(ctx, s.node.SettingsStore, argStr(a, "scope_type"), argStr(a, "scope_id"))
+	if err != nil {
+		return errResult("settings_get: %v", err), nil
+	}
+	return jsonOrError(out)
+}
+
+func (s *Server) handleSettingsSet(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := args(req)
+	out, err := doSettingsSet(ctx, s.node.SettingsStore, s.loadActiveVisceralRules,
+		argStr(a, "scope_type"), argStr(a, "scope_id"),
+		argStr(a, "key"), argStr(a, "value"),
+		mcpSetAuthor(ctx))
+	if err != nil {
+		return errResult("settings_set: %v", err), nil
+	}
+	return jsonOrError(out)
+}
+
+func (s *Server) handleSettingsResolve(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := args(req)
+	out, err := doSettingsResolve(ctx, s.node.SettingsResolver, argStr(a, "task_id"))
+	if err != nil {
+		return errResult("settings_resolve: %v", err), nil
+	}
+	return jsonOrError(out)
+}
+
+// -------- core (testable) ----------------------------------------------------
+
+type catalogOut struct {
+	Knobs []settings.KnobDef `json:"knobs"`
+}
+
+func doSettingsCatalog() catalogOut {
+	return catalogOut{Knobs: settings.Catalog()}
+}
+
+type getOut struct {
+	ScopeType string           `json:"scope_type"`
+	ScopeID   string           `json:"scope_id"`
+	Entries   []settings.Entry `json:"entries"`
+}
+
+func doSettingsGet(ctx context.Context, store *settings.Store, scopeType, scopeID string) (getOut, error) {
+	if store == nil {
+		return getOut{}, fmt.Errorf("settings store not configured")
+	}
+	if scopeType == "" || scopeID == "" {
+		return getOut{}, fmt.Errorf("scope_type and scope_id are required")
+	}
+	st := settings.ScopeType(scopeType)
+	if err := validateWritableScope(st); err != nil {
+		return getOut{}, err
+	}
+	entries, err := store.ListScope(ctx, st, scopeID)
+	if err != nil {
+		return getOut{}, err
+	}
+	if entries == nil {
+		entries = []settings.Entry{}
+	}
+	return getOut{ScopeType: scopeType, ScopeID: scopeID, Entries: entries}, nil
+}
+
+type setOut struct {
+	OK       bool             `json:"ok"`
+	Warnings []string         `json:"warnings,omitempty"`
+	Entry    *settings.Entry  `json:"entry,omitempty"`
+	Catalog  *settings.KnobDef `json:"catalog,omitempty"`
+}
+
+func doSettingsSet(
+	ctx context.Context,
+	store *settings.Store,
+	loadRules visceralRuleLoader,
+	scopeType, scopeID, key, value, author string,
+) (setOut, error) {
+	if store == nil {
+		return setOut{}, fmt.Errorf("settings store not configured")
+	}
+	if scopeType == "" || scopeID == "" || key == "" || value == "" {
+		return setOut{}, fmt.Errorf("scope_type, scope_id, key, value are required")
+	}
+	st := settings.ScopeType(scopeType)
+	if err := validateWritableScope(st); err != nil {
+		return setOut{}, err
+	}
+
+	warnings, err := settings.ValidateValue(key, value)
+	if err != nil {
+		return setOut{}, err
+	}
+
+	// Visceral-rule clamp — MCP layer only. Catalog layer intentionally
+	// skips this so pure catalog validation stays shape/type focused.
+	if hasVisceralCap(key) {
+		var rules []string
+		if loadRules != nil {
+			loaded, lerr := loadRules(ctx)
+			if lerr != nil {
+				return setOut{}, fmt.Errorf("load visceral rules: %w", lerr)
+			}
+			rules = loaded
+		}
+		if ceiling, ok := visceralCapFor(key, rules); ok {
+			exceeds, err := valueExceedsCap(value, ceiling)
+			if err != nil {
+				return setOut{}, err
+			}
+			if exceeds {
+				return setOut{}, fmt.Errorf("Visceral rule #8 caps %s at $%v. Raise the rule first via visceral_set.", key, ceiling)
+			}
+		}
+	}
+
+	if err := store.Set(ctx, st, scopeID, key, value, author); err != nil {
+		return setOut{}, err
+	}
+
+	entry, err := store.Get(ctx, st, scopeID, key)
+	if err != nil {
+		return setOut{}, fmt.Errorf("readback after set: %w", err)
+	}
+	knob, _ := settings.KnobByKey(key)
+	return setOut{OK: true, Warnings: warnings, Entry: &entry, Catalog: &knob}, nil
+}
+
+type resolveOut struct {
+	TaskID   string                       `json:"task_id"`
+	Resolved map[string]settings.Resolved `json:"resolved"`
+}
+
+func doSettingsResolve(ctx context.Context, resolver *settings.Resolver, taskID string) (resolveOut, error) {
+	if resolver == nil {
+		return resolveOut{}, fmt.Errorf("settings resolver not configured")
+	}
+	if taskID == "" {
+		return resolveOut{}, fmt.Errorf("task_id is required")
+	}
+	resolved, err := resolver.ResolveAll(ctx, settings.Scope{TaskID: taskID})
+	if err != nil {
+		return resolveOut{}, err
+	}
+	return resolveOut{TaskID: taskID, Resolved: resolved}, nil
+}
+
+// -------- helpers ------------------------------------------------------------
+
+// validateWritableScope rejects scope_type values that aren't one of the three
+// user-writable tiers. System-scope values come from the catalog defaults and
+// cannot be mutated via the MCP surface.
+func validateWritableScope(st settings.ScopeType) error {
+	switch st {
+	case settings.ScopeProduct, settings.ScopeManifest, settings.ScopeTask:
+		return nil
+	case settings.ScopeSystem:
+		return fmt.Errorf("scope_type %q is read-only — system defaults come from the catalog", st)
+	default:
+		return fmt.Errorf("scope_type must be one of product|manifest|task, got %q", string(st))
+	}
+}
+
+// hasVisceralCap reports whether a knob key has a visceral-rule ceiling
+// registered in v1. Used to short-circuit the visceral-rule load for keys
+// that never need it.
+func hasVisceralCap(key string) bool {
+	return key == "daily_budget_usd"
+}
+
+// valueExceedsCap parses a JSON-encoded numeric value and reports whether it
+// is greater than the ceiling. Type mismatch returns an error; non-numeric
+// knobs should never reach this path (hasVisceralCap gates entry).
+func valueExceedsCap(jsonValue string, ceiling float64) (bool, error) {
+	var n float64
+	if err := json.Unmarshal([]byte(jsonValue), &n); err != nil {
+		return false, fmt.Errorf("visceral cap check: %q is not numeric: %w", jsonValue, err)
+	}
+	return n > ceiling, nil
+}
+
+// loadActiveVisceralRules pulls the text of every active visceral rule from
+// the memory index. Production wiring for doSettingsSet.
+func (s *Server) loadActiveVisceralRules(_ context.Context) ([]string, error) {
+	mems, err := s.node.Index.ListByType("visceral", 100)
+	if err != nil {
+		return nil, err
+	}
+	texts := make([]string, 0, len(mems))
+	for _, m := range mems {
+		texts = append(texts, m.L2)
+	}
+	return texts, nil
+}
+
+// mcpSetAuthor returns the author string recorded on settings writes. Uses the
+// MCP session id when available so audits can trace who set what; falls back
+// to "mcp:unknown" for calls that arrive without a session (e.g. bare stdio
+// invocations before initialize). The "mcp:" prefix distinguishes MCP writes
+// from HTTP/UI writes M2-T6 will add later.
+func mcpSetAuthor(ctx context.Context) string {
+	session := mcpserver.ClientSessionFromContext(ctx)
+	if session == nil {
+		return "mcp:unknown"
+	}
+	id := session.SessionID()
+	if id == "" {
+		return "mcp:unknown"
+	}
+	return "mcp:" + id
+}
+
+// jsonOrError marshals v as pretty JSON and returns it as a tool text result,
+// or returns an MCP error result when marshal fails.
+func jsonOrError(v interface{}) (*mcplib.CallToolResult, error) {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errResult("marshal: %v", err), nil
+	}
+	return textResult(string(data)), nil
+}

--- a/internal/mcp/tools_settings_test.go
+++ b/internal/mcp/tools_settings_test.go
@@ -1,0 +1,377 @@
+package mcp
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/k8nstantin/OpenPraxis/internal/settings"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// -------- test harness -------------------------------------------------------
+
+type fakeTaskLookup struct {
+	tasks map[string]settings.TaskRec
+}
+
+func (f *fakeTaskLookup) GetTaskForSettings(_ context.Context, taskID string) (settings.TaskRec, error) {
+	r, ok := f.tasks[taskID]
+	if !ok {
+		return settings.TaskRec{}, fmt.Errorf("fake task lookup: %q not found", taskID)
+	}
+	return r, nil
+}
+
+type fakeManifestLookup struct {
+	manifests map[string]settings.ManifestRec
+}
+
+func (f *fakeManifestLookup) GetManifestForSettings(_ context.Context, manifestID string) (settings.ManifestRec, error) {
+	r, ok := f.manifests[manifestID]
+	if !ok {
+		return settings.ManifestRec{}, fmt.Errorf("fake manifest lookup: %q not found", manifestID)
+	}
+	return r, nil
+}
+
+// settingsHarness wires a real settings.Store (in-memory sqlite) and a
+// Resolver with fake lookups covering one task → manifest → product chain
+// (t1 → m1 → p1). Individual tests mutate the fake maps or Store as needed.
+type settingsHarness struct {
+	db       *sql.DB
+	store    *settings.Store
+	resolver *settings.Resolver
+	tasks    *fakeTaskLookup
+	mans     *fakeManifestLookup
+}
+
+func newSettingsHarness(t *testing.T) *settingsHarness {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "settings.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		t.Fatalf("set WAL: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
+		t.Fatalf("set busy_timeout: %v", err)
+	}
+	if err := settings.InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	store := settings.NewStore(db)
+	tasks := &fakeTaskLookup{tasks: map[string]settings.TaskRec{
+		"t1": {ID: "t1", ManifestID: "m1"},
+	}}
+	mans := &fakeManifestLookup{manifests: map[string]settings.ManifestRec{
+		"m1": {ID: "m1", ProductID: "p1"},
+	}}
+	return &settingsHarness{
+		db:       db,
+		store:    store,
+		resolver: settings.NewResolver(store, tasks, mans),
+		tasks:    tasks,
+		mans:     mans,
+	}
+}
+
+// noVisceralRules is the visceralRuleLoader used when the test does not care
+// about visceral clamping.
+func noVisceralRules(_ context.Context) ([]string, error) { return nil, nil }
+
+// budgetRuleLoader returns a single rule mirroring rule #8 ("daily budget =
+// $100") so tests can exercise the visceral cap path deterministically.
+func budgetRuleLoader(ceiling string) visceralRuleLoader {
+	return func(_ context.Context) ([]string, error) {
+		return []string{"daily budget = " + ceiling}, nil
+	}
+}
+
+// -------- settings_catalog ---------------------------------------------------
+
+func TestTool_SettingsCatalog_ReturnsAllKnobs(t *testing.T) {
+	out := doSettingsCatalog()
+	if got, want := len(out.Knobs), len(settings.Catalog()); got != want {
+		t.Fatalf("knob count: got %d want %d", got, want)
+	}
+	// Order must match catalog order — UIs depend on it.
+	for i, k := range out.Knobs {
+		if k.Key != settings.Catalog()[i].Key {
+			t.Fatalf("knob[%d] key: got %q want %q", i, k.Key, settings.Catalog()[i].Key)
+		}
+	}
+}
+
+func TestTool_SettingsCatalog_EveryKnobHasRequiredFields(t *testing.T) {
+	out := doSettingsCatalog()
+	for _, k := range out.Knobs {
+		if k.Key == "" {
+			t.Errorf("knob has empty key: %+v", k)
+		}
+		if k.Type == "" {
+			t.Errorf("knob %q has empty type", k.Key)
+		}
+		if k.Description == "" {
+			t.Errorf("knob %q has empty description", k.Key)
+		}
+		// Every knob must declare a default so the resolver can fall back.
+		if _, ok := settings.SystemDefault(k.Key); !ok {
+			t.Errorf("knob %q has no SystemDefault", k.Key)
+		}
+	}
+}
+
+// -------- settings_get -------------------------------------------------------
+
+func TestTool_SettingsGet_ReturnsExplicitOnly(t *testing.T) {
+	h := newSettingsHarness(t)
+	ctx := context.Background()
+
+	// Seed explicit entries at product + manifest scopes. settings_get at the
+	// product scope must return ONLY the product row, not the manifest row.
+	if err := h.store.Set(ctx, settings.ScopeProduct, "p1", "max_turns", "100", "seed"); err != nil {
+		t.Fatalf("seed product: %v", err)
+	}
+	if err := h.store.Set(ctx, settings.ScopeManifest, "m1", "max_turns", "200", "seed"); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+
+	out, err := doSettingsGet(ctx, h.store, "product", "p1")
+	if err != nil {
+		t.Fatalf("doSettingsGet: %v", err)
+	}
+	if len(out.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %+v", len(out.Entries), out.Entries)
+	}
+	if out.Entries[0].Value != "100" {
+		t.Errorf("explicit value: got %q want %q", out.Entries[0].Value, "100")
+	}
+	if out.ScopeType != "product" || out.ScopeID != "p1" {
+		t.Errorf("scope echoed incorrectly: %+v", out)
+	}
+}
+
+func TestTool_SettingsGet_EmptyScope_ReturnsEmptyList(t *testing.T) {
+	h := newSettingsHarness(t)
+	out, err := doSettingsGet(context.Background(), h.store, "task", "t-empty")
+	if err != nil {
+		t.Fatalf("doSettingsGet: %v", err)
+	}
+	if len(out.Entries) != 0 {
+		t.Fatalf("expected empty, got %+v", out.Entries)
+	}
+	// Must be an empty non-nil slice so JSON serializes to [] not null.
+	if out.Entries == nil {
+		t.Fatal("Entries is nil; expected empty slice")
+	}
+}
+
+func TestTool_SettingsGet_UnknownScopeType_Returns400(t *testing.T) {
+	h := newSettingsHarness(t)
+	_, err := doSettingsGet(context.Background(), h.store, "region", "us-east")
+	if err == nil {
+		t.Fatal("expected error for unknown scope_type, got nil")
+	}
+	if !strings.Contains(err.Error(), "scope_type") {
+		t.Errorf("error should mention scope_type, got: %v", err)
+	}
+	// system scope is declared but not writable via the MCP surface.
+	if _, err := doSettingsGet(context.Background(), h.store, "system", "whatever"); err == nil {
+		t.Fatal("expected error for system scope, got nil")
+	}
+}
+
+// -------- settings_set -------------------------------------------------------
+
+func TestTool_SettingsSet_ValidValue_Persists(t *testing.T) {
+	h := newSettingsHarness(t)
+	ctx := context.Background()
+
+	out, err := doSettingsSet(ctx, h.store, noVisceralRules,
+		"product", "p1", "max_turns", "250", "mcp:sess-A")
+	if err != nil {
+		t.Fatalf("doSettingsSet: %v", err)
+	}
+	if !out.OK {
+		t.Fatalf("OK=false: %+v", out)
+	}
+	if out.Entry == nil || out.Entry.Value != "250" {
+		t.Fatalf("readback entry wrong: %+v", out.Entry)
+	}
+
+	// Verify persistence with a direct store read.
+	entry, err := h.store.Get(ctx, settings.ScopeProduct, "p1", "max_turns")
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	if entry.Value != "250" {
+		t.Errorf("persisted value: got %q want %q", entry.Value, "250")
+	}
+}
+
+func TestTool_SettingsSet_TypeMismatch_Returns400(t *testing.T) {
+	h := newSettingsHarness(t)
+	// max_turns is int; passing a JSON string must hard-fail.
+	_, err := doSettingsSet(context.Background(), h.store, noVisceralRules,
+		"product", "p1", "max_turns", `"lots"`, "mcp:sess-A")
+	if err == nil {
+		t.Fatal("expected type mismatch error, got nil")
+	}
+	if !errors.Is(err, settings.ErrTypeMismatch) {
+		t.Errorf("expected ErrTypeMismatch, got %v", err)
+	}
+
+	// Nothing should have been written.
+	if _, gerr := h.store.Get(context.Background(), settings.ScopeProduct, "p1", "max_turns"); !errors.Is(gerr, sql.ErrNoRows) {
+		t.Errorf("expected sql.ErrNoRows after hard-fail; got %v", gerr)
+	}
+}
+
+func TestTool_SettingsSet_UnknownKey_Returns400(t *testing.T) {
+	h := newSettingsHarness(t)
+	_, err := doSettingsSet(context.Background(), h.store, noVisceralRules,
+		"product", "p1", "no_such_knob", "42", "mcp:sess-A")
+	if err == nil {
+		t.Fatal("expected unknown-key error, got nil")
+	}
+	if !errors.Is(err, settings.ErrUnknownKey) {
+		t.Errorf("expected ErrUnknownKey, got %v", err)
+	}
+}
+
+func TestTool_SettingsSet_SliderOverRange_ReturnsWarningButPersists(t *testing.T) {
+	h := newSettingsHarness(t)
+	ctx := context.Background()
+
+	// max_turns slider caps at 10000 per catalog. 99999 should warn, not block.
+	out, err := doSettingsSet(ctx, h.store, noVisceralRules,
+		"product", "p1", "max_turns", "99999", "mcp:sess-A")
+	if err != nil {
+		t.Fatalf("doSettingsSet: %v", err)
+	}
+	if !out.OK {
+		t.Fatalf("OK=false: %+v", out)
+	}
+	if len(out.Warnings) == 0 {
+		t.Fatalf("expected at least one warning, got none")
+	}
+	entry, err := h.store.Get(ctx, settings.ScopeProduct, "p1", "max_turns")
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	if entry.Value != "99999" {
+		t.Errorf("persisted value: got %q want %q", entry.Value, "99999")
+	}
+}
+
+func TestTool_SettingsSet_DailyBudgetOverVisceralCap_Rejected(t *testing.T) {
+	h := newSettingsHarness(t)
+	ctx := context.Background()
+
+	// Visceral rule #8 caps daily_budget_usd at $100.
+	_, err := doSettingsSet(ctx, h.store, budgetRuleLoader("$100"),
+		"product", "p1", "daily_budget_usd", "500", "mcp:sess-A")
+	if err == nil {
+		t.Fatal("expected visceral cap rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "Visceral rule") {
+		t.Errorf("error should reference visceral rule, got: %v", err)
+	}
+
+	// Must NOT have written anything.
+	if _, gerr := h.store.Get(ctx, settings.ScopeProduct, "p1", "daily_budget_usd"); !errors.Is(gerr, sql.ErrNoRows) {
+		t.Errorf("write leaked past visceral cap: %v", gerr)
+	}
+
+	// Value at the cap must pass.
+	if _, err := doSettingsSet(ctx, h.store, budgetRuleLoader("$100"),
+		"product", "p1", "daily_budget_usd", "100", "mcp:sess-A"); err != nil {
+		t.Fatalf("value at cap should pass: %v", err)
+	}
+
+	// Non-budget keys must not be blocked even when visceral rules are loaded.
+	if _, err := doSettingsSet(ctx, h.store, budgetRuleLoader("$100"),
+		"product", "p1", "max_turns", "200", "mcp:sess-A"); err != nil {
+		t.Fatalf("unrelated key blocked by cap path: %v", err)
+	}
+}
+
+func TestTool_SettingsSet_RecordsAuthor(t *testing.T) {
+	h := newSettingsHarness(t)
+	ctx := context.Background()
+
+	author := "mcp:sess-deadbeef"
+	if _, err := doSettingsSet(ctx, h.store, noVisceralRules,
+		"manifest", "m1", "temperature", "0.5", author); err != nil {
+		t.Fatalf("doSettingsSet: %v", err)
+	}
+	entry, err := h.store.Get(ctx, settings.ScopeManifest, "m1", "temperature")
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	if entry.UpdatedBy != author {
+		t.Errorf("author: got %q want %q", entry.UpdatedBy, author)
+	}
+}
+
+// -------- settings_resolve ---------------------------------------------------
+
+func TestTool_SettingsResolve_ReturnsProvenanceForEveryKnob(t *testing.T) {
+	h := newSettingsHarness(t)
+	ctx := context.Background()
+
+	// Seed one override at each scope tier so provenance is unambiguous.
+	if err := h.store.Set(ctx, settings.ScopeTask, "t1", "max_turns", "7", "seed"); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+	if err := h.store.Set(ctx, settings.ScopeManifest, "m1", "temperature", "0.9", "seed"); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+	if err := h.store.Set(ctx, settings.ScopeProduct, "p1", "max_parallel", "8", "seed"); err != nil {
+		t.Fatalf("seed product: %v", err)
+	}
+
+	out, err := doSettingsResolve(ctx, h.resolver, "t1")
+	if err != nil {
+		t.Fatalf("doSettingsResolve: %v", err)
+	}
+	if got, want := len(out.Resolved), len(settings.Catalog()); got != want {
+		t.Fatalf("resolved count: got %d want %d", got, want)
+	}
+
+	assertSource := func(key string, src settings.ScopeType, srcID string) {
+		t.Helper()
+		r, ok := out.Resolved[key]
+		if !ok {
+			t.Fatalf("missing resolved entry for %q", key)
+		}
+		if r.Source != src || r.SourceID != srcID {
+			t.Errorf("%s provenance: got source=%q id=%q want source=%q id=%q",
+				key, r.Source, r.SourceID, src, srcID)
+		}
+	}
+
+	assertSource("max_turns", settings.ScopeTask, "t1")
+	assertSource("temperature", settings.ScopeManifest, "m1")
+	assertSource("max_parallel", settings.ScopeProduct, "p1")
+
+	// A knob with no override anywhere falls back to system.
+	assertSource("approval_mode", settings.ScopeSystem, "")
+}
+
+func TestTool_SettingsResolve_UnknownTask_ReturnsError(t *testing.T) {
+	h := newSettingsHarness(t)
+	_, err := doSettingsResolve(context.Background(), h.resolver, "t-does-not-exist")
+	if err == nil {
+		t.Fatal("expected resolver lookup error, got nil")
+	}
+}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -23,21 +23,23 @@ import (
 
 // Node is the central orchestrator that wires all components together.
 type Node struct {
-	Config        *config.Config
-	Store         *memory.Store
-	Index         *memory.Index
-	Conversations *conversation.Store
-	Markers       *marker.Store
-	Actions       *action.Store
-	Products      *product.Store
-	Manifests     *manifest.Store
-	Ideas         *idea.Store
-	Tasks         *task.Store
-	ChatSessions  *chat.SessionStore
-	Watcher       *watcher.Store
-	runner        *task.Runner
-	Embedder      *embedding.Engine
-	StartedAt     time.Time
+	Config           *config.Config
+	Store            *memory.Store
+	Index            *memory.Index
+	Conversations    *conversation.Store
+	Markers          *marker.Store
+	Actions          *action.Store
+	Products         *product.Store
+	Manifests        *manifest.Store
+	Ideas            *idea.Store
+	Tasks            *task.Store
+	ChatSessions     *chat.SessionStore
+	Watcher          *watcher.Store
+	SettingsStore    *settings.Store
+	SettingsResolver *settings.Resolver
+	runner           *task.Runner
+	Embedder         *embedding.Engine
+	StartedAt        time.Time
 }
 
 // New creates and initializes a Node.
@@ -102,23 +104,30 @@ func New(cfg *config.Config) (*Node, error) {
 		return nil, fmt.Errorf("init settings schema: %w", err)
 	}
 
+	settingsStore := settings.NewStore(index.DB())
+	taskSettingsAdapter := &task.SettingsAdapter{Store: taskStore}
+	manifestSettingsAdapter := &manifest.SettingsAdapter{Store: manifestStore}
+	settingsResolver := settings.NewResolver(settingsStore, taskSettingsAdapter, manifestSettingsAdapter)
+
 	embedder := embedding.NewEngine(cfg.Embedding.OllamaURL, cfg.Embedding.Model, cfg.Embedding.Dimension)
 
 	n := &Node{
-		Config:        cfg,
-		Store:         store,
-		Index:         index,
-		Conversations: convStore,
-		Markers:       markerStore,
-		Actions:       actionStore,
-		Products:      productStore,
-		Manifests:     manifestStore,
-		Ideas:         ideaStore,
-		Tasks:         taskStore,
-		ChatSessions:  chatStore,
-		Watcher:       watcherStore,
-		Embedder:      embedder,
-		StartedAt:     time.Now(),
+		Config:           cfg,
+		Store:            store,
+		Index:            index,
+		Conversations:    convStore,
+		Markers:          markerStore,
+		Actions:          actionStore,
+		Products:         productStore,
+		Manifests:        manifestStore,
+		Ideas:            ideaStore,
+		Tasks:            taskStore,
+		ChatSessions:     chatStore,
+		Watcher:          watcherStore,
+		SettingsStore:    settingsStore,
+		SettingsResolver: settingsResolver,
+		Embedder:         embedder,
+		StartedAt:        time.Now(),
 	}
 
 	// One-time migration: normalize source_node from hostname to UUID

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -95,7 +95,9 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 	// Build the prompt
 	prompt := buildPrompt(t, manifestTitle, manifestContent, visceralRules)
 
-	// Build allowed tools list — OpenPraxis MCP tools + standard tools
+	// Build allowed tools list — OpenPraxis MCP tools + standard tools.
+	// settings_set is deliberately NOT allowlisted: agents should consult their
+	// own budgets via settings_get/resolve but must not mutate them mid-run.
 	allowedTools := []string{
 		"Bash", "Read", "Write", "Edit", "Glob", "Grep",
 		"mcp__openpraxis__memory_store",
@@ -105,6 +107,9 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 		"mcp__openpraxis__visceral_confirm",
 		"mcp__openpraxis__manifest_get",
 		"mcp__openpraxis__conversation_save",
+		"mcp__openpraxis__settings_get",
+		"mcp__openpraxis__settings_resolve",
+		"mcp__openpraxis__settings_catalog",
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)

--- a/internal/task/settings_adapter.go
+++ b/internal/task/settings_adapter.go
@@ -1,0 +1,33 @@
+package task
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/k8nstantin/OpenPraxis/internal/settings"
+)
+
+// SettingsAdapter implements settings.TaskLookup for the settings resolver.
+// It lives in internal/task (not internal/settings) so the settings package
+// stays free of a task import — the resolver needs only the minimal interface
+// declared in internal/settings/resolver.go.
+type SettingsAdapter struct {
+	Store *Store
+}
+
+// GetTaskForSettings returns the manifest id for a task, or an error if the
+// task cannot be found. The resolver uses this to promote a task-scoped lookup
+// to its parent manifest scope during inheritance walks.
+func (a *SettingsAdapter) GetTaskForSettings(_ context.Context, taskID string) (settings.TaskRec, error) {
+	if a == nil || a.Store == nil {
+		return settings.TaskRec{}, fmt.Errorf("task settings adapter: store is nil")
+	}
+	t, err := a.Store.Get(taskID)
+	if err != nil {
+		return settings.TaskRec{}, fmt.Errorf("task settings adapter: get %q: %w", taskID, err)
+	}
+	if t == nil {
+		return settings.TaskRec{}, fmt.Errorf("task settings adapter: task %q not found", taskID)
+	}
+	return settings.TaskRec{ID: t.ID, ManifestID: t.ManifestID}, nil
+}


### PR DESCRIPTION
## Summary
- 4 MCP tools exposing M1's Resolver + Store + Catalog: `settings_catalog`, `settings_get`, `settings_set`, `settings_resolve`
- Visceral-rule clamp on `daily_budget_usd` enforced at the MCP layer only — catalog/store boundaries preserved
- `TaskSettingsAdapter` + `ManifestSettingsAdapter` live in their own packages (`internal/task`, `internal/manifest`) to keep `internal/settings` import-cycle free
- Node wires Resolver once at startup, exposes `SettingsStore` + `SettingsResolver`
- Agent default allowlist updated: get/resolve/catalog YES, set NO (agents can consult their budgets but cannot mutate them mid-run)
- 13 tests covering every tool + failure mode + visceral enforcement

## Design notes
- Author field: `"mcp:" + session_id` from the MCP request context (falls back to `"mcp:unknown"` when no session is bound)
- Visceral cap helper (`visceralCapFor`) currently hardcodes one mapping (`daily_budget_usd` → rule #8) and extracts the numeric ceiling with a regex; extensible as new caps are added
- `hasVisceralCap` gates the visceral-rule load so non-budget writes don't pay the cost
- Soft warnings (e.g. slider over-range) surface in the response but do not block the save — matches the spec

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -race ./internal/mcp/... ./internal/task/... ./internal/manifest/... ./internal/node/... ./internal/settings/...` — all green
- [x] `make test` — all green, no M1 regression

Closes M2-T5 of #34. Builds on PRs #36, #37, #39, #40.

Refs manifest `019d9b70-7e3`, product `019d9b6f-343`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)