### PR TITLE
feat(deps): product-tier enforcement — task seeding + close propagation + removal rehab (#91)

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -95,6 +95,13 @@ func New(cfg *config.Config) (*Node, error) {
 	// Typed as task.ManifestReadinessChecker — manifest.Store satisfies
 	// the interface via IsSatisfied(ctx, manifestID).
 	taskStore.SetManifestChecker(manifestStore)
+	// Product-tier readiness check. product.Store satisfies
+	// task.ProductReadinessChecker via IsSatisfied. A task whose
+	// containing manifest belongs to a product with open product-level
+	// deps gets seeded in 'waiting' with a product-prefix block_reason,
+	// distinct from manifest- and task-level blockers so each tier's
+	// propagation walker only flips its own tasks.
+	taskStore.SetProductChecker(productStore)
 
 	// Wire the terminal-transition handler: when a manifest moves from
 	// non-terminal (draft/open) → terminal (closed/archive), walk its
@@ -144,6 +151,44 @@ func New(cfg *config.Config) (*Node, error) {
 			// succeeded; activation failure is recoverable by firing
 			// tasks manually or by the next close retriggering.
 			_ = err // keep the handler pure; no slog here to avoid import churn in node.go
+		}
+	})
+
+	// Product-tier dep removal rehab (symmetric to manifest above).
+	// When an operator removes a product dep, if the product is now
+	// satisfied, flip its product-blocked tasks from waiting → pending
+	// (Option B — operator arms manually so an accidental click
+	// doesn't auto-spend).
+	productStore.SetDepRemovedHandler(func(ctx context.Context, productID string) {
+		ok, _, err := productStore.IsSatisfied(ctx, productID)
+		if err != nil || !ok {
+			return
+		}
+		_, _ = taskStore.FlipProductBlockedTasks(ctx, productID, task.StatusPending)
+	})
+
+	// Product close propagation. Closing a product walks its
+	// dependents; for each newly-satisfied dependent product, flip
+	// its product-blocked tasks to scheduled so the chain self-
+	// advances.
+	productStore.SetTerminalTransitionHandler(func(ctx context.Context, productID string) {
+		depsFor := func(ctx context.Context, pid string) ([]string, error) {
+			deps, err := productStore.ListDependents(ctx, pid)
+			if err != nil {
+				return nil, err
+			}
+			ids := make([]string, 0, len(deps))
+			for _, d := range deps {
+				ids = append(ids, d.ID)
+			}
+			return ids, nil
+		}
+		satisfiedFor := func(ctx context.Context, pid string) (bool, error) {
+			ok, _, err := productStore.IsSatisfied(ctx, pid)
+			return ok, err
+		}
+		if _, err := taskStore.PropagateProductClosed(ctx, productID, depsFor, satisfiedFor); err != nil {
+			_ = err
 		}
 	})
 

--- a/internal/product/dependencies.go
+++ b/internal/product/dependencies.go
@@ -118,11 +118,20 @@ func (s *Store) AddDep(ctx context.Context, productID, dependsOnID, createdBy st
 // RemoveDep is idempotent — removing an edge that doesn't exist
 // returns nil. Matches the #79 pattern at the manifest tier so the
 // operator-surface semantics are consistent across tiers.
+//
+// Fires the onDepRemoved handler (if wired) after a successful
+// delete. The handler rehabs now-unblocked waiting tasks per Option B.
+// Firing unconditionally (not just when the edge actually existed)
+// keeps the contract simple: "after this call, the edge is gone and
+// any rehab that should have happened has happened."
 func (s *Store) RemoveDep(ctx context.Context, productID, dependsOnID string) error {
 	if _, err := s.db.ExecContext(ctx,
 		`DELETE FROM product_dependencies WHERE product_id = ? AND depends_on_product_id = ?`,
 		productID, dependsOnID); err != nil {
 		return fmt.Errorf("delete product dep: %w", err)
+	}
+	if s.onDepRemoved != nil {
+		s.onDepRemoved(ctx, productID)
 	}
 	return nil
 }

--- a/internal/product/store.go
+++ b/internal/product/store.go
@@ -1,6 +1,7 @@
 package product
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -33,6 +34,30 @@ type Product struct {
 // Store manages product persistence.
 type Store struct {
 	db *sql.DB
+	// onTerminalTransition fires AFTER a successful Update that moved
+	// the product from a non-terminal status (draft/open) into a
+	// terminal one (closed/archive). Wired in node.go to
+	// task.Store.PropagateProductClosed so waiting tasks in downstream
+	// products' manifests auto-activate. Nil disables.
+	onTerminalTransition func(ctx context.Context, productID string)
+	// onDepRemoved fires AFTER a successful RemoveDep. Wired handler
+	// rehabs now-unblocked waiting tasks from the product's manifests
+	// into 'pending' per Option B. Nil disables.
+	onDepRemoved func(ctx context.Context, productID string)
+}
+
+// SetTerminalTransitionHandler registers the callback fired when a
+// product moves into a terminal status. Call once at startup; no mutex
+// because production wiring runs before any HTTP/MCP handler is
+// serving.
+func (s *Store) SetTerminalTransitionHandler(fn func(ctx context.Context, productID string)) {
+	s.onTerminalTransition = fn
+}
+
+// SetDepRemovedHandler registers the callback fired after RemoveDep.
+// The handler rehabs product-blocked tasks per Option B.
+func (s *Store) SetDepRemovedHandler(fn func(ctx context.Context, productID string)) {
+	s.onDepRemoved = fn
 }
 
 // NewStore creates a product store.
@@ -151,14 +176,37 @@ func (s *Store) List(status string, limit int) ([]*Product, error) {
 	return results, rows.Err()
 }
 
-// Update modifies a product.
+// Update modifies a product. Fires the terminal-transition handler
+// (if wired) when status moves from a non-terminal value (draft/open)
+// to a terminal one (closed/archive). The handler propagates the
+// close into downstream products' task queues — see
+// SetTerminalTransitionHandler.
 func (s *Store) Update(id, title, description, status string, tags []string) error {
+	// Read prior status before the UPDATE so we can detect the
+	// non-terminal → terminal edge. Missing row falls through; the
+	// UPDATE will either be a no-op or surface the real error.
+	var priorStatus, fullID string
+	_ = s.db.QueryRow(`SELECT id, status FROM products WHERE (id = ? OR id LIKE ?) AND deleted_at = ''`,
+		id, id+"%").Scan(&fullID, &priorStatus)
+
 	now := time.Now().UTC().Format(time.RFC3339)
 	tagsJSON, _ := json.Marshal(tags)
 	_, err := s.db.Exec(`UPDATE products SET title = ?, description = ?, status = ?, tags = ?, updated_at = ?
 		WHERE (id = ? OR id LIKE ?) AND deleted_at = ''`,
 		title, description, status, string(tagsJSON), now, id, id+"%")
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Fire propagation only on the non-terminal → terminal edge.
+	// Repeat writes of an already-terminal status (closed → closed)
+	// must not re-trigger; the handler is idempotent on its own but
+	// we save the walk.
+	if s.onTerminalTransition != nil && fullID != "" &&
+		!IsTerminalStatus(priorStatus) && IsTerminalStatus(status) {
+		s.onTerminalTransition(context.Background(), fullID)
+	}
+	return nil
 }
 
 // Delete soft-deletes a product.

--- a/internal/task/product_activation.go
+++ b/internal/task/product_activation.go
@@ -1,0 +1,133 @@
+package task
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// productBlockPrefix is the literal prefix Store.Create writes into
+// block_reason when seeding a task as 'waiting' due to an unsatisfied
+// product-level dependency. FlipProductBlockedTasks filters on it so
+// tasks waiting for a different reason (task-level or manifest-level
+// dep) don't get swept up by product-close propagation.
+const productBlockPrefix = "product not satisfied"
+
+// ProductReadinessChecker is the hook task.Store consults to decide
+// whether a new task's product has all its product-level dependencies
+// satisfied. Mirrors ManifestReadinessChecker from #77. Wired in
+// node.go.
+type ProductReadinessChecker interface {
+	IsSatisfied(ctx context.Context, productID string) (ok bool, unsatisfied []string, err error)
+}
+
+// SetProductChecker wires a product readiness checker. Nil-safe.
+func (s *Store) SetProductChecker(c ProductReadinessChecker) {
+	s.productChecker = c
+}
+
+// FlipProductBlockedTasks moves tasks in every manifest belonging to
+// productID that are currently 'waiting' with a product-level
+// block_reason to `newStatus`, clearing block_reason.
+//
+// Joins tasks → manifests → products so the filter works even though
+// tasks don't carry product_id directly. The block_reason prefix
+// filter guarantees we never touch tasks blocked at a different tier.
+//
+// Valid targets:
+//
+//   - StatusScheduled — fired by close propagation (dep just satisfied;
+//     tasks auto-run).
+//   - StatusPending — fired by dep-removal rehab per Option B
+//     (operator must arm manually after a scope change).
+//
+// Caller verifies the product is satisfied before invoking with
+// StatusScheduled.
+func (s *Store) FlipProductBlockedTasks(ctx context.Context, productID string, newStatus Status) (int, error) {
+	if productID == "" {
+		return 0, fmt.Errorf("FlipProductBlockedTasks: empty product id")
+	}
+	if newStatus != StatusScheduled && newStatus != StatusPending {
+		return 0, fmt.Errorf("FlipProductBlockedTasks: newStatus must be scheduled or pending, got %q", newStatus)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE tasks
+		 SET status = ?, block_reason = '', updated_at = ?
+		 WHERE id IN (
+		   SELECT t.id FROM tasks t
+		   JOIN manifests m ON m.id = t.manifest_id
+		   WHERE m.project_id = ?
+		     AND t.status = 'waiting'
+		     AND t.block_reason LIKE ?
+		     AND t.deleted_at = ''
+		     AND m.deleted_at = ''
+		 )`,
+		string(newStatus), now, productID, productBlockPrefix+"%")
+	if err != nil {
+		return 0, fmt.Errorf("flip product-blocked tasks: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n > 0 {
+		slog.Info("flipped product-blocked tasks",
+			"component", "task", "product_id", productID,
+			"new_status", newStatus, "count", n)
+	}
+	return int(n), nil
+}
+
+// PropagateProductClosed is the activation walker fired when a product
+// transitions to a terminal status. Mirror of PropagateManifestClosed
+// (#78): BFS with visited set, closures injected so task doesn't
+// import product.
+func (s *Store) PropagateProductClosed(
+	ctx context.Context,
+	closedProductID string,
+	depsFor func(ctx context.Context, productID string) ([]string, error),
+	satisfiedFor func(ctx context.Context, productID string) (bool, error),
+) (totalActivated int, err error) {
+	if closedProductID == "" {
+		return 0, fmt.Errorf("PropagateProductClosed: empty product id")
+	}
+
+	visited := map[string]bool{closedProductID: true}
+	queue := []string{closedProductID}
+
+	for len(queue) > 0 {
+		head := queue[0]
+		queue = queue[1:]
+
+		dependents, derr := depsFor(ctx, head)
+		if derr != nil {
+			return totalActivated, fmt.Errorf("list product dependents of %s: %w", head, derr)
+		}
+		for _, dep := range dependents {
+			if visited[dep] {
+				continue
+			}
+			visited[dep] = true
+
+			ok, sErr := satisfiedFor(ctx, dep)
+			if sErr != nil {
+				slog.Warn("product IsSatisfied failed during propagation",
+					"component", "task", "product_id", dep, "error", sErr)
+				continue
+			}
+			if !ok {
+				continue
+			}
+
+			flipped, fErr := s.FlipProductBlockedTasks(ctx, dep, StatusScheduled)
+			if fErr != nil {
+				slog.Warn("flip failed during product propagation",
+					"component", "task", "product_id", dep, "error", fErr)
+				continue
+			}
+			totalActivated += flipped
+			queue = append(queue, dep)
+		}
+	}
+	return totalActivated, nil
+}

--- a/internal/task/product_activation_test.go
+++ b/internal/task/product_activation_test.go
@@ -1,0 +1,251 @@
+package task
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeProductChecker struct {
+	responses map[string]fakeProductResult
+	errFor    string
+}
+
+type fakeProductResult struct {
+	satisfied   bool
+	unsatisfied []string
+}
+
+func (f *fakeProductChecker) IsSatisfied(_ context.Context, productID string) (bool, []string, error) {
+	if f.errFor == productID {
+		return false, nil, errors.New("fake product lookup failure")
+	}
+	if r, ok := f.responses[productID]; ok {
+		return r.satisfied, r.unsatisfied, nil
+	}
+	return true, nil, nil
+}
+
+// seedManifestForProduct inserts a minimal manifest row. task.Create's
+// product lookup joins manifests.project_id; internal/manifest import
+// from tests here would produce a cycle, so raw SQL it is.
+func seedManifestForProduct(t *testing.T, s *Store, manifestID, productID string) {
+	t.Helper()
+	if _, err := s.db.Exec(`CREATE TABLE IF NOT EXISTS manifests (
+		id TEXT PRIMARY KEY, title TEXT, description TEXT, content TEXT,
+		status TEXT, jira_refs TEXT, tags TEXT, author TEXT, source_node TEXT,
+		project_id TEXT, depends_on TEXT, version INT, created_at TEXT,
+		updated_at TEXT, deleted_at TEXT DEFAULT ''
+	)`); err != nil {
+		t.Fatalf("create manifests fixture: %v", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := s.db.Exec(`INSERT OR REPLACE INTO manifests
+		(id, title, description, content, status, jira_refs, tags, author, source_node, project_id, depends_on, version, created_at, updated_at, deleted_at)
+		VALUES (?, 'm', '', '', 'open', '[]', '[]', 't', '', ?, '', 1, ?, ?, '')`,
+		manifestID, productID, now, now); err != nil {
+		t.Fatalf("seed manifest row: %v", err)
+	}
+}
+
+// TestCreate_ProductUnsatisfied_SeedsWaitingWithProductReason — task
+// whose product has open deps lands waiting with a product-prefix
+// block_reason.
+func TestCreate_ProductUnsatisfied_SeedsWaitingWithProductReason(t *testing.T) {
+	s := openRepoTestStore(t)
+	seedManifestForProduct(t, s, "mf-x", "prod-blocked")
+	s.SetProductChecker(&fakeProductChecker{
+		responses: map[string]fakeProductResult{
+			"prod-blocked": {satisfied: false, unsatisfied: []string{"prod-dep-1"}},
+		},
+	})
+
+	task, err := s.Create("mf-x", "t", "", "once", "claude-code", "node", "user", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if got := readStatus(t, s, task.ID); got != "waiting" {
+		t.Fatalf("status = %q, want waiting", got)
+	}
+	br := readBlockReason(t, s, task.ID)
+	if !strings.HasPrefix(br, "product not satisfied") {
+		t.Errorf("block_reason = %q, want 'product not satisfied' prefix", br)
+	}
+	if !strings.Contains(br, "prod-dep-1") {
+		t.Errorf("block_reason = %q, want marker prod-dep-1", br)
+	}
+}
+
+// TestCreate_ManifestBlockTrumpsProduct — precedence: innermost
+// blocker is named first. Manifest block wins over product block.
+func TestCreate_ManifestBlockTrumpsProduct(t *testing.T) {
+	s := openRepoTestStore(t)
+	seedManifestForProduct(t, s, "mf-y", "prod-blocked")
+	s.SetManifestChecker(&fakeChecker{
+		responses: map[string]fakeCheckResult{"mf-y": {satisfied: false, unsatisfied: []string{"mf-dep"}}},
+	})
+	s.SetProductChecker(&fakeProductChecker{
+		responses: map[string]fakeProductResult{"prod-blocked": {satisfied: false, unsatisfied: []string{"prod-dep"}}},
+	})
+
+	task, err := s.Create("mf-y", "t", "", "once", "claude-code", "node", "user", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	br := readBlockReason(t, s, task.ID)
+	if !strings.HasPrefix(br, "manifest not satisfied") {
+		t.Errorf("block_reason = %q, want manifest-level prefix", br)
+	}
+	if strings.Contains(br, "product not satisfied") {
+		t.Errorf("block_reason = %q, must not mention product when manifest is closer blocker", br)
+	}
+}
+
+// TestFlipProductBlockedTasks_ScopedByProduct — flip touches only the
+// given product's manifests. Other products' product-blocked tasks
+// stay put.
+func TestFlipProductBlockedTasks_ScopedByProduct(t *testing.T) {
+	s := openRepoTestStore(t)
+	seedManifestForProduct(t, s, "mf-A", "prod-A")
+	seedManifestForProduct(t, s, "mf-B", "prod-B")
+
+	mkBlocked := func(manifestID, title string) string {
+		t.Helper()
+		tsk, err := s.Create(manifestID, title, "", "once", "claude-code", "node", "t", "")
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if _, err := s.db.Exec(
+			`UPDATE tasks SET status = 'waiting', block_reason = ? WHERE id = ?`,
+			"product not satisfied — blocked by: prod-dep", tsk.ID); err != nil {
+			t.Fatalf("force waiting: %v", err)
+		}
+		return tsk.ID
+	}
+	inA := mkBlocked("mf-A", "A")
+	inB := mkBlocked("mf-B", "B")
+
+	n, err := s.FlipProductBlockedTasks(context.Background(), "prod-A", StatusScheduled)
+	if err != nil {
+		t.Fatalf("FlipProductBlockedTasks: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("flipped = %d, want 1 (only prod-A)", n)
+	}
+	if got := readStatus(t, s, inA); got != "scheduled" {
+		t.Errorf("inA = %q, want scheduled", got)
+	}
+	if got := readStatus(t, s, inB); got != "waiting" {
+		t.Errorf("inB = %q, want waiting (untouched, different product)", got)
+	}
+}
+
+// TestFlipProductBlockedTasks_SkipsOtherBlockPrefixes — only tasks
+// with the product-prefix block_reason get flipped. Task-level and
+// manifest-level blocks stay put.
+func TestFlipProductBlockedTasks_SkipsOtherBlockPrefixes(t *testing.T) {
+	s := openRepoTestStore(t)
+	seedManifestForProduct(t, s, "mf-P", "prod-P")
+
+	mk := func(title, blockReason string) string {
+		tsk, err := s.Create("mf-P", title, "", "once", "claude-code", "node", "t", "")
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if _, err := s.db.Exec(
+			`UPDATE tasks SET status = 'waiting', block_reason = ? WHERE id = ?`,
+			blockReason, tsk.ID); err != nil {
+			t.Fatalf("force waiting: %v", err)
+		}
+		return tsk.ID
+	}
+	productBlocked := mk("P", "product not satisfied — blocked by: other")
+	manifestBlocked := mk("M", "manifest not satisfied — blocked by: dep-M")
+	taskBlocked := mk("T", "task xyz not completed")
+
+	n, err := s.FlipProductBlockedTasks(context.Background(), "prod-P", StatusScheduled)
+	if err != nil {
+		t.Fatalf("FlipProductBlockedTasks: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("flipped = %d, want 1", n)
+	}
+	if got := readStatus(t, s, productBlocked); got != "scheduled" {
+		t.Errorf("product-blocked = %q, want scheduled", got)
+	}
+	if got := readStatus(t, s, manifestBlocked); got != "waiting" {
+		t.Errorf("manifest-blocked was flipped: %q", got)
+	}
+	if got := readStatus(t, s, taskBlocked); got != "waiting" {
+		t.Errorf("task-blocked was flipped: %q", got)
+	}
+}
+
+// TestPropagateProductClosed_ActivatesDownstream — end-to-end walk.
+// prod-A depends on prod-B. Close prod-B → prod-A satisfied → tasks
+// in prod-A flip to scheduled.
+func TestPropagateProductClosed_ActivatesDownstream(t *testing.T) {
+	s := openRepoTestStore(t)
+	seedManifestForProduct(t, s, "mf-A", "prod-A")
+
+	tsk, err := s.Create("mf-A", "downstream", "", "once", "claude-code", "node", "t", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := s.db.Exec(
+		`UPDATE tasks SET status = 'waiting', block_reason = 'product not satisfied — blocked by: prod-B' WHERE id = ?`,
+		tsk.ID); err != nil {
+		t.Fatalf("force waiting: %v", err)
+	}
+
+	depsFor := func(_ context.Context, id string) ([]string, error) {
+		if id == "prod-B" {
+			return []string{"prod-A"}, nil
+		}
+		return nil, nil
+	}
+	satisfiedFor := func(_ context.Context, _ string) (bool, error) { return true, nil }
+
+	activated, err := s.PropagateProductClosed(context.Background(), "prod-B", depsFor, satisfiedFor)
+	if err != nil {
+		t.Fatalf("PropagateProductClosed: %v", err)
+	}
+	if activated != 1 {
+		t.Fatalf("activated = %d, want 1", activated)
+	}
+	if got := readStatus(t, s, tsk.ID); got != "scheduled" {
+		t.Errorf("task = %q, want scheduled", got)
+	}
+}
+
+// TestPropagateProductClosed_CycleSafe — visited set guarantees
+// termination even if the dep graph contains a back-edge.
+func TestPropagateProductClosed_CycleSafe(t *testing.T) {
+	s := openRepoTestStore(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	depsFor := func(_ context.Context, id string) ([]string, error) {
+		switch id {
+		case "prod-A":
+			return []string{"prod-B"}, nil
+		case "prod-B":
+			return []string{"prod-A"}, nil
+		}
+		return nil, nil
+	}
+	satisfiedFor := func(_ context.Context, _ string) (bool, error) { return true, nil }
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = s.PropagateProductClosed(ctx, "prod-A", depsFor, satisfiedFor)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("PropagateProductClosed did not terminate within 2s on cyclical graph")
+	}
+}

--- a/internal/task/repository.go
+++ b/internal/task/repository.go
@@ -95,6 +95,28 @@ func (s *Store) Create(manifestID, title, description, schedule, agent, sourceNo
 		}
 	}
 
+	// Product-level dep check runs only if task-level + manifest-level
+	// gates are both clear. Same precedence as the manifest check:
+	// innermost blocker is named in block_reason; outer checks re-run
+	// at activation time as inner blockers clear.
+	//
+	// productID is derived from manifests.project_id. Kept as a local
+	// SELECT rather than a dedicated cross-package store method so the
+	// task package doesn't need to import product.
+	if initialStatus == StatusPending && manifestID != "" && s.productChecker != nil {
+		var productID string
+		_ = s.db.QueryRow(`SELECT project_id FROM manifests WHERE id = ? AND deleted_at = ''`,
+			manifestID).Scan(&productID)
+		if productID != "" {
+			ok, unsatisfied, err := s.productChecker.IsSatisfied(context.Background(), productID)
+			if err == nil && !ok {
+				initialStatus = StatusWaiting
+				blockReason = fmt.Sprintf("product not satisfied — blocked by: %s",
+					joinMarkers(unsatisfied))
+			}
+		}
+	}
+
 	_, err := s.db.Exec(`INSERT INTO tasks (id, manifest_id, title, description, schedule, status, agent, source_node, created_by, depends_on, block_reason, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		id, manifestID, title, description, schedule, string(initialStatus), agent, sourceNode, createdBy, dependsOn, blockReason,

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -57,6 +57,7 @@ type TaskRun struct {
 type Store struct {
 	db              *sql.DB
 	manifestChecker ManifestReadinessChecker // nil = skip manifest-level satisfaction check
+	productChecker  ProductReadinessChecker  // nil = skip product-level satisfaction check
 }
 
 // NewStore creates a task store.


### PR DESCRIPTION
Closes #91.

Three-tier dep enforcement complete. Manifest tier was in place via #77/#78/#79; this PR is the symmetric path at the product tier.

## Per session direction

Products and manifests don't execute; only tasks do. But dep enforcement at every tier is what makes autonomy work — a dep that doesn't gate execution is decoration. So both product AND manifest dep chains now block + auto-advance task execution end-to-end.

## Three code paths (mirror manifest tier)

1. **\`task.Store.Create\`** consults a \`ProductReadinessChecker\` after the task-level + manifest-level gates. Unsatisfied product → seed \`waiting\` with \`block_reason = "product not satisfied — blocked by: <markers>"\`.
   Precedence: task > manifest > product. Innermost blocker wins in \`block_reason\`; outer checks re-run at activation time.
2. **\`FlipProductBlockedTasks(productID, newStatus)\`** — tasks→manifests→products join filtered by the product-prefix block_reason so only product-blocked tasks flip. \`StatusScheduled\` for close propagation, \`StatusPending\` for removal rehab (Option B).
3. **\`PropagateProductClosed\`** BFS walker with visited set; closures injected so \`task\` doesn't import \`product\`. Mirror of \`PropagateManifestClosed\` (#78).

## Wiring

- \`taskStore.SetProductChecker(productStore)\`
- \`productStore.SetTerminalTransitionHandler\` → propagate on close
- \`productStore.SetDepRemovedHandler\` → rehab on dep removal

## Test plan

- [x] \`go test ./internal/task/\` — 6 new tests:
  - Product unsatisfied → \`waiting\` with product-prefix \`block_reason\`
  - Manifest block trumps product block (precedence)
  - Flip scoped by product (other products untouched)
  - Flip skips task-level + manifest-level block prefixes
  - End-to-end downstream activation
  - Cycle-safe BFS (2s timeout guard)
- [x] \`go test ./...\` full suite green
- [x] \`go build\`, \`go vet\` clean

## What this unlocks

After this PR lands, the whole three-tier DAG self-advances on close (autonomous execution) AND freezes correctly when any edge is unsatisfied at any tier. The Visual DAG Designer product (019da5e8-47f) can be planned as manifests+tasks now — its remaining prereqs are non-blocking UX work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)