### PR TITLE
fix(web): keep newly created task visible after submit

### DIFF
--- a/internal/web/ui/views/tasks.js
+++ b/internal/web/ui/views/tasks.js
@@ -711,17 +711,26 @@
         schedule = 'at:' + new Date(dt).toISOString();
       }
 
-      await fetch('/api/tasks', {
+      const resp = await fetch('/api/tasks', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({manifest_id: manifestId, title, description: desc, schedule, agent})
       });
+      if (!resp.ok) {
+        bodyEl.querySelector('#tc-status').textContent = 'Error: ' + resp.status;
+        return;
+      }
+      const newTask = await resp.json();
       bodyEl.querySelector('#tc-status').textContent = 'Created!';
       OL.loadTasks();
-      setTimeout(() => {
-        titleEl.textContent = 'Select a task';
-        bodyEl.innerHTML = '<div class="empty-state">Task created. Click it in the tree to view details.</div>';
-      }, 1000);
+      if (newTask && newTask.id) {
+        setTimeout(() => OL.loadTaskDetail(newTask.id), 300);
+      } else {
+        setTimeout(() => {
+          titleEl.textContent = 'Select a task';
+          bodyEl.innerHTML = '<div class="empty-state">Task created. Click it in the tree to view details.</div>';
+        }, 1000);
+      }
     };
   };
 


### PR DESCRIPTION
## Summary
- After creating a task via the + New Task form, the form cleared to an empty "Select a task" state — the task was saved but invisible until the user clicked it in the tree.
- Capture the POST `/api/tasks` response and auto-navigate to the new task's detail via `OL.loadTaskDetail(newTask.id)`, mirroring `OL.promoteToManifest`'s post-submit flow.
- Also surfaces non-2xx responses instead of silently "Created!".

## Test plan
- [ ] Open dashboard → Tasks → + New Task
- [ ] Fill instructions, pick schedule, submit → detail view should stay on the newly created task (not reset to "Select a task")
- [ ] Task tree on the left should include the new task
- [ ] Force a 500 (kill serve mid-submit) → status should show "Error: …" instead of "Created!"

🤖 Generated with [Claude Code](https://claude.com/claude-code)