### PR TITLE
Wire OL.renderKnobSection into product detail view (M3-T8)

### DIFF
--- a/internal/web/ui/views/products.js
+++ b/internal/web/ui/views/products.js
@@ -257,8 +257,14 @@
             <button class="btn-search btn-action" onclick="OL.showProductDiagram('${esc(p.id)}','${esc(p.title)}')">&#x25C8; Product DAG</button>
           </div>
           ${manifestsHtml}
+          <div id="product-knobs-mount" style="margin-top:16px"></div>
           ${ideasHtml}
         </div>`;
+
+      const knobMount = document.getElementById('product-knobs-mount');
+      if (knobMount && OL.renderKnobSection) {
+        OL.renderKnobSection(knobMount, { type: 'product', id: p.id });
+      }
 
     } catch (e) {
       console.error('Load product detail failed:', e);


### PR DESCRIPTION
## Summary

- Mounts `OL.renderKnobSection` in `OL.loadProductDetail` inside `internal/web/ui/views/products.js` (after linked-manifests, before linked-ideas), so the 12 execution-control knobs render on every product detail page.
- View-only wiring change: no backend, catalog, component, or CSS changes. The knob component (shipped in M3-T7) owns its wrapper, fetching, debounced PUTs, and Reset.

## Where

`internal/web/ui/views/products.js` — new `<div id="product-knobs-mount">` placeholder inside the product detail template, followed by `OL.renderKnobSection(knobMount, {type: 'product', id: p.id})` right after `bodyEl.innerHTML` is set.

Diff is 6 lines added, 0 removed. Existing product detail behavior (breadcrumb, metadata bar, metrics, controls, description, diagram button, manifest list, ideas list, all existing actions) is unchanged.

## Verification

Spun up an isolated smoke server on port 8799 (fresh `storage.data_dir`) off the HEAD binary, then exercised the full knob lifecycle via curl + a headless Chrome render of `#view-products/<id>`:

- `GET /api/settings/catalog` → 12 knobs, types covering int/float/enum/string/multiselect
- `GET /api/products/<id>/settings` → empty → after PUT → 2 entries → after DELETE → 1 entry
- `PUT /api/products/<id>/settings` `{"max_parallel":5}` and `{"temperature":0.5}` → both `ok:true`
- `DELETE /api/products/<id>/settings/max_parallel` → HTTP 200, `{"ok":true}`, entry removed
- Headless browser render confirms all 12 knob rows, section title "Execution Controls", per-row source labels ("system default" / "set at product"), sliders + selects + multiselect text input, and the `daily_budget_usd=100` soft warning "Within \$10 of visceral rule cap (\$100)".

`go build ./... && go vet ./...` clean. `make test` clean (all settings package tests green, including `TestHandleDeleteScopeSettings_*` and `TestResolver_*`).

## Screenshot

Rendered view at 1600×2200 (headless Chrome against the HEAD binary on a fresh node with one smoke product):

![Execution Controls rendered on product detail — 12 knobs, temperature explicit at 0.5 with "set at product" label, daily_budget_usd at cap showing warning pill, system default source lines on the other 11 knobs](/tmp/op-smoke-t8/product-detail-big.png)

(Screenshot lives at `/tmp/op-smoke-t8/product-detail-big.png` on the dev machine; attach to the PR description directly if the inline path does not resolve in the web view.)

## Test plan

- [ ] `make build && ./openpraxis serve` then open a product detail — confirm "Execution Controls" section with 12 knobs
- [ ] Drag `max_parallel` slider — confirm one debounced PUT (no flood) and green "set at product" appears under the knob with a Reset button
- [ ] Click Reset on `max_parallel` — confirm row re-renders, source flips back to "system default", Reset button disappears
- [ ] Reload page — confirm all explicit values persist
- [ ] Browser console stays empty

Completes acceptance criterion "Integrated into product view" for M3. Manifest (M3-T9) and task (M3-T10) wiring follow.