### PR TITLE
Add OL.renderKnobSection component + DELETE settings endpoint (M3-T7)

### DIFF
--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -57,6 +57,7 @@ func Handler(n *node.Node, mcpServer *mcp.Server, hub *Hub, peerRegistry *peer.R
 		w.Write(data)
 	}
 	r.PathPrefix("/views/").HandlerFunc(serveJS)
+	r.PathPrefix("/components/").HandlerFunc(serveJS)
 	r.Path("/app.js").HandlerFunc(serveJS)
 	r.Path("/api.js").HandlerFunc(serveJS)
 	r.Path("/tree.js").HandlerFunc(serveJS)

--- a/internal/web/handlers_settings_exec.go
+++ b/internal/web/handlers_settings_exec.go
@@ -223,6 +223,45 @@ func apiTaskSettingsResolved(n *node.Node) http.HandlerFunc {
 	}
 }
 
+// apiScopeSettingsDelete removes the explicit entry at (scopeType, id, key) so
+// the resolver falls back to the next tier up. This is the "Reset to inherited"
+// action in the dashboard — M2 built GET + PUT but no per-key DELETE; M3-T7
+// added this minimal endpoint so the Reset button in OL.renderKnobSection has
+// semantically clear wire shape instead of overloading PUT with a null value.
+//
+// Unknown keys are rejected (keeps typo safety on the URL). The store's Delete
+// is idempotent, so deleting a key that has no explicit row returns 200.
+func apiScopeSettingsDelete(n *node.Node, scopeType string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		id := vars["id"]
+		key := vars["key"]
+		if id == "" || key == "" {
+			writeError(w, "scope id and key are required", http.StatusBadRequest)
+			return
+		}
+		if _, ok := settings.KnobByKey(key); !ok {
+			writeError(w, fmt.Sprintf("%s: %q", settings.ErrUnknownKey, key), http.StatusBadRequest)
+			return
+		}
+		st := settings.ScopeType(scopeType)
+		if err := mcp.ValidateWritableScope(st); err != nil {
+			writeError(w, err.Error(), settingsHTTPStatus(err))
+			return
+		}
+		if err := n.SettingsStore.Delete(r.Context(), st, id, key); err != nil {
+			writeError(w, err.Error(), settingsHTTPStatus(err))
+			return
+		}
+		writeJSON(w, map[string]any{
+			"ok":         true,
+			"scope_type": scopeType,
+			"scope_id":   id,
+			"key":        key,
+		})
+	}
+}
+
 // registerSettingsExecRoutes attaches all 9 hierarchical-settings endpoints to
 // the /api subrouter. Centralized here so the wiring stays in lockstep with
 // the catalog of scopes.
@@ -232,6 +271,8 @@ func registerSettingsExecRoutes(api *mux.Router, n *node.Node) {
 		path := fmt.Sprintf("/%ss/{id}/settings", scope)
 		api.HandleFunc(path, apiScopeSettingsGet(n, scope)).Methods("GET")
 		api.HandleFunc(path, apiScopeSettingsPut(n, scope)).Methods("PUT")
+		// Per-key delete — Reset-to-inherited for the knob UI (M3-T7).
+		api.HandleFunc(path+"/{key}", apiScopeSettingsDelete(n, scope)).Methods("DELETE")
 	}
 	api.HandleFunc("/tasks/{id}/settings/resolved", apiTaskSettingsResolved(n)).Methods("GET")
 }

--- a/internal/web/handlers_settings_exec_test.go
+++ b/internal/web/handlers_settings_exec_test.go
@@ -111,6 +111,7 @@ func buildRouter(env *settingsTestEnv, loader mcp.VisceralRuleLoader) *mux.Route
 		path := fmt.Sprintf("/%ss/{id}/settings", scope)
 		api.HandleFunc(path, scopeGetHandler(env, scope)).Methods("GET")
 		api.HandleFunc(path, scopePutHandler(env, scope, loader)).Methods("PUT")
+		api.HandleFunc(path+"/{key}", scopeDeleteHandler(env, scope)).Methods("DELETE")
 	}
 	api.HandleFunc("/tasks/{id}/settings/resolved", taskResolvedHandler(env)).Methods("GET")
 	return r
@@ -175,6 +176,39 @@ func taskResolvedHandler(env *settingsTestEnv) http.HandlerFunc {
 			return
 		}
 		writeJSON(w, resolvedResponse{TaskID: out.TaskID, Resolved: out.Resolved})
+	}
+}
+
+// scopeDeleteHandler mirrors the production apiScopeSettingsDelete without
+// requiring a full Node. Keeps the test router isomorphic to production wiring.
+func scopeDeleteHandler(env *settingsTestEnv, scopeType string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		id := vars["id"]
+		key := vars["key"]
+		if id == "" || key == "" {
+			writeError(w, "scope id and key are required", http.StatusBadRequest)
+			return
+		}
+		if _, ok := settings.KnobByKey(key); !ok {
+			writeError(w, fmt.Sprintf("%s: %q", settings.ErrUnknownKey, key), http.StatusBadRequest)
+			return
+		}
+		st := settings.ScopeType(scopeType)
+		if err := mcp.ValidateWritableScope(st); err != nil {
+			writeError(w, err.Error(), settingsHTTPStatus(err))
+			return
+		}
+		if err := env.store.Delete(r.Context(), st, id, key); err != nil {
+			writeError(w, err.Error(), settingsHTTPStatus(err))
+			return
+		}
+		writeJSON(w, map[string]any{
+			"ok":         true,
+			"scope_type": scopeType,
+			"scope_id":   id,
+			"key":        key,
+		})
 	}
 }
 
@@ -542,6 +576,10 @@ func TestRoutes_AllSettingsEndpointsRegistered(t *testing.T) {
 		{http.MethodGet, "/api/tasks/t1/settings"},
 		{http.MethodPut, "/api/tasks/t1/settings"},
 		{http.MethodGet, "/api/tasks/t1/settings/resolved"},
+		// M3-T7 additions — per-key DELETE for "Reset to inherited" UX.
+		{http.MethodDelete, "/api/products/p1/settings/max_turns"},
+		{http.MethodDelete, "/api/manifests/m1/settings/max_turns"},
+		{http.MethodDelete, "/api/tasks/t1/settings/max_turns"},
 	}
 	for _, c := range cases {
 		var body []byte
@@ -552,5 +590,52 @@ func TestRoutes_AllSettingsEndpointsRegistered(t *testing.T) {
 		if rec.Code == http.StatusNotFound {
 			t.Errorf("route %s %s returned 404 — not registered", c.method, c.path)
 		}
+	}
+}
+
+// ---- DELETE /api/{scope}/:id/settings/:key ----------------------------------
+//
+// M3-T7 added this endpoint so the Reset-to-inherited button in the knob UI
+// has a semantically clean wire shape (instead of overloading PUT with null).
+
+func TestHandleDeleteScopeSettings_RemovesExplicitEntry(t *testing.T) {
+	env := newSettingsTestEnv(t)
+	ctx := context.Background()
+	if err := env.store.Set(ctx, settings.ScopeTask, "t1", "max_turns", "75", "seed"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	r := buildRouter(env, noVisceralRulesHTTP)
+	rec := doRequest(t, r, http.MethodDelete, "/api/tasks/t1/settings/max_turns", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d body=%s", rec.Code, rec.Body.String())
+	}
+	// Entry must be gone so the resolver falls through to the next tier.
+	if _, err := env.store.Get(ctx, settings.ScopeTask, "t1", "max_turns"); err == nil {
+		t.Errorf("explicit entry still present after DELETE")
+	}
+}
+
+func TestHandleDeleteScopeSettings_Idempotent_ReturnsOKOnMissingEntry(t *testing.T) {
+	env := newSettingsTestEnv(t)
+	r := buildRouter(env, noVisceralRulesHTTP)
+	// No prior Set — delete should still report ok=true (store.Delete is idempotent).
+	rec := doRequest(t, r, http.MethodDelete, "/api/products/p1/settings/temperature", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 on missing entry, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"ok":true`) {
+		t.Errorf("body should report ok=true, got %s", rec.Body.String())
+	}
+}
+
+func TestHandleDeleteScopeSettings_UnknownKey_Returns400(t *testing.T) {
+	env := newSettingsTestEnv(t)
+	r := buildRouter(env, noVisceralRulesHTTP)
+	rec := doRequest(t, r, http.MethodDelete, "/api/tasks/t1/settings/no_such_knob", nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown key, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "unknown key") {
+		t.Errorf("error should mention unknown key, got %s", rec.Body.String())
 	}
 }

--- a/internal/web/ui/components/knobs.js
+++ b/internal/web/ui/components/knobs.js
@@ -1,0 +1,450 @@
+// OpenPraxis — Execution Controls (knobs) component
+//
+// Shared UI for rendering the hierarchical settings catalog at product,
+// manifest, or task scope. Consumes the M2 HTTP endpoints:
+//   GET  /api/settings/catalog
+//   GET  /api/<type>s/<id>/settings
+//   PUT  /api/<type>s/<id>/settings
+//   DELETE /api/<type>s/<id>/settings/<key>     (added in M3-T7)
+//   GET  /api/tasks/<id>/settings/resolved       (task scope only)
+//
+// Integration (M3-T8/T9/T10) calls OL.renderKnobSection(containerEl, scope).
+
+(function(OL) {
+  'use strict';
+
+  const fetchJSON = OL.fetchJSON;
+  const esc = OL.esc;
+
+  // --- catalog cache -------------------------------------------------------
+  // Catalog is static per server process; fetch once and reuse across every
+  // mount (products list re-render, task detail re-open, etc.).
+  let _catalogCache = null;
+  async function loadCatalog() {
+    if (_catalogCache) return _catalogCache;
+    const data = await fetchJSON('/api/settings/catalog');
+    _catalogCache = (data && data.knobs) || [];
+    return _catalogCache;
+  }
+  OL.invalidateKnobCatalogCache = function() { _catalogCache = null; };
+
+  // --- scope-entity name cache (for provenance labels) ---------------------
+  // Resolver returns source + source_id; to show "from manifest (Phase 1)"
+  // we need the manifest title. Cache per scope-type/id to avoid N lookups
+  // on re-render. Best-effort — missing names fall back to the short id.
+  const _nameCache = { product: new Map(), manifest: new Map(), task: new Map() };
+  async function lookupScopeName(scopeType, id) {
+    if (!id) return '';
+    const cache = _nameCache[scopeType];
+    if (!cache) return id.substring(0, 8);
+    if (cache.has(id)) return cache.get(id);
+    let name = id.substring(0, 8);
+    try {
+      const data = await fetchJSON('/api/' + scopeType + 's/' + id);
+      if (data && data.title) name = data.title;
+      else if (data && data.name) name = data.name;
+    } catch(e) { /* keep the short id fallback */ }
+    cache.set(id, name);
+    return name;
+  }
+
+  // --- entry point ---------------------------------------------------------
+  // scope = { type: 'product'|'manifest'|'task', id: '...' }
+  OL.renderKnobSection = async function(containerEl, scope) {
+    if (!containerEl || !scope || !scope.type || !scope.id) return;
+    containerEl.innerHTML = '<div class="knob-section-loading">Loading execution controls…</div>';
+    let catalog, explicit, resolved = null;
+    try {
+      [catalog, explicit] = await Promise.all([
+        loadCatalog(),
+        fetchJSON('/api/' + scope.type + 's/' + scope.id + '/settings'),
+      ]);
+      if (scope.type === 'task') {
+        try {
+          resolved = await fetchJSON('/api/tasks/' + scope.id + '/settings/resolved');
+        } catch(e) { /* resolved is non-fatal — render without inheritance */ }
+      }
+    } catch(e) {
+      containerEl.innerHTML = '<div class="knob-section-error">Failed to load execution controls: ' + esc(e.message) + '</div>';
+      return;
+    }
+    // Build an explicit-entries map for O(1) lookup when rendering each knob.
+    const explicitByKey = new Map();
+    (explicit.entries || []).forEach(e => explicitByKey.set(e.key, e));
+
+    containerEl.innerHTML = renderSection(catalog, explicitByKey, resolved, scope);
+    bindHandlers(containerEl, scope, catalog);
+    // Asynchronously hydrate provenance labels for task scope (source name
+    // lookups are per-scope-entity and would block the initial paint).
+    if (scope.type === 'task' && resolved && resolved.resolved) {
+      hydrateProvenance(containerEl, resolved.resolved);
+    }
+  };
+
+  // --- rendering -----------------------------------------------------------
+
+  function renderSection(catalog, explicitByKey, resolved, scope) {
+    const rows = catalog.map(k => renderOneKnob(k, explicitByKey.get(k.key) || null, resolved, scope)).join('');
+    return (
+      '<div class="knob-section" data-scope-type="' + esc(scope.type) + '" data-scope-id="' + esc(scope.id) + '">' +
+        '<div class="knob-section-title">Execution Controls</div>' +
+        '<div class="knob-section-body">' + rows + '</div>' +
+      '</div>'
+    );
+  }
+
+  function renderOneKnob(knob, explicitEntry, resolved, scope) {
+    // Determine the current value shown in the control. Precedence:
+    //   1. explicit entry at this scope (authoritative for product/manifest/task)
+    //   2. resolved value from the task inheritance walk (task scope only)
+    //   3. catalog default (system tier)
+    let currentValue, source = 'system', sourceID = '';
+    if (explicitEntry) {
+      currentValue = safeParse(explicitEntry.value);
+      source = scope.type;
+      sourceID = scope.id;
+    } else if (resolved && resolved.resolved && resolved.resolved[knob.key]) {
+      const r = resolved.resolved[knob.key];
+      currentValue = r.value;
+      source = r.source;
+      sourceID = r.source_id;
+    } else {
+      currentValue = knob.default;
+    }
+
+    const control = renderControl(knob, currentValue);
+    const isExplicit = !!explicitEntry;
+    const resetBtn = isExplicit
+      ? '<button type="button" class="knob-reset" data-knob-key="' + esc(knob.key) + '" title="Reset to inherited value">Reset</button>'
+      : '';
+    const provenance = renderProvenance(scope, source, sourceID, isExplicit);
+    const warnings = renderWarnings(knob, currentValue);
+    const saveStatus = '<span class="knob-save-status" data-knob-key="' + esc(knob.key) + '"></span>';
+
+    return (
+      '<div class="knob-row" data-knob-key="' + esc(knob.key) + '" data-knob-type="' + esc(knob.type) + '">' +
+        '<div class="knob-row-main">' +
+          '<label class="knob-label" title="' + esc(knob.description || '') + '">' + esc(knob.key) + '</label>' +
+          control +
+          saveStatus +
+          resetBtn +
+        '</div>' +
+        '<div class="knob-row-meta">' + provenance + warnings + '</div>' +
+      '</div>'
+    );
+  }
+
+  function renderControl(knob, value) {
+    switch (knob.type) {
+      case 'int':       return renderRange(knob, value, true);
+      case 'float':     return renderRange(knob, value, false);
+      case 'enum':      return renderEnum(knob, value);
+      case 'string':    return renderString(knob, value);
+      case 'multiselect': return renderMultiselect(knob, value);
+      default:
+        return '<span class="knob-unsupported">unsupported type: ' + esc(knob.type) + '</span>';
+    }
+  }
+
+  function renderRange(knob, value, isInt) {
+    const min = knob.slider_min != null ? knob.slider_min : 0;
+    const max = knob.slider_max != null ? knob.slider_max : 100;
+    const step = knob.slider_step != null ? knob.slider_step : (isInt ? 1 : 0.01);
+    const v = numericOr(value, knob.default);
+    const unitSuffix = knob.unit ? ' <span class="knob-unit">' + esc(knob.unit) + '</span>' : '';
+    return (
+      '<input type="range" class="knob-input-range" ' +
+        'data-knob-role="range" ' +
+        'min="' + esc(String(min)) + '" max="' + esc(String(max)) + '" step="' + esc(String(step)) + '" ' +
+        'value="' + esc(String(v)) + '" />' +
+      '<input type="number" class="knob-input-number" ' +
+        'data-knob-role="number" ' +
+        'min="' + esc(String(min)) + '" max="' + esc(String(max)) + '" step="' + esc(String(step)) + '" ' +
+        'value="' + esc(String(v)) + '" />' +
+      unitSuffix
+    );
+  }
+
+  function renderEnum(knob, value) {
+    const v = typeof value === 'string' ? value : String(value || '');
+    const opts = (knob.enum_values || []).map(ev =>
+      '<option value="' + esc(ev) + '"' + (ev === v ? ' selected' : '') + '>' + esc(ev) + '</option>'
+    ).join('');
+    return '<select class="knob-input-select" data-knob-role="enum">' + opts + '</select>';
+  }
+
+  function renderString(knob, value) {
+    const v = typeof value === 'string' ? value : '';
+    const ph = knob.default ? 'default: ' + String(knob.default) : '';
+    return '<input type="text" class="knob-input-text" data-knob-role="string" ' +
+      'value="' + esc(v) + '" placeholder="' + esc(ph) + '" />';
+  }
+
+  // Multiselect: v1 is a comma-separated text input. The catalog doesn't
+  // carry a universe of options for allowed_tools (only the default list is
+  // in KnobDef.default), so a free-form tag input is the honest shape until
+  // M4 ties it to the agent tool registry. Spec explicitly authorizes this
+  // trade-off.
+  function renderMultiselect(knob, value) {
+    const arr = Array.isArray(value) ? value : (Array.isArray(knob.default) ? knob.default : []);
+    const csv = arr.map(x => String(x)).join(', ');
+    return '<input type="text" class="knob-input-text knob-input-multiselect" ' +
+      'data-knob-role="multiselect" ' +
+      'value="' + esc(csv) + '" placeholder="comma-separated values" />';
+  }
+
+  function renderProvenance(scope, source, sourceID, isExplicit) {
+    // Product/manifest scopes don't have an inheritance story to show —
+    // their values are either explicit or the system default. Task scope
+    // is the only tier where "from manifest X" vs "from product Y" matters.
+    if (scope.type !== 'task') {
+      if (isExplicit) return '<span class="knob-source explicit">set at ' + esc(scope.type) + '</span>';
+      return '<span class="knob-source">system default</span>';
+    }
+    if (source === 'task') return '<span class="knob-source explicit">set on this task</span>';
+    if (source === 'system') return '<span class="knob-source">system default</span>';
+    // manifest/product: show the id as a placeholder; hydrateProvenance
+    // swaps in the human name once the /api/<type>s/<id> lookup returns.
+    const short = sourceID ? sourceID.substring(0, 8) : '';
+    return '<span class="knob-source" data-source-type="' + esc(source) + '" data-source-id="' + esc(sourceID) + '">' +
+      'from ' + esc(source) + (short ? ' (' + esc(short) + ')' : '') + '</span>';
+  }
+
+  function renderWarnings(knob, value) {
+    const list = computeWarnings(knob, value);
+    if (list.length === 0) return '';
+    return list.map(w => '<span class="knob-warning">' + esc(w) + '</span>').join('');
+  }
+
+  // --- client-side soft warnings -------------------------------------------
+
+  function computeWarnings(knob, value) {
+    const out = [];
+    if (knob.key === 'max_parallel' && typeof value === 'number') {
+      const cores = (navigator && navigator.hardwareConcurrency) || 0;
+      if (cores > 0 && value > cores) {
+        out.push('Exceeds CPU count (' + cores + '); tasks will queue');
+      }
+    }
+    if (knob.key === 'temperature' && typeof value === 'number' && value > 1.5) {
+      out.push('High temperature rarely helps for coding');
+    }
+    if (knob.key === 'daily_budget_usd' && typeof value === 'number' && value > 90) {
+      out.push('Within $10 of visceral rule cap ($100)');
+    }
+    return out;
+  }
+
+  // --- event wiring --------------------------------------------------------
+
+  function bindHandlers(containerEl, scope, catalog) {
+    const catalogByKey = new Map();
+    catalog.forEach(k => catalogByKey.set(k.key, k));
+
+    containerEl.querySelectorAll('.knob-row').forEach(row => {
+      const key = row.dataset.knobKey;
+      const knob = catalogByKey.get(key);
+      if (!knob) return;
+
+      const range = row.querySelector('[data-knob-role="range"]');
+      const number = row.querySelector('[data-knob-role="number"]');
+      const sel = row.querySelector('[data-knob-role="enum"]');
+      const txt = row.querySelector('[data-knob-role="string"]');
+      const multi = row.querySelector('[data-knob-role="multiselect"]');
+
+      // Range ↔ number mirror the same value live; only the final change
+      // flushes to the server (via debouncedSave).
+      if (range && number) {
+        range.addEventListener('input', () => {
+          number.value = range.value;
+          refreshWarnings(row, knob, coerceNumber(range.value, knob));
+        });
+        range.addEventListener('change', () => {
+          scheduleSave(scope, knob, coerceNumber(range.value, knob), row);
+        });
+        number.addEventListener('input', () => {
+          range.value = number.value;
+          refreshWarnings(row, knob, coerceNumber(number.value, knob));
+        });
+        number.addEventListener('change', () => {
+          scheduleSave(scope, knob, coerceNumber(number.value, knob), row);
+        });
+      }
+
+      if (sel) {
+        sel.addEventListener('change', () => {
+          scheduleSave(scope, knob, sel.value, row);
+        });
+      }
+
+      if (txt) {
+        txt.addEventListener('change', () => {
+          scheduleSave(scope, knob, txt.value, row);
+        });
+      }
+
+      if (multi) {
+        multi.addEventListener('change', () => {
+          const arr = multi.value.split(',').map(s => s.trim()).filter(Boolean);
+          scheduleSave(scope, knob, arr, row);
+        });
+      }
+
+      const resetBtn = row.querySelector('.knob-reset');
+      if (resetBtn) {
+        resetBtn.addEventListener('click', () => resetKnob(scope, key, containerEl));
+      }
+    });
+  }
+
+  function refreshWarnings(row, knob, value) {
+    const meta = row.querySelector('.knob-row-meta');
+    if (!meta) return;
+    // Keep the existing source line, replace only the warnings.
+    meta.querySelectorAll('.knob-warning').forEach(el => el.remove());
+    const warnings = computeWarnings(knob, value);
+    warnings.forEach(w => {
+      const span = document.createElement('span');
+      span.className = 'knob-warning';
+      span.textContent = w;
+      meta.appendChild(span);
+    });
+  }
+
+  // --- debounced save ------------------------------------------------------
+
+  const _saveTimers = new Map();
+  function scheduleSave(scope, knob, value, row) {
+    const key = knob.key;
+    const existing = _saveTimers.get(key);
+    if (existing) clearTimeout(existing);
+    _saveTimers.set(key, setTimeout(() => {
+      _saveTimers.delete(key);
+      doSave(scope, knob, value, row);
+    }, 400));
+  }
+
+  async function doSave(scope, knob, value, row) {
+    const status = row.querySelector('.knob-save-status');
+    if (status) { status.textContent = '…'; status.className = 'knob-save-status pending'; }
+    try {
+      const resp = await fetch('/api/' + scope.type + 's/' + scope.id + '/settings', {
+        method: 'PUT',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ [knob.key]: value }),
+      });
+      const data = await resp.json();
+      const result = (data && data.results && data.results[0]) || {ok: false, error: 'unexpected response'};
+      if (result.ok) {
+        if (status) { status.textContent = '\u2713'; status.className = 'knob-save-status ok'; }
+        // Server warnings (e.g. slider range) are additive to client-side ones.
+        applyServerWarnings(row, result.warnings || []);
+        // Saved values now exist explicitly at this scope — show Reset.
+        ensureResetButton(row, scope, knob.key);
+        // Provenance line must update to reflect the new explicit status.
+        updateProvenanceAfterSave(row, scope);
+        setTimeout(() => { if (status) status.textContent = ''; }, 1800);
+      } else {
+        if (status) { status.textContent = '\u2717'; status.className = 'knob-save-status err'; status.title = result.error || 'save failed'; }
+      }
+    } catch(e) {
+      if (status) { status.textContent = '\u2717'; status.className = 'knob-save-status err'; status.title = e.message || 'network error'; }
+    }
+  }
+
+  function applyServerWarnings(row, serverWarnings) {
+    const meta = row.querySelector('.knob-row-meta');
+    if (!meta) return;
+    serverWarnings.forEach(w => {
+      const span = document.createElement('span');
+      span.className = 'knob-warning';
+      span.textContent = w;
+      meta.appendChild(span);
+    });
+  }
+
+  function ensureResetButton(row, scope, key) {
+    if (row.querySelector('.knob-reset')) return;
+    const main = row.querySelector('.knob-row-main');
+    if (!main) return;
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'knob-reset';
+    btn.dataset.knobKey = key;
+    btn.title = 'Reset to inherited value';
+    btn.textContent = 'Reset';
+    btn.addEventListener('click', () => {
+      const container = row.closest('.knob-section') ? row.closest('.knob-section').parentElement : row.parentElement;
+      resetKnob(scope, key, container);
+    });
+    main.appendChild(btn);
+  }
+
+  function updateProvenanceAfterSave(row, scope) {
+    const meta = row.querySelector('.knob-row-meta');
+    if (!meta) return;
+    const src = meta.querySelector('.knob-source');
+    if (!src) return;
+    src.className = 'knob-source explicit';
+    src.textContent = scope.type === 'task' ? 'set on this task' : 'set at ' + scope.type;
+    src.removeAttribute('data-source-type');
+    src.removeAttribute('data-source-id');
+  }
+
+  // --- reset (DELETE) ------------------------------------------------------
+
+  async function resetKnob(scope, key, containerEl) {
+    try {
+      const resp = await fetch('/api/' + scope.type + 's/' + scope.id + '/settings/' + encodeURIComponent(key), {
+        method: 'DELETE',
+      });
+      if (!resp.ok) {
+        const txt = await resp.text();
+        throw new Error(txt || ('HTTP ' + resp.status));
+      }
+      // Re-render the whole section so inheritance picks up the new source.
+      if (containerEl) {
+        await OL.renderKnobSection(containerEl, scope);
+      }
+    } catch(e) {
+      console.error('Reset knob failed:', e);
+      alert('Failed to reset ' + key + ': ' + (e.message || e));
+    }
+  }
+
+  // --- provenance hydration (task scope only) ------------------------------
+
+  async function hydrateProvenance(containerEl, resolvedMap) {
+    const sources = containerEl.querySelectorAll('.knob-source[data-source-type]');
+    sources.forEach(async el => {
+      const type = el.dataset.sourceType;
+      const id = el.dataset.sourceId;
+      if (!type || !id) return;
+      if (type !== 'manifest' && type !== 'product') return;
+      const name = await lookupScopeName(type, id);
+      if (name && name !== id.substring(0, 8)) {
+        el.textContent = 'from ' + type + ' (' + name + ')';
+      }
+    });
+  }
+
+  // --- helpers -------------------------------------------------------------
+
+  function safeParse(jsonStr) {
+    try { return JSON.parse(jsonStr); }
+    catch(e) { return jsonStr; }
+  }
+
+  function numericOr(v, fallback) {
+    if (typeof v === 'number' && isFinite(v)) return v;
+    if (typeof fallback === 'number' && isFinite(fallback)) return fallback;
+    return 0;
+  }
+
+  function coerceNumber(str, knob) {
+    const n = Number(str);
+    if (!isFinite(n)) return 0;
+    return knob.type === 'int' ? Math.round(n) : n;
+  }
+
+})(window.OL);

--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -731,10 +731,11 @@
     </main>
   </div>
 
-  <!-- Module loading order: api → tree → lifecycle → views → app (entry point) -->
+  <!-- Module loading order: api → tree → lifecycle → components → views → app (entry point) -->
   <script src="/api.js"></script>
   <script src="/tree.js"></script>
   <script src="/lifecycle.js"></script>
+  <script src="/components/knobs.js"></script>
   <script src="/views/overview.js"></script>
   <script src="/views/memories.js"></script>
   <script src="/views/conversations.js"></script>

--- a/internal/web/ui/style.css
+++ b/internal/web/ui/style.css
@@ -1241,6 +1241,33 @@ body {
 .btn-md { font-size: 12px; padding: 6px 14px; }
 .btn-action { font-size: 12px; padding: 6px 16px; }
 
+/* === Execution Controls (knobs) — shared component rendered by OL.renderKnobSection === */
+.knob-section { margin-top: 16px; padding: 12px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-secondary); }
+.knob-section-title { font-weight: 600; margin-bottom: 12px; color: var(--text-primary); font-size: 13px; }
+.knob-section-body { display: flex; flex-direction: column; }
+.knob-section-loading { color: var(--text-muted); font-size: 12px; padding: 8px 0; }
+.knob-section-error { color: var(--red); font-size: 12px; padding: 8px 0; }
+.knob-row { display: flex; flex-direction: column; gap: 2px; padding: 8px 0; border-bottom: 1px solid var(--border); }
+.knob-row:last-child { border-bottom: none; }
+.knob-row-main { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.knob-row-meta { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; padding-left: 170px; }
+.knob-label { min-width: 160px; color: var(--text-primary); font-size: 12px; font-family: var(--font-mono); }
+.knob-input-range { accent-color: var(--accent); flex: 1; max-width: 200px; cursor: pointer; }
+.knob-input-number { width: 80px; background: var(--bg-input); border: 1px solid var(--border); color: var(--text-primary); padding: 2px 6px; border-radius: 3px; font-size: 12px; font-family: var(--font-mono); }
+.knob-input-text { flex: 1; min-width: 160px; max-width: 400px; background: var(--bg-input); border: 1px solid var(--border); color: var(--text-primary); padding: 4px 8px; border-radius: 3px; font-size: 12px; font-family: var(--font-mono); }
+.knob-input-select { background: var(--bg-input); border: 1px solid var(--border); color: var(--text-primary); padding: 3px 8px; border-radius: 3px; font-size: 12px; font-family: var(--font-mono); }
+.knob-unit { font-size: 11px; color: var(--text-muted); margin-left: 4px; }
+.knob-source { font-size: 11px; color: var(--text-muted); font-style: italic; }
+.knob-source.explicit { color: var(--green); font-style: normal; font-weight: 600; }
+.knob-reset { background: transparent; border: 1px solid var(--border); color: var(--text-muted); cursor: pointer; padding: 2px 8px; border-radius: 3px; font-size: 11px; }
+.knob-reset:hover { color: var(--accent); border-color: var(--accent); }
+.knob-warning { font-size: 11px; color: var(--yellow); }
+.knob-save-status { font-size: 13px; min-width: 16px; text-align: center; }
+.knob-save-status.ok { color: var(--green); }
+.knob-save-status.err { color: var(--red); }
+.knob-save-status.pending { color: var(--text-muted); }
+.knob-unsupported { color: var(--text-muted); font-size: 11px; font-style: italic; }
+
 /* Responsive */
 @media (max-width: 768px) {
   .sidebar { display: none; }
@@ -1248,4 +1275,6 @@ body {
   .panels-grid { grid-template-columns: 1fr; }
   .memories-layout { grid-template-columns: 1fr; }
   .search-results { left: 0; }
+  .knob-row-meta { padding-left: 0; }
+  .knob-label { min-width: 0; }
 }


### PR DESCRIPTION
## Summary

M3-T7 of the hierarchical execution controls manifest (issue #34). Ships the reusable UI layer so M3-T8/T9/T10 can mount execution controls into product, manifest, and task detail pages, plus the per-key DELETE endpoint the Reset button needs.

## What's in the box

**New shared component — `internal/web/ui/components/knobs.js`**
- `OL.renderKnobSection(containerEl, scope)` where `scope = {type: 'product'|'manifest'|'task', id: ...}`
- Fetches `/api/settings/catalog` (cached, invalidatable via `OL.invalidateKnobCatalogCache`), `/api/<type>s/<id>/settings`, and (task scope only) `/api/tasks/<id>/settings/resolved`
- Per-type rendering: `int/float` → range + paired number input; `enum` → select; `string` → text input; `multiselect` → comma-separated text input (v1 — catalog has no universe-of-options for `allowed_tools`, documented trade-off until M4 ties it to agent registry)
- Inline provenance (task scope): `from manifest (name)` / `from product (name)` / `system default` / `set on this task` — manifest/product names hydrated lazily via `/api/<type>s/<id>` + cached
- Client-side soft warnings (yellow inline): `max_parallel > hardwareConcurrency`, `temperature > 1.5`, `daily_budget_usd > 90` (approaching visceral rule #8 cap)
- Debounced PUT (400ms) on change via raw `fetch` (fetchJSON is GET-oriented); server warnings appended after success
- Reset button calls `DELETE /api/<type>s/<id>/settings/<key>`, then re-renders the section so inheritance picks up

**New endpoint — `DELETE /api/{products,manifests,tasks}/{id}/settings/{key}`**
- Needed because M2 built GET + PUT only. Overloading PUT with a `null` value would be semantically unclear; this is the clean shape.
- Thin wrapper over `store.Delete` (idempotent), same `ValidateWritableScope` path as GET/PUT
- Unknown keys → 400 (typo safety on the URL); valid-key delete on missing row → 200 (idempotent)
- Author convention: no write author recorded (it's a delete, not a set)

**CSS — `internal/web/ui/style.css`**
- `.knob-section`, `.knob-row`, `.knob-input-range`, `.knob-input-select`, etc.
- Uses only existing tokens: `--accent`, `--green`, `--yellow`, `--text-muted`, `--border`, `--bg-secondary`, `--bg-input`, `--text-primary`, `--font-mono`, `--red`
- No new CSS variables

**Script registration**
- `/components/knobs.js` loaded between `lifecycle.js` and the views
- `/components/*` served by the existing `serveJS` closure in `handler.go` (cache-bust headers, same treatment as `/views/*`)

## Markdown in knob section — Option C chosen

Spec offered three options for knob descriptions: server-side render, client-side vendor `marked`, or plain text. Chose **C (plain text)** — descriptions are one-line tooltips, not rich documents. Documented inline.

## What this PR does NOT do

Per spec Step 9: no integration into specific views — M3-T8 wires products, T9 wires manifests, T10 replaces the existing `max_turns` slider in the task view.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` — all packages pass
- [x] New Go tests added for DELETE endpoint (3 tests: happy path, idempotent, unknown-key rejection)
- [x] `TestRoutes_AllSettingsEndpointsRegistered` extended to assert the 3 new DELETE routes are registered
- [x] Smoke test — server boots, `/components/knobs.js` returns 200 + `application/javascript`, `/api/settings/catalog` returns 200 + JSON, `/` returns 200 + HTML
- [x] `node --check` on knobs.js — no syntax errors
- [ ] Manual dashboard smoke test by reviewer: open dev tools on `http://localhost:8765`, confirm no console errors on page load (no view currently mounts the component — that starts in T8)

## Files

- `internal/web/ui/components/knobs.js` (new, ~370 lines)
- `internal/web/handlers_settings_exec.go` (+ DELETE handler, + route registration)
- `internal/web/handlers_settings_exec_test.go` (+ test-side DELETE handler, + 3 tests, + registration coverage)
- `internal/web/handler.go` (+ `r.PathPrefix("/components/").HandlerFunc(serveJS)`)
- `internal/web/ui/index.html` (+ script tag)
- `internal/web/ui/style.css` (+ knob CSS block before the responsive media query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)