### PR TITLE
Wire OL.renderKnobSection into task detail view + remove legacy max_turns slider (M3-T10)

### DIFF
--- a/internal/web/ui/views/tasks.js
+++ b/internal/web/ui/views/tasks.js
@@ -290,8 +290,6 @@
             <span>Agent: <strong style="color:var(--text-primary)">${esc(t.agent)}</strong></span>
             <span>Branch: <strong style="color:var(--text-primary)">openpraxis/${esc(t.marker)}</strong></span>
             ${t.manifest_id ? `<span>Manifest: <span class="manifest-nav" style="cursor:pointer;color:var(--accent);text-decoration:underline;font-weight:600" data-mid="${esc(t.manifest_id)}">${esc(t.manifest_id.substring(0,12))} &#x2192;</span></span>` : '<span>standalone</span>'}
-            <span class="separator">|</span>
-            <span style="display:flex;align-items:center;gap:6px">Max turns: <input type="range" id="task-max-turns" value="${t.max_turns || 100}" min="10" max="500" step="10" style="width:100px;accent-color:var(--accent);cursor:pointer" oninput="document.getElementById('task-max-turns-val').textContent=this.value" onchange="OL.updateMaxTurns('${esc(t.id)}',this.value)" /><strong id="task-max-turns-val" style="color:var(--text-primary);min-width:28px">${t.max_turns || 100}</strong></span>
             ${t.last_run_at ? `<span class="separator">|</span><span>Last: ${new Date(t.last_run_at).toLocaleString()}</span>` : ''}
             <span>Created: ${new Date(t.created_at).toLocaleString()}</span>
           </div>
@@ -412,7 +410,8 @@
             </div>
           </div>
 
-          <!-- META INFO (now in header above) -->
+          <!-- EXECUTION CONTROLS -->
+          <div id="task-knobs-mount" style="margin-top:16px"></div>
 
           <!-- 5. LIVE OUTPUT (if running/paused) -->
           ${isRunningOrPaused ? `
@@ -451,6 +450,11 @@
           </div>
         </div>
       `;
+
+      const knobMount = document.getElementById('task-knobs-mount');
+      if (knobMount && OL.renderKnobSection) {
+        OL.renderKnobSection(knobMount, { type: 'task', id: t.id });
+      }
 
       // Manifest cross-link — fetch title + wire click
       bodyEl.querySelectorAll('.manifest-nav').forEach(el => {
@@ -789,17 +793,6 @@
     await fetch('/api/tasks/' + id + '/' + action, {method: 'POST'});
     OL.loadTaskDetail(id);
     OL.loadTasks();
-  };
-
-  // Re-run now (uses existing schedule)
-  OL.updateMaxTurns = async function(id, val) {
-    const maxTurns = parseInt(val);
-    if (!maxTurns || maxTurns < 1) return;
-    await fetch('/api/tasks/' + id, {
-      method: 'PUT',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({max_turns: maxTurns})
-    });
   };
 
   OL.taskStart = async function(id) {


### PR DESCRIPTION
Closes **M3 phase** of the Hierarchical Execution Controls initiative. Part 10 of 14; final M3 task.

Manifest: [019d9b70-bf1](https://github.com/k8nstantin/OpenPraxis/issues/34)
Task: `019d9fca-030`

## Summary

- Mount `OL.renderKnobSection` into the task detail view after the Instructions section.
- Remove the legacy `max_turns` range slider (and its preceding `|` separator) from the metadata bar.
- Delete `OL.updateMaxTurns` — its only purpose was driving the removed slider.
- All `max_turns` persistence for the task detail view now flows through `PUT /api/tasks/:id/settings` (via the knob component), not `PATCH /api/tasks/:id {max_turns:N}`.

## Files changed

- `internal/web/ui/views/tasks.js` — +7 / −14 lines

No backend changes, no CSS changes, no component changes, no go.mod changes.

## PATCH `/api/tasks/:id` endpoint decision

**Preserved.** The task-create form (`views/tasks.js`, OL.createTask) still sends `max_turns` on the initial `POST /api/tasks` body, which writes to the `Task.MaxTurns` column. External callers may also rely on `PATCH /api/tasks/:id {max_turns:N}`. M4-T14 will migrate the column into the settings table and can drop both in one move. Removing the endpoint now would be scope creep and break the task-create path.

## What is NOT in this PR

- Task create-form `max_turns` field is preserved (per task spec — Option A).
- The `max_turns` column on the tasks table is preserved (M4-T14 handles the migration + drop).
- `components/knobs.js` is untouched.
- `handlers_settings_exec.go` is untouched.

## Inheritance walk verification

Smoke test on isolated instance (`/tmp/op-smoke-t10/`, port 9878, separate DB). Created a product → manifest → task hierarchy, then walked the inheritance chain by PUT/DELETE on `max_turns` at each scope and reloaded the task detail page at `#view-tasks/<id>`.

| Frame | Product | Manifest | Task | Resolver returns | Screenshot |
| ----- | ------- | -------- | ---- | ---------------- | ---------- |
| 1 | explicit 200 | explicit 500 | (none) | `500` from manifest | `frame1-inherit-from-manifest.png` |
| 2 | explicit 200 | explicit 500 | explicit 75 | `75` set on this task (green) | `frame2-explicit-on-task.png` |
| 3 | explicit 200 | (reset) | (reset) | `200` from product | `frame3-from-product.png` |
| 4 | (reset) | (reset) | (reset) | `50` system default | `frame4-system-default.png` |

Screenshots saved under `/tmp/op-smoke-t10/` on my dev box and referenced in the M3-T10 memory note.

`curl` verification of frame 4:

```
max_turns = 50 source=system source_id=
```

This is the first view that exercised the full task-scope inheritance walk end-to-end, completing the M1→M2→M3 stack integration demonstration.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `make test` — all packages pass (mcp, settings, web; including the 16 settings-handler tests from M2)
- `make build` — produces signed binary
- No orphan references to `task-max-turns` or `updateMaxTurns` anywhere in `internal/web/ui/`. (The only remaining hit is a stale entry in `tools/replace_window_globals.py` mapping table — a one-time codemod utility; harmless, untouched.)

## Test plan

- [ ] Open a task detail view — the Execution Controls section appears below Instructions.
- [ ] Click the task's `max_turns` slider — value updates live, debounced PUT persists.
- [ ] Inherited values render with muted `from manifest (<name>)` / `from product (<name>)` / `system default` labels.
- [ ] Reset button reverts to the inherited value.
- [ ] No `Max turns` slider in the metadata bar.
- [ ] Task-create form still accepts `max_turns` (unchanged).
- [ ] `curl -X PATCH /api/tasks/:id -d '{"max_turns":50}'` still works (backward compat).

## M3 closure

After this PR merges, the M3 manifest (`019d9b70-bf1`) should be closed so M4 tasks become eligible (per the `close-manifest-to-unblock-next-phase` project pattern). That's a human/assistant step, not part of this PR.