### PR TITLE
feat(product): data layer for product→product dependencies (#88)

### DIFF
--- a/internal/product/dependencies.go
+++ b/internal/product/dependencies.go
@@ -1,0 +1,252 @@
+package product
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// ErrCycle is returned by AddDep when the requested edge would close a
+// cycle in the product dependency graph. Handlers translate to HTTP 409
+// / MCP error text verbatim so the operator sees the rejected pair.
+var ErrCycle = errors.New("product_dependencies: cycle detected")
+
+// ErrSelfLoop is returned when a product is asked to depend on itself.
+// Enforced at the DB layer via CHECK but guarded before INSERT so the
+// error message is clearer than the raw sqlite constraint text.
+var ErrSelfLoop = errors.New("product_dependencies: a product cannot depend on itself")
+
+// Dep is the denormalized row UI + MCP callers want when listing deps
+// or dependents: id + marker + title + current status is enough to
+// render without a second lookup per row. Matches the Dep shape in
+// manifest.Dep so consumers can reuse render helpers across tiers.
+type Dep struct {
+	ID        string    `json:"id"`
+	Marker    string    `json:"marker"`
+	Title     string    `json:"title"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
+	CreatedBy string    `json:"created_by"`
+}
+
+// terminalProductStatuses mirrors the manifest convention (#76): a
+// product's dep is "satisfied" when it reaches one of these terminal
+// states. Kept as a var so scheduler code can build IN clauses from
+// the same source of truth and the two tiers don't drift.
+var terminalProductStatuses = []string{"closed", "archive"}
+
+// IsTerminalStatus reports whether a product.status value counts as
+// satisfying dependents.
+func IsTerminalStatus(status string) bool {
+	for _, s := range terminalProductStatuses {
+		if s == status {
+			return true
+		}
+	}
+	return false
+}
+
+// TerminalStatuses returns a copy of the terminal-status set for use
+// in scheduler / runner SQL predicates. Matches manifest.TerminalManifestStatuses.
+func TerminalStatuses() []string {
+	out := make([]string, len(terminalProductStatuses))
+	copy(out, terminalProductStatuses)
+	return out
+}
+
+// initDependenciesSchema creates the product_dependencies join table.
+// Called from Store.init() after the main products table exists.
+// Idempotent.
+func (s *Store) initDependenciesSchema() error {
+	_, err := s.db.Exec(`CREATE TABLE IF NOT EXISTS product_dependencies (
+		product_id            TEXT NOT NULL,
+		depends_on_product_id TEXT NOT NULL,
+		created_at            INTEGER NOT NULL,
+		created_by            TEXT NOT NULL DEFAULT '',
+		PRIMARY KEY (product_id, depends_on_product_id),
+		CHECK (product_id != depends_on_product_id)
+	)`)
+	if err != nil {
+		return fmt.Errorf("create product_dependencies table: %w", err)
+	}
+	if _, err := s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_product_deps_src ON product_dependencies(product_id)`); err != nil {
+		return fmt.Errorf("create product_deps src index: %w", err)
+	}
+	if _, err := s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_product_deps_dst ON product_dependencies(depends_on_product_id)`); err != nil {
+		return fmt.Errorf("create product_deps dst index: %w", err)
+	}
+	return nil
+}
+
+// AddDep adds a product→depends_on_product edge after cycle detection.
+//
+//   - rejects self-loops (ErrSelfLoop)
+//   - rejects edges that would close a cycle (ErrCycle), via DFS from
+//     depends_on_product_id back to product_id over the current edge set
+//   - idempotent on duplicate edges (INSERT OR IGNORE)
+//
+// On success the row carries created_at + created_by for audit.
+func (s *Store) AddDep(ctx context.Context, productID, dependsOnID, createdBy string) error {
+	if productID == "" || dependsOnID == "" {
+		return fmt.Errorf("product_dependencies: empty product id")
+	}
+	if productID == dependsOnID {
+		return ErrSelfLoop
+	}
+
+	reaches, err := s.pathExists(ctx, dependsOnID, productID)
+	if err != nil {
+		return fmt.Errorf("cycle check: %w", err)
+	}
+	if reaches {
+		return fmt.Errorf("%w: %s → %s would close a cycle",
+			ErrCycle, productID, dependsOnID)
+	}
+
+	now := time.Now().UTC().Unix()
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO product_dependencies (product_id, depends_on_product_id, created_at, created_by)
+		 VALUES (?, ?, ?, ?)`,
+		productID, dependsOnID, now, createdBy); err != nil {
+		return fmt.Errorf("insert product dep: %w", err)
+	}
+	return nil
+}
+
+// RemoveDep is idempotent — removing an edge that doesn't exist
+// returns nil. Matches the #79 pattern at the manifest tier so the
+// operator-surface semantics are consistent across tiers.
+func (s *Store) RemoveDep(ctx context.Context, productID, dependsOnID string) error {
+	if _, err := s.db.ExecContext(ctx,
+		`DELETE FROM product_dependencies WHERE product_id = ? AND depends_on_product_id = ?`,
+		productID, dependsOnID); err != nil {
+		return fmt.Errorf("delete product dep: %w", err)
+	}
+	return nil
+}
+
+// ListDeps returns out-edges: products this one depends on. Joined
+// against products so each row carries denormalized status + title
+// for direct rendering. Sorted by created_at so the order of addition
+// is preserved in the UI.
+func (s *Store) ListDeps(ctx context.Context, productID string) ([]Dep, error) {
+	return s.queryDeps(ctx,
+		`SELECT p.id, p.title, p.status, d.created_at, d.created_by
+		 FROM product_dependencies d
+		 JOIN products p ON p.id = d.depends_on_product_id
+		 WHERE d.product_id = ? AND p.deleted_at = ''
+		 ORDER BY d.created_at ASC`,
+		productID)
+}
+
+// ListDependents returns in-edges: products that depend on this one.
+// Used by activation walkers when a product becomes terminal.
+func (s *Store) ListDependents(ctx context.Context, productID string) ([]Dep, error) {
+	return s.queryDeps(ctx,
+		`SELECT p.id, p.title, p.status, d.created_at, d.created_by
+		 FROM product_dependencies d
+		 JOIN products p ON p.id = d.product_id
+		 WHERE d.depends_on_product_id = ? AND p.deleted_at = ''
+		 ORDER BY d.created_at ASC`,
+		productID)
+}
+
+// IsSatisfied reports whether every product this one depends on is in
+// a terminal status. Second return is the list of unsatisfied dep ids
+// so callers can build human-readable block reasons.
+func (s *Store) IsSatisfied(ctx context.Context, productID string) (bool, []string, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT p.id, p.status
+		 FROM product_dependencies d
+		 JOIN products p ON p.id = d.depends_on_product_id
+		 WHERE d.product_id = ? AND p.deleted_at = ''`, productID)
+	if err != nil {
+		return false, nil, err
+	}
+	defer rows.Close()
+	var unsatisfied []string
+	for rows.Next() {
+		var id, status string
+		if err := rows.Scan(&id, &status); err != nil {
+			return false, nil, err
+		}
+		if !IsTerminalStatus(status) {
+			unsatisfied = append(unsatisfied, id)
+		}
+	}
+	return len(unsatisfied) == 0, unsatisfied, rows.Err()
+}
+
+// pathExists does a DFS from src over product_dependencies edges,
+// returning true if dst is reachable. Cycle detection on AddDep uses
+// this in reverse: "does B already reach A? if so A→B would cycle."
+// Visited-set guards against pre-existing cycles in legacy data.
+func (s *Store) pathExists(ctx context.Context, src, dst string) (bool, error) {
+	visited := map[string]bool{}
+	stack := []string{src}
+	for len(stack) > 0 {
+		node := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if node == dst {
+			return true, nil
+		}
+		if visited[node] {
+			continue
+		}
+		visited[node] = true
+
+		rows, err := s.db.QueryContext(ctx,
+			`SELECT depends_on_product_id FROM product_dependencies WHERE product_id = ?`, node)
+		if err != nil {
+			return false, err
+		}
+		for rows.Next() {
+			var next string
+			if err := rows.Scan(&next); err != nil {
+				rows.Close()
+				return false, err
+			}
+			if !visited[next] {
+				stack = append(stack, next)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return false, err
+		}
+		rows.Close()
+	}
+	return false, nil
+}
+
+// queryDeps is the shared scan for ListDeps + ListDependents. Marker
+// is derived here (12-char prefix) so callers don't redo the rule.
+func (s *Store) queryDeps(ctx context.Context, query, id string) ([]Dep, error) {
+	rows, err := s.db.QueryContext(ctx, query, id)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Dep
+	for rows.Next() {
+		var d Dep
+		var createdAtUnix int64
+		if err := rows.Scan(&d.ID, &d.Title, &d.Status, &createdAtUnix, &d.CreatedBy); err != nil {
+			return nil, err
+		}
+		d.CreatedAt = time.Unix(createdAtUnix, 0).UTC()
+		if len(d.ID) >= 12 {
+			d.Marker = d.ID[:12]
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}
+
+// logSchemaReady emits a one-line info log on startup so operators see
+// which tier's dep schema is active. Not called from hot paths.
+func (s *Store) logSchemaReady() {
+	slog.Debug("product_dependencies schema ready", "component", "product")
+}

--- a/internal/product/dependencies_test.go
+++ b/internal/product/dependencies_test.go
@@ -1,0 +1,286 @@
+package product
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func openDepsTestStore(t *testing.T) *Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "p.db") + "?_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	s, err := NewStore(db)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return s
+}
+
+func mustCreate(t *testing.T, s *Store, title, status string) string {
+	t.Helper()
+	p, err := s.Create(title, "", status, "node", nil)
+	if err != nil {
+		t.Fatalf("Create(%q): %v", title, err)
+	}
+	return p.ID
+}
+
+// TestTerminalStatusClassification — locks the set so future drift
+// between product + manifest terminal classification is caught.
+func TestTerminalStatusClassification(t *testing.T) {
+	cases := map[string]bool{
+		"draft": false, "open": false,
+		"closed": true, "archive": true,
+		"": false, "unknown": false,
+	}
+	for status, want := range cases {
+		if got := IsTerminalStatus(status); got != want {
+			t.Errorf("IsTerminalStatus(%q) = %v, want %v", status, got, want)
+		}
+	}
+}
+
+// TestAddDep_BasicEdgeAndIdempotency — happy path plus repeat add
+// must be a no-op, not an error.
+func TestAddDep_BasicEdgeAndIdempotency(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+	a := mustCreate(t, s, "A", "open")
+	b := mustCreate(t, s, "B", "open")
+
+	if err := s.AddDep(ctx, a, b, "tester"); err != nil {
+		t.Fatalf("first AddDep: %v", err)
+	}
+	if err := s.AddDep(ctx, a, b, "tester"); err != nil {
+		t.Fatalf("second AddDep (idempotency): %v", err)
+	}
+	deps, err := s.ListDeps(ctx, a)
+	if err != nil {
+		t.Fatalf("ListDeps: %v", err)
+	}
+	if len(deps) != 1 || deps[0].ID != b {
+		t.Fatalf("ListDeps = %+v, want single row for B", deps)
+	}
+}
+
+// TestAddDep_SelfLoopRejected — must return ErrSelfLoop, not a raw
+// sqlite CHECK constraint error.
+func TestAddDep_SelfLoopRejected(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+	a := mustCreate(t, s, "A", "open")
+	err := s.AddDep(ctx, a, a, "tester")
+	if !errors.Is(err, ErrSelfLoop) {
+		t.Fatalf("err = %v, want ErrSelfLoop", err)
+	}
+}
+
+// TestAddDep_DirectCycleRejected — A→B exists, B→A would close a
+// length-2 cycle.
+func TestAddDep_DirectCycleRejected(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+	a := mustCreate(t, s, "A", "open")
+	b := mustCreate(t, s, "B", "open")
+	if err := s.AddDep(ctx, a, b, "t"); err != nil {
+		t.Fatal(err)
+	}
+	err := s.AddDep(ctx, b, a, "t")
+	if !errors.Is(err, ErrCycle) {
+		t.Fatalf("err = %v, want ErrCycle", err)
+	}
+	if !strings.Contains(err.Error(), a) || !strings.Contains(err.Error(), b) {
+		t.Errorf("cycle error doesn't name the pair: %v", err)
+	}
+}
+
+// TestAddDep_TransitiveCycleRejected — A→B, B→C. Adding C→A closes
+// a length-3 cycle; DFS must catch it.
+func TestAddDep_TransitiveCycleRejected(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+	a := mustCreate(t, s, "A", "open")
+	b := mustCreate(t, s, "B", "open")
+	c := mustCreate(t, s, "C", "open")
+	if err := s.AddDep(ctx, a, b, "t"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddDep(ctx, b, c, "t"); err != nil {
+		t.Fatal(err)
+	}
+	err := s.AddDep(ctx, c, a, "t")
+	if !errors.Is(err, ErrCycle) {
+		t.Fatalf("err = %v, want ErrCycle (transitive)", err)
+	}
+}
+
+// TestAddDep_DeepNonCyclingChain — verifies the "many levels deep"
+// guarantee: A depends on B depends on C depends on D depends on E
+// with no cycles must all insert. Session directive requires deep
+// dep graphs to be supported.
+func TestAddDep_DeepNonCyclingChain(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+	ids := make([]string, 8)
+	for i := range ids {
+		ids[i] = mustCreate(t, s, string(rune('A'+i)), "open")
+	}
+	// Linear chain: 0→1→2→...→7
+	for i := 0; i < len(ids)-1; i++ {
+		if err := s.AddDep(ctx, ids[i], ids[i+1], "t"); err != nil {
+			t.Fatalf("chain edge %d→%d: %v", i, i+1, err)
+		}
+	}
+	// Attempting to close the chain 7→0 must be refused.
+	if err := s.AddDep(ctx, ids[7], ids[0], "t"); !errors.Is(err, ErrCycle) {
+		t.Fatalf("7→0 close attempt err = %v, want ErrCycle", err)
+	}
+	// But adding a cross-link that doesn't cycle (say 0→3) is fine.
+	if err := s.AddDep(ctx, ids[0], ids[3], "t"); err != nil {
+		t.Fatalf("0→3 shortcut: %v", err)
+	}
+}
+
+// TestAddDep_NonCyclingDiamond — parallel deps are fine: A→B, A→C,
+// B→D, C→D. Canonical pattern for a product waiting on two parallel
+// workstreams.
+func TestAddDep_NonCyclingDiamond(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+	a := mustCreate(t, s, "A", "open")
+	b := mustCreate(t, s, "B", "open")
+	c := mustCreate(t, s, "C", "open")
+	d := mustCreate(t, s, "D", "open")
+
+	for _, pair := range [][2]string{{a, b}, {a, c}, {b, d}, {c, d}} {
+		if err := s.AddDep(ctx, pair[0], pair[1], "t"); err != nil {
+			t.Fatalf("%s→%s: %v", pair[0], pair[1], err)
+		}
+	}
+	deps, err := s.ListDeps(ctx, a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deps) != 2 {
+		t.Errorf("A deps = %d, want 2", len(deps))
+	}
+}
+
+// TestRemoveDep_IdempotentOnMissingEdge — "after this call, the
+// edge is gone" is the contract. Removing a non-existent edge
+// returns nil, not an error.
+func TestRemoveDep_IdempotentOnMissingEdge(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+	a := mustCreate(t, s, "A", "open")
+	b := mustCreate(t, s, "B", "open")
+	if err := s.RemoveDep(ctx, a, b); err != nil {
+		t.Fatalf("RemoveDep on missing edge: %v", err)
+	}
+}
+
+// TestListDependents_InEdges — in-edge listing is how the
+// activation walker finds impacted products when a parent closes.
+func TestListDependents_InEdges(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+	target := mustCreate(t, s, "target", "open")
+	a := mustCreate(t, s, "A", "open")
+	b := mustCreate(t, s, "B", "open")
+	_ = mustCreate(t, s, "C", "open") // does NOT depend on target
+
+	if err := s.AddDep(ctx, a, target, "t"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddDep(ctx, b, target, "t"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.ListDependents(ctx, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("dependents = %d, want 2", len(got))
+	}
+}
+
+// TestIsSatisfied_AllTerminalOrEmpty — empty dep set is vacuously
+// satisfied; all-terminal is satisfied; any non-terminal makes it
+// unsatisfied and the list names the blocker.
+func TestIsSatisfied_AllTerminalOrEmpty(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+	m := mustCreate(t, s, "M", "open")
+
+	ok, blockers, err := s.IsSatisfied(ctx, m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || len(blockers) != 0 {
+		t.Fatalf("no-deps IsSatisfied = (%v, %v), want (true, nil)", ok, blockers)
+	}
+
+	closedDep := mustCreate(t, s, "closed-dep", "closed")
+	archiveDep := mustCreate(t, s, "archive-dep", "archive")
+	openDep := mustCreate(t, s, "open-dep", "open")
+
+	for _, d := range []string{closedDep, archiveDep} {
+		if err := s.AddDep(ctx, m, d, "t"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ok, blockers, err = s.IsSatisfied(ctx, m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || len(blockers) != 0 {
+		t.Fatalf("all-terminal IsSatisfied = (%v, %v), want (true, nil)", ok, blockers)
+	}
+
+	if err := s.AddDep(ctx, m, openDep, "t"); err != nil {
+		t.Fatal(err)
+	}
+	ok, blockers, err = s.IsSatisfied(ctx, m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatalf("IsSatisfied = true, want false (open dep blocking)")
+	}
+	if len(blockers) != 1 || blockers[0] != openDep {
+		t.Fatalf("blockers = %v, want [%s]", blockers, openDep)
+	}
+}
+
+// TestIsSatisfied_IgnoresDeletedDeps — deleted products must not
+// count as blockers. Deleted entities are invisible to the rest of
+// the system; their edges should be invisible too.
+func TestIsSatisfied_IgnoresDeletedDeps(t *testing.T) {
+	s := openDepsTestStore(t)
+	ctx := context.Background()
+	m := mustCreate(t, s, "M", "open")
+	dep := mustCreate(t, s, "dep", "open")
+	if err := s.AddDep(ctx, m, dep, "t"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.Exec(`UPDATE products SET deleted_at='2026-01-01T00:00:00Z' WHERE id=?`, dep); err != nil {
+		t.Fatal(err)
+	}
+	ok, blockers, err := s.IsSatisfied(ctx, m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || len(blockers) != 0 {
+		t.Fatalf("IsSatisfied with deleted dep = (%v, %v), want (true, nil)", ok, blockers)
+	}
+}

--- a/internal/product/store.go
+++ b/internal/product/store.go
@@ -41,6 +41,10 @@ func NewStore(db *sql.DB) (*Store, error) {
 	if err := s.init(); err != nil {
 		return nil, err
 	}
+	if err := s.initDependenciesSchema(); err != nil {
+		return nil, err
+	}
+	s.logSchemaReady()
 	return s, nil
 }
 


### PR DESCRIPTION
Closes #88.

Top tier of the three-tier dep graph. Data layer + cycle detection + IsSatisfied, mirroring #76 exactly so products behave identically to manifests at the dep API.

## What's in

- \`product_dependencies\` join table with PRIMARY KEY dedupe, self-loop CHECK, indexes in both directions
- \`AddDep\`, \`RemoveDep\`, \`ListDeps\`, \`ListDependents\`, \`IsSatisfied\`, \`ErrCycle\`, \`ErrSelfLoop\`
- DFS cycle detection before insert; error names the rejected pair
- Terminal status classification (\`closed\`/\`archive\`) exported for scheduler / runner code to share one source of truth

## Test plan

- [x] \`go test ./internal/product/\` — 11 tests: basic + idempotency, self-loop rejected, direct cycle, transitive cycle, **deep chain (8-product linear, 7 edges)** exercising the "many levels deep" guarantee, diamond non-cycling, remove idempotent, in-edges via ListDependents, IsSatisfied empty/all-terminal/mixed, IsSatisfied ignores deleted deps
- [x] \`go test ./...\` full suite green
- [x] \`go build\`, \`go vet\` clean

## Not in this PR (prereqs for the Visual DAG Designer product 019da5e8-47f)

- Task seeding based on product-level deps
- Close propagation: product terminal transition walks dependents
- MCP + HTTP surface (mirror of #81)
- UI controls in product detail (mirror of #83)
- SCD Type 2 for product deps (covered by umbrella idea 019da5e4-601)

Each of the above is a tight follow-up PR; none blocks this data layer from landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)