### PR TITLE
feat(web): add + New Manifest button on product detail

### DIFF
--- a/internal/web/ui/views/manifests.js
+++ b/internal/web/ui/views/manifests.js
@@ -127,11 +127,17 @@
     }).join('');
   }
 
-  // Promote idea or memory to manifest -- opens manifest detail panel with creation form pre-filled
-  OL.promoteToManifest = async function(title, description, content) {
+  // Open the "New Manifest" form in the manifest detail panel.
+  // opts: { title, description, content, productId } — all optional.
+  OL.createManifest = async function(opts) {
+    opts = opts || {};
+    const title = opts.title || '';
+    const description = opts.description || '';
+    const content = opts.content || '';
+    const preselectProductId = opts.productId || '';
+
     OL.switchView('manifests');
 
-    // Fetch products for the dropdown
     let products = [];
     try {
       const groups = await fetchJSON('/api/products/by-peer');
@@ -150,7 +156,7 @@
       titleEl.textContent = 'New Manifest';
 
       const productOptions = products.map(p =>
-        `<option value="${esc(p.id)}">${esc(p.marker)} ${esc(p.title)}</option>`
+        `<option value="${esc(p.id)}"${p.id === preselectProductId ? ' selected' : ''}>${esc(p.marker)} ${esc(p.title)}</option>`
       ).join('');
 
       bodyEl.innerHTML = `
@@ -179,7 +185,7 @@
             <div style="flex:1">
               <label class="form-label">Product</label>
               <select id="pm-product-id" class="conv-filter" style="font-size:13px;width:100%;padding:8px">
-                <option value="">No Product</option>
+                <option value=""${preselectProductId ? '' : ' selected'}>No Product</option>
                 ${productOptions}
               </select>
             </div>
@@ -209,12 +215,18 @@
           headers: {'Content-Type': 'application/json'},
           body: JSON.stringify({title: t, description: d, content: c, status: s, project_id: pid, jira_refs: j ? j.split(',').map(s => s.trim()) : []})
         });
+        if (!resp.ok) { bodyEl.querySelector('#pm-status-msg').textContent = 'Error: ' + resp.status; return; }
         const m = await resp.json();
         bodyEl.querySelector('#pm-status-msg').textContent = 'Created!';
         OL.loadManifests();
         setTimeout(() => OL.loadManifest(m.id), 500);
       };
     }, 300);
+  };
+
+  // Promote idea or memory to manifest -- opens manifest detail panel with creation form pre-filled.
+  OL.promoteToManifest = function(title, description, content) {
+    return OL.createManifest({ title: title, description: description, content: content });
   };
 
   OL.loadManifest = async function(id) {

--- a/internal/web/ui/views/products.js
+++ b/internal/web/ui/views/products.js
@@ -244,6 +244,7 @@
           <!-- CONTROLS -->
           <div style="display:flex;gap:8px;margin-bottom:12px;flex-wrap:wrap">
             <button class="btn-search" style="font-size:11px;padding:4px 12px" onclick="OL.editProduct('${esc(p.id)}')">&#9998; Edit</button>
+            <button class="btn-search" style="font-size:11px;padding:4px 12px" onclick="OL.createManifest({productId:'${esc(p.id)}'})">+ New Manifest</button>
             <button class="btn-search" style="font-size:11px;padding:4px 12px;background:var(--bg-input)" onclick="OL.linkManifestToProduct('${esc(p.id)}')">+ Link Manifest</button>
             ${['draft','open','closed','archive'].map(s => {
               const active = p.status === s;


### PR DESCRIPTION
## Summary
- Product detail view had "+ Link Manifest" (attach existing) but no button to create a new manifest — users had to navigate to Manifests view, create one, then return to link.
- Extract the shared create form into `OL.createManifest({title?, description?, content?, productId?})`; `OL.promoteToManifest` now delegates to it.
- Adds "+ New Manifest" button next to "+ Link Manifest" on product detail; clicking opens the form with the product preselected.
- Also surfaces non-2xx POST responses in the form status line.

## Test plan
- [ ] Open any product → click "+ New Manifest" → form opens with product preselected, title empty
- [ ] Submit → dashboard switches to new manifest's detail view; manifest appears in the product's "Linked Manifests" section after refresh
- [ ] Regression: idea/memory "promote to manifest" flow still works (OL.promoteToManifest path)
- [ ] Regression: Manifests view "(existing create flows)" unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)