### PR TITLE
fix(runner): live $ updates from per-message usage + self-calibrating rates

### DIFF
--- a/internal/task/pricing.go
+++ b/internal/task/pricing.go
@@ -1,0 +1,239 @@
+package task
+
+import (
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// parseFinalResultUsage scans the tail of a run's combined output for the
+// terminal `type:"result"` event and returns the usage block from it. Used
+// for pricing calibration — the result event carries the cumulative usage
+// the billing engine actually charged on.
+func parseFinalResultUsage(output string) (Usage, bool) {
+	if output == "" {
+		return Usage{}, false
+	}
+	lines := strings.Split(output, "\n")
+	for i := len(lines) - 1; i >= 0 && i >= len(lines)-20; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		var event map[string]any
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			continue
+		}
+		t, _ := event["type"].(string)
+		if t != "result" {
+			continue
+		}
+		usage, _ := event["usage"].(map[string]any)
+		if usage == nil {
+			return Usage{}, false
+		}
+		return Usage{
+			InputTokens:         intFromAny(usage["input_tokens"]),
+			OutputTokens:        intFromAny(usage["output_tokens"]),
+			CacheCreationTokens: intFromAny(usage["cache_creation_input_tokens"]),
+			CacheReadTokens:     intFromAny(usage["cache_read_input_tokens"]),
+		}, true
+	}
+	return Usage{}, false
+}
+
+// Usage holds the token counts we bill on. Fields mirror the stream-json
+// message.usage shape emitted by Claude Code.
+type Usage struct {
+	InputTokens         int
+	OutputTokens        int
+	CacheCreationTokens int
+	CacheReadTokens     int
+}
+
+// Add returns the sum of two Usage values — handy for aggregating per-message
+// usage into a run total.
+func (u Usage) Add(o Usage) Usage {
+	return Usage{
+		InputTokens:         u.InputTokens + o.InputTokens,
+		OutputTokens:        u.OutputTokens + o.OutputTokens,
+		CacheCreationTokens: u.CacheCreationTokens + o.CacheCreationTokens,
+		CacheReadTokens:     u.CacheReadTokens + o.CacheReadTokens,
+	}
+}
+
+// ModelRates holds the per-million-token rates for a model family. Values are
+// the list-price defaults; real billing is calibrated per model by
+// Store.CalibrateModelPricing against the authoritative total_cost_usd
+// emitted by Claude Code in the terminal result event.
+type ModelRates struct {
+	InputPerMTok      float64
+	OutputPerMTok     float64
+	CacheWritePerMTok float64
+	CacheReadPerMTok  float64
+}
+
+// DefaultRates returns the list-price rates for the given model id. Used as
+// the cold-start estimate before the pricing multiplier has been calibrated
+// from a real run. Substring match — picks the Claude family by keyword.
+func DefaultRates(model string) ModelRates {
+	m := strings.ToLower(model)
+	switch {
+	case strings.Contains(m, "opus"):
+		return ModelRates{InputPerMTok: 15, OutputPerMTok: 75, CacheWritePerMTok: 18.75, CacheReadPerMTok: 1.5}
+	case strings.Contains(m, "sonnet"):
+		return ModelRates{InputPerMTok: 3, OutputPerMTok: 15, CacheWritePerMTok: 3.75, CacheReadPerMTok: 0.3}
+	case strings.Contains(m, "haiku"):
+		return ModelRates{InputPerMTok: 1, OutputPerMTok: 5, CacheWritePerMTok: 1.25, CacheReadPerMTok: 0.1}
+	}
+	return ModelRates{InputPerMTok: 15, OutputPerMTok: 75, CacheWritePerMTok: 18.75, CacheReadPerMTok: 1.5}
+}
+
+// ComputeCost applies rates to usage. Result is USD for this usage block.
+func ComputeCost(r ModelRates, u Usage) float64 {
+	return float64(u.InputTokens)*r.InputPerMTok/1_000_000 +
+		float64(u.OutputTokens)*r.OutputPerMTok/1_000_000 +
+		float64(u.CacheCreationTokens)*r.CacheWritePerMTok/1_000_000 +
+		float64(u.CacheReadTokens)*r.CacheReadPerMTok/1_000_000
+}
+
+// EstimateCost is the live-run estimator: default rates × the model's
+// calibration multiplier (defaults to 1.0 before any calibration).
+func EstimateCost(model string, multiplier float64, u Usage) float64 {
+	if multiplier <= 0 {
+		multiplier = 1.0
+	}
+	return ComputeCost(DefaultRates(model), u) * multiplier
+}
+
+// ModelPricing is what we persist per model — a single scalar that scales
+// the default rate table to match the actual total_cost_usd reported by the
+// terminal result event. EMA-updated on every completed run.
+type ModelPricing struct {
+	Model      string
+	Multiplier float64
+	Samples    int
+	UpdatedAt  time.Time
+}
+
+// calibrationAlpha is the EMA weight applied to a new sample. 0.3 gives the
+// latest run moderate influence without losing history — the multiplier
+// settles within ~10 runs if pricing is stable.
+const calibrationAlpha = 0.3
+
+// initPricingSchema creates the model_pricing table. Called from Store.init().
+func (s *Store) initPricingSchema() error {
+	_, err := s.db.Exec(`CREATE TABLE IF NOT EXISTS model_pricing (
+		model TEXT PRIMARY KEY,
+		multiplier REAL NOT NULL,
+		samples INTEGER NOT NULL DEFAULT 0,
+		updated_at INTEGER NOT NULL
+	)`)
+	return err
+}
+
+// GetModelMultiplier returns the calibration multiplier for model, or 1.0 if
+// we have never calibrated it. Safe to call on any code path that needs a
+// live-cost estimate.
+func (s *Store) GetModelMultiplier(model string) float64 {
+	if model == "" {
+		return 1.0
+	}
+	var m float64
+	err := s.db.QueryRow(`SELECT multiplier FROM model_pricing WHERE model = ?`, model).Scan(&m)
+	if err == sql.ErrNoRows || err != nil || m <= 0 {
+		return 1.0
+	}
+	return m
+}
+
+// GetModelPricing returns the full pricing row, or a zero-value row if
+// absent. Used by the dashboard + tests to inspect calibration state.
+func (s *Store) GetModelPricing(model string) (ModelPricing, error) {
+	var p ModelPricing
+	var ts int64
+	err := s.db.QueryRow(`SELECT model, multiplier, samples, updated_at FROM model_pricing WHERE model = ?`, model).
+		Scan(&p.Model, &p.Multiplier, &p.Samples, &ts)
+	if err == sql.ErrNoRows {
+		return ModelPricing{Model: model, Multiplier: 1.0}, nil
+	}
+	if err != nil {
+		return ModelPricing{}, err
+	}
+	p.UpdatedAt = time.Unix(ts, 0).UTC()
+	return p, nil
+}
+
+// CalibrateModelPricing blends a new observation into the stored multiplier.
+// reportedCost must be the authoritative total_cost_usd from the result event;
+// u must be the matching final usage. Called once per completed run.
+//
+// The new sample is reported / predicted_at_default_rates. We EMA-blend into
+// the prior multiplier so a single outlier does not jerk the estimate around.
+func (s *Store) CalibrateModelPricing(model string, reportedCost float64, u Usage) error {
+	if model == "" || reportedCost <= 0 {
+		return nil
+	}
+	predicted := ComputeCost(DefaultRates(model), u)
+	if predicted <= 0 {
+		return nil
+	}
+	sample := reportedCost / predicted
+
+	prior, err := s.GetModelPricing(model)
+	if err != nil {
+		return err
+	}
+	var next float64
+	if prior.Samples == 0 {
+		next = sample
+	} else {
+		next = prior.Multiplier*(1-calibrationAlpha) + sample*calibrationAlpha
+	}
+	now := time.Now().UTC().Unix()
+	_, err = s.db.Exec(`INSERT INTO model_pricing (model, multiplier, samples, updated_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(model) DO UPDATE SET
+			multiplier = excluded.multiplier,
+			samples = model_pricing.samples + 1,
+			updated_at = excluded.updated_at`,
+		model, next, 1, now)
+	return err
+}
+
+// parseAssistantUsage reads (messageID, model, usage) from the parsed event
+// map of a stream-json assistant line. Returns ok=false if the event is not
+// an assistant event with usage present. The caller dedupes by messageID
+// because Claude Code may emit the same assistant message more than once as
+// it streams — last-write-wins matches the terminal result event.
+func parseAssistantUsage(event map[string]any) (id, model string, u Usage, ok bool) {
+	msg, _ := event["message"].(map[string]any)
+	if msg == nil {
+		return "", "", Usage{}, false
+	}
+	id, _ = msg["id"].(string)
+	model, _ = msg["model"].(string)
+	usage, _ := msg["usage"].(map[string]any)
+	if usage == nil {
+		return id, model, Usage{}, false
+	}
+	u.InputTokens = intFromAny(usage["input_tokens"])
+	u.OutputTokens = intFromAny(usage["output_tokens"])
+	u.CacheCreationTokens = intFromAny(usage["cache_creation_input_tokens"])
+	u.CacheReadTokens = intFromAny(usage["cache_read_input_tokens"])
+	return id, model, u, true
+}
+
+func intFromAny(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	case int64:
+		return int(n)
+	}
+	return 0
+}
+

--- a/internal/task/pricing_e2e_test.go
+++ b/internal/task/pricing_e2e_test.go
@@ -1,0 +1,98 @@
+package task
+
+import (
+	"bufio"
+	"encoding/json"
+	"math"
+	"os"
+	"testing"
+)
+
+// TestPricingE2E_ReplaysRealRun — optional end-to-end check that replays a
+// recorded Claude Code stream-json run against the live-cost path.
+//
+// Enables only when OPENPRAXIS_E2E_RUN_PATH points at a run-output file
+// (one event JSON per line, same format we store in task_runs.output). The
+// test:
+//   1. Walks the file exactly like runner.go does: per-message-id usage
+//      dedupe + live cost estimate.
+//   2. Calibrates a fresh pricing multiplier from the terminal result event.
+//   3. Asserts that, after calibration, re-computing EstimateCost on the
+//      final summed usage lands within 1 cent of the reported total_cost_usd.
+//
+// Skipped in CI. Run locally with:
+//   OPENPRAXIS_E2E_RUN_PATH=/tmp/run120.jsonl go test ./internal/task/ -run PricingE2E -v
+func TestPricingE2E_ReplaysRealRun(t *testing.T) {
+	path := os.Getenv("OPENPRAXIS_E2E_RUN_PATH")
+	if path == "" {
+		t.Skip("OPENPRAXIS_E2E_RUN_PATH not set; skipping replay test")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+
+	usageByMessage := make(map[string]Usage)
+	var model string
+	var allOutput []byte
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 1024*1024), 1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		allOutput = append(allOutput, line...)
+		allOutput = append(allOutput, '\n')
+		var event map[string]any
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+		if id, m, u, ok := parseAssistantUsage(event); ok {
+			if model == "" && m != "" {
+				model = m
+			}
+			if id != "" {
+				usageByMessage[id] = u
+			}
+		}
+	}
+
+	// Final summed usage from the dedupe map.
+	var summed Usage
+	for _, u := range usageByMessage {
+		summed = summed.Add(u)
+	}
+
+	// Pull the authoritative cost + usage from the result event.
+	reported, _ := ParseCostFromOutput(string(allOutput))
+	resultUsage, _ := parseFinalResultUsage(string(allOutput))
+
+	t.Logf("model=%s", model)
+	t.Logf("summed-from-assistant-events: %+v", summed)
+	t.Logf("result-event-usage: %+v", resultUsage)
+	t.Logf("reported total_cost_usd: %.6f", reported)
+
+	// Calibrate against the result event (authoritative).
+	s := openPricingTestDB(t)
+	if err := s.CalibrateModelPricing(model, reported, resultUsage); err != nil {
+		t.Fatalf("Calibrate: %v", err)
+	}
+	mult := s.GetModelMultiplier(model)
+	t.Logf("calibrated multiplier: %.6f", mult)
+
+	// Re-estimate using the calibrated rates against the authoritative usage
+	// — this must reproduce the reported cost to near-float-precision, since
+	// calibration is literally the ratio that makes this hold.
+	est := EstimateCost(model, mult, resultUsage)
+	if math.Abs(est-reported) > 0.01 {
+		t.Fatalf("post-calibration estimate = $%.4f, want ~$%.4f", est, reported)
+	}
+
+	// And the live-estimate path (pre-calibration, default multiplier 1.0,
+	// summed per-message usage) should have been > 0 — confirming the bug
+	// fix: the running-task card would have shown a real number, not $0.
+	live := EstimateCost(model, 1.0, summed)
+	if live <= 0 {
+		t.Fatalf("live estimate was $0 — the bug still reproduces")
+	}
+	t.Logf("live estimate (pre-calibration): $%.4f (reported $%.4f)", live, reported)
+}

--- a/internal/task/pricing_test.go
+++ b/internal/task/pricing_test.go
@@ -1,0 +1,168 @@
+package task
+
+import (
+	"database/sql"
+	"math"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func openPricingTestDB(t *testing.T) *Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "p.db") + "?_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	s, err := NewStore(db)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return s
+}
+
+// TestDefaultRates_OpusSonnetHaiku — the family dispatch is substring-based;
+// it must pick the right rate card even for versioned model ids like
+// "claude-opus-4-7" and is case-insensitive.
+func TestDefaultRates_OpusSonnetHaiku(t *testing.T) {
+	cases := []struct {
+		model    string
+		wantIn   float64
+		wantOut  float64
+	}{
+		{"claude-opus-4-7", 15, 75},
+		{"Claude-Sonnet-4-6", 3, 15},
+		{"claude-haiku-4-5-20251001", 1, 5},
+		{"unknown-model", 15, 75}, // fallback = opus
+	}
+	for _, c := range cases {
+		r := DefaultRates(c.model)
+		if r.InputPerMTok != c.wantIn || r.OutputPerMTok != c.wantOut {
+			t.Errorf("DefaultRates(%q) = {in:%.2f out:%.2f}, want {in:%.2f out:%.2f}",
+				c.model, r.InputPerMTok, r.OutputPerMTok, c.wantIn, c.wantOut)
+		}
+	}
+}
+
+// TestComputeCost — sanity check the math. $15/M in × 1M tokens = $15, etc.
+func TestComputeCost(t *testing.T) {
+	r := ModelRates{InputPerMTok: 15, OutputPerMTok: 75, CacheWritePerMTok: 18.75, CacheReadPerMTok: 1.5}
+	u := Usage{InputTokens: 1_000_000, OutputTokens: 1_000_000, CacheCreationTokens: 1_000_000, CacheReadTokens: 1_000_000}
+	got := ComputeCost(r, u)
+	want := 15.0 + 75.0 + 18.75 + 1.5
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("ComputeCost = %.6f, want %.6f", got, want)
+	}
+}
+
+// TestGetModelMultiplier_DefaultOne — an uncalibrated model must estimate at
+// default rates (multiplier 1.0), not at 0.
+func TestGetModelMultiplier_DefaultOne(t *testing.T) {
+	s := openPricingTestDB(t)
+	if m := s.GetModelMultiplier("claude-opus-4-7"); m != 1.0 {
+		t.Fatalf("uncalibrated multiplier = %.4f, want 1.0", m)
+	}
+}
+
+// TestCalibrateModelPricing_FirstSampleReplaces — the first calibration
+// should snap the multiplier to the observed ratio with no EMA damping.
+// Reproduces the real task 120 numbers from the production DB: 1.25625375
+// final cost against the usage that default opus rates would price at ~3.77.
+func TestCalibrateModelPricing_FirstSampleReplaces(t *testing.T) {
+	s := openPricingTestDB(t)
+	u := Usage{
+		InputTokens:         38,
+		OutputTokens:        9942,
+		CacheCreationTokens: 58391,
+		CacheReadTokens:     1278022,
+	}
+	const model = "claude-opus-4-7"
+	const reported = 1.25625375
+
+	if err := s.CalibrateModelPricing(model, reported, u); err != nil {
+		t.Fatalf("Calibrate: %v", err)
+	}
+	mult := s.GetModelMultiplier(model)
+	predicted := ComputeCost(DefaultRates(model), u)
+	wantSample := reported / predicted
+	if math.Abs(mult-wantSample) > 1e-9 {
+		t.Fatalf("multiplier = %.6f, want first-sample %.6f", mult, wantSample)
+	}
+	// EstimateCost with the calibrated multiplier must reproduce the reported
+	// cost to within float noise — this is the whole point of the calibration.
+	if est := EstimateCost(model, mult, u); math.Abs(est-reported) > 1e-6 {
+		t.Fatalf("EstimateCost = %.6f, want %.6f", est, reported)
+	}
+}
+
+// TestCalibrateModelPricing_EMABlendsOnSecondSample — a second sample must
+// be EMA-blended (not overwrite), so a single outlier cannot jerk the
+// estimate. Concretely: prior 0.3, new sample 1.0, alpha 0.3 → 0.3*0.7 + 1.0*0.3 = 0.51.
+func TestCalibrateModelPricing_EMABlendsOnSecondSample(t *testing.T) {
+	s := openPricingTestDB(t)
+	const model = "claude-opus-4-7"
+
+	// First run: usage priced at default $1 (1M input tokens), reported $0.30 → multiplier 0.3.
+	u1 := Usage{InputTokens: 66_667} // 66_667 * 15 / 1e6 ≈ $1.00005
+	if err := s.CalibrateModelPricing(model, 0.30003, u1); err != nil {
+		t.Fatalf("first calibrate: %v", err)
+	}
+	first := s.GetModelMultiplier(model)
+	if math.Abs(first-0.3) > 1e-3 {
+		t.Fatalf("first multiplier = %.4f, want ~0.3", first)
+	}
+
+	// Second run: usage priced at $1, reported $1.00 → sample multiplier 1.0.
+	// Blended: 0.3 * 0.7 + 1.0 * 0.3 = 0.51.
+	if err := s.CalibrateModelPricing(model, 1.00005, u1); err != nil {
+		t.Fatalf("second calibrate: %v", err)
+	}
+	blended := s.GetModelMultiplier(model)
+	if math.Abs(blended-0.51) > 0.01 {
+		t.Fatalf("blended multiplier = %.4f, want ~0.51", blended)
+	}
+}
+
+// TestParseAssistantUsage — confirms we read the four token fields off a
+// realistic stream-json assistant event, and dedupe key is message.id.
+func TestParseAssistantUsage(t *testing.T) {
+	event := map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"id":    "msg_abc",
+			"model": "claude-opus-4-7",
+			"usage": map[string]any{
+				"input_tokens":                float64(5),
+				"output_tokens":               float64(8),
+				"cache_creation_input_tokens": float64(15955),
+				"cache_read_input_tokens":     float64(16204),
+			},
+		},
+	}
+	id, model, u, ok := parseAssistantUsage(event)
+	if !ok || id != "msg_abc" || model != "claude-opus-4-7" {
+		t.Fatalf("got id=%q model=%q ok=%v", id, model, ok)
+	}
+	if u.InputTokens != 5 || u.OutputTokens != 8 || u.CacheCreationTokens != 15955 || u.CacheReadTokens != 16204 {
+		t.Fatalf("usage = %+v", u)
+	}
+}
+
+// TestParseFinalResultUsage — scans the tail for the result event and pulls
+// its usage block. Mirrors the run-output format we persist.
+func TestParseFinalResultUsage(t *testing.T) {
+	output := `{"type":"system","subtype":"init"}
+{"type":"assistant","message":{"id":"m1","usage":{"input_tokens":5}}}
+{"type":"result","subtype":"success","total_cost_usd":1.25,"usage":{"input_tokens":38,"output_tokens":9942,"cache_creation_input_tokens":58391,"cache_read_input_tokens":1278022}}
+`
+	u, ok := parseFinalResultUsage(output)
+	if !ok {
+		t.Fatal("parseFinalResultUsage = !ok")
+	}
+	if u.InputTokens != 38 || u.OutputTokens != 9942 || u.CacheCreationTokens != 58391 || u.CacheReadTokens != 1278022 {
+		t.Fatalf("result usage = %+v", u)
+	}
+}

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -37,8 +37,15 @@ type RunningTask struct {
 	// cost cap has a live value to compare against.
 	CumulativeCostUSD float64  `json:"cumulative_cost_usd"`
 	Output            []string `json:"-"` // ring buffer, not serialized
-	cancel            context.CancelFunc
-	cmd               *exec.Cmd
+	// Model is the model id reported by the first assistant event — used to
+	// pick a pricing table and for calibration after the run.
+	Model string `json:"model"`
+	// usageByMessage tracks the last-seen usage per message id so we can
+	// dedupe the repeated assistant events Claude Code emits while a single
+	// logical message streams. Not serialized; live-estimate only.
+	usageByMessage map[string]Usage
+	cancel         context.CancelFunc
+	cmd            *exec.Cmd
 }
 
 // Runner manages task execution — spawning agents and tracking running tasks.
@@ -561,17 +568,18 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 	}
 
 	rt := &RunningTask{
-		TaskID:    t.ID,
-		Marker:    marker,
-		Title:     t.Title,
-		Manifest:  manifestTitle,
-		ProductID: scope.ProductID,
-		Agent:     t.Agent,
-		PID:       cmd.Process.Pid,
-		StartedAt: time.Now(),
-		Output:    make([]string, 0, 200),
-		cancel:    cancel,
-		cmd:       cmd,
+		TaskID:         t.ID,
+		Marker:         marker,
+		Title:          t.Title,
+		Manifest:       manifestTitle,
+		ProductID:      scope.ProductID,
+		Agent:          t.Agent,
+		PID:            cmd.Process.Pid,
+		StartedAt:      time.Now(),
+		Output:         make([]string, 0, 200),
+		usageByMessage: make(map[string]Usage),
+		cancel:         cancel,
+		cmd:            cmd,
 	}
 
 	r.mu.Lock()
@@ -714,22 +722,50 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 				}
 			}
 
-			// Live cost tracking: each stream event may carry a cost field.
-			// We accept cumulative (total_cost_usd) directly and treat per-
-			// event cost_usd as an additive delta. Either way rt tracks the
-			// max seen so the mid-run cap has a monotonic value to compare.
+			// Live cost tracking.
+			//
+			// Real Claude Code stream-json only puts total_cost_usd on the
+			// terminal result event, so the cost cap would have nothing to
+			// read mid-run if we relied on it alone. Instead, each assistant
+			// event carries message.usage (input/output/cache tokens); we
+			// dedupe by message.id (Claude Code re-emits the same message as
+			// the response streams) and multiply by the model's calibrated
+			// rates. The authoritative total_cost_usd still wins when the
+			// result event arrives — it snaps rt.CumulativeCostUSD to the
+			// exact billed value before the run is recorded.
+			if event != nil {
+				if id, model, u, ok := parseAssistantUsage(event); ok {
+					if rt.Model == "" && model != "" {
+						rt.Model = model
+					}
+					if id != "" {
+						rt.usageByMessage[id] = u
+					}
+					var total Usage
+					for _, mu := range rt.usageByMessage {
+						total = total.Add(mu)
+					}
+					mult := r.store.GetModelMultiplier(rt.Model)
+					est := EstimateCost(rt.Model, mult, total)
+					if est > rt.CumulativeCostUSD {
+						rt.CumulativeCostUSD = est
+					}
+				}
+			}
+			// Still accept an authoritative total_cost_usd if the stream
+			// emits one (future Claude Code versions may send it earlier).
 			if c, ok := extractCostFromEvent(line); ok {
 				if c > rt.CumulativeCostUSD {
 					rt.CumulativeCostUSD = c
 				}
-				if maxCostCap > 0 && rt.CumulativeCostUSD > maxCostCap && !costCapExceeded {
-					costCapExceeded = true
-					slog.Warn("killing task: cost cap exceeded",
-						"component", "runner", "marker", marker,
-						"cap_usd", maxCostCap, "cost_usd", rt.CumulativeCostUSD)
-					if cmd.Process != nil {
-						_ = cmd.Process.Signal(syscall.SIGTERM)
-					}
+			}
+			if maxCostCap > 0 && rt.CumulativeCostUSD > maxCostCap && !costCapExceeded {
+				costCapExceeded = true
+				slog.Warn("killing task: cost cap exceeded",
+					"component", "runner", "marker", marker,
+					"cap_usd", maxCostCap, "cost_usd", rt.CumulativeCostUSD)
+				if cmd.Process != nil {
+					_ = cmd.Process.Signal(syscall.SIGTERM)
 				}
 			}
 
@@ -793,6 +829,25 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 		costUSD, numTurns := ParseCostFromOutput(output)
 		if costUSD == 0 && rt.CumulativeCostUSD > 0 {
 			costUSD = rt.CumulativeCostUSD
+		}
+
+		// Calibrate model pricing from the authoritative final cost so the
+		// next run's live estimate is closer to reality. We use the result
+		// event's usage if present; otherwise fall back to the summed
+		// per-message usage we tracked during the run.
+		if costUSD > 0 {
+			var finalUsage Usage
+			if ru, ok := parseFinalResultUsage(output); ok {
+				finalUsage = ru
+			} else {
+				for _, mu := range rt.usageByMessage {
+					finalUsage = finalUsage.Add(mu)
+				}
+			}
+			if err := r.store.CalibrateModelPricing(rt.Model, costUSD, finalUsage); err != nil {
+				slog.Warn("calibrate model pricing failed", "component", "runner",
+					"marker", marker, "model", rt.Model, "error", err)
+			}
 		}
 
 		// Record the run with history — always use real status, not "scheduled"

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -168,6 +168,10 @@ func (s *Store) init() error {
 		return fmt.Errorf("create task_manifests table: %w", err)
 	}
 
+	if err := s.initPricingSchema(); err != nil {
+		return fmt.Errorf("create model_pricing table: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Running-task card always showed \$0 mid-run — Claude Code's stream-json only emits `total_cost_usd` on the terminal `result` event, so the previous extractor never saw cost until the run was already finishing.
- Live estimate now tracks `message.usage` per message id (last-write-wins to dedupe repeated assistant events) and prices it via per-model rates × a calibration multiplier.
- The multiplier is self-calibrating: after every completed run we blend `reported_total_cost / predicted_at_default_rates` into the stored value (EMA, α=0.3). Cold start uses list prices by family (opus/sonnet/haiku); the first real run snaps the estimate to reality and it keeps tracking even if pricing changes.

## Files

- `internal/task/pricing.go` (new) — `Usage`, `ModelRates`, `DefaultRates`, `ComputeCost`, `EstimateCost`, `Store.{Get,Calibrate}ModelPricing`, plus event parsers.
- `internal/task/store.go` — `model_pricing` table added in `Store.init()`.
- `internal/task/runner.go` — scanner loop dedupes per-message usage → live estimate; post-run calibrates against `result.total_cost_usd`.
- Tests: 7 unit tests + 1 opt-in e2e replay test (`OPENPRAXIS_E2E_RUN_PATH=/path/to/run.jsonl`).

## Test plan

- [x] `go test ./...` green
- [x] `go vet ./...` clean
- [x] E2E replay vs real task 120 output: pre-calibration live estimate \$3.12 (was \$0), post-calibration multiplier 0.33 reproduces the reported \$1.26
- [ ] Start a fresh task on the dashboard and confirm the live \$ field ticks up per turn (not \$0)
- [ ] After the run completes, inspect `SELECT * FROM model_pricing` — row for the model, multiplier ≈ 0.33 for opus-4-7

🤖 Generated with [Claude Code](https://claude.com/claude-code)