### PR TITLE
feat(comments): M3-T8 wire comments into manifest + product detail

### DIFF
--- a/internal/web/ui/views/manifests.js
+++ b/internal/web/ui/views/manifests.js
@@ -463,6 +463,7 @@
           ${linkedIdeasHtml}
           ${linkedTasksHtml}
           <div id="manifest-knobs-mount" style="margin-top:16px"></div>
+          <div id="manifest-comments-mount" style="margin-top:16px"></div>
           ${jira ? `<div style="margin-bottom:12px">Jira: ${jira}</div>` : ''}
           ${tags ? `<div style="margin-bottom:12px">${tags}</div>` : ''}
           <div style="margin-bottom:4px;display:flex;align-items:center;gap:8px">
@@ -487,6 +488,11 @@
       const knobMount = document.getElementById('manifest-knobs-mount');
       if (knobMount && OL.renderKnobSection) {
         OL.renderKnobSection(knobMount, { type: 'manifest', id: m.id });
+      }
+
+      const commentsMount = document.getElementById('manifest-comments-mount');
+      if (commentsMount && OL.renderCommentsSection) {
+        OL.renderCommentsSection(commentsMount, { type: 'manifest', id: m.id });
       }
 
       // Bind idea navigation links

--- a/internal/web/ui/views/products.js
+++ b/internal/web/ui/views/products.js
@@ -348,12 +348,18 @@
           </div>
           ${manifestsHtml}
           <div id="product-knobs-mount" style="margin-top:16px"></div>
+          <div id="product-comments-mount" style="margin-top:16px"></div>
           ${ideasHtml}
         </div>`;
 
       const knobMount = document.getElementById('product-knobs-mount');
       if (knobMount && OL.renderKnobSection) {
         OL.renderKnobSection(knobMount, { type: 'product', id: p.id });
+      }
+
+      const commentsMount = document.getElementById('product-comments-mount');
+      if (commentsMount && OL.renderCommentsSection) {
+        OL.renderCommentsSection(commentsMount, { type: 'product', id: p.id });
       }
 
       // Wire dep pill nav: click a marker → open that product.


### PR DESCRIPTION
## Summary
- Add `manifest-comments-mount` + `product-comments-mount` divs and `OL.renderCommentsSection()` calls to the manifest and product detail views.
- Placement matches the M3 manifest spec: manifest → after knob section; product → after knob section, before ideas section.
- Guarded by existence check on `OL.renderCommentsSection`, so this change is safe to merge ahead of M3-T6 (the comments component itself).

## Depends on
- M3-T6 (`019da140-058`) — adds `OL.renderCommentsSection` in `internal/web/ui/components/comments.js`. Until M3-T6 lands, the mount divs stay empty.

## Parallel with
- M3-T7 (task detail wire-up). No file overlap.

## Test plan
- [ ] Open a manifest detail — comments section renders under the knob section, add/edit/delete/filter all work (post-M3-T6).
- [ ] Open a product detail — comments section renders between knob and linked-ideas sections.
- [ ] Scope isolation: comment on manifest X doesn't leak onto product X.
- [ ] No regression on knob section or linked-ideas section.
- [ ] Dogfood: post an `execution_review` comment on manifest `019d9be8-dbd` and product `019d9be7-2cc` via the UI once M3-T6 is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)