### PR TITLE
feat(comments): HTTP API for entity comments — M2-T5 (#38)

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -38,6 +38,7 @@ type Node struct {
 	Watcher          *watcher.Store
 	SettingsStore    *settings.Store
 	SettingsResolver *settings.Resolver
+	Comments         *comments.Store
 	runner           *task.Runner
 	Embedder         *embedding.Engine
 	StartedAt        time.Time
@@ -256,6 +257,7 @@ func New(cfg *config.Config) (*Node, error) {
 		Watcher:          watcherStore,
 		SettingsStore:    settingsStore,
 		SettingsResolver: settingsResolver,
+		Comments:         commentsStore,
 		Embedder:         embedder,
 		StartedAt:        time.Now(),
 	}

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -197,6 +197,7 @@ func Handler(n *node.Node, mcpServer *mcp.Server, hub *Hub, peerRegistry *peer.R
 	// paths in registration order. catalog + scope-keyed endpoints share the
 	// /settings prefix without colliding (different verbs / suffixes).
 	registerSettingsExecRoutes(api, n)
+	registerCommentsRoutesFromNode(api, n)
 
 	api.HandleFunc("/settings/profile", apiProfileGet(n)).Methods("GET")
 	api.HandleFunc("/settings/profile", apiProfileUpdate(n)).Methods("PUT")

--- a/internal/web/handlers_comments.go
+++ b/internal/web/handlers_comments.go
@@ -1,0 +1,322 @@
+package web
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
+	"github.com/k8nstantin/OpenPraxis/internal/node"
+)
+
+// M2-T5 — HTTP surface for comments. Thin wrapper over comments.Store;
+// mirrors the MCP surface in parallel task M2-T4. Error codes match the
+// sentinel table documented in the M2 manifest so UI + agents can share
+// one taxonomy.
+
+// commentMaxBodyBytes caps request bodies at 1 MiB. Longer bodies produce
+// 413 with code=body_too_large before JSON decode.
+const commentMaxBodyBytes = 1 << 20
+
+// commentView is the wire shape — the comments.Comment with added ISO
+// timestamp fields. Defined here (not in internal/comments/model.go) so
+// the core model stays free of HTTP concerns.
+type commentView struct {
+	ID            string  `json:"id"`
+	TargetType    string  `json:"target_type"`
+	TargetID      string  `json:"target_id"`
+	Author        string  `json:"author"`
+	Type          string  `json:"type"`
+	Body          string  `json:"body"`
+	CreatedAt     int64   `json:"created_at"`
+	CreatedAtISO  string  `json:"created_at_iso"`
+	UpdatedAt     *int64  `json:"updated_at,omitempty"`
+	UpdatedAtISO  string  `json:"updated_at_iso,omitempty"`
+	ParentID      *string `json:"parent_id,omitempty"`
+}
+
+func toCommentView(c comments.Comment) commentView {
+	v := commentView{
+		ID:           c.ID,
+		TargetType:   string(c.TargetType),
+		TargetID:     c.TargetID,
+		Author:       c.Author,
+		Type:         string(c.Type),
+		Body:         c.Body,
+		CreatedAt:    c.CreatedAt.Unix(),
+		CreatedAtISO: c.CreatedAt.UTC().Format(time.RFC3339),
+		ParentID:     c.ParentID,
+	}
+	if c.UpdatedAt != nil {
+		u := c.UpdatedAt.Unix()
+		v.UpdatedAt = &u
+		v.UpdatedAtISO = c.UpdatedAt.UTC().Format(time.RFC3339)
+	}
+	return v
+}
+
+// writeCommentError emits {error, code} at the given status. The code field
+// is what test and UI clients match on; error carries a human message.
+func writeCommentError(w http.ResponseWriter, code, msg string, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg, "code": code})
+}
+
+// commentErrorStatus maps a comments sentinel to (code, status).
+func commentErrorStatus(err error) (string, int) {
+	switch {
+	case errors.Is(err, comments.ErrUnknownTargetType):
+		return "unknown_target_type", http.StatusNotFound
+	case errors.Is(err, comments.ErrEmptyTargetID):
+		return "empty_target_id", http.StatusBadRequest
+	case errors.Is(err, comments.ErrUnknownCommentType):
+		return "unknown_type", http.StatusBadRequest
+	case errors.Is(err, comments.ErrEmptyAuthor):
+		return "empty_author", http.StatusBadRequest
+	case errors.Is(err, comments.ErrEmptyBody):
+		return "empty_body", http.StatusBadRequest
+	}
+	return "internal", http.StatusInternalServerError
+}
+
+// validCommentTypesList is the stable, sorted set surfaced in error messages
+// so clients get a deterministic list of acceptable types.
+func validCommentTypesList() string {
+	all := comments.AllCommentTypes()
+	parts := make([]string, 0, len(all))
+	for _, t := range all {
+		parts = append(parts, string(t))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// readBodyCapped enforces the 1 MiB cap and surfaces body_too_large before
+// invoking JSON decode. It returns false iff a response has already been
+// written.
+func readBodyCapped(w http.ResponseWriter, r *http.Request, dst any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, commentMaxBodyBytes)
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		if errors.As(err, new(*http.MaxBytesError)) ||
+			strings.Contains(err.Error(), "http: request body too large") {
+			writeCommentError(w, "body_too_large",
+				fmt.Sprintf("request body exceeds %d bytes", commentMaxBodyBytes),
+				http.StatusRequestEntityTooLarge)
+			return false
+		}
+		writeCommentError(w, "invalid_body", "invalid request body: "+err.Error(),
+			http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
+// parseLimit honors the ?limit query param. Returns (limit, true) on success,
+// or (0, false) after writing a 400 response for non-numeric input. limit<=0
+// is passed through to the store (which applies its own default/cap).
+func parseLimit(w http.ResponseWriter, r *http.Request) (int, bool) {
+	raw := r.URL.Query().Get("limit")
+	if raw == "" {
+		return 0, true
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		writeCommentError(w, "invalid_limit",
+			"limit must be an integer", http.StatusBadRequest)
+		return 0, false
+	}
+	return n, true
+}
+
+// parseTypeFilter honors the ?type query param. Returns (nil, true) when no
+// type is provided. Returns (nil, false) after writing a 400 for an unknown
+// type string.
+func parseTypeFilter(w http.ResponseWriter, r *http.Request) (*comments.CommentType, bool) {
+	raw := r.URL.Query().Get("type")
+	if raw == "" {
+		return nil, true
+	}
+	if !comments.IsValidCommentType(raw) {
+		writeCommentError(w, "unknown_type",
+			fmt.Sprintf("unknown type %q (valid: %s)", raw, validCommentTypesList()),
+			http.StatusBadRequest)
+		return nil, false
+	}
+	ct := comments.CommentType(raw)
+	return &ct, true
+}
+
+// listCommentsResponse is the GET-list shape.
+type listCommentsResponse struct {
+	Comments []commentView `json:"comments"`
+}
+
+// addCommentRequest is the POST body shape.
+type addCommentRequest struct {
+	Author string `json:"author"`
+	Type   string `json:"type"`
+	Body   string `json:"body"`
+}
+
+// editCommentRequest is the PATCH body shape.
+type editCommentRequest struct {
+	Body string `json:"body"`
+}
+
+// listComments is the shared handler body for
+// GET /api/{products|manifests|tasks}/{id}/comments.
+func listComments(store *comments.Store, target comments.TargetType) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := mux.Vars(r)["id"]
+		if id == "" {
+			writeCommentError(w, "empty_target_id",
+				comments.ErrEmptyTargetID.Error(), http.StatusBadRequest)
+			return
+		}
+		limit, ok := parseLimit(w, r)
+		if !ok {
+			return
+		}
+		filter, ok := parseTypeFilter(w, r)
+		if !ok {
+			return
+		}
+		out, err := store.List(r.Context(), target, id, limit, filter)
+		if err != nil {
+			writeCommentError(w, "internal", err.Error(), http.StatusInternalServerError)
+			return
+		}
+		views := make([]commentView, 0, len(out))
+		for _, c := range out {
+			views = append(views, toCommentView(c))
+		}
+		writeJSON(w, listCommentsResponse{Comments: views})
+	}
+}
+
+// addComment is the shared handler body for
+// POST /api/{products|manifests|tasks}/{id}/comments.
+func addComment(store *comments.Store, target comments.TargetType) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := mux.Vars(r)["id"]
+		if id == "" {
+			writeCommentError(w, "empty_target_id",
+				comments.ErrEmptyTargetID.Error(), http.StatusBadRequest)
+			return
+		}
+		var req addCommentRequest
+		if !readBodyCapped(w, r, &req) {
+			return
+		}
+		cType := comments.CommentType(req.Type)
+		if err := comments.ValidateAdd(target, id, req.Author, cType, req.Body); err != nil {
+			code, status := commentErrorStatus(err)
+			writeCommentError(w, code, err.Error(), status)
+			return
+		}
+		c, err := store.Add(r.Context(), target, id, req.Author, cType, req.Body)
+		if err != nil {
+			code, status := commentErrorStatus(err)
+			writeCommentError(w, code, err.Error(), status)
+			return
+		}
+		writeJSON(w, toCommentView(c))
+	}
+}
+
+// editComment handles PATCH /api/comments/:id.
+func editComment(store *comments.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := mux.Vars(r)["id"]
+		if id == "" {
+			writeCommentError(w, "empty_id", "comment id required",
+				http.StatusBadRequest)
+			return
+		}
+		var req editCommentRequest
+		if !readBodyCapped(w, r, &req) {
+			return
+		}
+		if err := comments.ValidateEdit(req.Body); err != nil {
+			code, status := commentErrorStatus(err)
+			writeCommentError(w, code, err.Error(), status)
+			return
+		}
+		if err := store.Edit(r.Context(), id, req.Body); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				writeCommentError(w, "not_found",
+					"comment not found", http.StatusNotFound)
+				return
+			}
+			writeCommentError(w, "internal", err.Error(),
+				http.StatusInternalServerError)
+			return
+		}
+		c, err := store.Get(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				writeCommentError(w, "not_found",
+					"comment not found", http.StatusNotFound)
+				return
+			}
+			writeCommentError(w, "internal", err.Error(),
+				http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, toCommentView(c))
+	}
+}
+
+// deleteComment handles DELETE /api/comments/:id. Idempotent per store
+// semantics — repeated deletes return 200.
+func deleteComment(store *comments.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := mux.Vars(r)["id"]
+		if id == "" {
+			writeCommentError(w, "empty_id", "comment id required",
+				http.StatusBadRequest)
+			return
+		}
+		if err := store.Delete(r.Context(), id); err != nil {
+			writeCommentError(w, "internal", err.Error(),
+				http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, map[string]any{"ok": true, "id": id})
+	}
+}
+
+// commentScopeRoutes pairs a URL-plural segment with its TargetType so the
+// registration loop stays declarative.
+var commentScopeRoutes = []struct {
+	segment string
+	target  comments.TargetType
+}{
+	{"products", comments.TargetProduct},
+	{"manifests", comments.TargetManifest},
+	{"tasks", comments.TargetTask},
+}
+
+// registerCommentsRoutes attaches the 8 comment endpoints to /api.
+func registerCommentsRoutes(api *mux.Router, store *comments.Store) {
+	for _, s := range commentScopeRoutes {
+		path := "/" + s.segment + "/{id}/comments"
+		api.HandleFunc(path, listComments(store, s.target)).Methods("GET")
+		api.HandleFunc(path, addComment(store, s.target)).Methods("POST")
+	}
+	api.HandleFunc("/comments/{id}", editComment(store)).Methods("PATCH")
+	api.HandleFunc("/comments/{id}", deleteComment(store)).Methods("DELETE")
+}
+
+// registerCommentsRoutesFromNode is the production entry point. Keeps the
+// wire-up in handler.go a single line.
+func registerCommentsRoutesFromNode(api *mux.Router, n *node.Node) {
+	registerCommentsRoutes(api, n.Comments)
+}

--- a/internal/web/handlers_comments_test.go
+++ b/internal/web/handlers_comments_test.go
@@ -1,0 +1,425 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"database/sql"
+
+	"github.com/gorilla/mux"
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
+)
+
+// ---- harness ----------------------------------------------------------------
+
+type commentsTestEnv struct {
+	store  *comments.Store
+	server *httptest.Server
+}
+
+func newCommentsTestEnv(t *testing.T) *commentsTestEnv {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "comments.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		t.Fatalf("set WAL: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
+		t.Fatalf("busy_timeout: %v", err)
+	}
+	if err := comments.InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	store := comments.NewStore(db)
+
+	r := mux.NewRouter()
+	api := r.PathPrefix("/api").Subrouter()
+	registerCommentsRoutes(api, store)
+
+	srv := httptest.NewServer(r)
+	t.Cleanup(func() {
+		srv.Close()
+		db.Close()
+	})
+	return &commentsTestEnv{store: store, server: srv}
+}
+
+func (e *commentsTestEnv) do(t *testing.T, method, path string, body any) (*http.Response, []byte) {
+	t.Helper()
+	var buf io.Reader
+	if body != nil {
+		switch v := body.(type) {
+		case []byte:
+			buf = bytes.NewReader(v)
+		default:
+			b, err := json.Marshal(body)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			buf = bytes.NewReader(b)
+		}
+	}
+	req, err := http.NewRequest(method, e.server.URL+path, buf)
+	if err != nil {
+		t.Fatalf("req: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp, out
+}
+
+func decodeErr(t *testing.T, body []byte) map[string]string {
+	t.Helper()
+	var m map[string]string
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("decode error body: %v raw=%s", err, body)
+	}
+	return m
+}
+
+func decodeComment(t *testing.T, body []byte) commentView {
+	t.Helper()
+	var v commentView
+	if err := json.Unmarshal(body, &v); err != nil {
+		t.Fatalf("decode comment: %v raw=%s", err, body)
+	}
+	return v
+}
+
+func decodeList(t *testing.T, body []byte) []commentView {
+	t.Helper()
+	var v listCommentsResponse
+	if err := json.Unmarshal(body, &v); err != nil {
+		t.Fatalf("decode list: %v raw=%s", err, body)
+	}
+	return v.Comments
+}
+
+// ---- POST -------------------------------------------------------------------
+
+func TestPOST_AddComment_ProductScope(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "POST", "/api/products/p1/comments", addCommentRequest{
+		Author: "alice",
+		Type:   string(comments.TypeUserNote),
+		Body:   "hello",
+	})
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, body)
+	}
+	c := decodeComment(t, body)
+	if c.ID == "" || c.TargetType != "product" || c.TargetID != "p1" ||
+		c.Author != "alice" || c.Type != "user_note" || c.Body != "hello" {
+		t.Fatalf("bad comment: %+v", c)
+	}
+	if c.CreatedAt == 0 || c.CreatedAtISO == "" {
+		t.Fatalf("missing timestamps: %+v", c)
+	}
+	if c.UpdatedAt != nil || c.UpdatedAtISO != "" {
+		t.Fatalf("unexpected updated fields on create: %+v", c)
+	}
+}
+
+func TestPOST_AddComment_ManifestScope(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "POST", "/api/manifests/m1/comments", addCommentRequest{
+		Author: "bob", Type: string(comments.TypeDecision), Body: "chose plan X",
+	})
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, body)
+	}
+	c := decodeComment(t, body)
+	if c.TargetType != "manifest" || c.TargetID != "m1" || c.Type != "decision" {
+		t.Fatalf("bad comment: %+v", c)
+	}
+}
+
+func TestPOST_AddComment_TaskScope(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "POST", "/api/tasks/t1/comments", addCommentRequest{
+		Author: "carol", Type: string(comments.TypeExecutionReview), Body: "ran fine",
+	})
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, body)
+	}
+	c := decodeComment(t, body)
+	if c.TargetType != "task" || c.Type != "execution_review" {
+		t.Fatalf("bad comment: %+v", c)
+	}
+}
+
+func TestPOST_RejectsEmptyBody(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "POST", "/api/products/p1/comments", addCommentRequest{
+		Author: "alice", Type: string(comments.TypeUserNote), Body: "   ",
+	})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, body)
+	}
+	if got := decodeErr(t, body)["code"]; got != "empty_body" {
+		t.Fatalf("code: got %q", got)
+	}
+}
+
+func TestPOST_RejectsUnknownType(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "POST", "/api/products/p1/comments", addCommentRequest{
+		Author: "alice", Type: "not_a_type", Body: "hi",
+	})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, body)
+	}
+	if got := decodeErr(t, body)["code"]; got != "unknown_type" {
+		t.Fatalf("code: got %q", got)
+	}
+}
+
+func TestPOST_RejectsEmptyAuthor(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "POST", "/api/products/p1/comments", addCommentRequest{
+		Author: "", Type: string(comments.TypeUserNote), Body: "hi",
+	})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, body)
+	}
+	if got := decodeErr(t, body)["code"]; got != "empty_author" {
+		t.Fatalf("code: got %q", got)
+	}
+}
+
+// ---- GET --------------------------------------------------------------------
+
+func TestGET_ListComments_NewestFirst(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	// Insert three comments directly; store assigns UUID v7 ids (monotonic).
+	for i, body := range []string{"first", "second", "third"} {
+		if _, err := env.store.Add(t.Context(), comments.TargetProduct, "p1",
+			"alice", comments.TypeUserNote, body); err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+	}
+	resp, body := env.do(t, "GET", "/api/products/p1/comments", nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+	list := decodeList(t, body)
+	if len(list) != 3 {
+		t.Fatalf("len: got %d", len(list))
+	}
+	// Newest-first: "third", "second", "first".
+	if list[0].Body != "third" || list[2].Body != "first" {
+		t.Fatalf("order: got %+v", list)
+	}
+}
+
+func TestGET_ListComments_TypeFilter(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	_, _ = env.store.Add(t.Context(), comments.TargetProduct, "p1", "a",
+		comments.TypeUserNote, "u1")
+	_, _ = env.store.Add(t.Context(), comments.TargetProduct, "p1", "a",
+		comments.TypeDecision, "d1")
+	resp, body := env.do(t, "GET", "/api/products/p1/comments?type=decision", nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+	list := decodeList(t, body)
+	if len(list) != 1 || list[0].Type != "decision" {
+		t.Fatalf("filter: got %+v", list)
+	}
+}
+
+func TestGET_ListComments_LimitAndCap(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	for i := 0; i < 5; i++ {
+		_, _ = env.store.Add(t.Context(), comments.TargetProduct, "p1", "a",
+			comments.TypeUserNote, fmt.Sprintf("n%d", i))
+	}
+	resp, body := env.do(t, "GET", "/api/products/p1/comments?limit=2", nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+	if list := decodeList(t, body); len(list) != 2 {
+		t.Fatalf("limit=2: got %d", len(list))
+	}
+	// limit=2000 should be capped at 1000 — store caps; endpoint must not
+	// reject the value. Only 5 rows exist so we just confirm 200 + 5 rows.
+	resp, body = env.do(t, "GET", "/api/products/p1/comments?limit=2000", nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+	if list := decodeList(t, body); len(list) != 5 {
+		t.Fatalf("limit=2000 cap: got %d want 5", len(list))
+	}
+}
+
+func TestGET_ListComments_InvalidLimit(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "GET", "/api/products/p1/comments?limit=abc", nil)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, body)
+	}
+}
+
+func TestGET_ListComments_InvalidType(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "GET", "/api/products/p1/comments?type=foo", nil)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+	if got := decodeErr(t, body)["code"]; got != "unknown_type" {
+		t.Fatalf("code: got %q", got)
+	}
+}
+
+func TestGET_ListComments_ScopeIsolation(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	_, _ = env.store.Add(t.Context(), comments.TargetProduct, "X", "a",
+		comments.TypeUserNote, "product-X")
+	resp, body := env.do(t, "GET", "/api/tasks/X/comments", nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+	if list := decodeList(t, body); len(list) != 0 {
+		t.Fatalf("expected empty list on task/X: got %+v", list)
+	}
+}
+
+// ---- PATCH ------------------------------------------------------------------
+
+func TestPATCH_EditComment(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	c, err := env.store.Add(t.Context(), comments.TargetProduct, "p1",
+		"alice", comments.TypeUserNote, "original")
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	resp, body := env.do(t, "PATCH", "/api/comments/"+c.ID, editCommentRequest{Body: "edited"})
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, body)
+	}
+	out := decodeComment(t, body)
+	if out.Body != "edited" {
+		t.Fatalf("body: got %q", out.Body)
+	}
+	if out.UpdatedAt == nil || out.UpdatedAtISO == "" {
+		t.Fatalf("updated_at fields not set: %+v", out)
+	}
+}
+
+func TestPATCH_NotFound(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "PATCH", "/api/comments/missing-id",
+		editCommentRequest{Body: "x"})
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+	if got := decodeErr(t, body)["code"]; got != "not_found" {
+		t.Fatalf("code: got %q", got)
+	}
+}
+
+func TestPATCH_EmptyBody(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	c, _ := env.store.Add(t.Context(), comments.TargetProduct, "p1", "a",
+		comments.TypeUserNote, "orig")
+	resp, body := env.do(t, "PATCH", "/api/comments/"+c.ID, editCommentRequest{Body: "   "})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+	if got := decodeErr(t, body)["code"]; got != "empty_body" {
+		t.Fatalf("code: got %q", got)
+	}
+}
+
+// ---- DELETE -----------------------------------------------------------------
+
+func TestDELETE_Idempotent(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	c, _ := env.store.Add(t.Context(), comments.TargetProduct, "p1", "a",
+		comments.TypeUserNote, "x")
+	for i := 0; i < 2; i++ {
+		resp, body := env.do(t, "DELETE", "/api/comments/"+c.ID, nil)
+		if resp.StatusCode != 200 {
+			t.Fatalf("iter %d: got %d body=%s", i, resp.StatusCode, body)
+		}
+	}
+}
+
+// ---- body size --------------------------------------------------------------
+
+func TestPOST_BodyTooLarge(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	huge := strings.Repeat("a", commentMaxBodyBytes+1024)
+	resp, body := env.do(t, "POST", "/api/products/p1/comments",
+		[]byte(`{"author":"a","type":"user_note","body":"`+huge+`"}`))
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, body)
+	}
+	if got := decodeErr(t, body)["code"]; got != "body_too_large" {
+		t.Fatalf("code: got %q", got)
+	}
+}
+
+// ---- route wiring -----------------------------------------------------------
+
+// TestRoutes_AllCommentEndpointsRegistered enforces that the registration
+// function exposes every URL + method the spec requires.
+func TestRoutes_AllCommentEndpointsRegistered(t *testing.T) {
+	r := mux.NewRouter()
+	api := r.PathPrefix("/api").Subrouter()
+	registerCommentsRoutes(api, nil)
+
+	want := map[string]string{
+		"GET /api/products/{id}/comments":   "",
+		"POST /api/products/{id}/comments":  "",
+		"GET /api/manifests/{id}/comments":  "",
+		"POST /api/manifests/{id}/comments": "",
+		"GET /api/tasks/{id}/comments":      "",
+		"POST /api/tasks/{id}/comments":     "",
+		"PATCH /api/comments/{id}":          "",
+		"DELETE /api/comments/{id}":         "",
+	}
+	if err := r.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
+		pathTmpl, err := route.GetPathTemplate()
+		if err != nil {
+			return nil
+		}
+		methods, _ := route.GetMethods()
+		for _, m := range methods {
+			key := m + " " + pathTmpl
+			if _, ok := want[key]; ok {
+				want[key] = "seen"
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	for k, v := range want {
+		if v != "seen" {
+			t.Errorf("route missing: %s", k)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Exposes the M1 `comments.Store` over HTTP: 8 routes for GET/POST per-entity and PATCH/DELETE by id.
- Shared `listComments` / `addComment` helpers — no per-entity duplication. `commentView` DTO carries ISO timestamps alongside unix seconds; core model untouched.
- Error-code taxonomy matches the M2 manifest sentinel table (`empty_body`, `unknown_type`, `empty_author`, `not_found`, `body_too_large`, …).
- 1 MiB request body cap via `http.MaxBytesReader` → 413 `body_too_large`.
- Independent of M2-T4 — no `internal/mcp/` imports, can land in parallel.

## Endpoints
```
GET    /api/products/:id/comments?limit=&type=
GET    /api/manifests/:id/comments
GET    /api/tasks/:id/comments
POST   /api/{scope}/:id/comments        body: {author, type, body}
PATCH  /api/comments/:id                 body: {body}
DELETE /api/comments/:id
```

## Tests (`-race` clean)
Uses `httptest.NewServer` + real SQLite (temp dir, WAL). Covers: add per scope, rejects empty/unknown fields, newest-first order, `type` filter, `limit` honored + cap, invalid `limit`/`type`, scope isolation, edit success + not-found + empty-body, idempotent delete, body-too-large, and route registration completeness.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./internal/web/` passes
- [ ] M3 consumes these endpoints
- [ ] M2-T4 (MCP tools) lands independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)