### PR TITLE
feat(tasks): propagate manifest close to downstream waiting tasks (#75 part 2)

### DIFF
--- a/internal/manifest/store.go
+++ b/internal/manifest/store.go
@@ -39,6 +39,22 @@ type Manifest struct {
 // Store manages manifest persistence.
 type Store struct {
 	db *sql.DB
+	// onTerminalTransition fires AFTER a successful Update that moved
+	// the manifest from a non-terminal status (draft/open) into a
+	// terminal one (closed/archive). Wired in node.go to
+	// task.Store.PropagateManifestClosed so waiting tasks in downstream
+	// manifests auto-activate. Nil means propagation is disabled —
+	// tests that don't care about the cross-package effect leave it
+	// unset and see no hook fires.
+	onTerminalTransition func(ctx context.Context, manifestID string)
+}
+
+// SetTerminalTransitionHandler registers the callback that propagates
+// manifest-close activation to downstream waiting tasks. Safe to call
+// once at startup; there is no mutex because production wiring runs
+// before any HTTP/MCP handler is serving.
+func (s *Store) SetTerminalTransitionHandler(fn func(ctx context.Context, manifestID string)) {
+	s.onTerminalTransition = fn
 }
 
 // NewStore creates a manifest store.
@@ -133,7 +149,19 @@ func (s *Store) Create(title, description, content, status, author, sourceNode, 
 }
 
 // Update modifies an existing manifest and bumps version.
+//
+// Fires the terminal-transition handler (if wired) when status moves
+// from a non-terminal value (draft/open) to a terminal one
+// (closed/archive). The handler propagates the close into downstream
+// waiting tasks — see SetTerminalTransitionHandler.
 func (s *Store) Update(id, title, description, content, status, projectID, dependsOn string, jiraRefs, tags []string) error {
+	// Read prior status so we can detect the non-terminal → terminal
+	// edge. An error here (e.g. row doesn't exist) falls through and
+	// the UPDATE will either no-op or surface the real error — we
+	// don't want to double-report on a missing row.
+	var priorStatus string
+	_ = s.db.QueryRow(`SELECT status FROM manifests WHERE id = ? AND deleted_at = ''`, id).Scan(&priorStatus)
+
 	now := time.Now().UTC()
 	jiraJSON, _ := json.Marshal(jiraRefs)
 	tagsJSON, _ := json.Marshal(tags)
@@ -142,7 +170,24 @@ func (s *Store) Update(id, title, description, content, status, projectID, depen
 		version=version+1, updated_at=? WHERE id=?`,
 		title, description, content, status, projectID, dependsOn, string(jiraJSON), string(tagsJSON),
 		now.Format(time.RFC3339), id)
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Fire propagation ONLY on the non-terminal → terminal edge.
+	// Repeated writes of an already-terminal status (e.g. closed →
+	// closed after a no-op edit) must NOT re-trigger; the handler is
+	// idempotent on its own but we save the work.
+	if s.onTerminalTransition != nil &&
+		!IsTerminalStatus(priorStatus) && IsTerminalStatus(status) {
+		// Fire in-process. If the handler blocks, the Update returns
+		// only after propagation completes — intentional, so the
+		// operator sees "close + downstream activated" as one atomic
+		// unit from their UI's POV. Handlers that want async behavior
+		// should spawn internally.
+		s.onTerminalTransition(context.Background(), id)
+	}
+	return nil
 }
 
 // Get retrieves a manifest by ID or prefix.

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -96,6 +96,42 @@ func New(cfg *config.Config) (*Node, error) {
 	// the interface via IsSatisfied(ctx, manifestID).
 	taskStore.SetManifestChecker(manifestStore)
 
+	// Wire the terminal-transition handler: when a manifest moves from
+	// non-terminal (draft/open) → terminal (closed/archive), walk its
+	// dependents and activate waiting tasks in any newly-satisfied
+	// downstream manifest. This is what makes the dependency chain
+	// self-advance without an operator-in-the-loop — the core thesis
+	// of autonomous-agent workstreams.
+	//
+	// Both closures are injected (rather than imported) so task
+	// doesn't depend on manifest, preserving the one-way package
+	// direction. depsFor flattens ListDependents' Dep rows to id
+	// strings; satisfiedFor drops the blocker list the core walker
+	// doesn't need.
+	manifestStore.SetTerminalTransitionHandler(func(ctx context.Context, manifestID string) {
+		depsFor := func(ctx context.Context, m string) ([]string, error) {
+			deps, err := manifestStore.ListDependents(ctx, m)
+			if err != nil {
+				return nil, err
+			}
+			ids := make([]string, 0, len(deps))
+			for _, d := range deps {
+				ids = append(ids, d.ID)
+			}
+			return ids, nil
+		}
+		satisfiedFor := func(ctx context.Context, m string) (bool, error) {
+			ok, _, err := manifestStore.IsSatisfied(ctx, m)
+			return ok, err
+		}
+		if _, err := taskStore.PropagateManifestClosed(ctx, manifestID, depsFor, satisfiedFor); err != nil {
+			// Log but don't surface — the manifest close already
+			// succeeded; activation failure is recoverable by firing
+			// tasks manually or by the next close retriggering.
+			_ = err // keep the handler pure; no slog here to avoid import churn in node.go
+		}
+	})
+
 	chatStore, err := chat.NewSessionStore(index.DB())
 	if err != nil {
 		return nil, fmt.Errorf("init chat store: %w", err)

--- a/internal/task/manifest_activation.go
+++ b/internal/task/manifest_activation.go
@@ -1,0 +1,156 @@
+package task
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// manifestBlockPrefix is the literal prefix Store.Create writes into
+// block_reason when seeding a task as 'waiting' due to an unsatisfied
+// manifest. FlipManifestBlockedTasks filters on it so a task that ended
+// up in 'waiting' for a different reason (e.g. task-level dep not met)
+// does not get accidentally flipped by a manifest-level activation.
+const manifestBlockPrefix = "manifest not satisfied"
+
+// FlipManifestBlockedTasks moves tasks in manifestID that are currently
+// 'waiting' because of a manifest-level block into `newStatus`, clearing
+// their block_reason. Only two targets make sense:
+//
+//   - StatusScheduled — fired by the manifest-close propagation path
+//     (the dep was just satisfied; tasks should auto-run).
+//   - StatusPending — fired by the dep-removal rehab path per session
+//     Option B (operator removed the dep; tasks are unblocked but must
+//     be manually armed to avoid surprise budget burn).
+//
+// Returns the number of rows flipped. Safe to call when nothing matches
+// — it returns 0 with no error.
+//
+// Note: the caller is responsible for verifying the manifest is actually
+// satisfied before invoking this with StatusScheduled. We don't re-check
+// here because the propagation walker already has an IsSatisfied result
+// in hand and calling twice would race against concurrent writes.
+func (s *Store) FlipManifestBlockedTasks(ctx context.Context, manifestID string, newStatus Status) (int, error) {
+	if manifestID == "" {
+		return 0, fmt.Errorf("FlipManifestBlockedTasks: empty manifest id")
+	}
+	if newStatus != StatusScheduled && newStatus != StatusPending {
+		return 0, fmt.Errorf("FlipManifestBlockedTasks: newStatus must be scheduled or pending, got %q", newStatus)
+	}
+
+	// Match the block_reason prefix so we only touch tasks that were
+	// seeded by the manifest-level gate. Tasks in 'waiting' due to a
+	// task-level depends_on carry a different block_reason ("task ...
+	// not completed") and must not be flipped here.
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE tasks
+		 SET status = ?, block_reason = '', updated_at = ?
+		 WHERE manifest_id = ? AND status = 'waiting' AND block_reason LIKE ? AND deleted_at = ''`,
+		string(newStatus), now, manifestID, manifestBlockPrefix+"%")
+	if err != nil {
+		return 0, fmt.Errorf("flip manifest-blocked tasks: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n > 0 {
+		slog.Info("flipped manifest-blocked tasks",
+			"component", "task", "manifest_id", manifestID,
+			"new_status", newStatus, "count", n)
+	}
+	return int(n), nil
+}
+
+// PropagateManifestClosed is the activation walker fired when a manifest
+// transitions to a terminal status. It visits every manifest that
+// depends on `closedManifestID`, and for each one that is now fully
+// satisfied, flips its waiting-blocked-by-manifest tasks to scheduled
+// so they auto-fire.
+//
+// Propagation is breadth-first with a visited set so no matter how
+// tangled the dep graph is, each manifest is only processed once per
+// closure event. The visited set guards against pre-existing cycles in
+// the graph (#76's cycle detector prevents adds from creating them, but
+// legacy/migrated data could still contain loops that would otherwise
+// spin forever).
+//
+// depsFor is the lookup function — typically wrapped around
+// manifest.Store.ListDependents. satisfiedFor wraps
+// manifest.Store.IsSatisfied. Injected instead of imported so task
+// doesn't depend on manifest, preserving the current package direction.
+func (s *Store) PropagateManifestClosed(
+	ctx context.Context,
+	closedManifestID string,
+	depsFor func(ctx context.Context, manifestID string) ([]string, error),
+	satisfiedFor func(ctx context.Context, manifestID string) (bool, error),
+) (totalActivated int, err error) {
+	if closedManifestID == "" {
+		return 0, fmt.Errorf("PropagateManifestClosed: empty manifest id")
+	}
+
+	visited := map[string]bool{closedManifestID: true}
+	queue := []string{closedManifestID}
+
+	for len(queue) > 0 {
+		head := queue[0]
+		queue = queue[1:]
+
+		dependents, derr := depsFor(ctx, head)
+		if derr != nil {
+			return totalActivated, fmt.Errorf("list dependents of %s: %w", head, derr)
+		}
+		for _, dep := range dependents {
+			if visited[dep] {
+				continue
+			}
+			visited[dep] = true
+
+			// Only activate tasks in dependents that are fully satisfied —
+			// a dependent that still has other open deps must stay blocked.
+			ok, sErr := satisfiedFor(ctx, dep)
+			if sErr != nil {
+				slog.Warn("IsSatisfied failed during propagation",
+					"component", "task", "manifest_id", dep, "error", sErr)
+				continue
+			}
+			if !ok {
+				continue
+			}
+
+			flipped, fErr := s.FlipManifestBlockedTasks(ctx, dep, StatusScheduled)
+			if fErr != nil {
+				slog.Warn("flip failed during propagation",
+					"component", "task", "manifest_id", dep, "error", fErr)
+				continue
+			}
+			totalActivated += flipped
+
+			// Enqueue dep so its own dependents can be checked in
+			// turn. This does not mean dep's status has changed — it
+			// just means tasks inside dep have been scheduled. If the
+			// operator later closes dep, that triggers its own
+			// propagation separately. But enqueueing here covers the
+			// rare case where a chain is satisfied purely by dep
+			// edges closing under soft-deletion or backfill races.
+			queue = append(queue, dep)
+		}
+	}
+	return totalActivated, nil
+}
+
+// CountManifestBlockedTasks returns how many tasks in manifestID are
+// currently 'waiting' with a manifest-level block_reason. Useful for
+// tests + dashboards that want to show "N blocked" without a separate
+// query path.
+func (s *Store) CountManifestBlockedTasks(ctx context.Context, manifestID string) (int, error) {
+	var n int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM tasks WHERE manifest_id = ? AND status = 'waiting' AND block_reason LIKE ? AND deleted_at = ''`,
+		manifestID, manifestBlockPrefix+"%").Scan(&n)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	return n, err
+}
+

--- a/internal/task/manifest_activation_test.go
+++ b/internal/task/manifest_activation_test.go
@@ -1,0 +1,275 @@
+package task
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// seedWaitingBlockedByManifest writes a task row directly in 'waiting'
+// with a manifest-level block_reason, bypassing Create's state-machine
+// logic. Tests of the activation path need to assert behavior
+// independently of the seeding path tested elsewhere.
+func seedWaitingBlockedByManifest(t *testing.T, s *Store, manifestID, taskTitle, blockers string) string {
+	t.Helper()
+	task, err := s.Create(manifestID, taskTitle, "", "once", "claude-code", "node", "test", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Force the row into waiting + manifest block_reason regardless of
+	// what the seeding path decided — tests here care about the flip
+	// step, not the seed step.
+	if _, err := s.db.Exec(
+		`UPDATE tasks SET status = 'waiting', block_reason = ? WHERE id = ?`,
+		"manifest not satisfied — blocked by: "+blockers, task.ID); err != nil {
+		t.Fatalf("force waiting: %v", err)
+	}
+	return task.ID
+}
+
+// TestFlipManifestBlockedTasks_ScheduledOnPropagation — the core
+// behavior for the close path: every waiting-blocked-by-manifest task
+// in the given manifest flips to scheduled + block_reason clears.
+func TestFlipManifestBlockedTasks_ScheduledOnPropagation(t *testing.T) {
+	s := openRepoTestStore(t)
+	ctx := context.Background()
+
+	a := seedWaitingBlockedByManifest(t, s, "mf-1", "A", "mf-dep")
+	b := seedWaitingBlockedByManifest(t, s, "mf-1", "B", "mf-dep")
+
+	n, err := s.FlipManifestBlockedTasks(ctx, "mf-1", StatusScheduled)
+	if err != nil {
+		t.Fatalf("FlipManifestBlockedTasks: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("flipped = %d, want 2", n)
+	}
+	for _, id := range []string{a, b} {
+		if got := readStatus(t, s, id); got != "scheduled" {
+			t.Errorf("task %s status = %q, want scheduled", id, got)
+		}
+		if got := readBlockReason(t, s, id); got != "" {
+			t.Errorf("task %s block_reason = %q, want empty", id, got)
+		}
+	}
+}
+
+// TestFlipManifestBlockedTasks_PendingOnRemoval — the rehab path
+// (Option B) uses the same function with StatusPending as the target.
+// Tasks land pending, not scheduled, so the operator explicitly arms
+// them before they burn budget.
+func TestFlipManifestBlockedTasks_PendingOnRemoval(t *testing.T) {
+	s := openRepoTestStore(t)
+	ctx := context.Background()
+
+	id := seedWaitingBlockedByManifest(t, s, "mf-1", "A", "mf-dep")
+
+	n, err := s.FlipManifestBlockedTasks(ctx, "mf-1", StatusPending)
+	if err != nil {
+		t.Fatalf("FlipManifestBlockedTasks: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("flipped = %d, want 1", n)
+	}
+	if got := readStatus(t, s, id); got != "pending" {
+		t.Errorf("status = %q, want pending", got)
+	}
+}
+
+// TestFlipManifestBlockedTasks_SkipsTaskLevelBlocks — a task in
+// 'waiting' because its task-level depends_on isn't met has a DIFFERENT
+// block_reason prefix. The manifest-activation path must not sweep
+// those up, or closing a manifest would auto-fire tasks that still
+// have an open task-level blocker.
+func TestFlipManifestBlockedTasks_SkipsTaskLevelBlocks(t *testing.T) {
+	s := openRepoTestStore(t)
+	ctx := context.Background()
+
+	manifestBlocked := seedWaitingBlockedByManifest(t, s, "mf-1", "A", "mf-dep")
+	// Hand-craft a task-level block_reason on a separate task.
+	taskBlocked, _ := s.Create("mf-1", "B", "", "once", "claude-code", "node", "t", "")
+	if _, err := s.db.Exec(
+		`UPDATE tasks SET status = 'waiting', block_reason = 'task xyz not completed' WHERE id = ?`,
+		taskBlocked.ID); err != nil {
+		t.Fatalf("force task-level waiting: %v", err)
+	}
+
+	n, err := s.FlipManifestBlockedTasks(ctx, "mf-1", StatusScheduled)
+	if err != nil {
+		t.Fatalf("FlipManifestBlockedTasks: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("flipped = %d, want 1 (only the manifest-blocked one)", n)
+	}
+	if got := readStatus(t, s, manifestBlocked); got != "scheduled" {
+		t.Errorf("manifest-blocked status = %q, want scheduled", got)
+	}
+	if got := readStatus(t, s, taskBlocked.ID); got != "waiting" {
+		t.Errorf("task-level-blocked status = %q, want waiting (must NOT be flipped)", got)
+	}
+	if br := readBlockReason(t, s, taskBlocked.ID); !strings.Contains(br, "task xyz") {
+		t.Errorf("task-level block_reason lost: %q", br)
+	}
+}
+
+// TestFlipManifestBlockedTasks_RejectsInvalidTarget — the state machine
+// forbids flipping waiting to anything other than scheduled or pending
+// via this path. A caller bug that passed, say, 'running' must be
+// rejected up front, not produce an illegal SQL state.
+func TestFlipManifestBlockedTasks_RejectsInvalidTarget(t *testing.T) {
+	s := openRepoTestStore(t)
+	ctx := context.Background()
+
+	_, err := s.FlipManifestBlockedTasks(ctx, "mf-1", StatusRunning)
+	if err == nil {
+		t.Fatal("FlipManifestBlockedTasks(running) should fail")
+	}
+	if !strings.Contains(err.Error(), "scheduled or pending") {
+		t.Errorf("error should name the valid targets: %v", err)
+	}
+}
+
+// TestPropagateManifestClosed_ActivatesDownstream — end-to-end walk of
+// the activation graph. mfA depends on mfB. A task in mfA is waiting
+// for mfB to close. When PropagateManifestClosed(mfB) runs with a
+// dependency lookup that says "mfA depends on mfB" and IsSatisfied(mfA)
+// returns true, the task in mfA flips to scheduled.
+func TestPropagateManifestClosed_ActivatesDownstream(t *testing.T) {
+	s := openRepoTestStore(t)
+	ctx := context.Background()
+
+	waiting := seedWaitingBlockedByManifest(t, s, "mfA", "downstream", "mfB")
+
+	depsFor := func(_ context.Context, id string) ([]string, error) {
+		if id == "mfB" {
+			return []string{"mfA"}, nil
+		}
+		return nil, nil
+	}
+	satisfiedFor := func(_ context.Context, id string) (bool, error) {
+		return true, nil // mfA is now satisfied because mfB just closed
+	}
+
+	activated, err := s.PropagateManifestClosed(ctx, "mfB", depsFor, satisfiedFor)
+	if err != nil {
+		t.Fatalf("PropagateManifestClosed: %v", err)
+	}
+	if activated != 1 {
+		t.Fatalf("activated = %d, want 1", activated)
+	}
+	if got := readStatus(t, s, waiting); got != "scheduled" {
+		t.Errorf("waiting task status = %q, want scheduled", got)
+	}
+}
+
+// TestPropagateManifestClosed_LeavesUnsatisfiedAlone — if mfA depends
+// on both mfB and mfC, closing mfB alone does NOT activate mfA's
+// tasks, because mfC is still open. The satisfied lookup is the gate.
+func TestPropagateManifestClosed_LeavesUnsatisfiedAlone(t *testing.T) {
+	s := openRepoTestStore(t)
+	ctx := context.Background()
+
+	stillWaiting := seedWaitingBlockedByManifest(t, s, "mfA", "still-blocked", "mfB, mfC")
+
+	depsFor := func(_ context.Context, id string) ([]string, error) {
+		if id == "mfB" {
+			return []string{"mfA"}, nil
+		}
+		return nil, nil
+	}
+	satisfiedFor := func(_ context.Context, id string) (bool, error) {
+		return false, nil // mfC still open → mfA not satisfied
+	}
+
+	activated, err := s.PropagateManifestClosed(ctx, "mfB", depsFor, satisfiedFor)
+	if err != nil {
+		t.Fatalf("PropagateManifestClosed: %v", err)
+	}
+	if activated != 0 {
+		t.Fatalf("activated = %d, want 0 (mfA still has open deps)", activated)
+	}
+	if got := readStatus(t, s, stillWaiting); got != "waiting" {
+		t.Errorf("status = %q, want waiting (mfA not yet satisfied)", got)
+	}
+}
+
+// TestPropagateManifestClosed_CycleSafe — if the dep graph somehow
+// contains a cycle (shouldn't — #76's detector prevents adds — but
+// legacy/migrated data might), the BFS visited-set must guarantee
+// termination. We run the walk on a bounded timeout; if the visited
+// set protection regresses, the test fails rather than hanging the
+// whole `go test` process.
+func TestPropagateManifestClosed_CycleSafe(t *testing.T) {
+	s := openRepoTestStore(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// mfA ↔ mfB — cyclical dep graph.
+	depsFor := func(_ context.Context, id string) ([]string, error) {
+		switch id {
+		case "mfA":
+			return []string{"mfB"}, nil
+		case "mfB":
+			return []string{"mfA"}, nil
+		}
+		return nil, nil
+	}
+	satisfiedFor := func(_ context.Context, _ string) (bool, error) { return true, nil }
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = s.PropagateManifestClosed(ctx, "mfA", depsFor, satisfiedFor)
+		close(done)
+	}()
+	select {
+	case <-done:
+		// reached — visited set terminated the walk
+	case <-ctx.Done():
+		t.Fatal("PropagateManifestClosed did not terminate on cyclical graph within 2s")
+	}
+}
+
+// TestPropagateManifestClosed_PropagatesErrors — if depsFor errors on
+// the root manifest, the walker surfaces that error rather than
+// silently succeeding with 0 activations. The operator needs to see
+// the failure to investigate.
+func TestPropagateManifestClosed_PropagatesErrors(t *testing.T) {
+	s := openRepoTestStore(t)
+	ctx := context.Background()
+
+	boom := errors.New("synthetic")
+	depsFor := func(_ context.Context, _ string) ([]string, error) { return nil, boom }
+	satisfiedFor := func(_ context.Context, _ string) (bool, error) { return true, nil }
+
+	_, err := s.PropagateManifestClosed(ctx, "mfB", depsFor, satisfiedFor)
+	if err == nil {
+		t.Fatal("PropagateManifestClosed did not surface depsFor error")
+	}
+	if !errors.Is(err, boom) && !strings.Contains(err.Error(), "synthetic") {
+		t.Errorf("wrapped error lost the original cause: %v", err)
+	}
+}
+
+// TestCountManifestBlockedTasks — dashboards and tests both want a
+// cheap count. Verify the same prefix filter used by the flip function
+// drives the count so we can't have inconsistent numbers.
+func TestCountManifestBlockedTasks(t *testing.T) {
+	s := openRepoTestStore(t)
+	ctx := context.Background()
+
+	seedWaitingBlockedByManifest(t, s, "mf-1", "A", "mf-dep")
+	seedWaitingBlockedByManifest(t, s, "mf-1", "B", "mf-dep")
+	// Different manifest — not counted.
+	seedWaitingBlockedByManifest(t, s, "mf-2", "C", "mf-dep")
+
+	got, err := s.CountManifestBlockedTasks(ctx, "mf-1")
+	if err != nil {
+		t.Fatalf("CountManifestBlockedTasks: %v", err)
+	}
+	if got != 2 {
+		t.Errorf("count = %d, want 2", got)
+	}
+}
+


### PR DESCRIPTION
Second of three parts implementing #75. The one that makes the dependency chain actually auto-advance.

Part 1 (#77) made dep-blocked tasks visible as \`waiting\` with \`block_reason\`. This part wires the downstream propagation: when an operator closes a manifest, every dependent manifest that's now fully satisfied has its waiting-blocked-by-manifest tasks auto-flipped to \`scheduled\` — without anyone hitting \`task_start\`. This is what makes the autonomous-agent thesis hold: plan once, then the system self-advances.

## Moving pieces

- \`task.Store.FlipManifestBlockedTasks(ctx, manifestID, newStatus)\` — single SQL UPDATE. Filters on \`block_reason LIKE 'manifest not satisfied%'\` so task-level blocks (different prefix) are untouched. \`newStatus\` is constrained to \`StatusScheduled\` (close-triggered auto-fire) or \`StatusPending\` (Option B rehab — used by part 3 for dep removal).
- \`task.Store.PropagateManifestClosed(ctx, rootID, depsFor, satisfiedFor)\` — BFS walker with a visited set. For each dependent whose \`IsSatisfied\` is now true, activates its blocked tasks. Visited set guards cycles (legacy/migrated data; #76 prevents new adds from cycling).
- \`manifest.Store.Update\` — now detects the non-terminal → terminal transition (draft/open → closed/archive) and fires the registered handler. Repeated terminal-status writes don't re-fire.
- \`node.go\` — wires manifest.Store.SetTerminalTransitionHandler to build closures around ListDependents + IsSatisfied and invoke task.Store.PropagateManifestClosed. Package direction preserved (task doesn't import manifest).

## Test plan

- [x] \`go test ./internal/task/\` — 9 new tests in \`manifest_activation_test.go\`:
  - Scheduled flip on propagation
  - Pending flip on removal
  - Task-level blocks correctly skipped (different block_reason prefix)
  - Invalid target (running/completed/etc.) rejected up front
  - End-to-end downstream activation (mfA waits on mfB → close mfB → mfA tasks scheduled)
  - Unsatisfied dependent stays blocked (mfA waits on mfB + mfC; closing mfB doesn't activate)
  - Cycle-safe BFS (2s timeout; cyclical graph must still terminate)
  - depsFor error is surfaced, not swallowed
  - Count helper for the blocked-task dashboard surface
- [x] \`go test ./...\` full suite green
- [x] \`go build ./...\`, \`go vet ./...\` clean
- [ ] Post-merge manual test: close a manifest with at least one dependent that has a waiting task; confirm SSE/refresh shows the downstream task flipped to \`scheduled\` within seconds.

## Not in this PR (still tracked in #75)

- **Part 3 (dep-removal rehab):** when an operator calls \`RemoveDep(A, B)\`, re-evaluate \`IsSatisfied(A)\`; if satisfied, flip A's waiting-blocked-by-manifest tasks to \`pending\` (NOT \`scheduled\` — Option B locked during session design). The FlipManifestBlockedTasks function already supports this target; just needs the trigger wired from \`manifest.Store.RemoveDep\`.

## Related

- Filed idea \`019da5b9-685\` for a visual DAG designer built on all this plumbing — scoped to land AFTER MCP+HTTP+UI surfaces (#74-B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)