### PR TITLE
feat(manifest): data layer for manifest→manifest dependencies (#74 part 1)

### DIFF
--- a/internal/manifest/dependencies.go
+++ b/internal/manifest/dependencies.go
@@ -1,0 +1,376 @@
+package manifest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// ErrCycle is returned by AddDep when the requested edge would introduce a
+// cycle into the manifest dependency graph. Callers translate this into a
+// 409 Conflict at the HTTP layer and into an MCP error text at the tool
+// layer — the operator sees the exact rejected pair.
+var ErrCycle = errors.New("manifest_dependencies: cycle detected")
+
+// ErrSelfLoop is returned when a manifest is asked to depend on itself.
+// Enforced at the DB layer via CHECK, but we also guard before the insert
+// so the error carries a clearer message than the raw sqlite constraint
+// text.
+var ErrSelfLoop = errors.New("manifest_dependencies: a manifest cannot depend on itself")
+
+// Dep is the denormalized row the UI + MCP callers want when listing
+// deps or dependents: id + marker + title + current status are enough to
+// render a row without a second lookup per entry.
+type Dep struct {
+	ID         string    `json:"id"`
+	Marker     string    `json:"marker"`
+	Title      string    `json:"title"`
+	Status     string    `json:"status"`
+	CreatedAt  time.Time `json:"created_at"`
+	CreatedBy  string    `json:"created_by"`
+}
+
+// terminalManifestStatuses are the statuses that mean "this manifest is
+// done enough that its dependents can stop waiting on it." Per the session
+// decision on issue #74 we use the existing status taxonomy — `closed`
+// and `archive` count as terminal; `draft` and `open` do not.
+//
+// Kept as a var (not a const) because the scheduler enforcement path
+// passes this set into a SQL IN clause and having it in one place means
+// the predicate can't drift between the store and the scheduler.
+var terminalManifestStatuses = []string{"closed", "archive"}
+
+// IsTerminalStatus reports whether a manifest.status value counts as
+// satisfying dependents.
+func IsTerminalStatus(status string) bool {
+	for _, s := range terminalManifestStatuses {
+		if s == status {
+			return true
+		}
+	}
+	return false
+}
+
+// TerminalManifestStatuses returns a copy of the terminal-status set.
+// Exported for use by scheduler/runner code that needs to build SQL IN
+// predicates from the same source of truth.
+func TerminalManifestStatuses() []string {
+	out := make([]string, len(terminalManifestStatuses))
+	copy(out, terminalManifestStatuses)
+	return out
+}
+
+// initDependenciesSchema creates the manifest_dependencies join table plus
+// its indexes. Idempotent. Called from Store.init() after the main
+// manifests table exists, so FK-like semantics can rely on the parent
+// tables being present.
+func (s *Store) initDependenciesSchema() error {
+	_, err := s.db.Exec(`CREATE TABLE IF NOT EXISTS manifest_dependencies (
+		manifest_id            TEXT NOT NULL,
+		depends_on_manifest_id TEXT NOT NULL,
+		created_at             INTEGER NOT NULL,
+		created_by             TEXT NOT NULL DEFAULT '',
+		PRIMARY KEY (manifest_id, depends_on_manifest_id),
+		CHECK (manifest_id != depends_on_manifest_id)
+	)`)
+	if err != nil {
+		return fmt.Errorf("create manifest_dependencies table: %w", err)
+	}
+	if _, err := s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_manifest_deps_src ON manifest_dependencies(manifest_id)`); err != nil {
+		return fmt.Errorf("create manifest_deps src index: %w", err)
+	}
+	if _, err := s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_manifest_deps_dst ON manifest_dependencies(depends_on_manifest_id)`); err != nil {
+		return fmt.Errorf("create manifest_deps dst index: %w", err)
+	}
+	return nil
+}
+
+// BackfillLegacyDependsOn copies edges out of the legacy comma-separated
+// manifests.depends_on column into manifest_dependencies. Idempotent —
+// re-running is a no-op because PRIMARY KEY dedup catches existing rows.
+// Safe to run on every startup until the legacy column is dropped in a
+// follow-up PR.
+//
+// Returns the number of new rows inserted. Does NOT clear the legacy
+// column; dual-read + dual-write keep the old path working while the
+// migration settles.
+func (s *Store) BackfillLegacyDependsOn(ctx context.Context) (int, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, depends_on FROM manifests WHERE depends_on != '' AND deleted_at = ''`)
+	if err != nil {
+		return 0, fmt.Errorf("scan legacy depends_on: %w", err)
+	}
+	defer rows.Close()
+
+	type entry struct{ manifestID, depList string }
+	var entries []entry
+	for rows.Next() {
+		var e entry
+		if err := rows.Scan(&e.manifestID, &e.depList); err != nil {
+			return 0, err
+		}
+		entries = append(entries, e)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	now := time.Now().UTC().Unix()
+	inserted := 0
+	for _, e := range entries {
+		for _, raw := range strings.Split(e.depList, ",") {
+			depID := strings.TrimSpace(raw)
+			if depID == "" || depID == e.manifestID {
+				continue
+			}
+			res, err := s.db.ExecContext(ctx,
+				`INSERT OR IGNORE INTO manifest_dependencies (manifest_id, depends_on_manifest_id, created_at, created_by)
+				 VALUES (?, ?, ?, 'legacy-backfill')`,
+				e.manifestID, depID, now)
+			if err != nil {
+				slog.Warn("backfill manifest dep failed",
+					"component", "manifest", "manifest_id", e.manifestID, "depends_on", depID, "error", err)
+				continue
+			}
+			n, _ := res.RowsAffected()
+			inserted += int(n)
+		}
+	}
+	if inserted > 0 {
+		slog.Info("backfilled manifest dependencies from legacy column",
+			"component", "manifest", "rows", inserted)
+	}
+	return inserted, nil
+}
+
+// AddDep adds a manifest→depends_on_manifest edge after cycle detection.
+//
+//   - rejects self-loops (ErrSelfLoop)
+//   - rejects edges that would close a cycle (ErrCycle), computed via DFS
+//     from depends_on_manifest_id back to manifest_id over the current
+//     edge set
+//   - idempotent on duplicate edges (INSERT OR IGNORE)
+//
+// On success, also appends to the legacy comma-separated column so any
+// un-migrated reader sees the new edge until the column is retired.
+func (s *Store) AddDep(ctx context.Context, manifestID, dependsOnID, createdBy string) error {
+	if manifestID == "" || dependsOnID == "" {
+		return fmt.Errorf("manifest_dependencies: empty manifest id")
+	}
+	if manifestID == dependsOnID {
+		return ErrSelfLoop
+	}
+
+	// Cycle check: would inserting (manifestID → dependsOnID) create a
+	// cycle? That happens iff dependsOnID can already reach manifestID
+	// by following existing edges. DFS from dependsOnID; bail on first
+	// hit.
+	reaches, err := s.pathExists(ctx, dependsOnID, manifestID)
+	if err != nil {
+		return fmt.Errorf("cycle check: %w", err)
+	}
+	if reaches {
+		return fmt.Errorf("%w: %s → %s would close a cycle",
+			ErrCycle, manifestID, dependsOnID)
+	}
+
+	now := time.Now().UTC().Unix()
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO manifest_dependencies (manifest_id, depends_on_manifest_id, created_at, created_by)
+		 VALUES (?, ?, ?, ?)`,
+		manifestID, dependsOnID, now, createdBy); err != nil {
+		return fmt.Errorf("insert manifest dep: %w", err)
+	}
+
+	// Dual-write: append to legacy comma-separated column so readers
+	// that still query `manifests.depends_on` see the edge.
+	if err := s.syncLegacyDependsOn(ctx, manifestID); err != nil {
+		slog.Warn("sync legacy depends_on failed", "component", "manifest",
+			"manifest_id", manifestID, "error", err)
+	}
+	return nil
+}
+
+// RemoveDep is idempotent — removing an edge that doesn't exist returns
+// nil, not an error. The legacy column is re-synced from the join table
+// after the delete so the comma-separated list stays canonical-ish.
+func (s *Store) RemoveDep(ctx context.Context, manifestID, dependsOnID string) error {
+	if _, err := s.db.ExecContext(ctx,
+		`DELETE FROM manifest_dependencies WHERE manifest_id = ? AND depends_on_manifest_id = ?`,
+		manifestID, dependsOnID); err != nil {
+		return fmt.Errorf("delete manifest dep: %w", err)
+	}
+	if err := s.syncLegacyDependsOn(ctx, manifestID); err != nil {
+		slog.Warn("sync legacy depends_on failed", "component", "manifest",
+			"manifest_id", manifestID, "error", err)
+	}
+	return nil
+}
+
+// ListDeps returns the out-edges: manifests this one depends on.
+// Joined against the manifests table so each row carries the denormalized
+// status + title the UI renders. Results sorted by created_at so the
+// UI order matches the insertion order.
+func (s *Store) ListDeps(ctx context.Context, manifestID string) ([]Dep, error) {
+	return s.queryDeps(ctx,
+		`SELECT m.id, m.title, m.status, d.created_at, d.created_by
+		 FROM manifest_dependencies d
+		 JOIN manifests m ON m.id = d.depends_on_manifest_id
+		 WHERE d.manifest_id = ? AND m.deleted_at = ''
+		 ORDER BY d.created_at ASC`,
+		manifestID)
+}
+
+// ListDependents returns the in-edges: manifests that depend on this one.
+// Same shape as ListDeps; used by the watcher audit callback to walk
+// impacted manifests when a parent closes.
+func (s *Store) ListDependents(ctx context.Context, manifestID string) ([]Dep, error) {
+	return s.queryDeps(ctx,
+		`SELECT m.id, m.title, m.status, d.created_at, d.created_by
+		 FROM manifest_dependencies d
+		 JOIN manifests m ON m.id = d.manifest_id
+		 WHERE d.depends_on_manifest_id = ? AND m.deleted_at = ''
+		 ORDER BY d.created_at ASC`,
+		manifestID)
+}
+
+// IsSatisfied reports whether every manifest this one depends on is in a
+// terminal status. The second return is the list of unsatisfied dep
+// manifest IDs — populated so the caller can build a human-readable
+// block_reason for the task row without a second round-trip.
+func (s *Store) IsSatisfied(ctx context.Context, manifestID string) (bool, []string, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT m.id, m.status
+		 FROM manifest_dependencies d
+		 JOIN manifests m ON m.id = d.depends_on_manifest_id
+		 WHERE d.manifest_id = ? AND m.deleted_at = ''`, manifestID)
+	if err != nil {
+		return false, nil, err
+	}
+	defer rows.Close()
+
+	var unsatisfied []string
+	for rows.Next() {
+		var id, status string
+		if err := rows.Scan(&id, &status); err != nil {
+			return false, nil, err
+		}
+		if !IsTerminalStatus(status) {
+			unsatisfied = append(unsatisfied, id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, nil, err
+	}
+	return len(unsatisfied) == 0, unsatisfied, nil
+}
+
+// pathExists does a DFS from src, returning true if dst is reachable by
+// walking manifest_dependencies edges (src → ... → dst). Cycle detection
+// uses it in reverse: "does B already reach A? if so A→B would close a
+// cycle."
+//
+// The visited set caps traversal so pre-existing cycles in the DB (which
+// shouldn't happen but mustn't hang the process) terminate. Manifests are
+// counted in the dozens per node so O(V+E) traversal is fine; if this
+// ever shows up in a profile, we switch to storing transitive closure on
+// each row.
+func (s *Store) pathExists(ctx context.Context, src, dst string) (bool, error) {
+	visited := map[string]bool{}
+	stack := []string{src}
+	for len(stack) > 0 {
+		// Pop.
+		node := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		if node == dst {
+			return true, nil
+		}
+		if visited[node] {
+			continue
+		}
+		visited[node] = true
+
+		rows, err := s.db.QueryContext(ctx,
+			`SELECT depends_on_manifest_id FROM manifest_dependencies WHERE manifest_id = ?`, node)
+		if err != nil {
+			return false, err
+		}
+		for rows.Next() {
+			var next string
+			if err := rows.Scan(&next); err != nil {
+				rows.Close()
+				return false, err
+			}
+			if !visited[next] {
+				stack = append(stack, next)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return false, err
+		}
+		rows.Close()
+	}
+	return false, nil
+}
+
+// queryDeps is the shared scan path for ListDeps + ListDependents. Marker
+// is derived here so callers don't have to duplicate the 12-char prefix
+// rule.
+func (s *Store) queryDeps(ctx context.Context, query, id string) ([]Dep, error) {
+	rows, err := s.db.QueryContext(ctx, query, id)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []Dep
+	for rows.Next() {
+		var d Dep
+		var createdAtUnix int64
+		if err := rows.Scan(&d.ID, &d.Title, &d.Status, &createdAtUnix, &d.CreatedBy); err != nil {
+			return nil, err
+		}
+		d.CreatedAt = time.Unix(createdAtUnix, 0).UTC()
+		if len(d.ID) >= 12 {
+			d.Marker = d.ID[:12]
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}
+
+// syncLegacyDependsOn regenerates the comma-separated manifests.depends_on
+// column from the current join-table rows for manifestID. Keeps legacy
+// readers seeing a consistent view until the column is dropped. Called
+// after Add/RemoveDep.
+func (s *Store) syncLegacyDependsOn(ctx context.Context, manifestID string) error {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT depends_on_manifest_id FROM manifest_dependencies WHERE manifest_id = ? ORDER BY created_at ASC`,
+		manifestID)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	_, err = s.db.ExecContext(ctx,
+		`UPDATE manifests SET depends_on = ?, updated_at = ? WHERE id = ?`,
+		strings.Join(ids, ","), time.Now().UTC().Format(time.RFC3339), manifestID)
+	return err
+}

--- a/internal/manifest/dependencies_test.go
+++ b/internal/manifest/dependencies_test.go
@@ -1,0 +1,401 @@
+package manifest
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func openDepsTestStore(t *testing.T) *Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "m.db") + "?_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	s, err := NewStore(db)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return s
+}
+
+// mustCreate is a terse helper: create a manifest with reasonable defaults
+// and return its id. Tests that care about dep edges rarely care about
+// manifest fields beyond id + status, so we skip the rest.
+func mustCreate(t *testing.T, s *Store, title, status string) string {
+	t.Helper()
+	m, err := s.Create(title, "", "", status, "test", "node", "", "", nil, nil)
+	if err != nil {
+		t.Fatalf("Create(%q): %v", title, err)
+	}
+	return m.ID
+}
+
+// TestTerminalStatusClassification — IsTerminalStatus is used by
+// IsSatisfied's predicate; if the set changes silently, dep activation
+// semantics drift. Lock the classification down.
+func TestTerminalStatusClassification(t *testing.T) {
+	cases := map[string]bool{
+		"draft":   false,
+		"open":    false,
+		"closed":  true,
+		"archive": true,
+		"":        false,
+		"unknown": false,
+	}
+	for status, want := range cases {
+		if got := IsTerminalStatus(status); got != want {
+			t.Errorf("IsTerminalStatus(%q) = %v, want %v", status, got, want)
+		}
+	}
+}
+
+// TestAddDep_BasicEdgeAndIdempotency — the simple happy path plus a
+// repeat add. The second add must be a no-op, not an error; operators
+// (and MCP callers that retry on transient failures) rely on
+// idempotency.
+func TestAddDep_BasicEdgeAndIdempotency(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+
+	a := mustCreate(t, s, "A", "open")
+	b := mustCreate(t, s, "B", "open")
+
+	if err := s.AddDep(ctx, a, b, "tester"); err != nil {
+		t.Fatalf("first AddDep: %v", err)
+	}
+	if err := s.AddDep(ctx, a, b, "tester"); err != nil {
+		t.Fatalf("second AddDep (idempotency): %v", err)
+	}
+
+	deps, err := s.ListDeps(ctx, a)
+	if err != nil {
+		t.Fatalf("ListDeps: %v", err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("ListDeps returned %d rows, want 1 (idempotent add)", len(deps))
+	}
+	if deps[0].ID != b {
+		t.Errorf("deps[0].ID = %q, want %q", deps[0].ID, b)
+	}
+}
+
+// TestAddDep_SelfLoopRejected — the trivial mistake must be refused with
+// ErrSelfLoop, not bubbled as a raw sqlite CHECK-constraint message.
+func TestAddDep_SelfLoopRejected(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+	a := mustCreate(t, s, "A", "open")
+
+	err := s.AddDep(ctx, a, a, "tester")
+	if !errors.Is(err, ErrSelfLoop) {
+		t.Fatalf("AddDep(self-loop) err = %v, want ErrSelfLoop", err)
+	}
+}
+
+// TestAddDep_CycleDetection_Direct — A→B exists; adding B→A closes a
+// length-2 cycle and must be rejected with ErrCycle.
+func TestAddDep_CycleDetection_Direct(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+
+	a := mustCreate(t, s, "A", "open")
+	b := mustCreate(t, s, "B", "open")
+
+	if err := s.AddDep(ctx, a, b, "tester"); err != nil {
+		t.Fatalf("A→B: %v", err)
+	}
+	err := s.AddDep(ctx, b, a, "tester")
+	if !errors.Is(err, ErrCycle) {
+		t.Fatalf("B→A err = %v, want ErrCycle (direct cycle)", err)
+	}
+	if !strings.Contains(err.Error(), b) || !strings.Contains(err.Error(), a) {
+		t.Errorf("cycle error doesn't name the edge: %v", err)
+	}
+}
+
+// TestAddDep_CycleDetection_Transitive — A→B, B→C. Adding C→A would
+// close a length-3 cycle. DFS must catch this, not just direct edges.
+func TestAddDep_CycleDetection_Transitive(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+
+	a := mustCreate(t, s, "A", "open")
+	b := mustCreate(t, s, "B", "open")
+	c := mustCreate(t, s, "C", "open")
+
+	if err := s.AddDep(ctx, a, b, "t"); err != nil {
+		t.Fatalf("A→B: %v", err)
+	}
+	if err := s.AddDep(ctx, b, c, "t"); err != nil {
+		t.Fatalf("B→C: %v", err)
+	}
+
+	err := s.AddDep(ctx, c, a, "t")
+	if !errors.Is(err, ErrCycle) {
+		t.Fatalf("C→A err = %v, want ErrCycle (transitive)", err)
+	}
+}
+
+// TestAddDep_NonCyclingParallel — diamond-shaped deps are fine. A→B,
+// A→C, B→D, C→D — no cycle, all four edges must insert. This is the
+// pattern where a manifest waits on two parallel workstreams.
+func TestAddDep_NonCyclingParallel(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+
+	a := mustCreate(t, s, "A", "open")
+	b := mustCreate(t, s, "B", "open")
+	c := mustCreate(t, s, "C", "open")
+	d := mustCreate(t, s, "D", "open")
+
+	for _, pair := range [][2]string{{a, b}, {a, c}, {b, d}, {c, d}} {
+		if err := s.AddDep(ctx, pair[0], pair[1], "t"); err != nil {
+			t.Fatalf("%s→%s: %v", pair[0], pair[1], err)
+		}
+	}
+
+	deps, err := s.ListDeps(ctx, a)
+	if err != nil {
+		t.Fatalf("ListDeps: %v", err)
+	}
+	if len(deps) != 2 {
+		t.Errorf("A deps = %d, want 2 (B and C)", len(deps))
+	}
+}
+
+// TestRemoveDep_IdempotentOnMissingEdge — removing an edge that doesn't
+// exist must not error. MCP/HTTP callers retry freely; the API contract
+// is "after this call, the edge is gone."
+func TestRemoveDep_IdempotentOnMissingEdge(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+	a := mustCreate(t, s, "A", "open")
+	b := mustCreate(t, s, "B", "open")
+
+	if err := s.RemoveDep(ctx, a, b); err != nil {
+		t.Fatalf("RemoveDep on missing edge: %v", err)
+	}
+}
+
+// TestListDependents_InEdges — ListDependents returns in-edges, i.e.
+// manifests that depend on *this* one. Used by the activation walker on
+// manifest close.
+func TestListDependents_InEdges(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+
+	target := mustCreate(t, s, "target", "open")
+	a := mustCreate(t, s, "A", "open")
+	b := mustCreate(t, s, "B", "open")
+	c := mustCreate(t, s, "C", "open") // does NOT depend on target
+
+	if err := s.AddDep(ctx, a, target, "t"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddDep(ctx, b, target, "t"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.ListDependents(ctx, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("dependents = %d, want 2 (A, B) — saw %+v", len(got), got)
+	}
+	gotIDs := map[string]bool{got[0].ID: true, got[1].ID: true}
+	if !gotIDs[a] || !gotIDs[b] {
+		t.Errorf("missing expected dependents A or B; got ids: %v", gotIDs)
+	}
+	if gotIDs[c] {
+		t.Errorf("ListDependents returned C, which doesn't depend on target")
+	}
+}
+
+// TestIsSatisfied_AllTerminalOrEmpty — a manifest with no deps is
+// trivially satisfied. A manifest whose every dep is closed/archive is
+// satisfied. Any non-terminal dep makes it unsatisfied and the
+// unsatisfied list names the blocker.
+func TestIsSatisfied_AllTerminalOrEmpty(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+
+	m := mustCreate(t, s, "M", "open")
+
+	// No deps — satisfied vacuously.
+	ok, blockers, err := s.IsSatisfied(ctx, m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || len(blockers) != 0 {
+		t.Fatalf("no-deps IsSatisfied = (%v, %v), want (true, nil)", ok, blockers)
+	}
+
+	closedDep := mustCreate(t, s, "closed-dep", "closed")
+	archiveDep := mustCreate(t, s, "archive-dep", "archive")
+	openDep := mustCreate(t, s, "open-dep", "open")
+
+	for _, d := range []string{closedDep, archiveDep} {
+		if err := s.AddDep(ctx, m, d, "t"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Two deps, both terminal.
+	ok, blockers, err = s.IsSatisfied(ctx, m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || len(blockers) != 0 {
+		t.Fatalf("all-terminal IsSatisfied = (%v, %v), want (true, nil)", ok, blockers)
+	}
+
+	// Add a non-terminal dep — must flip to unsatisfied with the open one named.
+	if err := s.AddDep(ctx, m, openDep, "t"); err != nil {
+		t.Fatal(err)
+	}
+	ok, blockers, err = s.IsSatisfied(ctx, m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatalf("IsSatisfied = true, want false (open dep blocking)")
+	}
+	if len(blockers) != 1 || blockers[0] != openDep {
+		t.Fatalf("blockers = %v, want [%s]", blockers, openDep)
+	}
+}
+
+// TestIsSatisfied_IgnoresDeletedDeps — a dep manifest that's been
+// soft-deleted (deleted_at != '') must not count as a blocker. Deleted
+// manifests are invisible to the rest of the system; their edges should
+// be invisible too.
+func TestIsSatisfied_IgnoresDeletedDeps(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+
+	m := mustCreate(t, s, "M", "open")
+	dep := mustCreate(t, s, "dep", "open")
+
+	if err := s.AddDep(ctx, m, dep, "t"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Soft-delete the dep.
+	if _, err := s.db.Exec(`UPDATE manifests SET deleted_at = '2026-01-01T00:00:00Z' WHERE id = ?`, dep); err != nil {
+		t.Fatal(err)
+	}
+
+	ok, blockers, err := s.IsSatisfied(ctx, m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || len(blockers) != 0 {
+		t.Fatalf("IsSatisfied with deleted dep = (%v, %v), want (true, nil)", ok, blockers)
+	}
+}
+
+// TestSyncLegacyDependsOn_DualWrite — writing to the join table keeps
+// the legacy comma-separated column in sync, so readers that still query
+// `manifests.depends_on` see the same edges. After the follow-up PR that
+// drops that column, this test becomes stale and can be removed.
+func TestSyncLegacyDependsOn_DualWrite(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+
+	a := mustCreate(t, s, "A", "open")
+	b := mustCreate(t, s, "B", "open")
+	c := mustCreate(t, s, "C", "open")
+
+	if err := s.AddDep(ctx, a, b, "t"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddDep(ctx, a, c, "t"); err != nil {
+		t.Fatal(err)
+	}
+
+	var legacy string
+	if err := s.db.QueryRow(`SELECT depends_on FROM manifests WHERE id = ?`, a).Scan(&legacy); err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(legacy, ",")
+	if len(parts) != 2 {
+		t.Fatalf("legacy depends_on = %q, want 2 comma-separated ids", legacy)
+	}
+
+	// Remove one — legacy column must reflect the removal.
+	if err := s.RemoveDep(ctx, a, b); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.db.QueryRow(`SELECT depends_on FROM manifests WHERE id = ?`, a).Scan(&legacy); err != nil {
+		t.Fatal(err)
+	}
+	if legacy != c {
+		t.Fatalf("legacy after remove = %q, want %q", legacy, c)
+	}
+}
+
+// TestBackfillLegacyDependsOn_Idempotent — pre-existing legacy column
+// values must migrate into the join table on store init, and re-running
+// the backfill must be a no-op. New installs hit this path the first
+// time the store opens a DB with legacy rows already in it.
+func TestBackfillLegacyDependsOn_Idempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "m.db") + "?_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	s, err := NewStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a := mustCreate(t, s, "A", "open")
+	b := mustCreate(t, s, "B", "open")
+	c := mustCreate(t, s, "C", "open")
+
+	// Simulate a legacy row: write comma-separated depends_on directly,
+	// bypassing AddDep, and wipe the join table so only the legacy
+	// column carries the edge.
+	if _, err := s.db.Exec(`UPDATE manifests SET depends_on = ? WHERE id = ?`, b+","+c, a); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.Exec(`DELETE FROM manifest_dependencies WHERE manifest_id = ?`, a); err != nil {
+		t.Fatal(err)
+	}
+
+	// First backfill: two rows inserted.
+	n, err := s.BackfillLegacyDependsOn(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("first backfill inserted %d, want 2", n)
+	}
+
+	// Second run: no-op.
+	n, err = s.BackfillLegacyDependsOn(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("second backfill inserted %d, want 0 (idempotent)", n)
+	}
+
+	deps, err := s.ListDeps(context.Background(), a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deps) != 2 {
+		t.Fatalf("deps after backfill = %d, want 2", len(deps))
+	}
+}

--- a/internal/manifest/store.go
+++ b/internal/manifest/store.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -51,6 +52,15 @@ func NewStore(db *sql.DB) (*Store, error) {
 	}
 	if err := s.InitLinks(); err != nil {
 		return nil, err
+	}
+	if err := s.initDependenciesSchema(); err != nil {
+		return nil, err
+	}
+	// One-shot backfill of the legacy comma-separated depends_on column
+	// into the new join table. Idempotent via PRIMARY KEY dedup; safe to
+	// run every boot until the column is retired in a follow-up PR.
+	if _, err := s.BackfillLegacyDependsOn(context.Background()); err != nil {
+		return nil, fmt.Errorf("backfill manifest dependencies: %w", err)
 	}
 	return s, nil
 }


### PR DESCRIPTION
Part 1 of #74. Enforcement tracked in #75, operator surface (MCP/HTTP/UI) in a later PR.

## What

Relational storage + invariants for manifest→manifest deps, so the later enforcement layer has something solid to build on.

- \`manifest_dependencies(manifest_id, depends_on_manifest_id, created_at, created_by)\` join table — PRIMARY KEY dedupe, CHECK rejects self-loops at the DB, indexes both directions.
- \`internal/manifest/dependencies.go\`: \`AddDep\`, \`RemoveDep\`, \`ListDeps\`, \`ListDependents\`, \`IsSatisfied\`, \`ErrCycle\`, \`ErrSelfLoop\`.
- DFS cycle detection on \`AddDep\` before insert; error names the rejected pair.
- \`IsSatisfied\` returns \`(ok, unsatisfied []string, err)\` so the caller can build \`block_reason\` without a second round-trip.
- Terminal-status classification: \`closed\` and \`archive\` satisfy dependents; \`draft\` and \`open\` do not. Exported via \`IsTerminalStatus\` + \`TerminalManifestStatuses\` as the single source of truth.
- \`BackfillLegacyDependsOn\` migrates the existing comma-separated \`manifests.depends_on\` column on every store init (idempotent). Dual-write on Add/Remove keeps the legacy column in sync until a follow-up PR drops it.

## Not in this PR (in #75 and beyond)

- Task seeding: create-with-unsatisfied-manifest → \`waiting\` + \`block_reason\`
- Watcher audit callback: activate dependent tasks on manifest close
- Dep-removal rehab: \`waiting → pending\` (Option B from session design discussion)
- MCP tools, HTTP endpoints, manifest-detail UI controls

## Test plan

- [x] \`go test ./internal/manifest/\` — 12 new tests
  - Terminal classification lock-down
  - Basic add + idempotency
  - Self-loop rejection with ErrSelfLoop
  - Direct cycle rejection (\`A→B\` exists, reject \`B→A\`)
  - Transitive cycle rejection (\`A→B→C\` exists, reject \`C→A\`)
  - Non-cycling diamond (A→B, A→C, B→D, C→D all succeed)
  - Remove idempotency on missing edge
  - ListDependents returns only in-edges
  - IsSatisfied across empty / all-terminal / mixed
  - IsSatisfied ignores soft-deleted deps
  - Legacy column stays in sync on add + remove
  - Backfill idempotent across repeat runs
- [x] \`go test ./...\` full suite green
- [x] \`go build ./...\`, \`go vet ./...\` clean
- [ ] Post-merge: inspect an existing manifest that had a legacy \`depends_on\` value — after server restart confirm \`SELECT * FROM manifest_dependencies WHERE manifest_id = ?\` shows the backfilled row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)