### PR TITLE
feat(tasks): seed waiting + block_reason when manifest unsatisfied (#75 part 1)

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -90,6 +90,11 @@ func New(cfg *config.Config) (*Node, error) {
 	if err != nil {
 		return nil, fmt.Errorf("init task store: %w", err)
 	}
+	// Wire the manifest store as the readiness checker so task.Create
+	// seeds tasks in 'waiting' when their manifest has unsatisfied deps.
+	// Typed as task.ManifestReadinessChecker — manifest.Store satisfies
+	// the interface via IsSatisfied(ctx, manifestID).
+	taskStore.SetManifestChecker(manifestStore)
 
 	chatStore, err := chat.NewSessionStore(index.DB())
 	if err != nil {

--- a/internal/task/manifest_seeding_test.go
+++ b/internal/task/manifest_seeding_test.go
@@ -1,0 +1,179 @@
+package task
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeChecker is a hand-rolled test double for ManifestReadinessChecker.
+// Each manifestID maps to a (satisfied, unsatisfied) response; lookups
+// for unknown ids return satisfied=true so tests that don't care about
+// the manifest layer don't have to configure each call.
+type fakeChecker struct {
+	responses map[string]fakeCheckResult
+	errFor    string // manifestID that should return a lookup error
+}
+
+type fakeCheckResult struct {
+	satisfied   bool
+	unsatisfied []string
+}
+
+func (f *fakeChecker) IsSatisfied(_ context.Context, manifestID string) (bool, []string, error) {
+	if f.errFor == manifestID {
+		return false, nil, errors.New("fake lookup failure")
+	}
+	if r, ok := f.responses[manifestID]; ok {
+		return r.satisfied, r.unsatisfied, nil
+	}
+	return true, nil, nil
+}
+
+// readBlockReason pulls the block_reason column directly. scanTask
+// strips it via taskColumns — fine for most paths but tests need the
+// raw value.
+func readBlockReason(t *testing.T, s *Store, id string) string {
+	t.Helper()
+	var br string
+	if err := s.db.QueryRow(`SELECT block_reason FROM tasks WHERE id = ?`, id).Scan(&br); err != nil {
+		t.Fatalf("read block_reason for %s: %v", id, err)
+	}
+	return br
+}
+
+// TestCreate_ManifestUnsatisfied_SeedsWaiting — the headline behavior
+// this PR introduces: a task created against an unsatisfied manifest
+// lands in 'waiting' with block_reason naming the unsatisfied dep(s),
+// not in 'pending'. Matches session Option B / issue #75 scope.
+func TestCreate_ManifestUnsatisfied_SeedsWaiting(t *testing.T) {
+	s := openRepoTestStore(t)
+	s.SetManifestChecker(&fakeChecker{
+		responses: map[string]fakeCheckResult{
+			"mf-blocked": {satisfied: false, unsatisfied: []string{"mf-dep-1", "mf-dep-2"}},
+		},
+	})
+
+	task, err := s.Create("mf-blocked", "t", "", "once", "claude-code", "node", "user", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if got := readStatus(t, s, task.ID); got != "waiting" {
+		t.Fatalf("status = %q, want waiting", got)
+	}
+	br := readBlockReason(t, s, task.ID)
+	if !strings.Contains(br, "manifest not satisfied") {
+		t.Errorf("block_reason = %q, want it to say 'manifest not satisfied'", br)
+	}
+	for _, want := range []string{"mf-dep-1", "mf-dep-2"} {
+		if !strings.Contains(br, want) {
+			t.Errorf("block_reason = %q, want marker %q present", br, want)
+		}
+	}
+}
+
+// TestCreate_ManifestSatisfied_NoDep_LandsPending — when the manifest
+// is satisfied AND there's no task-level dep, behavior matches the
+// pre-#75 no-dep case: plain 'pending', empty block_reason.
+func TestCreate_ManifestSatisfied_NoDep_LandsPending(t *testing.T) {
+	s := openRepoTestStore(t)
+	s.SetManifestChecker(&fakeChecker{
+		responses: map[string]fakeCheckResult{"mf-ready": {satisfied: true}},
+	})
+
+	task, err := s.Create("mf-ready", "t", "", "once", "claude-code", "node", "user", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if got := readStatus(t, s, task.ID); got != "pending" {
+		t.Fatalf("status = %q, want pending", got)
+	}
+	if br := readBlockReason(t, s, task.ID); br != "" {
+		t.Errorf("block_reason = %q, want empty", br)
+	}
+}
+
+// TestCreate_TaskDepTrumpsManifestCheck — when the task has a
+// task-level dep AND the manifest is also unsatisfied, the block_reason
+// must call out the task-level blocker (the closer one), not the
+// manifest. Once the task dep completes, the manifest check re-runs at
+// activation time.
+func TestCreate_TaskDepTrumpsManifestCheck(t *testing.T) {
+	s := openRepoTestStore(t)
+	s.SetManifestChecker(&fakeChecker{
+		responses: map[string]fakeCheckResult{"mf-blocked": {satisfied: false, unsatisfied: []string{"mf-dep"}}},
+	})
+
+	parent, err := s.Create("", "parent", "", "once", "claude-code", "node", "user", "")
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	child, err := s.Create("mf-blocked", "child", "", "once", "claude-code", "node", "user", parent.ID)
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	if got := readStatus(t, s, child.ID); got != "waiting" {
+		t.Fatalf("status = %q, want waiting", got)
+	}
+	br := readBlockReason(t, s, child.ID)
+	if !strings.Contains(br, "task ") {
+		t.Errorf("block_reason = %q, want task-level blocker named first", br)
+	}
+	if strings.Contains(br, "manifest not satisfied") {
+		t.Errorf("block_reason = %q, shouldn't mention manifest when task dep is the closer blocker", br)
+	}
+}
+
+// TestCreate_NilChecker_PreservesOldBehavior — for unit tests that
+// don't wire a checker (the majority) the manifest gate is skipped and
+// the no-dep path still lands pending. This makes the feature
+// opt-in at the test layer.
+func TestCreate_NilChecker_PreservesOldBehavior(t *testing.T) {
+	s := openRepoTestStore(t)
+	// No SetManifestChecker call.
+
+	task, err := s.Create("mf-anything", "t", "", "once", "claude-code", "node", "user", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if got := readStatus(t, s, task.ID); got != "pending" {
+		t.Fatalf("nil-checker status = %q, want pending", got)
+	}
+}
+
+// TestCreate_CheckerError_DegradesToPending — a transient error from
+// the checker (e.g. DB contention) must NOT fail the create. The task
+// lands pending; operator can later re-run activation or the seeding
+// retries naturally on the next create attempt.
+func TestCreate_CheckerError_DegradesToPending(t *testing.T) {
+	s := openRepoTestStore(t)
+	s.SetManifestChecker(&fakeChecker{errFor: "mf-broken"})
+
+	task, err := s.Create("mf-broken", "t", "", "once", "claude-code", "node", "user", "")
+	if err != nil {
+		t.Fatalf("Create should not fail on checker error: %v", err)
+	}
+	if got := readStatus(t, s, task.ID); got != "pending" {
+		t.Fatalf("status = %q, want pending (checker error fallback)", got)
+	}
+}
+
+// TestCreate_StandaloneTask_SkipsManifestCheck — tasks with empty
+// manifest_id can't be blocked by a manifest they don't have. The
+// checker should not be consulted.
+func TestCreate_StandaloneTask_SkipsManifestCheck(t *testing.T) {
+	s := openRepoTestStore(t)
+	checker := &fakeChecker{
+		responses: map[string]fakeCheckResult{"": {satisfied: false, unsatisfied: []string{"x"}}},
+	}
+	s.SetManifestChecker(checker)
+
+	task, err := s.Create("", "standalone", "", "once", "claude-code", "node", "user", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if got := readStatus(t, s, task.ID); got != "pending" {
+		t.Fatalf("standalone task status = %q, want pending", got)
+	}
+}

--- a/internal/task/repository.go
+++ b/internal/task/repository.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log/slog"
@@ -9,6 +10,27 @@ import (
 
 	"github.com/google/uuid"
 )
+
+// ManifestReadinessChecker is the hook task.Store consults to decide
+// whether a new task's manifest is currently satisfied (i.e. every one
+// of its manifest-level dependencies is in a terminal status). If a
+// manifest is unsatisfied, tasks created against it are seeded in
+// 'waiting' with a populated block_reason so the operator sees which
+// manifest is blocking them.
+//
+// Implemented by manifest.Store; wired via an adapter in node.go.
+// Optional — a nil checker skips the check, which preserves pre-fix
+// behavior and keeps unit tests standalone.
+type ManifestReadinessChecker interface {
+	IsSatisfied(ctx context.Context, manifestID string) (ok bool, unsatisfied []string, err error)
+}
+
+// SetManifestChecker wires a readiness checker. Safe to call once at
+// startup; there's no lock because the setter runs before any Create
+// call from the HTTP/MCP surfaces.
+func (s *Store) SetManifestChecker(c ManifestReadinessChecker) {
+	s.manifestChecker = c
+}
 
 // Create stores a new task. Per-task max_turns is set via the settings
 // resolver (PUT /api/tasks/:id/settings) after creation — the legacy
@@ -38,20 +60,43 @@ func (s *Store) Create(manifestID, title, description, schedule, agent, sourceNo
 	// a safety net, but the correct invariant is that dep-bearing tasks
 	// start in 'waiting' so the sort order + UI filters tell the truth.
 	initialStatus := StatusPending
+	blockReason := ""
+
+	// Task-level dep wins as the first blocker: if the parent task isn't
+	// completed, the task is waiting regardless of manifest state.
 	if dependsOn != "" {
 		var parentStatus string
 		err := s.db.QueryRow(`SELECT status FROM tasks WHERE (id = ? OR id LIKE ?) AND deleted_at = ''`,
 			dependsOn, dependsOn+"%").Scan(&parentStatus)
 		if err == nil && parentStatus != string(StatusCompleted) {
 			initialStatus = StatusWaiting
+			blockReason = fmt.Sprintf("task %s not completed", firstN(dependsOn, 12))
 		}
 		// sql.ErrNoRows or any other lookup failure: keep pending, operator
 		// can correct by attaching the dep later via Edit.
 	}
 
-	_, err := s.db.Exec(`INSERT INTO tasks (id, manifest_id, title, description, schedule, status, agent, source_node, created_by, depends_on, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		id, manifestID, title, description, schedule, string(initialStatus), agent, sourceNode, createdBy, dependsOn,
+	// Manifest-level dep check only runs when the task-level gate is
+	// already clear. Reason: if both blockers apply, the operator cares
+	// about the closer one (task dep) first — once that clears, the
+	// manifest-level check re-runs at activation time.
+	if initialStatus == StatusPending && manifestID != "" && s.manifestChecker != nil {
+		ok, unsatisfied, err := s.manifestChecker.IsSatisfied(context.Background(), manifestID)
+		if err != nil {
+			// Lookup failure shouldn't block task creation. Log via the
+			// caller's slog (we don't have one here) by returning the
+			// task normally; operator can re-trigger activation later.
+			// Keep pending.
+		} else if !ok {
+			initialStatus = StatusWaiting
+			blockReason = fmt.Sprintf("manifest not satisfied — blocked by: %s",
+				joinMarkers(unsatisfied))
+		}
+	}
+
+	_, err := s.db.Exec(`INSERT INTO tasks (id, manifest_id, title, description, schedule, status, agent, source_node, created_by, depends_on, block_reason, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, manifestID, title, description, schedule, string(initialStatus), agent, sourceNode, createdBy, dependsOn, blockReason,
 		now.Format(time.RFC3339), now.Format(time.RFC3339))
 	if err != nil {
 		return nil, err
@@ -61,8 +106,32 @@ func (s *Store) Create(manifestID, title, description, schedule, agent, sourceNo
 		ID: id, Marker: id[:12], ManifestID: manifestID,
 		Title: title, Description: description, Schedule: schedule,
 		Status: string(initialStatus), Agent: agent, SourceNode: sourceNode,
-		CreatedBy: createdBy, DependsOn: dependsOn, CreatedAt: now, UpdatedAt: now,
+		CreatedBy: createdBy, DependsOn: dependsOn, BlockReason: blockReason,
+		CreatedAt: now, UpdatedAt: now,
 	}, nil
+}
+
+// firstN returns the first n chars of s. Used for logging task/manifest
+// markers in block_reason strings without pulling the whole UUID.
+func firstN(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
+// joinMarkers formats a list of manifest ids as comma-separated markers
+// for inclusion in a block_reason. Empty input → "(unknown)" so the
+// reason is never ambiguous-looking to the operator.
+func joinMarkers(ids []string) string {
+	if len(ids) == 0 {
+		return "(unknown)"
+	}
+	markers := make([]string, 0, len(ids))
+	for _, id := range ids {
+		markers = append(markers, firstN(id, 12))
+	}
+	return strings.Join(markers, ", ")
 }
 
 // Get retrieves a task by ID or prefix.

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -55,7 +55,8 @@ type TaskRun struct {
 
 // Store manages task persistence.
 type Store struct {
-	db *sql.DB
+	db              *sql.DB
+	manifestChecker ManifestReadinessChecker // nil = skip manifest-level satisfaction check
 }
 
 // NewStore creates a task store.


### PR DESCRIPTION
First of three parts implementing #75. Follow-ups will wire activation propagation on manifest close and dep-removal rehab.

## What

When a task is created against a manifest whose manifest-level dependencies (from #76) aren't all terminal, the task row lands in \`waiting\` with \`block_reason\` naming the blocking manifests. Operator sees the block directly instead of a task that looks ready but never will be.

## Design

\`task.ManifestReadinessChecker\` interface keeps task.Store from importing manifest. manifest.Store satisfies it. node.New wires them via \`taskStore.SetManifestChecker(manifestStore)\` after both exist.

Precedence: task-level \`depends_on\` wins as the closer blocker — if the parent task isn't \`completed\`, block_reason names the task and doesn't mention the manifest. Once the task dep clears, the manifest check re-runs at activation time (part 2).

Graceful failure: transient checker error degrades to \`pending\`. Standalone tasks (no manifest_id) skip the check entirely.

## Test plan

- [x] \`go test ./internal/task/\` — 6 new tests in \`manifest_seeding_test.go\`:
  - Unsatisfied manifest → waiting + blockers named in block_reason
  - Satisfied manifest + no task dep → pending, empty block_reason
  - Task dep + unsatisfied manifest → waiting, task-level blocker named
  - Nil checker → old behavior preserved
  - Checker error → falls back to pending (Create does not fail)
  - Standalone task (empty manifest_id) → skips the check
- [x] \`go test ./...\` full suite green
- [x] \`go build ./...\`, \`go vet ./...\` clean
- [ ] Post-merge: create a task in a manifest with open deps (via dashboard or MCP) — confirm \`SELECT status, block_reason FROM tasks WHERE id = ?\` returns \`waiting\` + naming the blocker

## Not in this PR (tracked in #75)

- Watcher audit callback: on manifest close, walk dependents and auto-activate waiting-blocked-by-manifest tasks (→ scheduled)
- Dep removal: rehab previously-blocked tasks from \`waiting\` → \`pending\` + clear block_reason (Option B from session design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)