### PR TITLE
fix(deps): normalize manifest block_reason prefix across code paths (#97)

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -612,7 +612,12 @@ func (n *Node) CheckManifestDeps(manifestID string) (bool, string) {
 			if len(depID) >= 12 {
 				marker = depID[:12]
 			}
-			return false, fmt.Sprintf("blocked by manifest %s (%s)", marker, dep.Title)
+			// Canonical format — matches the prefix FlipManifestBlockedTasks
+			// filters on in task.Store. Diverging from this means the
+			// close-propagation walker (#78) can't see the task and the
+			// dep chain won't auto-advance. Kept trailing metadata
+			// (marker + title) for operator legibility.
+			return false, fmt.Sprintf("manifest not satisfied — blocked by: %s (%s)", marker, dep.Title)
 		}
 	}
 	return true, ""

--- a/internal/task/manifest_activation.go
+++ b/internal/task/manifest_activation.go
@@ -8,12 +8,21 @@ import (
 	"time"
 )
 
-// manifestBlockPrefix is the literal prefix Store.Create writes into
-// block_reason when seeding a task as 'waiting' due to an unsatisfied
-// manifest. FlipManifestBlockedTasks filters on it so a task that ended
-// up in 'waiting' for a different reason (e.g. task-level dep not met)
-// does not get accidentally flipped by a manifest-level activation.
+// manifestBlockPrefix is the canonical prefix both Store.Create and
+// the scheduler pre-dispatch gate (after #97) write into block_reason
+// when seeding a task as 'waiting' due to an unsatisfied manifest.
+// FlipManifestBlockedTasks filters on it so a task that ended up in
+// 'waiting' for a different reason (e.g. task-level dep not met) does
+// not get accidentally flipped by a manifest-level activation.
 const manifestBlockPrefix = "manifest not satisfied"
+
+// legacyManifestBlockPrefix is the prefix the scheduler's
+// pre-dispatch gate wrote BEFORE #97 normalized it. Kept so the
+// activation filter still catches waiting tasks that were seeded
+// under the old format — rows in the wild today were written with
+// "blocked by manifest <marker> (<title>)". Removable once a DB
+// audit confirms no row still has this prefix.
+const legacyManifestBlockPrefix = "blocked by manifest"
 
 // FlipManifestBlockedTasks moves tasks in manifestID that are currently
 // 'waiting' because of a manifest-level block into `newStatus`, clearing
@@ -44,12 +53,22 @@ func (s *Store) FlipManifestBlockedTasks(ctx context.Context, manifestID string,
 	// seeded by the manifest-level gate. Tasks in 'waiting' due to a
 	// task-level depends_on carry a different block_reason ("task ...
 	// not completed") and must not be flipped here.
+	// Filter accepts both block_reason prefixes: the canonical one
+	// seeded by #77 (task.Store.Create) AND the legacy prefix the
+	// scheduler's pre-dispatch gate wrote before #97 normalized
+	// node.go:615. Without the legacy clause, tasks that went to
+	// 'waiting' via the scheduler's path stay invisible to this
+	// walker and the chain doesn't advance on manifest close. Drop
+	// the legacy clause in a follow-up once DB is known-clean.
 	now := time.Now().UTC().Format(time.RFC3339)
 	res, err := s.db.ExecContext(ctx,
 		`UPDATE tasks
 		 SET status = ?, block_reason = '', updated_at = ?
-		 WHERE manifest_id = ? AND status = 'waiting' AND block_reason LIKE ? AND deleted_at = ''`,
-		string(newStatus), now, manifestID, manifestBlockPrefix+"%")
+		 WHERE manifest_id = ? AND status = 'waiting'
+		   AND (block_reason LIKE ? OR block_reason LIKE ?)
+		   AND deleted_at = ''`,
+		string(newStatus), now, manifestID,
+		manifestBlockPrefix+"%", legacyManifestBlockPrefix+"%")
 	if err != nil {
 		return 0, fmt.Errorf("flip manifest-blocked tasks: %w", err)
 	}

--- a/internal/task/manifest_activation_test.go
+++ b/internal/task/manifest_activation_test.go
@@ -29,6 +29,40 @@ func seedWaitingBlockedByManifest(t *testing.T, s *Store, manifestID, taskTitle,
 	return task.ID
 }
 
+// TestFlipManifestBlockedTasks_AcceptsLegacyPrefix — #97 regression
+// test. Tasks seeded by the scheduler's pre-dispatch gate before
+// that PR normalized node.go:615 carry the old prefix
+// "blocked by manifest ...". The activation walker must still find
+// and flip them during the compatibility window.
+func TestFlipManifestBlockedTasks_AcceptsLegacyPrefix(t *testing.T) {
+	s := openRepoTestStore(t)
+	ctx := context.Background()
+
+	tsk, err := s.Create("mf-legacy", "legacy waiter", "", "once", "claude-code", "node", "t", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Force legacy block_reason + status directly — bypasses #77's
+	// seeding logic to simulate a row written by the old scheduler
+	// path.
+	if _, err := s.db.Exec(
+		`UPDATE tasks SET status='waiting', block_reason='blocked by manifest mf-legacy (Some Manifest)' WHERE id=?`,
+		tsk.ID); err != nil {
+		t.Fatalf("force legacy: %v", err)
+	}
+
+	n, err := s.FlipManifestBlockedTasks(ctx, "mf-legacy", StatusScheduled)
+	if err != nil {
+		t.Fatalf("FlipManifestBlockedTasks: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("flipped = %d, want 1 (legacy prefix must match)", n)
+	}
+	if got := readStatus(t, s, tsk.ID); got != "scheduled" {
+		t.Errorf("status = %q, want scheduled", got)
+	}
+}
+
 // TestFlipManifestBlockedTasks_ScheduledOnPropagation — the core
 // behavior for the close path: every waiting-blocked-by-manifest task
 // in the given manifest flips to scheduled + block_reason clears.

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -222,6 +222,26 @@ func (s *Store) init() error {
 	// one seeded here so the dep history stream isn't blank on
 	// upgrade. Idempotent — the NOT EXISTS guard in the backfill
 	// makes repeat runs a no-op.
+	// Idempotent migration: rewrite legacy block_reason prefixes to
+	// the canonical form. Rows written before #97 normalized
+	// node.go:615 carry "blocked by manifest <marker> (<title>)".
+	// The activation walker's filter accepts both, but normalizing
+	// in place lets us drop the compatibility clause in a later
+	// release and keeps operator-visible text consistent.
+	//
+	// SQLite's REPLACE doesn't support prefix-rewrites directly;
+	// use a CASE expression gated on LIKE so rows without the
+	// legacy prefix aren't touched (idempotent on repeat boot).
+	if _, err := s.db.Exec(`
+		UPDATE tasks
+		SET block_reason = 'manifest not satisfied — blocked by: ' ||
+		    substr(block_reason, length('blocked by manifest ') + 1),
+		    updated_at = ?
+		WHERE block_reason LIKE 'blocked by manifest %'
+		  AND deleted_at = ''`, time.Now().UTC().Format(time.RFC3339)); err != nil {
+		return fmt.Errorf("normalize legacy block_reason prefixes: %w", err)
+	}
+
 	if _, err := s.BackfillTaskDepSCD(); err != nil {
 		return fmt.Errorf("backfill task dep SCD: %w", err)
 	}


### PR DESCRIPTION
Closes #97.

Two code paths wrote different \`block_reason\` prefixes for the same underlying "manifest unsatisfied" condition, and the activation filter only caught one of them.

## Observed today

Entity Comments product, M1 manifest marked \`closed\`. M2-T4 + M2-T5 had \`block_reason = "blocked by manifest 019d9be8-4b7 ..."\` (legacy scheduler format). The #78 propagation handler fired, \`FlipManifestBlockedTasks\` ran \`UPDATE\`, matched 0 rows, logged nothing. Operator had to manually flip.

## Fix (three parts)

1. **\`node.go:615\` writes the canonical prefix.** \`"manifest not satisfied — blocked by: %s (%s)"\`, matching \`#77\` in \`task.Store.Create\`.
2. **\`FlipManifestBlockedTasks\` accepts both prefixes** during the compatibility window. \`legacyManifestBlockPrefix\` constant + comment points at this PR for follow-up removal.
3. **One-shot idempotent migration** in \`task.Store.init\` rewrites existing legacy rows to the canonical form via \`substr\` concat. No-op after the first pass thanks to the \`LIKE\` predicate.

## Test plan

- [x] \`TestFlipManifestBlockedTasks_AcceptsLegacyPrefix\` pins the compatibility behavior; follow-up PR that drops the legacy clause must also update this test to assert the filter rejects the old prefix (or delete the test).
- [x] Existing propagation + rehab + seeding tests still green
- [x] \`go build\`, \`go vet\`, \`go test ./...\` all clean

## Related

Idea \`019da5e4-601\` (SCD Type 2 everywhere) captures the broader pattern: filter-by-string-prefix is brittle; a typed \`block_reason_kind\` column structurally prevents this class of divergence. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)