### PR TITLE
feat(tasks): SCD Type 2 dep history + cycle detection + block_reason on SetDependency (#86)

### DIFF
--- a/internal/task/dependency_test.go
+++ b/internal/task/dependency_test.go
@@ -1,0 +1,234 @@
+package task
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// mustCreateTask is a terse Create helper for tests that don't care
+// about most fields. Returns the full task row so the caller can ID
+// it back and check status.
+func mustCreateTask(t *testing.T, s *Store, title, dependsOn string) *Task {
+	t.Helper()
+	tk, err := s.Create("mf-1", title, "", "once", "claude-code", "node", "tester", dependsOn)
+	if err != nil {
+		t.Fatalf("Create(%q): %v", title, err)
+	}
+	return tk
+}
+
+// force overwrites a task's status directly, bypassing the state
+// machine. Needed for fixtures where we want the parent to already
+// be "completed" without running the whole runner loop.
+func force(t *testing.T, s *Store, id, status string) {
+	t.Helper()
+	if _, err := s.db.Exec(`UPDATE tasks SET status = ? WHERE id = ?`, status, id); err != nil {
+		t.Fatalf("force status %s: %v", status, err)
+	}
+}
+
+// TestSetDependency_ClearsDepAndFlipsWaitingToPending — clearing a
+// dep on a task that was waiting (the typical "operator realized
+// the chain was wrong and removed the block") must flip the task
+// to pending and wipe block_reason. Option B locked earlier in
+// session means we do NOT auto-schedule; operator arms.
+func TestSetDependency_ClearsDepAndFlipsWaitingToPending(t *testing.T) {
+	s := openRepoTestStore(t)
+	parent := mustCreateTask(t, s, "parent", "")
+	child := mustCreateTask(t, s, "child", parent.ID) // seeded as waiting per #77
+
+	if got := readStatus(t, s, child.ID); got != "waiting" {
+		t.Fatalf("initial child status = %q, want waiting", got)
+	}
+
+	if err := s.SetDependency(child.ID, ""); err != nil {
+		t.Fatalf("SetDependency clear: %v", err)
+	}
+	if got := readStatus(t, s, child.ID); got != "pending" {
+		t.Errorf("child status after clear = %q, want pending", got)
+	}
+	if br := readBlockReason(t, s, child.ID); br != "" {
+		t.Errorf("block_reason = %q, want empty after clear", br)
+	}
+}
+
+// TestSetDependency_ParentCompletedLandsScheduled — setting a dep
+// on a task whose parent is already completed must land the task
+// in scheduled (the dep is already satisfied). The pre-fix handler
+// always wrote waiting; this asserts the Store now does the right
+// thing regardless of caller.
+func TestSetDependency_ParentCompletedLandsScheduled(t *testing.T) {
+	s := openRepoTestStore(t)
+	parent := mustCreateTask(t, s, "parent", "")
+	force(t, s, parent.ID, "completed")
+
+	child := mustCreateTask(t, s, "orphan", "")
+	if got := readStatus(t, s, child.ID); got != "pending" {
+		t.Fatalf("initial orphan status = %q, want pending", got)
+	}
+
+	if err := s.SetDependency(child.ID, parent.ID); err != nil {
+		t.Fatalf("SetDependency: %v", err)
+	}
+	if got := readStatus(t, s, child.ID); got != "scheduled" {
+		t.Errorf("child status = %q, want scheduled (parent already done)", got)
+	}
+	if br := readBlockReason(t, s, child.ID); br != "" {
+		t.Errorf("block_reason = %q, want empty (dep is satisfied)", br)
+	}
+}
+
+// TestSetDependency_ParentOpenLandsWaitingWithBlockReason — the
+// headline case. Parent still open → child parks in waiting with
+// populated block_reason that the #85 UI surfaces as a visible bar.
+func TestSetDependency_ParentOpenLandsWaitingWithBlockReason(t *testing.T) {
+	s := openRepoTestStore(t)
+	parent := mustCreateTask(t, s, "parent", "")
+	// parent stays at the default 'pending'
+
+	child := mustCreateTask(t, s, "orphan", "")
+	if err := s.SetDependency(child.ID, parent.ID); err != nil {
+		t.Fatalf("SetDependency: %v", err)
+	}
+	if got := readStatus(t, s, child.ID); got != "waiting" {
+		t.Errorf("status = %q, want waiting", got)
+	}
+	br := readBlockReason(t, s, child.ID)
+	if !strings.Contains(br, "not completed") {
+		t.Errorf("block_reason = %q, want 'not completed' phrasing", br)
+	}
+	if !strings.Contains(br, parent.ID[:12]) {
+		t.Errorf("block_reason = %q, want parent marker %q", br, parent.ID[:12])
+	}
+}
+
+// TestSetDependency_SelfLoopRejected — sentinel error, row unchanged.
+func TestSetDependency_SelfLoopRejected(t *testing.T) {
+	s := openRepoTestStore(t)
+	tk := mustCreateTask(t, s, "solo", "")
+
+	err := s.SetDependency(tk.ID, tk.ID)
+	if !errors.Is(err, ErrTaskDepSelfLoop) {
+		t.Fatalf("err = %v, want ErrTaskDepSelfLoop", err)
+	}
+	if got := readStatus(t, s, tk.ID); got != "pending" {
+		t.Errorf("status mutated after rejected self-loop: %q", got)
+	}
+}
+
+// TestSetDependency_DirectCycleRejected — A→B exists, set B→A →
+// rejected. Error message names the rejected pair so the operator
+// sees which edge was refused.
+func TestSetDependency_DirectCycleRejected(t *testing.T) {
+	s := openRepoTestStore(t)
+	a := mustCreateTask(t, s, "A", "")
+	b := mustCreateTask(t, s, "B", a.ID) // B depends on A
+
+	err := s.SetDependency(a.ID, b.ID) // attempt A → B
+	if !errors.Is(err, ErrTaskDepCycle) {
+		t.Fatalf("err = %v, want ErrTaskDepCycle", err)
+	}
+	if !strings.Contains(err.Error(), a.ID[:12]) || !strings.Contains(err.Error(), b.ID[:12]) {
+		t.Errorf("cycle error doesn't name the rejected pair: %v", err)
+	}
+}
+
+// TestSetDependency_TransitiveCycleRejected — A → B → C. Setting
+// C → A would close a length-3 cycle; DFS must catch it.
+func TestSetDependency_TransitiveCycleRejected(t *testing.T) {
+	s := openRepoTestStore(t)
+	a := mustCreateTask(t, s, "A", "")
+	b := mustCreateTask(t, s, "B", a.ID)
+	c := mustCreateTask(t, s, "C", b.ID)
+
+	err := s.SetDependency(a.ID, c.ID) // A → C would make A → C → B → A
+	if !errors.Is(err, ErrTaskDepCycle) {
+		t.Fatalf("err = %v, want ErrTaskDepCycle on transitive cycle", err)
+	}
+}
+
+// TestSetDependency_SCDHistoryAccumulates — every SetDependency
+// call produces one SCD row. Previous active row gets valid_to
+// stamped; new row becomes active. ListDepHistory returns them
+// newest-first.
+func TestSetDependency_SCDHistoryAccumulates(t *testing.T) {
+	s := openRepoTestStore(t)
+	parent1 := mustCreateTask(t, s, "P1", "")
+	parent2 := mustCreateTask(t, s, "P2", "")
+	child := mustCreateTask(t, s, "child", "")
+
+	// 1) set dep to P1
+	if err := s.SetDependency(child.ID, parent1.ID); err != nil {
+		t.Fatalf("set to P1: %v", err)
+	}
+	// 2) change dep to P2
+	if err := s.SetDependency(child.ID, parent2.ID); err != nil {
+		t.Fatalf("change to P2: %v", err)
+	}
+	// 3) clear dep
+	if err := s.SetDependency(child.ID, ""); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+
+	hist, err := s.ListDepHistory(child.ID, 10)
+	if err != nil {
+		t.Fatalf("ListDepHistory: %v", err)
+	}
+	if len(hist) != 3 {
+		t.Fatalf("history rows = %d, want 3 (one per set call)", len(hist))
+	}
+	// Newest first: cleared (depends_on=''), then P2, then P1
+	if hist[0].DependsOn != "" || hist[0].ValidTo != "" {
+		t.Errorf("newest row = %+v, want cleared dep with valid_to=''", hist[0])
+	}
+	if hist[1].DependsOn != parent2.ID {
+		t.Errorf("second row depends_on = %q, want %q", hist[1].DependsOn, parent2.ID)
+	}
+	if hist[2].DependsOn != parent1.ID {
+		t.Errorf("third row depends_on = %q, want %q", hist[2].DependsOn, parent1.ID)
+	}
+	// Older rows must have valid_to stamped (no longer active).
+	if hist[1].ValidTo == "" {
+		t.Errorf("second row valid_to = empty; should be stamped when the next revision was written")
+	}
+	if hist[2].ValidTo == "" {
+		t.Errorf("third row valid_to = empty; should be stamped")
+	}
+}
+
+// TestBackfillTaskDepSCD_Idempotent — legacy tasks with a non-empty
+// depends_on column but no SCD row get one seeded on first run;
+// second run is a no-op.
+func TestBackfillTaskDepSCD_Idempotent(t *testing.T) {
+	s := openRepoTestStore(t)
+	// Manual insert: mimic a pre-SCD row — tasks.depends_on set,
+	// task_dependency empty.
+	parent := mustCreateTask(t, s, "P", "")
+	orphan, _ := s.Create("mf-1", "legacy", "", "once", "claude-code", "node", "t", "")
+	if _, err := s.db.Exec(`UPDATE tasks SET depends_on = ? WHERE id = ?`, parent.ID, orphan.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.Exec(`DELETE FROM task_dependency WHERE task_id = ?`, orphan.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Store.NewStore already ran the backfill, so force a second
+	// round to assert idempotency on top of whatever the legacy
+	// state produced.
+	n, err := s.BackfillTaskDepSCD()
+	if err != nil {
+		t.Fatalf("first explicit backfill: %v", err)
+	}
+	// Exactly one row seeded — the legacy orphan.
+	if n != 1 {
+		t.Errorf("first backfill inserted %d, want 1", n)
+	}
+	n, err = s.BackfillTaskDepSCD()
+	if err != nil {
+		t.Fatalf("second backfill: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("second backfill inserted %d, want 0 (idempotent)", n)
+	}
+}

--- a/internal/task/repository.go
+++ b/internal/task/repository.go
@@ -3,6 +3,7 @@ package task
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -276,12 +277,278 @@ func (s *Store) SetBlockReason(id, reason string) error {
 	return err
 }
 
-// SetDependency sets or clears the depends_on field for a task.
+// ErrTaskDepCycle is returned when SetDependency would create a cycle in
+// the task dependency graph. Handlers translate this to HTTP 409 / an
+// MCP tool error.
+var ErrTaskDepCycle = errors.New("task dependency: cycle detected")
+
+// ErrTaskDepSelfLoop is returned when a task is asked to depend on itself.
+var ErrTaskDepSelfLoop = errors.New("task dependency: a task cannot depend on itself")
+
+// SetDependency sets or clears the depends_on field for a task, and
+// transitions the task's status + block_reason to match the new
+// dependency state. Centralizes the four invariants that previously
+// leaked into the HTTP handler at handlers_task.go:
+//
+//   1. Cycle detection. DFS from the proposed parent following the
+//      single-parent depends_on column; if we ever hit taskID, reject.
+//      Single-parent makes this O(depth), effectively O(1) for real
+//      graphs.
+//   2. Self-loop rejection with ErrTaskDepSelfLoop, so the HTTP / MCP
+//      surfaces can surface a 400 rather than raw storage error text.
+//   3. Parent-status-aware seeding. If the parent is already
+//      StatusCompleted the dep is already satisfied — status flips
+//      to Scheduled (ready to fire), not Waiting. Matches the
+//      post-#77 invariant for Create so both paths agree.
+//   4. block_reason is populated when parking in Waiting and cleared
+//      on every other transition. The #85 UI renders a "Blocked:"
+//      bar from this field; leaving it stale or empty breaks that
+//      signal.
+//
+// Clearing the dep (dependsOn=="") is symmetric: column blanked, and
+// if the task was Waiting on a task-level block, it flips to Pending
+// with block_reason cleared (Option B symmetry with manifest-dep
+// removal from #79 — operator arms explicitly).
 func (s *Store) SetDependency(id, dependsOn string) error {
+	return s.SetDependencyWithAudit(id, dependsOn, "", "")
+}
+
+// SetDependencyWithAudit writes the new dep via SCD Type 2 semantics.
+//
+//   - The currently-active row (valid_to='') in task_dependency is
+//     closed by stamping valid_to=now.
+//   - A fresh row is inserted with valid_from=now, valid_to='', the
+//     new depends_on value, changedBy + reason for attribution.
+//   - tasks.depends_on is updated as a cache of the new active value
+//     so existing queries (scanTask, the scheduler) don't need an
+//     SCD join on every read.
+//
+// Result: the dep history for a task is just the rows in
+// task_dependency ordered by valid_from. No separate audit log —
+// history and current state share one table.
+//
+// changedBy identifies the caller ("http-api", session id, operator
+// name, etc.); reason is free-form. Both are optional but worth
+// populating on every write because the table can't be purged without
+// losing the decision trail.
+//
+// Cycle / self-loop rejection happens before any write so a refused
+// change never produces an SCD row.
+func (s *Store) SetDependencyWithAudit(id, dependsOn, changedBy, reason string) error {
+	// Resolve the full row so prefix inputs still work + we see the
+	// current status for the state transition.
+	var (
+		fullID, currentStatus string
+	)
+	if err := s.db.QueryRow(
+		`SELECT id, status FROM tasks WHERE (id = ? OR id LIKE ?) AND deleted_at = ''`,
+		id, id+"%").Scan(&fullID, &currentStatus); err != nil {
+		return err
+	}
+
 	now := time.Now().UTC().Format(time.RFC3339)
-	_, err := s.db.Exec(`UPDATE tasks SET depends_on = ?, updated_at = ? WHERE (id = ? OR id LIKE ?) AND deleted_at = ''`,
-		dependsOn, now, id, id+"%")
+
+	// Clear-path: no dep. Writes an SCD row with depends_on=''
+	// so "dep cleared" is visible in the history stream.
+	if dependsOn == "" {
+		nextStatus := currentStatus
+		if currentStatus == string(StatusWaiting) {
+			nextStatus = string(StatusPending)
+		}
+		if err := s.writeSCDDepRow(fullID, "", now, changedBy, reason); err != nil {
+			return err
+		}
+		_, err := s.db.Exec(
+			`UPDATE tasks SET depends_on = '', block_reason = '', status = ?, updated_at = ? WHERE id = ?`,
+			nextStatus, now, fullID)
+		return err
+	}
+
+	// Resolve + validate the proposed parent.
+	var parentID, parentStatus string
+	if err := s.db.QueryRow(
+		`SELECT id, status FROM tasks WHERE (id = ? OR id LIKE ?) AND deleted_at = ''`,
+		dependsOn, dependsOn+"%").Scan(&parentID, &parentStatus); err != nil {
+		return err
+	}
+	if parentID == fullID {
+		return ErrTaskDepSelfLoop
+	}
+	if reaches, err := s.taskDepPathExists(parentID, fullID); err != nil {
+		return fmt.Errorf("cycle check: %w", err)
+	} else if reaches {
+		return fmt.Errorf("%w: %s → %s would close a cycle",
+			ErrTaskDepCycle, shortID(fullID), shortID(parentID))
+	}
+
+	nextStatus, blockReason := deriveDepState(currentStatus, parentStatus, parentID)
+
+	if err := s.writeSCDDepRow(fullID, parentID, now, changedBy, reason); err != nil {
+		return err
+	}
+	_, err := s.db.Exec(
+		`UPDATE tasks SET depends_on = ?, status = ?, block_reason = ?, updated_at = ? WHERE id = ?`,
+		parentID, nextStatus, blockReason, now, fullID)
 	return err
+}
+
+// writeSCDDepRow closes the currently-active row (if any) and inserts
+// a new active row. Uses two statements in sequence — SQLite
+// transactions would add correctness if the two statements could race
+// against concurrent writers for the same task_id, but SetDependency
+// is operator-initiated and per-task serialization is implicit.
+func (s *Store) writeSCDDepRow(taskID, dependsOn, now, changedBy, reason string) error {
+	if _, err := s.db.Exec(
+		`UPDATE task_dependency SET valid_to = ? WHERE task_id = ? AND valid_to = ''`,
+		now, taskID); err != nil {
+		return fmt.Errorf("close prior dep row: %w", err)
+	}
+	if _, err := s.db.Exec(
+		`INSERT INTO task_dependency (task_id, depends_on, valid_from, valid_to, changed_by, reason)
+		 VALUES (?, ?, ?, '', ?, ?)`,
+		taskID, dependsOn, now, changedBy, reason); err != nil {
+		return fmt.Errorf("insert new dep row: %w", err)
+	}
+	return nil
+}
+
+// DepHistoryEntry is one row of the SCD Type 2 task_dependency table.
+// Rows are the full history of the task's dep relationship in
+// chronological order. The current/active row has ValidTo == "".
+type DepHistoryEntry struct {
+	ID         int    `json:"id"`
+	TaskID     string `json:"task_id"`
+	DependsOn  string `json:"depends_on"` // empty = dep cleared in this revision
+	ValidFrom  string `json:"valid_from"`
+	ValidTo    string `json:"valid_to"`   // empty = currently active
+	ChangedBy  string `json:"changed_by"`
+	Reason     string `json:"reason"`
+}
+
+// ListDepHistory returns every dep revision for a task, newest
+// valid_from first. limit<=0 defaults to 50.
+func (s *Store) ListDepHistory(taskID string, limit int) ([]DepHistoryEntry, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := s.db.Query(
+		`SELECT id, task_id, depends_on, valid_from, valid_to, changed_by, reason
+		 FROM task_dependency WHERE task_id = ? ORDER BY valid_from DESC, id DESC LIMIT ?`,
+		taskID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []DepHistoryEntry
+	for rows.Next() {
+		var e DepHistoryEntry
+		if err := rows.Scan(&e.ID, &e.TaskID, &e.DependsOn,
+			&e.ValidFrom, &e.ValidTo, &e.ChangedBy, &e.Reason); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// BackfillTaskDepSCD seeds task_dependency for tasks that had a
+// non-empty tasks.depends_on cache but no SCD row yet. Runs on
+// startup; idempotent via the "already has an active row" check.
+// Legacy rows land with valid_from = the task's updated_at so the
+// history doesn't all collapse to "now".
+func (s *Store) BackfillTaskDepSCD() (int, error) {
+	rows, err := s.db.Query(`
+		SELECT t.id, t.depends_on, t.updated_at
+		FROM tasks t
+		WHERE t.depends_on != '' AND t.deleted_at = ''
+		  AND NOT EXISTS (SELECT 1 FROM task_dependency d
+		                  WHERE d.task_id = t.id AND d.valid_to = '')`)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	type pair struct{ id, dep, when string }
+	var pending []pair
+	for rows.Next() {
+		var p pair
+		if err := rows.Scan(&p.id, &p.dep, &p.when); err != nil {
+			return 0, err
+		}
+		pending = append(pending, p)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	n := 0
+	for _, p := range pending {
+		if _, err := s.db.Exec(
+			`INSERT INTO task_dependency (task_id, depends_on, valid_from, valid_to, changed_by, reason)
+			 VALUES (?, ?, ?, '', 'scd-backfill', 'seeded from legacy tasks.depends_on')`,
+			p.id, p.dep, p.when); err == nil {
+			n++
+		}
+	}
+	return n, nil
+}
+
+// deriveDepState picks the status + block_reason for a task whose dep is
+// being set. Extracted so tests can exercise the classification without
+// touching the DB.
+func deriveDepState(currentStatus, parentStatus, parentID string) (string, string) {
+	// If the current status is Running or Paused we leave it alone —
+	// the task is mid-flight, changing its dep shouldn't derail it.
+	// block_reason stays whatever it was.
+	if currentStatus == string(StatusRunning) || currentStatus == string(StatusPaused) ||
+		currentStatus == string(StatusCompleted) || currentStatus == string(StatusFailed) ||
+		currentStatus == string(StatusCancelled) {
+		return currentStatus, "" // block_reason cleared; dep is recorded but status stays
+	}
+	if parentStatus == string(StatusCompleted) {
+		// Parent is already done — task is armed.
+		return string(StatusScheduled), ""
+	}
+	// Parent is in some non-terminal state — task parks in Waiting
+	// with a populated block_reason that the UI surfaces.
+	return string(StatusWaiting), fmt.Sprintf("task %s not completed (is %s)",
+		shortID(parentID), parentStatus)
+}
+
+// shortID returns the first 12 chars of an ID (the marker convention).
+// Defensive for ids shorter than 12 (which shouldn't happen in prod).
+func shortID(id string) string {
+	if len(id) <= 12 {
+		return id
+	}
+	return id[:12]
+}
+
+// taskDepPathExists runs a bounded DFS from src following single-parent
+// depends_on edges. Returns true if dst is reachable. O(chain depth) in
+// a well-formed graph; visited set caps work if the data contains a
+// pre-existing cycle.
+func (s *Store) taskDepPathExists(src, dst string) (bool, error) {
+	visited := map[string]bool{}
+	cur := src
+	for cur != "" {
+		if cur == dst {
+			return true, nil
+		}
+		if visited[cur] {
+			return false, nil // pre-existing cycle — treat as no-reach
+		}
+		visited[cur] = true
+		var next string
+		err := s.db.QueryRow(
+			`SELECT depends_on FROM tasks WHERE id = ? AND deleted_at = ''`, cur).Scan(&next)
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		cur = next
+	}
+	return false, nil
 }
 
 // ActivateDependents finds tasks that depend on the given task ID and

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -175,8 +175,52 @@ func (s *Store) init() error {
 		return fmt.Errorf("create task_manifests table: %w", err)
 	}
 
+	// SCD Type 2 for the task→task dependency relationship. Every
+	// SetDependency call closes the current row (sets valid_to) and
+	// inserts a fresh row (valid_from=now, valid_to=NULL). The
+	// "current" dep is whatever row has valid_to IS NULL for that
+	// task; any prior state is recoverable by querying rows ordered
+	// by valid_from. tasks.depends_on stays as a cache of the current
+	// row so existing queries keep working without the SCD join.
+	//
+	// depends_on='' represents "no dep" — a cleared dep writes a row
+	// with depends_on='' rather than leaving the table unchanged, so
+	// an operator can see that a dep was deliberately removed (vs.
+	// never set).
+	_, err = s.db.Exec(`CREATE TABLE IF NOT EXISTS task_dependency (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		task_id TEXT NOT NULL,
+		depends_on TEXT NOT NULL DEFAULT '',
+		valid_from TEXT NOT NULL,
+		valid_to TEXT NOT NULL DEFAULT '',
+		changed_by TEXT NOT NULL DEFAULT '',
+		reason TEXT NOT NULL DEFAULT ''
+	)`)
+	if err != nil {
+		return fmt.Errorf("create task_dependency table: %w", err)
+	}
+	_, err = s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_task_dep_task ON task_dependency(task_id, valid_from DESC)`)
+	if err != nil {
+		return fmt.Errorf("create task_dep index: %w", err)
+	}
+	// Partial index for the current-dep lookup path. valid_to='' means
+	// "still active" in our SCD encoding (we use empty string not NULL
+	// for consistency with the rest of the schema).
+	_, err = s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_task_dep_current ON task_dependency(task_id) WHERE valid_to = ''`)
+	if err != nil {
+		return fmt.Errorf("create task_dep current index: %w", err)
+	}
+
 	if err := s.initPricingSchema(); err != nil {
 		return fmt.Errorf("create model_pricing table: %w", err)
+	}
+
+	// Legacy tasks with a non-empty depends_on but no SCD row yet get
+	// one seeded here so the dep history stream isn't blank on
+	// upgrade. Idempotent — the NOT EXISTS guard in the backfill
+	// makes repeat runs a no-op.
+	if _, err := s.BackfillTaskDepSCD(); err != nil {
+		return fmt.Errorf("backfill task dep SCD: %w", err)
 	}
 
 	return nil

--- a/internal/web/handlers_task.go
+++ b/internal/web/handlers_task.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -394,30 +395,33 @@ func apiTaskSetDependency(n *node.Node) http.HandlerFunc {
 			return
 		}
 
-		// Validate dependency target exists if setting one
-		if req.DependsOn != "" {
-			dep, err := n.Tasks.Get(req.DependsOn)
+		// Resolve the dep target to its full ID if the caller passed a
+		// marker. 404 here is a real error — the UI picker shouldn't
+		// offer something that doesn't exist, but guard defensively.
+		depID := req.DependsOn
+		if depID != "" {
+			dep, err := n.Tasks.Get(depID)
 			if err != nil || dep == nil {
-				writeError(w, "dependency task not found", 404)
+				writeError(w, "dependency task not found", http.StatusNotFound)
 				return
 			}
-			// Prevent self-dependency
-			if dep.ID == t.ID {
-				writeError(w, "task cannot depend on itself", 400)
-				return
-			}
+			depID = dep.ID
 		}
 
-		if err := n.Tasks.SetDependency(t.ID, req.DependsOn); err != nil {
-			writeError(w, err.Error(), 500)
+		// Store handles cycle detection, self-loop rejection,
+		// parent-status-aware seeding, and block_reason population.
+		// The handler just maps the typed errors to HTTP codes and
+		// returns the refreshed row.
+		if err := n.Tasks.SetDependency(t.ID, depID); err != nil {
+			switch {
+			case errors.Is(err, task.ErrTaskDepCycle):
+				writeError(w, err.Error(), http.StatusConflict)
+			case errors.Is(err, task.ErrTaskDepSelfLoop):
+				writeError(w, err.Error(), http.StatusBadRequest)
+			default:
+				writeError(w, err.Error(), http.StatusInternalServerError)
+			}
 			return
-		}
-
-		// Auto-adjust status
-		if req.DependsOn != "" && (t.Status == "pending" || t.Status == "scheduled") {
-			n.Tasks.UpdateStatus(t.ID, "waiting")
-		} else if req.DependsOn == "" && t.Status == "waiting" {
-			n.Tasks.UpdateStatus(t.ID, "pending")
 		}
 
 		updated, _ := n.Tasks.Get(t.ID)


### PR DESCRIPTION
Closes #86.

Four gaps in the task-level dep path, all fixed — and the whole thing is now slowly-changing-dimension-shaped per the session direction (nothing is deleted; every revision becomes a row).

## What changed

- **\`task_dependency\` table (SCD Type 2)** — one row per dep revision. Each SetDependency closes the prior active row (stamps \`valid_to=now\`) and inserts a fresh row (\`valid_from=now, valid_to=''\`). \`tasks.depends_on\` stays as a cache of the current active value so existing queries keep working.
- **Cycle detection** via DFS up the single-parent chain. Self-loops rejected with \`ErrTaskDepSelfLoop\`, cycles with \`ErrTaskDepCycle\` naming the rejected pair.
- **block_reason populated** when parking in waiting (so the #85 UI "Blocked:" bar shows the blocker), cleared on other transitions.
- **Parent-status-aware seeding** — if the parent is already completed at set time, the task goes to \`scheduled\` (dep already satisfied), not \`waiting\`. Matches the #77 Create-path invariant.
- **Clearing writes an SCD row with \`depends_on=''\`** so "operator deliberately removed this" is recoverable from history.
- **\`BackfillTaskDepSCD\`** seeds an SCD row for any legacy task whose \`tasks.depends_on\` was populated before the table existed. Idempotent via NOT EXISTS guard; runs on \`NewStore\` startup.
- **\`ListDepHistory(taskID, limit)\`** returns the full revision list newest-first. \`DepHistoryEntry\` carries \`{id, task_id, depends_on, valid_from, valid_to, changed_by, reason}\`.
- **HTTP handler** \`apiTaskSetDependency\` becomes a thin pass-through with \`errors.Is\` mapping: \`ErrTaskDepCycle → 409\`, \`ErrTaskDepSelfLoop → 400\`, missing task → 404. Business logic lives in the Store so MCP / migrations / future callers get the same behavior.

## Test plan

- [x] \`go test ./internal/task/\` — 8 new tests in \`dependency_test.go\`:
  - Clear flips waiting→pending + wipes block_reason
  - Parent-completed-at-set-time → scheduled
  - Parent-open-at-set-time → waiting with named block_reason
  - Self-loop rejected
  - Direct cycle rejected + error names the pair
  - Transitive cycle (A→B→C, attempt A→C) rejected
  - SCD history accumulates across 3 successive sets with correct valid_to stamping and newest-first ordering
  - Backfill seeds legacy rows + is idempotent
- [x] \`go test ./...\` full suite green
- [x] \`go build ./...\`, \`go vet ./...\` clean
- [ ] Post-merge manual: set a dep via the task detail picker → observe the blue "Blocked:" bar populated; change the dep → prior row's \`valid_to\` stamped + new row active; clear the dep → SCD row with \`depends_on=''\` and task flips to pending.

## Not in this PR (filed as follow-up)

- **SCD Type 2 for every slowly-changing column across products/manifests/tasks** — architectural rewrite; needs phased PRs.
- **Product-level dependencies as many-to-many arbitrary depth** — idea \`019da59d-a63\`. This PR cements the SCD pattern the product-dep implementation should follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)