### PR TITLE
feat(comments): M2-T4 — MCP tools (add/list/edit/delete)

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -125,6 +125,7 @@ These behaviors are automatic. Never mention OpenPraxis to the user unless they 
 	s.registerLinkTools()
 	s.registerTaskTools()
 	s.registerSettingsTools()
+	s.registerCommentsTools()
 
 	s.http = mcpserver.NewStreamableHTTPServer(s.mcp,
 		mcpserver.WithSessionIdleTTL(2*time.Hour),

--- a/internal/mcp/tools_comments.go
+++ b/internal/mcp/tools_comments.go
@@ -1,0 +1,238 @@
+package mcp
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+)
+
+// CommentErrorCode is the stable machine-readable string returned on the tool
+// error envelope's "code" field. The HTTP layer (M2-T5) reuses the same codes
+// so MCP + HTTP clients can share error-handling logic.
+const (
+	CodeUnknownTargetType = "unknown_target_type"
+	CodeEmptyTargetID     = "empty_target_id"
+	CodeUnknownType       = "unknown_type"
+	CodeEmptyAuthor       = "empty_author"
+	CodeEmptyBody         = "empty_body"
+	CodeNotFound          = "not_found"
+)
+
+// commentDTO is the wire shape returned by comment_add / comment_edit. Wraps
+// comments.Comment with RFC3339 timestamps so downstream UIs don't have to
+// re-derive them from unix seconds.
+type commentDTO struct {
+	comments.Comment
+	CreatedAtISO string `json:"created_at_iso"`
+	UpdatedAtISO string `json:"updated_at_iso,omitempty"`
+}
+
+func toDTO(c comments.Comment) commentDTO {
+	d := commentDTO{Comment: c, CreatedAtISO: c.CreatedAt.UTC().Format(time.RFC3339)}
+	if c.UpdatedAt != nil {
+		d.UpdatedAtISO = c.UpdatedAt.UTC().Format(time.RFC3339)
+	}
+	return d
+}
+
+func toDTOList(in []comments.Comment) []commentDTO {
+	out := make([]commentDTO, 0, len(in))
+	for _, c := range in {
+		out = append(out, toDTO(c))
+	}
+	return out
+}
+
+// commentTypesInline renders the 6 (or more) types from the Registry as a
+// bullet-list for tool descriptions. Generated at registration time so adding
+// a new type in internal/comments flows through automatically.
+func commentTypesInline() string {
+	reg := comments.Registry()
+	parts := make([]string, 0, len(reg))
+	for _, info := range reg {
+		parts = append(parts, fmt.Sprintf("%q (%s)", string(info.Type), info.Label))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func (s *Server) registerCommentsTools() {
+	typesList := commentTypesInline()
+
+	s.mcp.AddTool(
+		mcplib.NewTool("comment_add",
+			mcplib.WithDescription("Attach a comment to a product, manifest, or task. Valid types: "+typesList+". Returns the stored comment with RFC3339 timestamps."),
+			mcplib.WithString("target_type", mcplib.Required(), mcplib.Description("One of 'product', 'manifest', or 'task'")),
+			mcplib.WithString("target_id", mcplib.Required(), mcplib.Description("Entity id the comment attaches to")),
+			mcplib.WithString("author", mcplib.Required(), mcplib.Description("Author identity (agent, user, or bot)")),
+			mcplib.WithString("type", mcplib.Required(), mcplib.Description("Comment type; must be one of: "+typesList)),
+			mcplib.WithString("body", mcplib.Required(), mcplib.Description("Comment body (non-empty after trim)")),
+		),
+		s.handleCommentAdd,
+	)
+
+	s.mcp.AddTool(
+		mcplib.NewTool("comment_list",
+			mcplib.WithDescription("List comments for a (target_type, target_id) pair, newest first. Optional type_filter narrows to one of: "+typesList+". Server caps the page at 1000."),
+			mcplib.WithString("target_type", mcplib.Required(), mcplib.Description("One of 'product', 'manifest', or 'task'")),
+			mcplib.WithString("target_id", mcplib.Required(), mcplib.Description("Entity id the comments attach to")),
+			mcplib.WithNumber("limit", mcplib.Description("Max rows to return. Defaults to 100, capped at 1000.")),
+			mcplib.WithString("type_filter", mcplib.Description("Optional single comment type to filter to; empty string means all types")),
+		),
+		s.handleCommentList,
+	)
+
+	s.mcp.AddTool(
+		mcplib.NewTool("comment_edit",
+			mcplib.WithDescription("Replace a comment's body and bump updated_at. Only body is mutable — target, author, and type are immutable."),
+			mcplib.WithString("id", mcplib.Required(), mcplib.Description("Comment id to edit")),
+			mcplib.WithString("body", mcplib.Required(), mcplib.Description("New body (non-empty after trim)")),
+		),
+		s.handleCommentEdit,
+	)
+
+	s.mcp.AddTool(
+		mcplib.NewTool("comment_delete",
+			mcplib.WithDescription("Hard-delete a comment. Idempotent — deleting a missing id still returns ok."),
+			mcplib.WithString("id", mcplib.Required(), mcplib.Description("Comment id to delete")),
+		),
+		s.handleCommentDelete,
+	)
+}
+
+// -------- handlers -----------------------------------------------------------
+
+func (s *Server) handleCommentAdd(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := args(req)
+	target := comments.TargetType(argStr(a, "target_type"))
+	targetID := argStr(a, "target_id")
+	author := argStr(a, "author")
+	cType := comments.CommentType(argStr(a, "type"))
+	body := argStr(a, "body")
+
+	if verr := comments.ValidateAdd(target, targetID, author, cType, body); verr != nil {
+		return validationErrResult(verr), nil
+	}
+	if s.node.Comments == nil {
+		return errResult("comment_add: comments store not configured"), nil
+	}
+	c, err := s.node.Comments.Add(ctx, target, targetID, author, cType, body)
+	if err != nil {
+		return errResult("comment_add: %v", err), nil
+	}
+	_ = mcpSetAuthor(ctx) // reserved for future updated_by column; MCP author = c.Author
+	return jsonOrError(toDTO(c))
+}
+
+func (s *Server) handleCommentList(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := args(req)
+	target := comments.TargetType(argStr(a, "target_type"))
+	targetID := argStr(a, "target_id")
+
+	if !comments.IsValidTargetType(string(target)) {
+		return codedErrResult(CodeUnknownTargetType, comments.ErrUnknownTargetType.Error()), nil
+	}
+	if targetID == "" {
+		return codedErrResult(CodeEmptyTargetID, comments.ErrEmptyTargetID.Error()), nil
+	}
+
+	limit := int(argFloat(a, "limit"))
+	var typeFilter *comments.CommentType
+	if tf := argStr(a, "type_filter"); tf != "" {
+		if !comments.IsValidCommentType(tf) {
+			return codedErrResult(CodeUnknownType, comments.ErrUnknownCommentType.Error()), nil
+		}
+		ct := comments.CommentType(tf)
+		typeFilter = &ct
+	}
+
+	if s.node.Comments == nil {
+		return errResult("comment_list: comments store not configured"), nil
+	}
+	rows, err := s.node.Comments.List(ctx, target, targetID, limit, typeFilter)
+	if err != nil {
+		return errResult("comment_list: %v", err), nil
+	}
+	return jsonOrError(map[string]any{"comments": toDTOList(rows)})
+}
+
+func (s *Server) handleCommentEdit(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := args(req)
+	id := argStr(a, "id")
+	body := argStr(a, "body")
+
+	if id == "" {
+		return codedErrResult(CodeNotFound, "comments: id is required"), nil
+	}
+	if verr := comments.ValidateEdit(body); verr != nil {
+		return validationErrResult(verr), nil
+	}
+	if s.node.Comments == nil {
+		return errResult("comment_edit: comments store not configured"), nil
+	}
+	if err := s.node.Comments.Edit(ctx, id, body); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return codedErrResult(CodeNotFound, "comments: id not found"), nil
+		}
+		return errResult("comment_edit: %v", err), nil
+	}
+	c, err := s.node.Comments.Get(ctx, id)
+	if err != nil {
+		return errResult("comment_edit: readback: %v", err), nil
+	}
+	return jsonOrError(toDTO(c))
+}
+
+func (s *Server) handleCommentDelete(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := args(req)
+	id := argStr(a, "id")
+	if id == "" {
+		return codedErrResult(CodeNotFound, "comments: id is required"), nil
+	}
+	if s.node.Comments == nil {
+		return errResult("comment_delete: comments store not configured"), nil
+	}
+	if err := s.node.Comments.Delete(ctx, id); err != nil {
+		return errResult("comment_delete: %v", err), nil
+	}
+	return jsonOrError(map[string]any{"ok": true})
+}
+
+// -------- error helpers ------------------------------------------------------
+
+// validationErrResult translates comments validation sentinels to an MCP tool
+// error result with a machine-readable code embedded in the text payload.
+func validationErrResult(err error) *mcplib.CallToolResult {
+	switch {
+	case errors.Is(err, comments.ErrUnknownTargetType):
+		return codedErrResult(CodeUnknownTargetType, err.Error())
+	case errors.Is(err, comments.ErrEmptyTargetID):
+		return codedErrResult(CodeEmptyTargetID, err.Error())
+	case errors.Is(err, comments.ErrUnknownCommentType):
+		return codedErrResult(CodeUnknownType, err.Error())
+	case errors.Is(err, comments.ErrEmptyAuthor):
+		return codedErrResult(CodeEmptyAuthor, err.Error())
+	case errors.Is(err, comments.ErrEmptyBody):
+		return codedErrResult(CodeEmptyBody, err.Error())
+	default:
+		return errResult("comments: %v", err)
+	}
+}
+
+// codedErrResult returns an isError=true CallToolResult whose text payload is a
+// single-line JSON object `{"code":"...","message":"..."}`. Tool error
+// envelopes in mcp-go don't carry structured fields, so we encode the code
+// into the message — callers parse the JSON to branch on the code.
+func codedErrResult(code, message string) *mcplib.CallToolResult {
+	// Avoid json import churn — message is already human-friendly; code is a
+	// fixed identifier from this file's const block, so simple concatenation
+	// is safe (no unescaped quotes possible).
+	payload := fmt.Sprintf(`{"code":%q,"message":%q}`, code, message)
+	return mcplib.NewToolResultError(payload)
+}

--- a/internal/mcp/tools_comments_test.go
+++ b/internal/mcp/tools_comments_test.go
@@ -1,0 +1,490 @@
+package mcp
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
+	"github.com/k8nstantin/OpenPraxis/internal/node"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// -------- test harness -------------------------------------------------------
+
+type commentsHarness struct {
+	db     *sql.DB
+	store  *comments.Store
+	server *Server
+}
+
+func newCommentsHarness(t *testing.T) *commentsHarness {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "comments.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		t.Fatalf("set WAL: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
+		t.Fatalf("set busy_timeout: %v", err)
+	}
+	if err := comments.InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	store := comments.NewStore(db)
+
+	// Build a minimal MCP server with just the comments tools registered.
+	// registerCommentsTools only touches s.mcp + s.node.Comments, so we can
+	// skip the rest of node.Node construction.
+	s := &Server{
+		mcp:  mcpserver.NewMCPServer("openpraxis-comments-test", "0.0.0", mcpserver.WithToolCapabilities(true)),
+		node: &node.Node{Comments: store},
+	}
+	s.registerCommentsTools()
+
+	return &commentsHarness{db: db, store: store, server: s}
+}
+
+// callTool invokes a registered tool handler directly off the MCPServer's tool
+// registry so the test actually exercises the wiring (registration, schema,
+// handler) rather than calling the handler method in isolation.
+func (h *commentsHarness) callTool(t *testing.T, name string, argMap map[string]any) *mcplib.CallToolResult {
+	t.Helper()
+	tools := h.server.mcp.ListTools()
+	st, ok := tools[name]
+	if !ok {
+		t.Fatalf("tool %q not registered", name)
+	}
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = name
+	req.Params.Arguments = argMap
+	res, err := st.Handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("%s handler returned error: %v", name, err)
+	}
+	if res == nil {
+		t.Fatalf("%s handler returned nil result", name)
+	}
+	return res
+}
+
+func resultText(t *testing.T, res *mcplib.CallToolResult) string {
+	t.Helper()
+	var text string
+	for _, c := range res.Content {
+		if tc, ok := c.(mcplib.TextContent); ok {
+			text += tc.Text
+		}
+	}
+	return text
+}
+
+// expectErrCode asserts the result is an error envelope and the embedded
+// {"code":"...","message":"..."} matches the expected code.
+func expectErrCode(t *testing.T, res *mcplib.CallToolResult, want string) {
+	t.Helper()
+	if !res.IsError {
+		t.Fatalf("expected error result; got success: %s", resultText(t, res))
+	}
+	var env struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(resultText(t, res)), &env); err != nil {
+		t.Fatalf("error payload is not JSON: %v (raw=%q)", err, resultText(t, res))
+	}
+	if env.Code != want {
+		t.Fatalf("error code: got %q want %q (msg=%q)", env.Code, want, env.Message)
+	}
+}
+
+func expectOK(t *testing.T, res *mcplib.CallToolResult) string {
+	t.Helper()
+	if res.IsError {
+		t.Fatalf("expected success; got error: %s", resultText(t, res))
+	}
+	return resultText(t, res)
+}
+
+// -------- comment_add --------------------------------------------------------
+
+func TestCommentAdd_RoundTrip(t *testing.T) {
+	h := newCommentsHarness(t)
+
+	addRes := h.callTool(t, "comment_add", map[string]any{
+		"target_type": "product",
+		"target_id":   "p1",
+		"author":      "tester",
+		"type":        "user_note",
+		"body":        "hello",
+	})
+	var added commentDTO
+	if err := json.Unmarshal([]byte(expectOK(t, addRes)), &added); err != nil {
+		t.Fatalf("unmarshal add: %v", err)
+	}
+	if added.Body != "hello" || added.Author != "tester" {
+		t.Fatalf("unexpected stored comment: %+v", added)
+	}
+	if added.ID == "" {
+		t.Fatal("missing id in response")
+	}
+
+	listRes := h.callTool(t, "comment_list", map[string]any{
+		"target_type": "product",
+		"target_id":   "p1",
+	})
+	var listed struct {
+		Comments []commentDTO `json:"comments"`
+	}
+	if err := json.Unmarshal([]byte(expectOK(t, listRes)), &listed); err != nil {
+		t.Fatalf("unmarshal list: %v", err)
+	}
+	if len(listed.Comments) != 1 || listed.Comments[0].ID != added.ID {
+		t.Fatalf("round-trip mismatch: %+v", listed.Comments)
+	}
+}
+
+func TestCommentAdd_EmptyBody(t *testing.T) {
+	h := newCommentsHarness(t)
+	res := h.callTool(t, "comment_add", map[string]any{
+		"target_type": "product",
+		"target_id":   "p1",
+		"author":      "tester",
+		"type":        "user_note",
+		"body":        "   ",
+	})
+	expectErrCode(t, res, CodeEmptyBody)
+}
+
+func TestCommentAdd_UnknownType(t *testing.T) {
+	h := newCommentsHarness(t)
+	res := h.callTool(t, "comment_add", map[string]any{
+		"target_type": "product",
+		"target_id":   "p1",
+		"author":      "tester",
+		"type":        "not_a_type",
+		"body":        "hi",
+	})
+	expectErrCode(t, res, CodeUnknownType)
+}
+
+func TestCommentAdd_UnknownTargetType(t *testing.T) {
+	h := newCommentsHarness(t)
+	res := h.callTool(t, "comment_add", map[string]any{
+		"target_type": "widget",
+		"target_id":   "p1",
+		"author":      "tester",
+		"type":        "user_note",
+		"body":        "hi",
+	})
+	expectErrCode(t, res, CodeUnknownTargetType)
+}
+
+func TestCommentAdd_IsoTimestampsInResponse(t *testing.T) {
+	h := newCommentsHarness(t)
+	res := h.callTool(t, "comment_add", map[string]any{
+		"target_type": "task",
+		"target_id":   "t1",
+		"author":      "tester",
+		"type":        "agent_note",
+		"body":        "iso-test",
+	})
+	var dto commentDTO
+	if err := json.Unmarshal([]byte(expectOK(t, res)), &dto); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, err := time.Parse(time.RFC3339, dto.CreatedAtISO); err != nil {
+		t.Fatalf("created_at_iso not RFC3339: %q: %v", dto.CreatedAtISO, err)
+	}
+	if dto.UpdatedAtISO != "" {
+		t.Fatalf("updated_at_iso should be empty on fresh add; got %q", dto.UpdatedAtISO)
+	}
+}
+
+// -------- comment_list -------------------------------------------------------
+
+func TestCommentList_NewestFirst(t *testing.T) {
+	h := newCommentsHarness(t)
+	ctx := context.Background()
+
+	// Seed via the store directly, spaced by one second to make ordering
+	// deterministic since the Add unix-seconds grain is coarse.
+	for i, body := range []string{"first", "second", "third"} {
+		if _, err := h.store.Add(ctx, comments.TargetProduct, "p1", "tester",
+			comments.TypeUserNote, body); err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+		time.Sleep(1100 * time.Millisecond)
+	}
+
+	res := h.callTool(t, "comment_list", map[string]any{
+		"target_type": "product",
+		"target_id":   "p1",
+	})
+	var out struct {
+		Comments []commentDTO `json:"comments"`
+	}
+	if err := json.Unmarshal([]byte(expectOK(t, res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Comments) != 3 {
+		t.Fatalf("expected 3, got %d", len(out.Comments))
+	}
+	if out.Comments[0].Body != "third" || out.Comments[2].Body != "first" {
+		t.Fatalf("not newest-first: %+v", out.Comments)
+	}
+}
+
+func TestCommentList_TypeFilter(t *testing.T) {
+	h := newCommentsHarness(t)
+	ctx := context.Background()
+
+	if _, err := h.store.Add(ctx, comments.TargetManifest, "m1", "a",
+		comments.TypeUserNote, "note"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := h.store.Add(ctx, comments.TargetManifest, "m1", "a",
+		comments.TypeDecision, "decide"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	res := h.callTool(t, "comment_list", map[string]any{
+		"target_type": "manifest",
+		"target_id":   "m1",
+		"type_filter": "decision",
+	})
+	var out struct {
+		Comments []commentDTO `json:"comments"`
+	}
+	if err := json.Unmarshal([]byte(expectOK(t, res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Comments) != 1 || out.Comments[0].Body != "decide" {
+		t.Fatalf("filter mismatch: %+v", out.Comments)
+	}
+
+	// Empty string type_filter behaves as nil (all types).
+	res = h.callTool(t, "comment_list", map[string]any{
+		"target_type": "manifest",
+		"target_id":   "m1",
+		"type_filter": "",
+	})
+	if err := json.Unmarshal([]byte(expectOK(t, res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Comments) != 2 {
+		t.Fatalf("expected 2 with empty filter, got %d", len(out.Comments))
+	}
+
+	// Unknown filter type returns structured error.
+	res = h.callTool(t, "comment_list", map[string]any{
+		"target_type": "manifest",
+		"target_id":   "m1",
+		"type_filter": "bogus",
+	})
+	expectErrCode(t, res, CodeUnknownType)
+}
+
+func TestCommentList_LimitAndCap(t *testing.T) {
+	h := newCommentsHarness(t)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		if _, err := h.store.Add(ctx, comments.TargetTask, "t1", "a",
+			comments.TypeAgentNote, "msg"); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	// limit=2 honored
+	res := h.callTool(t, "comment_list", map[string]any{
+		"target_type": "task",
+		"target_id":   "t1",
+		"limit":       float64(2),
+	})
+	var out struct {
+		Comments []commentDTO `json:"comments"`
+	}
+	if err := json.Unmarshal([]byte(expectOK(t, res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Comments) != 2 {
+		t.Fatalf("limit=2 honored: got %d", len(out.Comments))
+	}
+
+	// limit=2000 capped server-side at 1000; with only 5 rows seeded the
+	// response is 5 — but the request must not error out from oversized limit.
+	res = h.callTool(t, "comment_list", map[string]any{
+		"target_type": "task",
+		"target_id":   "t1",
+		"limit":       float64(2000),
+	})
+	if err := json.Unmarshal([]byte(expectOK(t, res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Comments) != 5 {
+		t.Fatalf("limit=2000 rows: got %d want 5", len(out.Comments))
+	}
+}
+
+func TestCommentList_ScopeIsolation(t *testing.T) {
+	h := newCommentsHarness(t)
+	ctx := context.Background()
+
+	if _, err := h.store.Add(ctx, comments.TargetProduct, "X", "a",
+		comments.TypeUserNote, "p"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := h.store.Add(ctx, comments.TargetManifest, "X", "a",
+		comments.TypeUserNote, "m"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	res := h.callTool(t, "comment_list", map[string]any{
+		"target_type": "task",
+		"target_id":   "X",
+	})
+	var out struct {
+		Comments []commentDTO `json:"comments"`
+	}
+	if err := json.Unmarshal([]byte(expectOK(t, res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Comments) != 0 {
+		t.Fatalf("expected isolation, got %+v", out.Comments)
+	}
+}
+
+// -------- comment_edit -------------------------------------------------------
+
+func TestCommentEdit_UpdatesBodyAndTimestamp(t *testing.T) {
+	h := newCommentsHarness(t)
+	ctx := context.Background()
+
+	c, err := h.store.Add(ctx, comments.TargetProduct, "p1", "a",
+		comments.TypeUserNote, "before")
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	time.Sleep(1100 * time.Millisecond)
+	res := h.callTool(t, "comment_edit", map[string]any{
+		"id":   c.ID,
+		"body": "after",
+	})
+	var dto commentDTO
+	if err := json.Unmarshal([]byte(expectOK(t, res)), &dto); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if dto.Body != "after" {
+		t.Fatalf("body not updated: %q", dto.Body)
+	}
+	if dto.UpdatedAt == nil || dto.UpdatedAtISO == "" {
+		t.Fatalf("updated_at missing after edit: %+v", dto)
+	}
+	if _, err := time.Parse(time.RFC3339, dto.UpdatedAtISO); err != nil {
+		t.Fatalf("updated_at_iso bad: %v", err)
+	}
+}
+
+func TestCommentEdit_NotFound(t *testing.T) {
+	h := newCommentsHarness(t)
+	res := h.callTool(t, "comment_edit", map[string]any{
+		"id":   "does-not-exist",
+		"body": "new body",
+	})
+	expectErrCode(t, res, CodeNotFound)
+}
+
+func TestCommentEdit_EmptyBody(t *testing.T) {
+	h := newCommentsHarness(t)
+	ctx := context.Background()
+	c, err := h.store.Add(ctx, comments.TargetProduct, "p1", "a",
+		comments.TypeUserNote, "body")
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	res := h.callTool(t, "comment_edit", map[string]any{
+		"id":   c.ID,
+		"body": "   ",
+	})
+	expectErrCode(t, res, CodeEmptyBody)
+}
+
+// -------- comment_delete -----------------------------------------------------
+
+func TestCommentDelete_Idempotent(t *testing.T) {
+	h := newCommentsHarness(t)
+	ctx := context.Background()
+
+	c, err := h.store.Add(ctx, comments.TargetProduct, "p1", "a",
+		comments.TypeUserNote, "body")
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	res := h.callTool(t, "comment_delete", map[string]any{"id": c.ID})
+	if s := expectOK(t, res); !strings.Contains(s, `"ok": true`) {
+		t.Fatalf("first delete payload: %s", s)
+	}
+	res = h.callTool(t, "comment_delete", map[string]any{"id": c.ID})
+	if s := expectOK(t, res); !strings.Contains(s, `"ok": true`) {
+		t.Fatalf("second delete payload: %s", s)
+	}
+}
+
+// -------- registration smoke -------------------------------------------------
+
+func TestCommentTools_Registered(t *testing.T) {
+	h := newCommentsHarness(t)
+	tools := h.server.mcp.ListTools()
+
+	for _, name := range []string{"comment_add", "comment_list", "comment_edit", "comment_delete"} {
+		st, ok := tools[name]
+		if !ok {
+			t.Fatalf("%s not registered", name)
+		}
+		if st.Tool.Description == "" {
+			t.Errorf("%s has empty description", name)
+		}
+	}
+
+	// The add/list tool descriptions must reference every type from
+	// Registry() so a newly added type shows up inline automatically.
+	addDesc := tools["comment_add"].Tool.Description
+	for _, info := range comments.Registry() {
+		if !strings.Contains(addDesc, string(info.Type)) {
+			t.Errorf("comment_add description missing type %q", info.Type)
+		}
+	}
+
+	// Required-argument schema checks.
+	for name, wantRequired := range map[string][]string{
+		"comment_add":    {"target_type", "target_id", "author", "type", "body"},
+		"comment_list":   {"target_type", "target_id"},
+		"comment_edit":   {"id", "body"},
+		"comment_delete": {"id"},
+	} {
+		got := tools[name].Tool.InputSchema.Required
+		gotSet := map[string]bool{}
+		for _, r := range got {
+			gotSet[r] = true
+		}
+		for _, r := range wantRequired {
+			if !gotSet[r] {
+				t.Errorf("%s schema missing required %q (have %v)", name, r, got)
+			}
+		}
+	}
+}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -38,6 +38,7 @@ type Node struct {
 	Watcher          *watcher.Store
 	SettingsStore    *settings.Store
 	SettingsResolver *settings.Resolver
+	Comments         *comments.Store
 	runner           *task.Runner
 	Embedder         *embedding.Engine
 	StartedAt        time.Time
@@ -256,6 +257,7 @@ func New(cfg *config.Config) (*Node, error) {
 		Watcher:          watcherStore,
 		SettingsStore:    settingsStore,
 		SettingsResolver: settingsResolver,
+		Comments:         commentsStore,
 		Embedder:         embedder,
 		StartedAt:        time.Now(),
 	}


### PR DESCRIPTION
## Summary
- Adds 4 MCP tools on top of the M1 comments store: `comment_add`, `comment_list`, `comment_edit`, `comment_delete`
- Validation sentinels translate to stable error codes (`unknown_target_type`, `empty_target_id`, `unknown_type`, `empty_author`, `empty_body`, `not_found`) embedded in the isError tool envelope as JSON `{code,message}` so MCP + HTTP (M2-T5) share one taxonomy
- Tool descriptions render `comments.Registry()` inline at registration time — new types flow through automatically
- Exposes `comments.Store` on `node.Node` (`Comments` field) reusing the instance already built for the task-review adapters

## Error code table
| Sentinel | Code |
|---|---|
| `ErrUnknownTargetType` | `unknown_target_type` |
| `ErrEmptyTargetID` | `empty_target_id` |
| `ErrUnknownCommentType` | `unknown_type` |
| `ErrEmptyAuthor` | `empty_author` |
| `ErrEmptyBody` | `empty_body` |
| `sql.ErrNoRows` on edit + empty id on edit/delete | `not_found` |

## Response shape
`comment_add` / `comment_edit` return a `commentDTO` wrapping `comments.Comment` with `created_at_iso` (required) and `updated_at_iso` (present once edited) as RFC3339 strings alongside the unix timestamps from the base struct. `comment_list` returns `{"comments": [...]}`. `comment_delete` returns `{"ok": true}` (idempotent).

## Test plan
- [x] `go test ./internal/mcp/ -run TestComment -count=1`
- [x] `go test -race ./internal/mcp/ -run TestComment -count=1`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] 14 tests covering round-trip, validation codes, newest-first order, type filter, limit cap, scope isolation, edit timestamp, not-found, delete idempotency, ISO timestamp format, and tool registration schemas

## Out of scope
- HTTP endpoints — M2-T5
- UI — M3
- Watcher / runner auto-post — M4

🤖 Generated with [Claude Code](https://claude.com/claude-code)