### PR TITLE
feat(comments): wire comments section into task detail (M3-T7)

### DIFF
--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>OpenPraxis</title>
   <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/components/comments.css">
   <script src="https://cdn.jsdelivr.net/npm/cytoscape@3.30.4/dist/cytoscape.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dagre@0.8.5/dist/dagre.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/cytoscape-dagre@2.5.0/cytoscape-dagre.js"></script>
@@ -738,6 +739,7 @@
   <script src="/tree.js"></script>
   <script src="/lifecycle.js"></script>
   <script src="/components/knobs.js"></script>
+  <script src="/components/comments.js"></script>
   <script src="/views/overview.js"></script>
   <script src="/views/memories.js"></script>
   <script src="/views/conversations.js"></script>

--- a/internal/web/ui/views/tasks.js
+++ b/internal/web/ui/views/tasks.js
@@ -438,6 +438,9 @@
           <!-- EXECUTION CONTROLS -->
           <div id="task-knobs-mount" style="margin-top:16px"></div>
 
+          <!-- COMMENTS -->
+          <div id="task-comments-mount" style="margin-top:16px"></div>
+
           <!-- 5. LIVE OUTPUT (if running/paused) -->
           ${isRunningOrPaused ? `
             <div style="margin-bottom:12px;border-left:3px solid ${t.status === 'paused' ? 'var(--yellow)' : 'var(--green)'};padding-left:10px">
@@ -479,6 +482,11 @@
       const knobMount = document.getElementById('task-knobs-mount');
       if (knobMount && OL.renderKnobSection) {
         OL.renderKnobSection(knobMount, { type: 'task', id: t.id });
+      }
+
+      const commentsMount = document.getElementById('task-comments-mount');
+      if (commentsMount && OL.renderCommentsSection) {
+        OL.renderCommentsSection(commentsMount, { type: 'task', id: t.id });
       }
 
       // Manifest cross-link — fetch title + wire click


### PR DESCRIPTION
## Summary
- Mount `OL.renderCommentsSection` on the task detail view between exec controls and live output.
- Register `/components/comments.js` and `/components/comments.css` in `index.html` alongside `knobs.js`.
- Guard the render call with `if (OL.renderCommentsSection)` so the view stays intact until M3-T6 lands the component.

Manifest: `019d9be8-dbd` (M3 — UI comments section) · Task: `019da140-8b4` (M3-T7)
Depends on: M3-T6 (`019da140-058`) for the component itself.

## Test plan
Component ships in M3-T6. Once merged together:
- [ ] Open a task with zero comments — empty state renders
- [ ] Post a `user_note` — appears at top immediately
- [ ] Post an `execution_review` — color-coded badge shows
- [ ] Post with empty body — inline error; no double POST
- [ ] Edit a comment — body updates, `updated_at` changes, stream stays newest-first
- [ ] Delete a comment — removes from view
- [ ] Filter by type — stream filters correctly
- [ ] Reload page — stream restored from server
- [ ] Confirm knob section, actions list, and runs history are unchanged
- [ ] Dogfood: post `execution_review` on THIS task via the wired UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)