### PR TITLE
feat(tasks): canonical 8-state status taxonomy + state-machine enforcement

### DIFF
--- a/internal/task/repository.go
+++ b/internal/task/repository.go
@@ -25,9 +25,33 @@ func (s *Store) Create(manifestID, title, description, schedule, agent, sourceNo
 	id := uuid.Must(uuid.NewV7()).String()
 	now := time.Now().UTC()
 
+	// Initial status derives from the presence + state of depends_on.
+	//
+	//   - no dep                             → pending  (manual-only, won't auto-fire)
+	//   - dep set, parent not yet completed  → waiting  (ActivateDependents will flip to scheduled)
+	//   - dep set, parent already completed  → pending  (caller can schedule or manually start;
+	//                                                    we don't auto-schedule on create because
+	//                                                    there's no next_run_at to honor yet)
+	//
+	// This is the half of the state-machine fix that #67 couldn't reach:
+	// #67 loosened ActivateDependents to also match 'pending' children as
+	// a safety net, but the correct invariant is that dep-bearing tasks
+	// start in 'waiting' so the sort order + UI filters tell the truth.
+	initialStatus := StatusPending
+	if dependsOn != "" {
+		var parentStatus string
+		err := s.db.QueryRow(`SELECT status FROM tasks WHERE (id = ? OR id LIKE ?) AND deleted_at = ''`,
+			dependsOn, dependsOn+"%").Scan(&parentStatus)
+		if err == nil && parentStatus != string(StatusCompleted) {
+			initialStatus = StatusWaiting
+		}
+		// sql.ErrNoRows or any other lookup failure: keep pending, operator
+		// can correct by attaching the dep later via Edit.
+	}
+
 	_, err := s.db.Exec(`INSERT INTO tasks (id, manifest_id, title, description, schedule, status, agent, source_node, created_by, depends_on, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?)`,
-		id, manifestID, title, description, schedule, agent, sourceNode, createdBy, dependsOn,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, manifestID, title, description, schedule, string(initialStatus), agent, sourceNode, createdBy, dependsOn,
 		now.Format(time.RFC3339), now.Format(time.RFC3339))
 	if err != nil {
 		return nil, err
@@ -36,7 +60,7 @@ func (s *Store) Create(manifestID, title, description, schedule, agent, sourceNo
 	return &Task{
 		ID: id, Marker: id[:12], ManifestID: manifestID,
 		Title: title, Description: description, Schedule: schedule,
-		Status: "pending", Agent: agent, SourceNode: sourceNode,
+		Status: string(initialStatus), Agent: agent, SourceNode: sourceNode,
 		CreatedBy: createdBy, DependsOn: dependsOn, CreatedAt: now, UpdatedAt: now,
 	}, nil
 }
@@ -127,8 +151,23 @@ func (s *Store) Update(id string, title, description *string) (*Task, error) {
 	return s.Get(id)
 }
 
-// UpdateStatus changes a task's status.
+// UpdateStatus changes a task's status, validating the transition against
+// the canonical state machine in status.go. Returns the same validation
+// error surface ValidateTransition produces when the move is illegal — the
+// caller gets the exact reason and which next states would have been
+// legal. A no-op (current == target) is silently allowed so idempotent
+// writers don't see spurious errors.
 func (s *Store) UpdateStatus(id, status string) error {
+	// Resolve the row so we can read the current status for the
+	// transition check. Marker-prefix match is preserved.
+	var current string
+	if err := s.db.QueryRow(`SELECT status FROM tasks WHERE (id = ? OR id LIKE ?) AND deleted_at = ''`,
+		id, id+"%").Scan(&current); err != nil {
+		return err
+	}
+	if err := ValidateTransition(Status(current), Status(status)); err != nil {
+		return err
+	}
 	now := time.Now().UTC().Format(time.RFC3339)
 	_, err := s.db.Exec(`UPDATE tasks SET status = ?, updated_at = ? WHERE id = ? OR id LIKE ?`, status, now, id, id+"%")
 	return err

--- a/internal/task/repository_test.go
+++ b/internal/task/repository_test.go
@@ -34,12 +34,11 @@ func readStatus(t *testing.T, s *Store, id string) string {
 	return st
 }
 
-// TestActivateDependents_FlipsPendingToScheduled — reproduces the production
-// bug. Create() sets status='pending' even when depends_on is non-empty, so
-// before this fix ActivateDependents matched zero rows and every dependency
-// chain had to be fired by hand. After the fix, a pending child whose
-// depends_on matches the completed parent flips to 'scheduled'.
-func TestActivateDependents_FlipsPendingToScheduled(t *testing.T) {
+// TestActivateDependents_FlipsWaitingToScheduled — in the 8-state model,
+// Create seeds dep-bearing children in 'waiting' (not 'pending'). When the
+// parent completes, ActivateDependents flips the child to 'scheduled' so
+// the scheduler's dequeue query picks it up.
+func TestActivateDependents_FlipsWaitingToScheduled(t *testing.T) {
 	s := openRepoTestStore(t)
 
 	parent, err := s.Create("", "parent", "", "once", "claude-code", "node", "test", "")
@@ -50,8 +49,8 @@ func TestActivateDependents_FlipsPendingToScheduled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create child: %v", err)
 	}
-	if got := readStatus(t, s, child.ID); got != "pending" {
-		t.Fatalf("child initial status = %q, want pending (Create contract)", got)
+	if got := readStatus(t, s, child.ID); got != "waiting" {
+		t.Fatalf("child initial status = %q, want waiting (dep-bearing Create)", got)
 	}
 
 	n, err := s.ActivateDependents(parent.ID)
@@ -66,17 +65,36 @@ func TestActivateDependents_FlipsPendingToScheduled(t *testing.T) {
 	}
 }
 
-// TestActivateDependents_StillHandlesWaiting — we loosened the status
-// predicate, we did not replace it. Any path that parks a task at 'waiting'
-// (reserved for future use; not written by Create today but referenced in
-// the UI sort order) must continue to be picked up.
-func TestActivateDependents_StillHandlesWaiting(t *testing.T) {
+// TestCreate_NoDep_IsPending — a task with no depends_on starts in
+// 'pending' and will never auto-fire. This is the state-machine
+// invariant: pending tasks wait for manual start or an attached
+// next_run_at, they do NOT participate in dependency activation.
+func TestCreate_NoDep_IsPending(t *testing.T) {
+	s := openRepoTestStore(t)
+	loose, err := s.Create("", "loose", "", "once", "claude-code", "node", "t", "")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if got := readStatus(t, s, loose.ID); got != "pending" {
+		t.Fatalf("no-dep initial status = %q, want pending", got)
+	}
+}
+
+// TestActivateDependents_HandlesLegacyPending — tasks created before the
+// state-machine fix may still be sitting in 'pending' with depends_on set.
+// ActivateDependents must still activate them so nothing in the existing
+// DB gets stuck. Once the code has been in production for a while and
+// legacy rows have drained, this path becomes dead — but leaving it in is
+// a cheap safety net, and #67 documents the reasoning.
+func TestActivateDependents_HandlesLegacyPending(t *testing.T) {
 	s := openRepoTestStore(t)
 
 	parent, _ := s.Create("", "p", "", "once", "claude-code", "node", "t", "")
 	child, _ := s.Create("", "c", "", "once", "claude-code", "node", "t", parent.ID)
-	if _, err := s.db.Exec(`UPDATE tasks SET status = 'waiting' WHERE id = ?`, child.ID); err != nil {
-		t.Fatalf("force waiting: %v", err)
+	// Force-write legacy 'pending' so we simulate a row that pre-dates the
+	// Create-seeds-waiting change.
+	if _, err := s.db.Exec(`UPDATE tasks SET status = 'pending' WHERE id = ?`, child.ID); err != nil {
+		t.Fatalf("force pending: %v", err)
 	}
 
 	n, err := s.ActivateDependents(parent.ID)
@@ -84,7 +102,7 @@ func TestActivateDependents_StillHandlesWaiting(t *testing.T) {
 		t.Fatalf("ActivateDependents: %v", err)
 	}
 	if n != 1 {
-		t.Fatalf("activated count = %d, want 1 for waiting child", n)
+		t.Fatalf("activated count = %d, want 1 for legacy pending child", n)
 	}
 	if got := readStatus(t, s, child.ID); got != "scheduled" {
 		t.Fatalf("status = %q, want scheduled", got)
@@ -119,8 +137,10 @@ func TestActivateDependents_LeavesUnrelatedTasksAlone(t *testing.T) {
 	if got := readStatus(t, s, loose.ID); got != "pending" {
 		t.Fatalf("loose pending sibling was modified: status = %q, want pending", got)
 	}
-	if got := readStatus(t, s, cousin.ID); got != "pending" {
-		t.Fatalf("cousin depending on another parent was modified: status = %q, want pending", got)
+	// Cousin depends on otherParent (still 'pending'), so Create seeded
+	// it in 'waiting'. ActivateDependents(parent) must not touch it.
+	if got := readStatus(t, s, cousin.ID); got != "waiting" {
+		t.Fatalf("cousin depending on another parent was modified: status = %q, want waiting", got)
 	}
 }
 

--- a/internal/task/status.go
+++ b/internal/task/status.go
@@ -1,0 +1,173 @@
+package task
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Status is the canonical lifecycle state of a task row.
+//
+// This is a closed set of eight values. New code MUST use these constants
+// instead of literal strings so the compiler flags typos and downstream
+// exhaustive switches don't miss a case.
+type Status string
+
+const (
+	// StatusPending — the task exists but has nothing arming it to fire.
+	// No dependency, no schedule, no manual start. Stays here forever
+	// unless the operator does one of those three things. New rows with
+	// empty depends_on and no next_run_at land here.
+	StatusPending Status = "pending"
+
+	// StatusWaiting — the task has an unmet dependency and will auto-fire
+	// when its parent task reaches StatusCompleted. Written by
+	// Store.Create when depends_on is set and the parent isn't done, and
+	// by the scheduler when it dequeues a task whose dep has regressed.
+	// Distinct from Pending: Waiting participates in auto-activation,
+	// Pending does not.
+	StatusWaiting Status = "waiting"
+
+	// StatusScheduled — armed for execution. The scheduler's dequeue
+	// query picks up rows in this state where next_run_at <= now.
+	StatusScheduled Status = "scheduled"
+
+	// StatusRunning — agent subprocess is live.
+	StatusRunning Status = "running"
+
+	// StatusPaused — running process has been SIGSTOP'd by the operator
+	// and can be resumed. Distinct from Scheduled: a paused task is
+	// mid-execution with a live PID, not queued.
+	StatusPaused Status = "paused"
+
+	// StatusCompleted — agent exited and the watcher audit either passed
+	// or returned a warning (warnings don't downgrade). Terminal unless
+	// the watcher subsequently downgrades to Failed.
+	StatusCompleted Status = "completed"
+
+	// StatusFailed — agent exited with error, hit the cost cap, timed
+	// out, OR was downgraded from Completed by a failing watcher audit.
+	// Terminal.
+	StatusFailed Status = "failed"
+
+	// StatusCancelled — operator called task_cancel from any pre-terminal
+	// state. Terminal.
+	StatusCancelled Status = "cancelled"
+)
+
+// AllStatuses returns the eight canonical statuses in lifecycle order. Used
+// by UI dropdowns and docs so the order stays stable.
+func AllStatuses() []Status {
+	return []Status{
+		StatusPending, StatusWaiting, StatusScheduled,
+		StatusRunning, StatusPaused,
+		StatusCompleted, StatusFailed, StatusCancelled,
+	}
+}
+
+// IsValidStatus reports whether s is one of the eight canonical statuses.
+// Case-sensitive — callers must pass the exact string constant.
+func IsValidStatus(s string) bool {
+	for _, v := range AllStatuses() {
+		if string(v) == s {
+			return true
+		}
+	}
+	return false
+}
+
+// IsTerminal reports whether the task can no longer transition out of this
+// state under normal operation. Note: Completed is NOT terminal because
+// the watcher can downgrade it to Failed — that's the one documented
+// exception the state machine allows.
+func IsTerminal(s Status) bool {
+	return s == StatusFailed || s == StatusCancelled
+}
+
+// validTransitions encodes the state machine. Keys are the current state,
+// values are the set of legal next states. Missing keys mean "no
+// transitions allowed from this state" — used for Failed and Cancelled,
+// which are fully terminal.
+//
+// Completed → Failed is the only transition out of a post-run state. It
+// exists specifically for the watcher audit downgrade path (cmd/serve.go
+// around line 227) and nowhere else should write that transition.
+var validTransitions = map[Status]map[Status]bool{
+	StatusPending: {
+		StatusWaiting:   true, // operator or migration attaches a dependency
+		StatusScheduled: true, // manual start or schedule attached
+		StatusCancelled: true,
+	},
+	StatusWaiting: {
+		StatusScheduled: true, // parent dep completed — ActivateDependents
+		StatusPending:   true, // operator removed the dependency
+		StatusCancelled: true,
+	},
+	StatusScheduled: {
+		StatusRunning:   true, // scheduler dispatched
+		StatusWaiting:   true, // dep regressed before dispatch
+		StatusPending:   true, // operator cleared next_run_at + dep
+		StatusCancelled: true,
+	},
+	StatusRunning: {
+		StatusPaused:    true,
+		StatusCompleted: true,
+		StatusFailed:    true,
+		StatusCancelled: true,
+	},
+	StatusPaused: {
+		StatusRunning:   true,
+		StatusCancelled: true,
+	},
+	StatusCompleted: {
+		// Watcher audit downgrade is the only legal move out.
+		StatusFailed: true,
+	},
+	// StatusFailed and StatusCancelled have no entries — terminal.
+}
+
+// CanTransition reports whether status `from` may move to `to`. Same-state
+// "transitions" (from == to) return true as a convenience for idempotent
+// writers — a redundant UPDATE isn't a semantic violation.
+func CanTransition(from, to Status) bool {
+	if from == to {
+		return true
+	}
+	if !IsValidStatus(string(from)) {
+		return false
+	}
+	if !IsValidStatus(string(to)) {
+		return false
+	}
+	next, ok := validTransitions[from]
+	if !ok {
+		return false
+	}
+	return next[to]
+}
+
+// ValidateTransition returns nil if from → to is allowed, otherwise an
+// error describing what was attempted and what would have been legal. Used
+// by Store.UpdateStatus so operators + tests see the exact reason a write
+// was rejected.
+func ValidateTransition(from, to Status) error {
+	if CanTransition(from, to) {
+		return nil
+	}
+	if !IsValidStatus(string(from)) {
+		return fmt.Errorf("invalid source status %q", from)
+	}
+	if !IsValidStatus(string(to)) {
+		return fmt.Errorf("invalid target status %q", to)
+	}
+	allowed := []string{}
+	for s := range validTransitions[from] {
+		allowed = append(allowed, string(s))
+	}
+	sort.Strings(allowed)
+	if len(allowed) == 0 {
+		return fmt.Errorf("status %q is terminal; cannot transition to %q", from, to)
+	}
+	return fmt.Errorf("illegal transition %q → %q; legal next states from %q: %s",
+		from, to, from, strings.Join(allowed, ", "))
+}

--- a/internal/task/status_test.go
+++ b/internal/task/status_test.go
@@ -1,0 +1,186 @@
+package task
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAllStatuses_StableOrder — the lifecycle order matters for UI
+// dropdowns and docs. Any reordering is a breaking change visible to
+// users, so lock it down.
+func TestAllStatuses_StableOrder(t *testing.T) {
+	want := []Status{
+		StatusPending, StatusWaiting, StatusScheduled,
+		StatusRunning, StatusPaused,
+		StatusCompleted, StatusFailed, StatusCancelled,
+	}
+	got := AllStatuses()
+	if len(got) != len(want) {
+		t.Fatalf("AllStatuses len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("position %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestIsValidStatus — string round-trip catches typos in callers that
+// still pass literal strings (HTTP handlers, migration SQL, etc.).
+func TestIsValidStatus(t *testing.T) {
+	for _, s := range AllStatuses() {
+		if !IsValidStatus(string(s)) {
+			t.Errorf("IsValidStatus(%q) = false, want true", s)
+		}
+	}
+	bad := []string{"", "Running", "PENDING", "done", "error", "queued"}
+	for _, s := range bad {
+		if IsValidStatus(s) {
+			t.Errorf("IsValidStatus(%q) = true, want false", s)
+		}
+	}
+}
+
+// TestIsTerminal — only Failed and Cancelled are terminal. Completed is
+// explicitly NOT terminal because the watcher may downgrade it to Failed.
+// If this test fails, the cmd/serve.go audit callback needs review.
+func TestIsTerminal(t *testing.T) {
+	cases := map[Status]bool{
+		StatusPending:   false,
+		StatusWaiting:   false,
+		StatusScheduled: false,
+		StatusRunning:   false,
+		StatusPaused:    false,
+		StatusCompleted: false, // downgradable by watcher — see Completed→Failed
+		StatusFailed:    true,
+		StatusCancelled: true,
+	}
+	for s, want := range cases {
+		if got := IsTerminal(s); got != want {
+			t.Errorf("IsTerminal(%q) = %v, want %v", s, got, want)
+		}
+	}
+}
+
+// TestCanTransition_AllLegalMoves — the transitions we documented MUST be
+// allowed. Each row is a pair we deliberately support; breaking any of
+// them is a regression in the state machine.
+func TestCanTransition_AllLegalMoves(t *testing.T) {
+	legal := [][2]Status{
+		{StatusPending, StatusWaiting},
+		{StatusPending, StatusScheduled},
+		{StatusPending, StatusCancelled},
+		{StatusWaiting, StatusScheduled},
+		{StatusWaiting, StatusPending},
+		{StatusWaiting, StatusCancelled},
+		{StatusScheduled, StatusRunning},
+		{StatusScheduled, StatusWaiting},
+		{StatusScheduled, StatusPending},
+		{StatusScheduled, StatusCancelled},
+		{StatusRunning, StatusPaused},
+		{StatusRunning, StatusCompleted},
+		{StatusRunning, StatusFailed},
+		{StatusRunning, StatusCancelled},
+		{StatusPaused, StatusRunning},
+		{StatusPaused, StatusCancelled},
+		{StatusCompleted, StatusFailed}, // watcher downgrade — the one exception
+	}
+	for _, pair := range legal {
+		if !CanTransition(pair[0], pair[1]) {
+			t.Errorf("CanTransition(%q, %q) = false, want true (documented legal)", pair[0], pair[1])
+		}
+	}
+}
+
+// TestCanTransition_SelfLoopAlwaysTrue — writers that re-assert the
+// current status are idempotent, not errors. Same state is always allowed
+// so the UPDATE path doesn't reject a no-op.
+func TestCanTransition_SelfLoopAlwaysTrue(t *testing.T) {
+	for _, s := range AllStatuses() {
+		if !CanTransition(s, s) {
+			t.Errorf("CanTransition(%q, %q) = false; self-loop must be allowed", s, s)
+		}
+	}
+}
+
+// TestCanTransition_IllegalMovesRejected — the state machine's job is to
+// catch these. Completed→Running would mean rerunning a closed task;
+// Failed→anything would resurrect a terminal row; Cancelled→anything
+// likewise. These must all be refused.
+func TestCanTransition_IllegalMovesRejected(t *testing.T) {
+	illegal := [][2]Status{
+		{StatusCompleted, StatusRunning}, // already closed, can't reopen
+		{StatusCompleted, StatusScheduled},
+		{StatusCompleted, StatusCancelled}, // terminal after the fact isn't how cancel works
+		{StatusFailed, StatusRunning},      // terminal, no resurrection
+		{StatusFailed, StatusCompleted},
+		{StatusCancelled, StatusScheduled},
+		{StatusCancelled, StatusRunning},
+		{StatusPending, StatusRunning}, // must go through Scheduled
+		{StatusPending, StatusCompleted},
+		{StatusWaiting, StatusRunning}, // must go Waiting→Scheduled→Running
+		{StatusRunning, StatusScheduled},
+		{StatusRunning, StatusPending},
+	}
+	for _, pair := range illegal {
+		if CanTransition(pair[0], pair[1]) {
+			t.Errorf("CanTransition(%q, %q) = true, want false", pair[0], pair[1])
+		}
+	}
+}
+
+// TestValidateTransition_ErrorMessageHelps — when the state machine
+// rejects a move, the error should name the offending pair AND list what
+// would have been legal. Silent "permission denied" errors waste operator
+// debugging time.
+func TestValidateTransition_ErrorMessageHelps(t *testing.T) {
+	err := ValidateTransition(StatusPending, StatusRunning)
+	if err == nil {
+		t.Fatal("ValidateTransition(pending→running) should fail")
+	}
+	msg := err.Error()
+	for _, want := range []string{"pending", "running", "scheduled", "waiting"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q: %s", want, msg)
+		}
+	}
+}
+
+// TestValidateTransition_TerminalHasDedicatedMessage — for Failed and
+// Cancelled we want the error to say "terminal" explicitly, not just
+// list empty allowed states — that's actionable context.
+func TestValidateTransition_TerminalHasDedicatedMessage(t *testing.T) {
+	err := ValidateTransition(StatusFailed, StatusRunning)
+	if err == nil {
+		t.Fatal("failed→running should fail")
+	}
+	if !strings.Contains(err.Error(), "terminal") {
+		t.Errorf("terminal error message missing 'terminal': %s", err.Error())
+	}
+}
+
+// TestStoreUpdateStatus_ValidatesTransition — the Store boundary is where
+// the state machine is enforced. Writing an illegal transition must
+// return an error and leave the row unchanged; writing a legal one must
+// succeed and persist.
+func TestStoreUpdateStatus_ValidatesTransition(t *testing.T) {
+	s := openRepoTestStore(t)
+	task, err := s.Create("", "x", "", "once", "claude-code", "node", "t", "")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Pending→Running is illegal (must go through Scheduled). Must reject.
+	if err := s.UpdateStatus(task.ID, string(StatusRunning)); err == nil {
+		t.Fatal("UpdateStatus pending→running: want error, got nil")
+	}
+	if got := readStatus(t, s, task.ID); got != "pending" {
+		t.Fatalf("row mutated after rejected transition: status = %q", got)
+	}
+	// Pending→Scheduled is legal. Must succeed.
+	if err := s.UpdateStatus(task.ID, string(StatusScheduled)); err != nil {
+		t.Fatalf("UpdateStatus pending→scheduled: %v", err)
+	}
+	if got := readStatus(t, s, task.ID); got != "scheduled" {
+		t.Fatalf("status = %q, want scheduled after legal transition", got)
+	}
+}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -14,7 +14,13 @@ type Task struct {
 	Title       string    `json:"title"`
 	Description string    `json:"description"`
 	Schedule    string    `json:"schedule"`   // "once", "5m", "1h", cron expression
-	Status      string    `json:"status"`     // pending, scheduled, running, completed, failed, cancelled
+	// Status is one of the 8 canonical lifecycle states defined in
+	// status.go: pending, waiting, scheduled, running, paused, completed,
+	// failed, cancelled. See status.go's validTransitions map for the
+	// allowed edges of the state machine. Writes go through
+	// Store.UpdateStatus, which validates transitions and rejects
+	// illegal moves.
+	Status      string    `json:"status"`
 	Agent       string    `json:"agent"`      // agent type: claude-code, cursor, etc.
 	SourceNode  string    `json:"source_node"`
 	CreatedBy   string    `json:"created_by"` // session or dashboard


### PR DESCRIPTION
Closes #72.

## Summary

Lock the task \`status\` field to 8 canonical states enforced by a transition map. Prevents illegal moves (resurrecting a completed task, skipping \`scheduled\` on the way from \`pending\` to \`running\`, etc.) and seeds dep-bearing tasks in \`waiting\` instead of \`pending\` so the state machine tells the truth without relying on the safety-net loosening #67 added to \`ActivateDependents\`.

## Transition map

\`\`\`
pending   → waiting, scheduled, cancelled
waiting   → scheduled, pending, cancelled
scheduled → running, waiting, pending, cancelled
running   → paused, completed, failed, cancelled
paused    → running, cancelled
completed → failed   (watcher downgrade — the single post-terminal exception)
failed    → (terminal)
cancelled → (terminal)
\`\`\`

Self-loops (\`X → X\`) are allowed so idempotent UPDATE writers don't fail.

## What changed

- \`internal/task/status.go\` (new) — \`Status\` type, 8 constants, \`AllStatuses\`, \`IsValidStatus\`, \`IsTerminal\`, \`validTransitions\`, \`CanTransition\`, \`ValidateTransition\`.
- \`Store.UpdateStatus\` — reads current, validates, rejects illegal moves without touching the row. Errors name the offending pair + list legal next states.
- \`Store.Create\` — initial status derives from \`depends_on\`:
  - no dep → \`pending\`
  - dep set, parent not completed → \`waiting\`
  - dep set, parent already completed → \`pending\` (operator arms manually; no next_run_at to auto-schedule).
- \`store.go:17\` comment — updated from the stale 6-state list.
- Repo tests updated to match the new Create contract; \`status_test.go\` adds the state-machine coverage.

## Test plan

- [x] \`go test ./internal/task/...\` — 8 new tests: stable lifecycle order, string round-trip, terminal set (Completed is NOT terminal — watcher can downgrade), all documented legal transitions pass, self-loops pass, battery of illegal moves rejected (\`completed → running\`, \`failed → anything\`, \`pending → running\`), error message names the pair + lists allowed next states, terminal states get a dedicated 'terminal' message, \`Store.UpdateStatus\` leaves the row unchanged on rejection.
- [x] \`go test ./...\` full suite green.
- [x] \`go build ./...\`, \`go vet ./...\` clean.
- [ ] Post-merge: create a task with \`depends_on\` set, confirm the row lands in \`waiting\` (not \`pending\`) by inspecting \`SELECT status FROM tasks\`; confirm the dashboard task row shows the \`waiting\` badge.

## Not in this PR

- Manifest dependencies (next issue/PR).
- Task-dependency add/remove UI (follow-up).
- Many-to-many / cross-entity deep deps (filed as idea \`019da59d-a63\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)