### PR TITLE
feat(manifest): rehab waiting tasks to pending on dep removal (#75 part 3)

### DIFF
--- a/internal/manifest/dependencies.go
+++ b/internal/manifest/dependencies.go
@@ -197,6 +197,13 @@ func (s *Store) AddDep(ctx context.Context, manifestID, dependsOnID, createdBy s
 // RemoveDep is idempotent — removing an edge that doesn't exist returns
 // nil, not an error. The legacy column is re-synced from the join table
 // after the delete so the comma-separated list stays canonical-ish.
+//
+// Fires the onDepRemoved handler (if wired) after a successful delete +
+// legacy sync. The handler rehabs any now-unblocked waiting tasks per
+// Option B — see SetDepRemovedHandler. Firing unconditionally (not only
+// when the edge actually existed) keeps the contract simple: "after
+// this call, the edge is gone and any rehab that should have happened
+// has happened." A no-op delete followed by a no-op rehab is fine.
 func (s *Store) RemoveDep(ctx context.Context, manifestID, dependsOnID string) error {
 	if _, err := s.db.ExecContext(ctx,
 		`DELETE FROM manifest_dependencies WHERE manifest_id = ? AND depends_on_manifest_id = ?`,
@@ -206,6 +213,9 @@ func (s *Store) RemoveDep(ctx context.Context, manifestID, dependsOnID string) e
 	if err := s.syncLegacyDependsOn(ctx, manifestID); err != nil {
 		slog.Warn("sync legacy depends_on failed", "component", "manifest",
 			"manifest_id", manifestID, "error", err)
+	}
+	if s.onDepRemoved != nil {
+		s.onDepRemoved(ctx, manifestID)
 	}
 	return nil
 }

--- a/internal/manifest/rehab_test.go
+++ b/internal/manifest/rehab_test.go
@@ -1,0 +1,146 @@
+package manifest
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// openRehabTestStore opens a manifest.Store on a temp DB. The manifest
+// store is self-contained — the rehab handler is injected by tests so
+// they can assert the handler ran + with what args, without pulling in
+// the task package.
+func openRehabTestStore(t *testing.T) *Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "r.db") + "?_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	s, err := NewStore(db)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return s
+}
+
+// recordingHandler captures every invocation so tests can verify call
+// count + target manifest IDs. Thread-safe isn't required — the
+// RemoveDep path is synchronous.
+type recordingHandler struct {
+	calls []string
+}
+
+func (r *recordingHandler) fn(_ context.Context, manifestID string) {
+	r.calls = append(r.calls, manifestID)
+}
+
+// TestRemoveDep_FiresRehabHandler_OnRealEdge — the bread-and-butter
+// path. An edge exists; operator removes it; the handler fires with
+// the source manifest id. node.go wires this to the flip-to-pending
+// rehab.
+func TestRemoveDep_FiresRehabHandler_OnRealEdge(t *testing.T) {
+	s := openRehabTestStore(t)
+	ctx := context.Background()
+
+	rec := &recordingHandler{}
+	s.SetDepRemovedHandler(rec.fn)
+
+	a, _ := s.Create("A", "", "", "open", "t", "node", "", "", nil, nil)
+	b, _ := s.Create("B", "", "", "open", "t", "node", "", "", nil, nil)
+	if err := s.AddDep(ctx, a.ID, b.ID, "tester"); err != nil {
+		t.Fatalf("AddDep: %v", err)
+	}
+
+	if err := s.RemoveDep(ctx, a.ID, b.ID); err != nil {
+		t.Fatalf("RemoveDep: %v", err)
+	}
+	if len(rec.calls) != 1 || rec.calls[0] != a.ID {
+		t.Fatalf("handler calls = %v, want [%s]", rec.calls, a.ID)
+	}
+}
+
+// TestRemoveDep_FiresRehabHandler_EvenOnNoOpDelete — RemoveDep is
+// documented as idempotent. The handler fires even when the edge
+// didn't exist, because "after this call, the edge is gone and any
+// rehab that should have happened has happened" is the contract. A
+// no-op delete followed by a no-op rehab is cheap and keeps callers
+// from having to distinguish.
+func TestRemoveDep_FiresRehabHandler_EvenOnNoOpDelete(t *testing.T) {
+	s := openRehabTestStore(t)
+	ctx := context.Background()
+
+	rec := &recordingHandler{}
+	s.SetDepRemovedHandler(rec.fn)
+
+	a, _ := s.Create("A", "", "", "open", "t", "node", "", "", nil, nil)
+	b, _ := s.Create("B", "", "", "open", "t", "node", "", "", nil, nil)
+	// No AddDep first — the edge never existed.
+
+	if err := s.RemoveDep(ctx, a.ID, b.ID); err != nil {
+		t.Fatalf("RemoveDep: %v", err)
+	}
+	if len(rec.calls) != 1 {
+		t.Fatalf("handler calls = %d, want 1 (handler fires on no-op too)", len(rec.calls))
+	}
+}
+
+// TestRemoveDep_NoHandler_StillWorks — nil handler means the manifest
+// store is running standalone (tests, migrations). RemoveDep must
+// still behave correctly. Wired-in callers are the exception, not the
+// default.
+func TestRemoveDep_NoHandler_StillWorks(t *testing.T) {
+	s := openRehabTestStore(t)
+	ctx := context.Background()
+	// Explicitly leave SetDepRemovedHandler unset.
+
+	a, _ := s.Create("A", "", "", "open", "t", "node", "", "", nil, nil)
+	b, _ := s.Create("B", "", "", "open", "t", "node", "", "", nil, nil)
+	if err := s.AddDep(ctx, a.ID, b.ID, "tester"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.RemoveDep(ctx, a.ID, b.ID); err != nil {
+		t.Fatalf("RemoveDep without handler: %v", err)
+	}
+	deps, err := s.ListDeps(ctx, a.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deps) != 0 {
+		t.Errorf("expected edge gone, ListDeps returned %d rows", len(deps))
+	}
+}
+
+// TestUpdate_DoesNotFireRehabHandler — RemoveDep is the sole trigger
+// for the rehab handler. A manifest status update (even a close)
+// routes through the terminal-transition handler, not this one.
+// Keeping the paths distinct prevents accidental rehab firing when
+// operator behavior doesn't match the semantic.
+func TestUpdate_DoesNotFireRehabHandler(t *testing.T) {
+	s := openRehabTestStore(t)
+	ctx := context.Background()
+
+	rec := &recordingHandler{}
+	s.SetDepRemovedHandler(rec.fn)
+
+	a, _ := s.Create("A", "", "", "open", "t", "node", "", "", nil, nil)
+
+	// Close the manifest — different path, different handler.
+	if err := s.Update(a.ID, a.Title, "", "", "closed", "", "", nil, nil); err != nil {
+		t.Fatalf("Update to closed: %v", err)
+	}
+	// Also try a draft → open transition (non-terminal).
+	if err := s.Update(a.ID, a.Title, "", "", "open", "", "", nil, nil); err != nil {
+		t.Fatalf("Update back to open: %v", err)
+	}
+
+	if len(rec.calls) != 0 {
+		t.Fatalf("rehab handler fired on Update path: %v; should only fire on RemoveDep", rec.calls)
+	}
+	_ = ctx // silence unused — kept for symmetry with other tests
+}

--- a/internal/manifest/store.go
+++ b/internal/manifest/store.go
@@ -47,6 +47,14 @@ type Store struct {
 	// tests that don't care about the cross-package effect leave it
 	// unset and see no hook fires.
 	onTerminalTransition func(ctx context.Context, manifestID string)
+
+	// onDepRemoved fires AFTER a successful RemoveDep. The wired
+	// handler rehabs any now-unblocked waiting tasks into 'pending'
+	// per Option B (issue #74 comment). Distinct from
+	// onTerminalTransition: removal is operator-initiated scope
+	// reshuffling, not the normal close-advances-work flow, so we
+	// refuse to auto-burn budget by scheduling anything. Nil disables.
+	onDepRemoved func(ctx context.Context, manifestID string)
 }
 
 // SetTerminalTransitionHandler registers the callback that propagates
@@ -55,6 +63,16 @@ type Store struct {
 // before any HTTP/MCP handler is serving.
 func (s *Store) SetTerminalTransitionHandler(fn func(ctx context.Context, manifestID string)) {
 	s.onTerminalTransition = fn
+}
+
+// SetDepRemovedHandler registers the callback that fires after a
+// successful RemoveDep. The handler is expected to rehab any waiting
+// tasks in manifestID that are no longer blocked — per the Option B
+// decision recorded in issue #74, they go to `pending` (not
+// `scheduled`), so the operator has to explicitly arm them. This keeps
+// an accidental "remove dep" click from auto-burning budget.
+func (s *Store) SetDepRemovedHandler(fn func(ctx context.Context, manifestID string)) {
+	s.onDepRemoved = fn
 }
 
 // NewStore creates a manifest store.

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -108,6 +108,21 @@ func New(cfg *config.Config) (*Node, error) {
 	// direction. depsFor flattens ListDependents' Dep rows to id
 	// strings; satisfiedFor drops the blocker list the core walker
 	// doesn't need.
+	// Dep removal: when an operator removes a manifest→manifest edge,
+	// any waiting tasks in the source manifest that were blocked by
+	// a manifest-level dep are rehabbed to 'pending' — Option B, per
+	// issue #74 design comment. Pending (not scheduled) keeps an
+	// accidental click from auto-spending; operator arms explicitly.
+	// We only flip when the manifest is now fully satisfied; if other
+	// deps still block it, waiting tasks stay put.
+	manifestStore.SetDepRemovedHandler(func(ctx context.Context, manifestID string) {
+		ok, _, err := manifestStore.IsSatisfied(ctx, manifestID)
+		if err != nil || !ok {
+			return
+		}
+		_, _ = taskStore.FlipManifestBlockedTasks(ctx, manifestID, task.StatusPending)
+	})
+
 	manifestStore.SetTerminalTransitionHandler(func(ctx context.Context, manifestID string) {
 		depsFor := func(ctx context.Context, m string) ([]string, error) {
 			deps, err := manifestStore.ListDependents(ctx, m)


### PR DESCRIPTION
Closes #75.

Completes the three-part enforcement sequence:

1. **Part 1 (#77 merged):** seed waiting + block_reason when a task is created against an unsatisfied manifest.
2. **Part 2 (#78 merged):** on manifest close, propagate downstream — waiting tasks in newly-satisfied manifests flip to \`scheduled\` and auto-run.
3. **Part 3 (this PR):** on dep removal, rehab — waiting tasks in newly-satisfied manifests flip to \`pending\` (Option B). Operator must explicitly arm them; an accidental "remove dep" click doesn't auto-burn budget.

## What changed

- \`manifest.Store.onDepRemoved\` callback + \`SetDepRemovedHandler\` — mirror of \`onTerminalTransition\` from #78, different semantic trigger.
- \`RemoveDep\` fires the handler after delete + legacy-column sync (unconditionally, matching the documented "after this call, the edge is gone" contract).
- \`node.go\` wires the handler to check \`IsSatisfied\` first; only flips if the manifest is now fully satisfied. If other deps still block, waiting tasks stay put.
- No new task-layer code — the \`FlipManifestBlockedTasks\` function from #78 already supports \`StatusPending\` as a target.

## Test plan

- [x] \`go test ./internal/manifest/\` — 4 new tests in \`rehab_test.go\`:
  - Handler fires on a real edge removal with the source manifest id
  - Handler fires on an idempotent no-op delete (contract)
  - Nil handler is safe (standalone/test usage)
  - The \`Update\` (status-change) path does NOT fire the rehab handler — that path has its own terminal-transition handler from #78 and the two must stay distinct
- [x] \`go test ./...\` full suite green
- [x] \`go build ./...\`, \`go vet ./...\` clean
- [ ] Post-merge manual test: manifest with waiting task blocked by one dep; remove that dep; observe the task flips to \`pending\` (not \`scheduled\`), block_reason clears.

## After this lands

- #74 part 2 — MCP + HTTP + manifest-detail UI controls to actually call AddDep/RemoveDep from the operator surface. Right now these are DB-layer only.
- Then idea \`019da59d-a63\` (deep graph across products) and idea \`019da5b9-685\` (visual DAG designer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)