### PR TITLE
feat(web): add + New Manifest button in Manifests tab

### DIFF
--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -272,6 +272,7 @@
         <div style="display:flex;gap:8px;margin-bottom:16px">
           <input type="text" id="manifest-search-input" class="conv-search" placeholder="Search manifests by keyword, Jira ref, or tag..." style="flex:1" />
           <button id="manifest-search-btn" class="btn-search">Search</button>
+          <button id="manifest-new-btn" class="btn-search btn-action">+ New Manifest</button>
         </div>
         <div class="manifests-layout">
           <div class="manifest-list-panel">

--- a/internal/web/ui/views/manifests.js
+++ b/internal/web/ui/views/manifests.js
@@ -6,9 +6,11 @@
     const el = document.getElementById('manifest-list');
     const searchInput = document.getElementById('manifest-search-input');
     const searchBtn = document.getElementById('manifest-search-btn');
+    const newBtn = document.getElementById('manifest-new-btn');
 
     searchBtn.onclick = () => searchManifests(searchInput.value);
     searchInput.onkeypress = (e) => { if (e.key === 'Enter') searchManifests(searchInput.value); };
+    if (newBtn) newBtn.onclick = () => OL.createManifest();
 
     try {
       var results = await Promise.all([


### PR DESCRIPTION
## Summary
- Manifests tab top bar had search only — no way to create a manifest from the view itself (users had to go via a product's "+ New Manifest" or an idea promotion).
- Adds "+ New Manifest" button next to the Search button; delegates to `OL.createManifest()` (introduced in #52) with no preselected product, so the form's product dropdown lets the user pick any product or none.

## Test plan
- [ ] Dashboard → Manifests tab → new button appears next to Search
- [ ] Click it → create form opens, Product dropdown defaults to "No Product"
- [ ] Submit → new manifest appears in list + auto-navigates to its detail view
- [ ] Regression: product-scoped "+ New Manifest" (from #52) still preselects the product

🤖 Generated with [Claude Code](https://claude.com/claude-code)