### PR TITLE
feat(ui): all 8 task statuses distinctly visible everywhere (#84)

### DIFF
--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -62,6 +62,7 @@ func Handler(n *node.Node, mcpServer *mcp.Server, hub *Hub, peerRegistry *peer.R
 	r.Path("/api.js").HandlerFunc(serveJS)
 	r.Path("/tree.js").HandlerFunc(serveJS)
 	r.Path("/lifecycle.js").HandlerFunc(serveJS)
+	r.Path("/task-status.js").HandlerFunc(serveJS)
 
 	// WebSocket
 	r.HandleFunc("/ws", hub.HandleWS)

--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -734,6 +734,7 @@
 
   <!-- Module loading order: api → tree → lifecycle → components → views → app (entry point) -->
   <script src="/api.js"></script>
+  <script src="/task-status.js"></script>
   <script src="/tree.js"></script>
   <script src="/lifecycle.js"></script>
   <script src="/components/knobs.js"></script>

--- a/internal/web/ui/style.css
+++ b/internal/web/ui/style.css
@@ -879,6 +879,19 @@ body {
 .amnesia-item.confirmed { border-left-color: var(--red); }
 .amnesia-item.dismissed { border-left-color: var(--text-muted); opacity: 0.6; }
 
+/* Per-task-status border-left colors so each of the 8 canonical statuses
+ * is visually distinct at a glance in the task list. Matches the color
+ * map in /task-status.js. Keep these in sync. */
+.amnesia-item.status-pending   { border-left-color: var(--text-muted); }
+.amnesia-item.status-waiting   { border-left-color: var(--accent); }
+.amnesia-item.status-scheduled { border-left-color: var(--yellow); }
+.amnesia-item.status-running   { border-left-color: var(--green); }
+.amnesia-item.status-paused    { border-left-color: var(--yellow); }
+.amnesia-item.status-completed { border-left-color: var(--green); opacity: 0.8; }
+.amnesia-item.status-failed    { border-left-color: var(--red); }
+.amnesia-item.status-cancelled { border-left-color: var(--text-muted); opacity: 0.5; text-decoration: line-through; }
+.amnesia-item.status-unknown   { border-left-color: var(--text-muted); opacity: 0.7; }
+
 .amnesia-header {
   display: flex;
   align-items: center;

--- a/internal/web/ui/task-status.js
+++ b/internal/web/ui/task-status.js
@@ -1,0 +1,84 @@
+// Shared task-status styling — single source of truth for the 8 canonical
+// statuses defined in internal/task/status.go. Every view (tasks.js,
+// overview.js, manifests.js linked-tasks list) reads from here so a
+// status renders identically across tabs.
+//
+// If you add a status server-side (status.go), you MUST add the matching
+// color + icon + label + css class here, or the UI will silently render
+// the new state as grey/unknown.
+(function(OL) {
+  'use strict';
+
+  // Color mapping uses CSS custom properties from style.css so dark/light
+  // theme switches stay consistent. Paused shares running's green dot but
+  // adds a pause icon to distinguish it without pulling a separate color.
+  OL.TASK_STATUS_COLORS = {
+    pending:   'var(--text-muted)',
+    waiting:   'var(--accent)',
+    scheduled: 'var(--yellow)',
+    running:   'var(--green)',
+    paused:    'var(--yellow)',
+    completed: 'var(--green)',
+    failed:    'var(--red)',
+    cancelled: 'var(--text-muted)',
+  };
+
+  // HTML-entity icons so we don't need an icon font. Glyphs picked for
+  // semantic clarity at 11-12px; verified on macOS + iOS emoji stacks.
+  OL.TASK_STATUS_ICONS = {
+    pending:   '\u25CB', // white circle
+    waiting:   '\u23F3', // hourglass
+    scheduled: '\u23F0', // alarm clock
+    running:   '\u25CF', // filled circle
+    paused:    '\u23F8', // pause bars
+    completed: '\u2713', // checkmark
+    failed:    '\u2717', // cross
+    cancelled: '\u2015', // horizontal bar
+  };
+
+  // Human labels for the CAPS-display convention used across the dashboard.
+  OL.TASK_STATUS_LABELS = {
+    pending:   'PENDING',
+    waiting:   'WAITING',
+    scheduled: 'SCHEDULED',
+    running:   'RUNNING',
+    paused:    'PAUSED',
+    completed: 'COMPLETED',
+    failed:    'FAILED',
+    cancelled: 'CANCELLED',
+  };
+
+  // CSS class per status — used by the list renderer for row-level
+  // backgrounds. Classes are defined in style.css; adding a status here
+  // without a matching CSS rule falls back to the default row style.
+  OL.TASK_STATUS_CLASS = {
+    pending:   'status-pending',
+    waiting:   'status-waiting',
+    scheduled: 'status-scheduled',
+    running:   'status-running',
+    paused:    'status-paused',
+    completed: 'status-completed',
+    failed:    'status-failed',
+    cancelled: 'status-cancelled',
+  };
+
+  // Animation hint: whether a status should pulse its indicator to draw
+  // the eye. Running alone qualifies; everything else is static.
+  OL.TASK_STATUS_PULSE = {
+    running: true,
+  };
+
+  // Helper: returns the full render trio for a status in one shot so
+  // views don't have to look up three maps. Unknown statuses fall back
+  // to neutral grey so a server-side addition without a client update
+  // degrades legibly rather than disappearing.
+  OL.getStatusRender = function(status) {
+    return {
+      color: OL.TASK_STATUS_COLORS[status] || 'var(--text-muted)',
+      icon:  OL.TASK_STATUS_ICONS[status]  || '?',
+      label: OL.TASK_STATUS_LABELS[status] || (status ? status.toUpperCase() : 'UNKNOWN'),
+      cssClass: OL.TASK_STATUS_CLASS[status] || 'status-unknown',
+      pulse: !!OL.TASK_STATUS_PULSE[status],
+    };
+  };
+})(window.OL = window.OL || {});

--- a/internal/web/ui/views/manifests.js
+++ b/internal/web/ui/views/manifests.js
@@ -382,8 +382,9 @@
           const statusCounts = {};
           for (const t of linkedTasks) { statusCounts[t.status] = (statusCounts[t.status] || 0) + 1; }
           const summary = Object.entries(statusCounts).map(([s,c]) => `${c} ${s}`).join(', ');
-          const statusColors = {running:'var(--green)',paused:'var(--yellow)',scheduled:'var(--yellow)',waiting:'var(--accent)',pending:'var(--text-muted)',completed:'var(--green)',failed:'var(--red)',cancelled:'var(--text-muted)'};
-          const statusIcons = {running:'&#x25CF;',paused:'&#x23F8;',scheduled:'&#x23F0;',waiting:'&#x23F3;',pending:'&#x25CB;',completed:'&#x2713;',failed:'&#x2717;',cancelled:'&#x2015;'};
+          // Shared status styling — see internal/web/ui/task-status.js.
+          const statusColors = OL.TASK_STATUS_COLORS;
+          const statusIcons = OL.TASK_STATUS_ICONS;
           const taskRows = linkedTasks.map(t => {
             const color = statusColors[t.status] || 'var(--text-muted)';
             const icon = statusIcons[t.status] || '&#x25CB;';

--- a/internal/web/ui/views/overview.js
+++ b/internal/web/ui/views/overview.js
@@ -78,7 +78,8 @@
     }
     if (panel) panel.style.display = '';
 
-    var statusColors = {running:'var(--green)',paused:'var(--yellow)',scheduled:'var(--yellow)',waiting:'var(--accent)',pending:'var(--text-muted)',completed:'var(--green)',max_turns:'var(--yellow)',failed:'var(--red)',cancelled:'var(--text-muted)'};
+    // Shared status styling — see internal/web/ui/task-status.js.
+    var statusColors = OL.TASK_STATUS_COLORS;
 
     var totalCost = topTasks.reduce(function(s, t) { return s + t.cost; }, 0);
     var html = '<div style="max-height:300px;overflow-y:auto"><table class="top-tasks-table" style="width:100%">' +
@@ -121,7 +122,8 @@
     } else {
       if (pendingPanel) pendingPanel.style.display = '';
       var pendingStatusColors = {scheduled:'var(--yellow)',waiting:'var(--accent)',pending:'var(--text-muted)'};
-      var statusIcons = {scheduled:'&#x23F0;',waiting:'&#x23F3;',pending:'&#x25CB;'};
+      // Shared status icons — see internal/web/ui/task-status.js.
+      var statusIcons = OL.TASK_STATUS_ICONS;
       var phtml = '';
       for (var pi = 0; pi < pending.length; pi++) {
         var pt = pending[pi];

--- a/internal/web/ui/views/tasks.js
+++ b/internal/web/ui/views/tasks.js
@@ -75,7 +75,9 @@
 
     newBtn.onclick = () => OL.showTaskCreateForm();
 
-    var statusColors = {running:'green',paused:'yellow',scheduled:'yellow',waiting:'yellow',pending:'',completed:'green',max_turns:'yellow',failed:'red',cancelled:''};
+    // Status styling comes from OL.getStatusRender (task-status.js).
+    // Never add an inline map here — adding a status in status.go
+    // should update exactly one place: task-status.js.
 
     try {
       var peerGroups = await fetchJSON('/api/tasks/by-peer');
@@ -104,34 +106,51 @@
             count: function(mg) { return mg.tasks.length; },
             children: function(mg) { return mg.tasks; },
             dotColor: function(mg) {
-              var hasRunning = mg.tasks.some(function(t) { return t.status === 'running'; });
+              // Aggregate color for the manifest group: red if any
+              // task is failed, green if any is running, yellow if any
+              // is armed (scheduled or waiting), grey otherwise.
               var hasFailed = mg.tasks.some(function(t) { return t.status === 'failed'; });
-              var hasScheduled = mg.tasks.some(function(t) { return t.status === 'scheduled' || t.status === 'waiting'; });
-              return hasRunning ? 'green' : hasFailed ? 'red' : hasScheduled ? 'yellow' : 'green';
+              if (hasFailed) return 'red';
+              var hasRunning = mg.tasks.some(function(t) { return t.status === 'running'; });
+              if (hasRunning) return 'green';
+              var hasArmed = mg.tasks.some(function(t) { return t.status === 'scheduled' || t.status === 'waiting' || t.status === 'paused'; });
+              if (hasArmed) return 'yellow';
+              return 'green';
             },
             expanded: false,
           }
         ],
         renderLeaf: function(t) {
-          var sColor = statusColors[t.status] || '';
-          var statusClass = t.status === 'completed' ? 'confirmed' : t.status === 'failed' ? 'flagged' : t.status === 'running' ? 'confirmed' : 'dismissed';
+          var render = OL.getStatusRender(t.status);
           var metaParts = [];
           if (t.run_count > 0) metaParts.push(t.run_count + ' runs');
           if (t.total_turns > 0) metaParts.push(t.total_turns + ' turns');
           if (t.total_cost > 0) metaParts.push('$' + t.total_cost.toFixed(2));
           metaParts.push(t.schedule);
 
-          return '<div class="amnesia-item ' + statusClass + ' clickable tree-leaf tree-indent" data-id="' + esc(t.id) + '">' +
+          // block_reason surfaces the manifest/task that's holding this
+          // task in waiting. Clickable in the detail view; here it's
+          // a tooltip + short inline hint so the row stays compact.
+          var blockHint = '';
+          if (t.status === 'waiting' && t.block_reason) {
+            blockHint = ' &middot; <span style="color:var(--accent)" title="' + esc(t.block_reason) + '">blocked</span>';
+          }
+
+          var pulseClass = render.pulse ? ' status-pulse' : '';
+
+          return '<div class="amnesia-item ' + render.cssClass + ' clickable tree-leaf tree-indent" data-id="' + esc(t.id) + '">' +
             '<div class="amnesia-header">' +
-              (t.status === 'running' ? '<span class="status-dot green status-pulse"></span>' : '<span class="status-dot ' + sColor + '"></span>') +
-              '<span class="amnesia-status-label">' + esc(t.status) + '</span>' +
+              '<span class="status-dot" style="background:' + render.color + ';' + (render.pulse ? 'animation:pulse 1s infinite' : '') + '"></span>' +
+              '<span class="amnesia-status-label" style="color:' + render.color + ';font-weight:600" title="' + esc(render.label) + '">' +
+                render.icon + ' ' + esc(t.status) +
+              '</span>' +
               '<span class="session-uuid">' + esc(t.marker) + '</span>' +
               '<span class="badge type">' + esc(t.schedule) + '</span>' +
               (t.depends_on ? '<span class="badge scope">dep</span>' : '') +
               '<span class="meta-time">' + formatTime(t.updated_at || t.created_at) + '</span>' +
             '</div>' +
             '<div class="amnesia-rule">' + esc(t.title) + '</div>' +
-            '<div class="amnesia-action">' + metaParts.join(' &middot; ') + '</div>' +
+            '<div class="amnesia-action">' + metaParts.join(' &middot; ') + blockHint + '</div>' +
           '</div>';
         },
         leafSelector: '.tree-leaf',
@@ -153,7 +172,8 @@
       const titleEl = document.getElementById('task-detail-title');
       const bodyEl = document.getElementById('task-detail');
 
-      const statusColor = t.status === 'running' ? 'var(--green)' : t.status === 'paused' ? 'var(--yellow)' : t.status === 'scheduled' ? 'var(--yellow)' : t.status === 'failed' ? 'var(--red)' : 'var(--text-muted)';
+      const statusRender = OL.getStatusRender(t.status);
+      const statusColor = statusRender.color;
 
       // Fetch manifest + product for breadcrumb
       let taskManifest = null, taskProduct = null;
@@ -278,8 +298,13 @@
           <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
             <span class="session-uuid" style="font-size:14px">${esc(t.marker)}</span>
             <span style="flex:1;font-size:15px;font-weight:600;color:var(--text-primary)">${esc(t.title)}</span>
-            <span style="color:${statusColor};font-weight:700;font-size:13px;text-transform:uppercase;padding:3px 10px;border:2px solid ${statusColor};border-radius:4px">${esc(t.status)}</span>
+            <span style="color:${statusColor};font-weight:700;font-size:13px;text-transform:uppercase;padding:3px 10px;border:2px solid ${statusColor};border-radius:4px" title="${esc(statusRender.label)}">${statusRender.icon} ${esc(t.status)}</span>
           </div>
+          ${t.block_reason ? `
+          <div style="display:flex;align-items:center;gap:6px;margin-bottom:12px;padding:6px 10px;background:rgba(59,130,246,0.08);border-left:3px solid var(--accent);border-radius:4px;font-size:12px;color:var(--text-primary)">
+            <span style="color:var(--accent);font-weight:600">Blocked:</span>
+            <span>${esc(t.block_reason)}</span>
+          </div>` : ''}
 
           <!-- METADATA — runs, turns, cost, agent, manifest, branch -->
           <div style="display:flex;gap:12px;font-size:12px;color:var(--text-muted);margin-bottom:16px;align-items:center;flex-wrap:wrap;padding:8px 12px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;font-family:var(--font-mono)">


### PR DESCRIPTION
Closes #84.

Fixes three structural UI bugs exposed by the #72 taxonomy work:

1. **\`tasks.js\` hid \`pending\` and \`cancelled\`** — empty color strings meant invisible status dots. Five statuses collapsed into one CSS class, so the operator couldn't tell \`waiting\` from \`pending\` from \`scheduled\` at a glance.
2. **Same status had different colors in different views** — \`tasks.js\`, \`overview.js\`, and \`manifests.js\` each carried their own inline map. \`max_turns\` (a reason, not a status) leaked into two of them.
3. **\`block_reason\` never rendered** — populated by #77/#78/#79, but never surfaced, so a waiting task looked identical to one that simply hadn't been started. Exactly the signal the dep work was supposed to make visible.

## Single source of truth

New \`internal/web/ui/task-status.js\`: \`OL.TASK_STATUS_COLORS\`, \`OL.TASK_STATUS_ICONS\`, \`OL.TASK_STATUS_LABELS\`, \`OL.TASK_STATUS_CLASS\`, \`OL.TASK_STATUS_PULSE\`, plus an \`OL.getStatusRender(status)\` helper.

Added to \`index.html\` right after \`/api.js\` so every view sees it. Adding a status in \`status.go\` now means updating exactly one file on the client.

## What changed per file

- \`tasks.js\` — row renderer uses the shared helper; every row shows icon + status text + matching color + per-status CSS class. Task detail header gets the same treatment + a new \`block_reason\` bar when \`status === 'waiting'\`.
- \`overview.js\` — inline maps replaced; stale \`max_turns\` dropped.
- \`manifests.js\` — linked-tasks list uses the shared maps.
- \`style.css\` — \`.amnesia-item.status-*\` rules for all 8 statuses. Cancelled adds strikethrough.
- \`handler.go\` — \`/task-status.js\` added to the explicit \`serveJS\` route list.

## Test plan

- [x] \`go build ./...\`, \`go vet ./...\`, \`go test ./...\` all green (backend mostly untouched)
- [x] Rebuilt server on PID 40871; \`curl /task-status.js\` returns \`application/javascript\` with the 3195-byte payload; \`curl /\` shows the \`<script src="/task-status.js"></script>\` line
- [ ] Manual browser QA (post-merge) — see acceptance checklist in #84:
  - Open Tasks tab — each row shows a distinct color + icon + CAPS label tooltip
  - Open Overview — same 8 tasks show the same styling
  - Open a manifest with linked tasks — same styling in the linked-tasks list
  - Task detail shows the status badge correctly + block_reason bar when waiting
  - Cancelled tasks render with strikethrough + muted opacity

## Not in this PR

- Filtering the task list by status (separate UX ask)
- Task-level dep picker UI (separate follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)