### PR TITLE
fix(watcher): accept suffixed task branches in git gate

### DIFF
--- a/internal/watcher/store.go
+++ b/internal/watcher/store.go
@@ -44,7 +44,12 @@ type GitResult struct {
 	Deletions        int      `json:"deletions"`
 	UncommittedFiles []string `json:"uncommitted_files"`
 	BranchExists     bool     `json:"branch_exists"`
-	Reason           string   `json:"reason"`
+	// Branch is the branch the gate actually audited. Usually
+	// openpraxis/<taskMarker>, but tasks whose descriptions append a
+	// human-readable suffix (e.g. -m1-t1) land on the longer branch, so the
+	// gate resolves the real branch via prefix match.
+	Branch string `json:"branch"`
+	Reason string `json:"reason"`
 }
 
 // BuildResult holds the output of the build verification gate.

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -114,25 +114,68 @@ func (w *Watcher) AuditTask(taskID, taskMarker, taskTitle, manifestID, manifestT
 	return audit
 }
 
-// RunGitGate checks if the task branch has commits.
-func (w *Watcher) RunGitGate(taskMarker string) GitResult {
-	branch := "openpraxis/" + taskMarker
-	result := GitResult{}
-
-	// Check if branch exists
-	cmd := exec.Command("git", "branch", "--list", branch)
+// resolveTaskBranch finds the branch this task committed on. Accepts either
+// the plain openpraxis/<taskMarker> form or a suffixed openpraxis/<marker>-*
+// form. Returns the chosen branch and ok=true; ok=false if no branch
+// matches. Prefers the exact match; otherwise returns the most recently
+// updated suffixed branch (newest commit on the branch tip).
+func (w *Watcher) resolveTaskBranch(taskMarker string) (string, bool) {
+	exact := "openpraxis/" + taskMarker
+	pattern := exact + "-*"
+	// --sort=-committerdate gives newest-first; --format=%(refname:short)
+	// strips the refs/heads/ prefix.
+	cmd := exec.Command("git", "branch",
+		"--list", exact, pattern,
+		"--sort=-committerdate",
+		"--format=%(refname:short)")
 	cmd.Dir = w.repoDir
 	out, err := cmd.Output()
-	if err != nil || strings.TrimSpace(string(out)) == "" {
+	if err != nil {
+		return "", false
+	}
+	var suffixed string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.TrimSpace(line)
+		if name == "" {
+			continue
+		}
+		if name == exact {
+			return exact, true
+		}
+		if suffixed == "" {
+			suffixed = name
+		}
+	}
+	if suffixed != "" {
+		return suffixed, true
+	}
+	return "", false
+}
+
+// RunGitGate checks if the task branch has commits.
+//
+// Branch resolution accepts both the plain marker branch
+// (openpraxis/<taskMarker>) and any suffixed variant
+// (openpraxis/<taskMarker>-*). Task descriptions sometimes direct the agent
+// to include a human-readable suffix like `-m1-t1` in the branch name, and
+// before this change the gate looked only at the exact plain form and
+// reported BranchExists=false — which flipped completed runs to failed even
+// when all the work was on disk and pushed.
+func (w *Watcher) RunGitGate(taskMarker string) GitResult {
+	result := GitResult{}
+	branch, ok := w.resolveTaskBranch(taskMarker)
+	if !ok {
 		result.BranchExists = false
-		result.Reason = fmt.Sprintf("branch %s does not exist", branch)
+		result.Branch = "openpraxis/" + taskMarker
+		result.Reason = fmt.Sprintf("no branch matching openpraxis/%s or openpraxis/%s-* found", taskMarker, taskMarker)
 		return result
 	}
 	result.BranchExists = true
+	result.Branch = branch
 
 	// Find base branch — try sandbox, then main
 	baseBranch := "sandbox"
-	cmd = exec.Command("git", "rev-parse", "--verify", baseBranch)
+	cmd := exec.Command("git", "rev-parse", "--verify", baseBranch)
 	cmd.Dir = w.repoDir
 	if err := cmd.Run(); err != nil {
 		baseBranch = "main"
@@ -141,7 +184,7 @@ func (w *Watcher) RunGitGate(taskMarker string) GitResult {
 	// Count commits unique to task branch vs base
 	cmd = exec.Command("git", "log", "--oneline", baseBranch+".."+branch)
 	cmd.Dir = w.repoDir
-	out, err = cmd.Output()
+	out, err := cmd.Output()
 	if err != nil {
 		result.CommitCount = 0
 		result.Reason = fmt.Sprintf("failed to compare %s..%s: %v", baseBranch, branch, err)

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1,0 +1,125 @@
+package watcher
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// initTestRepo creates a temp git repo with an initial commit on main. Every
+// branch the test creates will include at least one new commit so the git
+// gate's CommitCount check sees non-zero diff.
+func initTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q", "-b", "main")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test")
+	run("commit", "--allow-empty", "-m", "init")
+	return dir
+}
+
+func commitOnBranch(t *testing.T, dir, branch, filename string) {
+	t.Helper()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("checkout", "-q", "-b", branch)
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, []byte("hello"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	run("add", filename)
+	run("commit", "-q", "-m", "work on "+branch)
+	run("checkout", "-q", "main")
+}
+
+// TestResolveTaskBranch_ExactPreferred — when both forms exist, the exact
+// plain-marker branch wins. Matches the historical contract for tasks that
+// don't rename their branch.
+func TestResolveTaskBranch_ExactPreferred(t *testing.T) {
+	dir := initTestRepo(t)
+	commitOnBranch(t, dir, "openpraxis/abc123-def", "exact.txt")
+	commitOnBranch(t, dir, "openpraxis/abc123-def-m1-t1", "suffixed.txt")
+
+	w := New(nil, dir, "", "node")
+	got, ok := w.resolveTaskBranch("abc123-def")
+	if !ok {
+		t.Fatal("resolveTaskBranch ok=false, want exact match")
+	}
+	if got != "openpraxis/abc123-def" {
+		t.Fatalf("got %q, want openpraxis/abc123-def (exact)", got)
+	}
+}
+
+// TestResolveTaskBranch_SuffixedOnly — this is the production bug we're
+// fixing: only the suffixed branch exists, the gate must still find it
+// rather than reporting BranchExists=false.
+func TestResolveTaskBranch_SuffixedOnly(t *testing.T) {
+	dir := initTestRepo(t)
+	commitOnBranch(t, dir, "openpraxis/019da13a-f33-m1-t1", "schema.go")
+
+	w := New(nil, dir, "", "node")
+	got, ok := w.resolveTaskBranch("019da13a-f33")
+	if !ok {
+		t.Fatal("resolveTaskBranch ok=false for suffixed-only branch; bug reproduces")
+	}
+	if got != "openpraxis/019da13a-f33-m1-t1" {
+		t.Fatalf("got %q, want openpraxis/019da13a-f33-m1-t1", got)
+	}
+}
+
+// TestResolveTaskBranch_None — neither form present, ok=false.
+func TestResolveTaskBranch_None(t *testing.T) {
+	dir := initTestRepo(t)
+
+	w := New(nil, dir, "", "node")
+	if _, ok := w.resolveTaskBranch("missing"); ok {
+		t.Fatal("resolveTaskBranch ok=true for missing branch")
+	}
+}
+
+// TestResolveTaskBranch_NoFalsePrefixMatch — a task marker must not match
+// a different task whose marker happens to start with the same characters.
+// "abc" must not resolve to a branch on marker "abcdef".
+func TestResolveTaskBranch_NoFalsePrefixMatch(t *testing.T) {
+	dir := initTestRepo(t)
+	commitOnBranch(t, dir, "openpraxis/abcdef-m1", "other.txt")
+
+	w := New(nil, dir, "", "node")
+	if got, ok := w.resolveTaskBranch("abc"); ok {
+		t.Fatalf("resolveTaskBranch matched %q for unrelated prefix", got)
+	}
+}
+
+// TestRunGitGate_ReportsResolvedBranch — the audit output must record which
+// branch was actually checked so downgrades are diagnosable from the audit
+// row without re-running the gate.
+func TestRunGitGate_ReportsResolvedBranch(t *testing.T) {
+	dir := initTestRepo(t)
+	commitOnBranch(t, dir, "openpraxis/019da13a-f33-m1-t1", "schema.go")
+
+	w := New(nil, dir, "", "node")
+	res := w.RunGitGate("019da13a-f33")
+	if !res.BranchExists {
+		t.Fatalf("BranchExists=false; want true. Reason: %s", res.Reason)
+	}
+	if res.Branch != "openpraxis/019da13a-f33-m1-t1" {
+		t.Fatalf("Branch = %q, want openpraxis/019da13a-f33-m1-t1", res.Branch)
+	}
+	if res.CommitCount < 1 {
+		t.Fatalf("CommitCount = %d, want >=1", res.CommitCount)
+	}
+}


### PR DESCRIPTION
## Summary

- The watcher's git gate required the task branch to be exactly \`openpraxis/<taskMarker>\`. Task descriptions that append a human-readable suffix (e.g. \`-m1-t1\`) land on a longer branch name, so the gate reported \`BranchExists=false\` → verdict \`failed\` → \`FinalStatus\` downgraded from \`completed\` to \`failed\`, even though all work was committed and the PR was open.
- Resolve the branch by matching both the exact form and \`openpraxis/<marker>-*\`. Exact wins when both exist; otherwise the newest-committed suffixed match is chosen. \`GitResult.Branch\` now records which branch was audited.

## Reproduction (production)

Task \`019da13a-f33\` (Entity Comments M1-T1) was told to commit on \`openpraxis/<task-marker>-m1-t1\`. Agent did exactly that — commit \`7a457ec\` on \`openpraxis/019da13a-f33-m1-t1\`, PR #60 opened, CI green. Watcher audit downgraded both runs to failed with \`git_passed=0\`, because it looked for \`openpraxis/019da13a-f33\` (no suffix) and found nothing.

## Test plan

- [x] \`go test ./internal/watcher/\` — 5 tests added: exact-preferred, suffixed-only (the bug reproduction), no-match, no-false-prefix (\"abc\" must not match marker \"abcdef\"), and a RunGitGate end-to-end that asserts \`GitResult.Branch\` is set
- [x] \`go test ./...\` full suite green
- [x] \`go build ./...\` and \`go vet ./...\` clean
- [ ] After merging: re-run M1-T1 and confirm the audit row shows \`git_passed=1\`, \`final_status=completed\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)