### PR TITLE
feat(comments): add validation + type registry (M1-T3)

### DIFF
--- a/internal/comments/types.go
+++ b/internal/comments/types.go
@@ -40,3 +40,49 @@ func IsValidTargetType(s string) bool {
 	}
 	return false
 }
+
+// CommentTypeInfo carries UI/doc metadata per type. M3 renders the filter
+// dropdown from Registry() so new types added here automatically appear.
+type CommentTypeInfo struct {
+	Type        CommentType `json:"type"`
+	Label       string      `json:"label"`
+	Description string      `json:"description"`
+}
+
+// Registry returns metadata for every comment type in the canonical order
+// from AllCommentTypes(). It is the single source of truth consumed by the
+// MCP tool descriptions, the HTTP enum payload, and the M3 UI dropdown.
+func Registry() []CommentTypeInfo {
+	return []CommentTypeInfo{
+		{
+			Type:        TypeExecutionReview,
+			Label:       "Execution Review",
+			Description: "Post-run retrospective; what shipped, what failed, what the agent learned",
+		},
+		{
+			Type:        TypeUserNote,
+			Label:       "Note",
+			Description: "Free-form human note on the entity",
+		},
+		{
+			Type:        TypeWatcherFinding,
+			Label:       "Watcher Finding",
+			Description: "Auto-posted gate result — failures, warnings, or passes",
+		},
+		{
+			Type:        TypeAgentNote,
+			Label:       "Agent Note",
+			Description: "Agent-authored observation; distinct from an execution review",
+		},
+		{
+			Type:        TypeDecision,
+			Label:       "Decision",
+			Description: "Architectural or scope decision recorded against the entity",
+		},
+		{
+			Type:        TypeLink,
+			Label:       "Link",
+			Description: "Cross-reference to another comment, PR, issue, or external doc",
+		},
+	}
+}

--- a/internal/comments/validate.go
+++ b/internal/comments/validate.go
@@ -1,0 +1,48 @@
+package comments
+
+import (
+	"errors"
+	"strings"
+)
+
+// Exported sentinels for validation failures. M2's MCP + HTTP layers match
+// these with errors.Is to translate into protocol-specific error codes /
+// HTTP status codes. ErrEmptyAuthor and ErrEmptyBody live in store.go and
+// are reused here — do not redeclare.
+var (
+	ErrUnknownTargetType  = errors.New("comments: unknown target_type")
+	ErrEmptyTargetID      = errors.New("comments: target_id cannot be empty")
+	ErrUnknownCommentType = errors.New("comments: unknown type")
+)
+
+// ValidateAdd checks every field of an Add-style request without touching
+// the DB. Returns the first failure as a sentinel error; nil means OK.
+// Body is trimmed before the empty check so whitespace-only input is
+// rejected with ErrEmptyBody.
+func ValidateAdd(target TargetType, targetID, author string, cType CommentType, body string) error {
+	if !IsValidTargetType(string(target)) {
+		return ErrUnknownTargetType
+	}
+	if targetID == "" {
+		return ErrEmptyTargetID
+	}
+	if author == "" {
+		return ErrEmptyAuthor
+	}
+	if !IsValidCommentType(string(cType)) {
+		return ErrUnknownCommentType
+	}
+	if strings.TrimSpace(body) == "" {
+		return ErrEmptyBody
+	}
+	return nil
+}
+
+// ValidateEdit checks only the new body. The id format is a store concern —
+// Store.Edit already returns sql.ErrNoRows when the id does not exist.
+func ValidateEdit(body string) error {
+	if strings.TrimSpace(body) == "" {
+		return ErrEmptyBody
+	}
+	return nil
+}

--- a/internal/comments/validate_test.go
+++ b/internal/comments/validate_test.go
@@ -1,0 +1,97 @@
+package comments
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestValidateAdd(t *testing.T) {
+	cases := []struct {
+		name   string
+		target TargetType
+		tid    string
+		author string
+		cType  CommentType
+		body   string
+		want   error
+	}{
+		{"ok product", TargetProduct, "p1", "alice", TypeUserNote, "hello", nil},
+		{"ok manifest", TargetManifest, "m1", "bob", TypeDecision, "decided", nil},
+		{"ok task", TargetTask, "t1", "carol", TypeAgentNote, "noted", nil},
+
+		{"unknown target type", TargetType("peer"), "id", "a", TypeUserNote, "body", ErrUnknownTargetType},
+		{"empty target type", TargetType(""), "id", "a", TypeUserNote, "body", ErrUnknownTargetType},
+
+		{"empty target id", TargetProduct, "", "a", TypeUserNote, "body", ErrEmptyTargetID},
+
+		{"empty author", TargetProduct, "id", "", TypeUserNote, "body", ErrEmptyAuthor},
+
+		{"unknown comment type", TargetProduct, "id", "a", CommentType("ranty"), "body", ErrUnknownCommentType},
+		{"empty comment type", TargetProduct, "id", "a", CommentType(""), "body", ErrUnknownCommentType},
+
+		{"empty body", TargetProduct, "id", "a", TypeUserNote, "", ErrEmptyBody},
+		{"whitespace-only body", TargetProduct, "id", "a", TypeUserNote, "   \t\n ", ErrEmptyBody},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ValidateAdd(tc.target, tc.tid, tc.author, tc.cType, tc.body)
+			if tc.want == nil {
+				if got != nil {
+					t.Fatalf("expected nil, got %v", got)
+				}
+				return
+			}
+			if !errors.Is(got, tc.want) {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestValidateEdit(t *testing.T) {
+	if err := ValidateEdit("new body"); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if err := ValidateEdit(""); !errors.Is(err, ErrEmptyBody) {
+		t.Fatalf("expected ErrEmptyBody, got %v", err)
+	}
+	if err := ValidateEdit("   \n\t "); !errors.Is(err, ErrEmptyBody) {
+		t.Fatalf("expected ErrEmptyBody for whitespace-only, got %v", err)
+	}
+}
+
+func TestRegistry(t *testing.T) {
+	reg := Registry()
+	all := AllCommentTypes()
+
+	if len(reg) != 6 {
+		t.Fatalf("Registry len = %d, want 6", len(reg))
+	}
+	if len(reg) != len(all) {
+		t.Fatalf("Registry (%d) and AllCommentTypes (%d) length mismatch", len(reg), len(all))
+	}
+
+	for i, info := range reg {
+		if info.Type != all[i] {
+			t.Errorf("Registry[%d].Type = %q, want %q (taxonomy order)", i, info.Type, all[i])
+		}
+		if info.Label == "" {
+			t.Errorf("Registry[%d] (%s) has empty Label", i, info.Type)
+		}
+		if info.Description == "" {
+			t.Errorf("Registry[%d] (%s) has empty Description", i, info.Type)
+		}
+		if !IsValidCommentType(string(info.Type)) {
+			t.Errorf("Registry[%d] type %q not recognised by IsValidCommentType", i, info.Type)
+		}
+	}
+}
+
+func TestAllCommentTypesRoundTrip(t *testing.T) {
+	for _, ct := range AllCommentTypes() {
+		if !IsValidCommentType(string(ct)) {
+			t.Errorf("AllCommentTypes contains %q which fails IsValidCommentType", ct)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/comments/validate.go` — `ValidateAdd` / `ValidateEdit` + sentinels (`ErrUnknownTargetType`, `ErrEmptyTargetID`, `ErrUnknownCommentType`). M2's MCP + HTTP layers match via `errors.Is` to translate to 400 responses.
- Adds `Registry()` returning `CommentTypeInfo` for all 6 types in taxonomy order — single source of truth for MCP tool descriptions, HTTP enum payload, and M3 UI filter dropdown.
- Whitespace-only bodies rejected (`strings.TrimSpace`). No max body length enforced — belongs at HTTP layer per manifest.

Base: `openpraxis/019da13d-a2a` (M1-T2) since M1-T1/T2 not yet on main.

Manifest: 019d9be8-4b7 · Task: 019da13e-2f8 · Depends on: M1-T2 (019da13d-a2a).

## Sentinel → HTTP mapping (for M2)
| Sentinel | Status |
|---|---|
| `ErrUnknownTargetType`, `ErrEmptyTargetID`, `ErrUnknownCommentType`, `ErrEmptyAuthor`, `ErrEmptyBody` | 400 |
| `sql.ErrNoRows` (from `Store.Get`/`Edit`) | 404 |

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./internal/comments/...` passes
- [x] Table-driven coverage: every sentinel + whitespace-only body + `ValidateEdit("")` + Registry shape/order + `AllCommentTypes` round-trip

Note: memory_store for `/project/openpraxis/entity-comments/m1-t3-complete` was blocked by permissions; sentinel table and Registry shape are captured in this PR body instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)