### PR TITLE
feat(web): show live $ on running-task card

### DIFF
--- a/internal/web/ui/views/overview.js
+++ b/internal/web/ui/views/overview.js
@@ -389,6 +389,7 @@
             '<span style="font-weight:500;font-size:13px;flex:1">' + esc(rt.title) + '</span>' +
             '<span class="badge type badge-sm">' + esc(rt.agent) + '</span>' +
             '<span style="font-size:12px;color:var(--text-muted)">' + rt.actions + ' actions</span>' +
+            '<span style="font-size:12px;color:var(--green);font-weight:500" title="Live cost — ticks up per turn; task terminates at max_cost_usd">$' + (rt.cumulative_cost_usd || 0).toFixed(2) + '</span>' +
             '<span style="font-size:12px;color:' + (rt.paused ? 'var(--yellow)' : 'var(--green)') + ';font-weight:500">' + (rt.paused ? 'PAUSED' : mins + 'm ' + secs + 's') + '</span>' +
             (rt.paused
               ? '<button class="btn-search" onclick="event.stopPropagation();OL.resumeTask(\'' + esc(rt.task_id) + '\')" style="font-size:11px;padding:3px 10px">Resume</button>'


### PR DESCRIPTION
## Summary
- The running-task card on Overview already ticks up **actions** and **elapsed time** live. The cumulative $ wasn't rendered even though the backend has been populating \`cumulative_cost_usd\` on every turn.
- Adds a green \`$X.XX\` cell between "N actions" and the elapsed-time pill, reading \`rt.cumulative_cost_usd\` (already on the API response from \`/api/tasks/running\`).
- Tooltip: *"Live cost — ticks up per turn; task terminates at max_cost_usd"* — makes the ship-guard visible.

## Test plan
- [ ] Start a task; open Overview; confirm the \$ cell renders \`$0.00\` at t=0
- [ ] As the agent makes tool calls, actions count + \$ both tick up on each refresh
- [ ] If task approaches \`max_cost_usd\`, \$ stops at the cap and the card flips to failed with terminal_reason=\`max_cost_exceeded\`
- [ ] Paused tasks still show last known \$
- [ ] No regression on the pause/resume/stop buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)