### PR TITLE
Wire OL.renderKnobSection into manifest detail view (M3-T9)

### DIFF
--- a/internal/web/ui/views/manifests.js
+++ b/internal/web/ui/views/manifests.js
@@ -407,6 +407,7 @@
           ${depsHtml}
           ${linkedIdeasHtml}
           ${linkedTasksHtml}
+          <div id="manifest-knobs-mount" style="margin-top:16px"></div>
           ${jira ? `<div style="margin-bottom:12px">Jira: ${jira}</div>` : ''}
           ${tags ? `<div style="margin-bottom:12px">${tags}</div>` : ''}
           <div style="margin-bottom:4px;display:flex;align-items:center;gap:8px">
@@ -427,6 +428,11 @@
             <span>ID: ${esc(m.id)}</span>
           </div>
         </div>`;
+
+      const knobMount = document.getElementById('manifest-knobs-mount');
+      if (knobMount && OL.renderKnobSection) {
+        OL.renderKnobSection(knobMount, { type: 'manifest', id: m.id });
+      }
 
       // Bind idea navigation links
       bodyEl.querySelectorAll('.idea-nav').forEach(el => {


### PR DESCRIPTION
## Summary

Part 3/4 of the Hierarchical Execution Controls manifest (M3 — `019d9b70-bf1`). Mounts the shared `OL.renderKnobSection` into the manifest detail view using the same 6-line pattern validated in #44 (M3-T8, products).

Insertion point (`internal/web/ui/views/manifests.js`, inside `OL.loadManifest`): an empty `<div id="manifest-knobs-mount" style="margin-top:16px">` placed between `${linkedTasksHtml}` and `${jira}`. Immediately after `bodyEl.innerHTML` is set, the component is invoked with `{ type: 'manifest', id: m.id }`. The component owns its own `.knob-section` wrapper (title included), so the mount div is left empty to avoid the doubly-nested wrapper case noted in the M3-T8 completion memo.

Placement keeps the Execution Controls visible above the fold between the main task-list block and the long spec/content body — no existing metadata, deps pills, linked tasks, ideas, or spec sections are reordered or touched.

## Files changed

- `internal/web/ui/views/manifests.js` — +6 lines, no other changes

## Not changed (per task spec)

- `internal/web/ui/components/knobs.js` — component is stable, M3-T7
- HTTP handlers (`internal/web/handlers_settings_exec.go`) — M2
- `style.css` — no new classes required
- Task and product detail views — task view wiring is M3-T10; product was M3-T8 (#44)

## Verification

`go build ./...`, `go vet ./...`, `make test`, `make build` — all clean.

Smoke test via isolated config under `/tmp/op-smoke-t9/` (`storage.data_dir` + unique `sync.port` to avoid clobbering production DB, per M3-T8 lesson):

- Server started on port 9876 with a throwaway manifest.
- `PUT /api/manifests/<id>/settings` body `{"max_turns":200,"temperature":0.7}` → both return `ok:true`. Headless screenshot shows both knobs rendering the explicit source label (`set at manifest`) in green.
- `DELETE /api/manifests/<id>/settings/<key>` for both keys → second screenshot shows the knobs reverted to the system default (muted `system default` label, handle back at default position).
- `daily_budget_usd` soft warning "Within $10 of visceral rule cap ($100)" renders inline on the cap value in both screenshots.
- Console is clean.

### Screenshots

Explicit values (max_turns=200, temperature=0.7): `/tmp/op-smoke-t9/explicit.png`
After reset (all system defaults): `/tmp/op-smoke-t9/defaults.png`

Both attached in the task thread.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` — all web settings handler tests still pass (16/16)
- [x] `make build` produces a signed binary
- [x] Manifest detail deep-link `#view-manifests/<id>` shows the Execution Controls section with all 12 knobs
- [x] Setting `max_turns=200` at manifest scope persists and displays green explicit source
- [x] Setting `temperature=0.7` persists; debounced save works
- [x] DELETE reverts to system default in-place
- [x] Existing manifest UI (breadcrumb, metadata, deps pills, linked ideas, linked tasks, jira, tags, spec/content, editor) unchanged

## Related

- Manifest: [`019d9b70-bf1`](https://github.com/k8nstantin/OpenPraxis/issues/34)
- Depends on: #44 (M3-T8, product view wiring) — merged e2ac045
- Next: M3-T10 will wire into the task detail view and remove the legacy `max_turns` slider

🤖 Generated with [Claude Code](https://claude.com/claude-code)