### PR TITLE
feat(comments): M3-T6 — renderCommentsSection + goldmark server-side markdown

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	github.com/yuin/goldmark v1.8.2 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
+github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -38,6 +38,7 @@ type Node struct {
 	Watcher          *watcher.Store
 	SettingsStore    *settings.Store
 	SettingsResolver *settings.Resolver
+	Comments         *comments.Store
 	runner           *task.Runner
 	Embedder         *embedding.Engine
 	StartedAt        time.Time
@@ -256,6 +257,7 @@ func New(cfg *config.Config) (*Node, error) {
 		Watcher:          watcherStore,
 		SettingsStore:    settingsStore,
 		SettingsResolver: settingsResolver,
+		Comments:         commentsStore,
 		Embedder:         embedder,
 		StartedAt:        time.Now(),
 	}

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -197,6 +197,7 @@ func Handler(n *node.Node, mcpServer *mcp.Server, hub *Hub, peerRegistry *peer.R
 	// paths in registration order. catalog + scope-keyed endpoints share the
 	// /settings prefix without colliding (different verbs / suffixes).
 	registerSettingsExecRoutes(api, n)
+	registerCommentsRoutesFromNode(api, n)
 
 	api.HandleFunc("/settings/profile", apiProfileGet(n)).Methods("GET")
 	api.HandleFunc("/settings/profile", apiProfileUpdate(n)).Methods("PUT")

--- a/internal/web/handlers_comments.go
+++ b/internal/web/handlers_comments.go
@@ -1,0 +1,322 @@
+package web
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
+	"github.com/k8nstantin/OpenPraxis/internal/node"
+)
+
+// M2-T5 — HTTP surface for comments. Thin wrapper over comments.Store;
+// mirrors the MCP surface in parallel task M2-T4. Error codes match the
+// sentinel table documented in the M2 manifest so UI + agents can share
+// one taxonomy.
+
+// commentMaxBodyBytes caps request bodies at 1 MiB. Longer bodies produce
+// 413 with code=body_too_large before JSON decode.
+const commentMaxBodyBytes = 1 << 20
+
+// commentView is the wire shape — the comments.Comment with added ISO
+// timestamp fields. Defined here (not in internal/comments/model.go) so
+// the core model stays free of HTTP concerns.
+type commentView struct {
+	ID            string  `json:"id"`
+	TargetType    string  `json:"target_type"`
+	TargetID      string  `json:"target_id"`
+	Author        string  `json:"author"`
+	Type          string  `json:"type"`
+	Body          string  `json:"body"`
+	CreatedAt     int64   `json:"created_at"`
+	CreatedAtISO  string  `json:"created_at_iso"`
+	UpdatedAt     *int64  `json:"updated_at,omitempty"`
+	UpdatedAtISO  string  `json:"updated_at_iso,omitempty"`
+	ParentID      *string `json:"parent_id,omitempty"`
+}
+
+func toCommentView(c comments.Comment) commentView {
+	v := commentView{
+		ID:           c.ID,
+		TargetType:   string(c.TargetType),
+		TargetID:     c.TargetID,
+		Author:       c.Author,
+		Type:         string(c.Type),
+		Body:         c.Body,
+		CreatedAt:    c.CreatedAt.Unix(),
+		CreatedAtISO: c.CreatedAt.UTC().Format(time.RFC3339),
+		ParentID:     c.ParentID,
+	}
+	if c.UpdatedAt != nil {
+		u := c.UpdatedAt.Unix()
+		v.UpdatedAt = &u
+		v.UpdatedAtISO = c.UpdatedAt.UTC().Format(time.RFC3339)
+	}
+	return v
+}
+
+// writeCommentError emits {error, code} at the given status. The code field
+// is what test and UI clients match on; error carries a human message.
+func writeCommentError(w http.ResponseWriter, code, msg string, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg, "code": code})
+}
+
+// commentErrorStatus maps a comments sentinel to (code, status).
+func commentErrorStatus(err error) (string, int) {
+	switch {
+	case errors.Is(err, comments.ErrUnknownTargetType):
+		return "unknown_target_type", http.StatusNotFound
+	case errors.Is(err, comments.ErrEmptyTargetID):
+		return "empty_target_id", http.StatusBadRequest
+	case errors.Is(err, comments.ErrUnknownCommentType):
+		return "unknown_type", http.StatusBadRequest
+	case errors.Is(err, comments.ErrEmptyAuthor):
+		return "empty_author", http.StatusBadRequest
+	case errors.Is(err, comments.ErrEmptyBody):
+		return "empty_body", http.StatusBadRequest
+	}
+	return "internal", http.StatusInternalServerError
+}
+
+// validCommentTypesList is the stable, sorted set surfaced in error messages
+// so clients get a deterministic list of acceptable types.
+func validCommentTypesList() string {
+	all := comments.AllCommentTypes()
+	parts := make([]string, 0, len(all))
+	for _, t := range all {
+		parts = append(parts, string(t))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// readBodyCapped enforces the 1 MiB cap and surfaces body_too_large before
+// invoking JSON decode. It returns false iff a response has already been
+// written.
+func readBodyCapped(w http.ResponseWriter, r *http.Request, dst any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, commentMaxBodyBytes)
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		if errors.As(err, new(*http.MaxBytesError)) ||
+			strings.Contains(err.Error(), "http: request body too large") {
+			writeCommentError(w, "body_too_large",
+				fmt.Sprintf("request body exceeds %d bytes", commentMaxBodyBytes),
+				http.StatusRequestEntityTooLarge)
+			return false
+		}
+		writeCommentError(w, "invalid_body", "invalid request body: "+err.Error(),
+			http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
+// parseLimit honors the ?limit query param. Returns (limit, true) on success,
+// or (0, false) after writing a 400 response for non-numeric input. limit<=0
+// is passed through to the store (which applies its own default/cap).
+func parseLimit(w http.ResponseWriter, r *http.Request) (int, bool) {
+	raw := r.URL.Query().Get("limit")
+	if raw == "" {
+		return 0, true
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		writeCommentError(w, "invalid_limit",
+			"limit must be an integer", http.StatusBadRequest)
+		return 0, false
+	}
+	return n, true
+}
+
+// parseTypeFilter honors the ?type query param. Returns (nil, true) when no
+// type is provided. Returns (nil, false) after writing a 400 for an unknown
+// type string.
+func parseTypeFilter(w http.ResponseWriter, r *http.Request) (*comments.CommentType, bool) {
+	raw := r.URL.Query().Get("type")
+	if raw == "" {
+		return nil, true
+	}
+	if !comments.IsValidCommentType(raw) {
+		writeCommentError(w, "unknown_type",
+			fmt.Sprintf("unknown type %q (valid: %s)", raw, validCommentTypesList()),
+			http.StatusBadRequest)
+		return nil, false
+	}
+	ct := comments.CommentType(raw)
+	return &ct, true
+}
+
+// listCommentsResponse is the GET-list shape.
+type listCommentsResponse struct {
+	Comments []commentView `json:"comments"`
+}
+
+// addCommentRequest is the POST body shape.
+type addCommentRequest struct {
+	Author string `json:"author"`
+	Type   string `json:"type"`
+	Body   string `json:"body"`
+}
+
+// editCommentRequest is the PATCH body shape.
+type editCommentRequest struct {
+	Body string `json:"body"`
+}
+
+// listComments is the shared handler body for
+// GET /api/{products|manifests|tasks}/{id}/comments.
+func listComments(store *comments.Store, target comments.TargetType) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := mux.Vars(r)["id"]
+		if id == "" {
+			writeCommentError(w, "empty_target_id",
+				comments.ErrEmptyTargetID.Error(), http.StatusBadRequest)
+			return
+		}
+		limit, ok := parseLimit(w, r)
+		if !ok {
+			return
+		}
+		filter, ok := parseTypeFilter(w, r)
+		if !ok {
+			return
+		}
+		out, err := store.List(r.Context(), target, id, limit, filter)
+		if err != nil {
+			writeCommentError(w, "internal", err.Error(), http.StatusInternalServerError)
+			return
+		}
+		views := make([]commentView, 0, len(out))
+		for _, c := range out {
+			views = append(views, toCommentView(c))
+		}
+		writeJSON(w, listCommentsResponse{Comments: views})
+	}
+}
+
+// addComment is the shared handler body for
+// POST /api/{products|manifests|tasks}/{id}/comments.
+func addComment(store *comments.Store, target comments.TargetType) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := mux.Vars(r)["id"]
+		if id == "" {
+			writeCommentError(w, "empty_target_id",
+				comments.ErrEmptyTargetID.Error(), http.StatusBadRequest)
+			return
+		}
+		var req addCommentRequest
+		if !readBodyCapped(w, r, &req) {
+			return
+		}
+		cType := comments.CommentType(req.Type)
+		if err := comments.ValidateAdd(target, id, req.Author, cType, req.Body); err != nil {
+			code, status := commentErrorStatus(err)
+			writeCommentError(w, code, err.Error(), status)
+			return
+		}
+		c, err := store.Add(r.Context(), target, id, req.Author, cType, req.Body)
+		if err != nil {
+			code, status := commentErrorStatus(err)
+			writeCommentError(w, code, err.Error(), status)
+			return
+		}
+		writeJSON(w, toCommentView(c))
+	}
+}
+
+// editComment handles PATCH /api/comments/:id.
+func editComment(store *comments.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := mux.Vars(r)["id"]
+		if id == "" {
+			writeCommentError(w, "empty_id", "comment id required",
+				http.StatusBadRequest)
+			return
+		}
+		var req editCommentRequest
+		if !readBodyCapped(w, r, &req) {
+			return
+		}
+		if err := comments.ValidateEdit(req.Body); err != nil {
+			code, status := commentErrorStatus(err)
+			writeCommentError(w, code, err.Error(), status)
+			return
+		}
+		if err := store.Edit(r.Context(), id, req.Body); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				writeCommentError(w, "not_found",
+					"comment not found", http.StatusNotFound)
+				return
+			}
+			writeCommentError(w, "internal", err.Error(),
+				http.StatusInternalServerError)
+			return
+		}
+		c, err := store.Get(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				writeCommentError(w, "not_found",
+					"comment not found", http.StatusNotFound)
+				return
+			}
+			writeCommentError(w, "internal", err.Error(),
+				http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, toCommentView(c))
+	}
+}
+
+// deleteComment handles DELETE /api/comments/:id. Idempotent per store
+// semantics — repeated deletes return 200.
+func deleteComment(store *comments.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := mux.Vars(r)["id"]
+		if id == "" {
+			writeCommentError(w, "empty_id", "comment id required",
+				http.StatusBadRequest)
+			return
+		}
+		if err := store.Delete(r.Context(), id); err != nil {
+			writeCommentError(w, "internal", err.Error(),
+				http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, map[string]any{"ok": true, "id": id})
+	}
+}
+
+// commentScopeRoutes pairs a URL-plural segment with its TargetType so the
+// registration loop stays declarative.
+var commentScopeRoutes = []struct {
+	segment string
+	target  comments.TargetType
+}{
+	{"products", comments.TargetProduct},
+	{"manifests", comments.TargetManifest},
+	{"tasks", comments.TargetTask},
+}
+
+// registerCommentsRoutes attaches the 8 comment endpoints to /api.
+func registerCommentsRoutes(api *mux.Router, store *comments.Store) {
+	for _, s := range commentScopeRoutes {
+		path := "/" + s.segment + "/{id}/comments"
+		api.HandleFunc(path, listComments(store, s.target)).Methods("GET")
+		api.HandleFunc(path, addComment(store, s.target)).Methods("POST")
+	}
+	api.HandleFunc("/comments/{id}", editComment(store)).Methods("PATCH")
+	api.HandleFunc("/comments/{id}", deleteComment(store)).Methods("DELETE")
+}
+
+// registerCommentsRoutesFromNode is the production entry point. Keeps the
+// wire-up in handler.go a single line.
+func registerCommentsRoutesFromNode(api *mux.Router, n *node.Node) {
+	registerCommentsRoutes(api, n.Comments)
+}

--- a/internal/web/handlers_comments.go
+++ b/internal/web/handlers_comments.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"bytes"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -11,10 +12,47 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/renderer/html"
 
 	"github.com/k8nstantin/OpenPraxis/internal/comments"
 	"github.com/k8nstantin/OpenPraxis/internal/node"
 )
+
+// markdownRenderer is the shared goldmark instance used to render comment
+// bodies to HTML. GFM extensions are enabled (tables, task lists, strike,
+// autolinks). Raw HTML in source is ALWAYS escaped — html.WithUnsafe() is
+// deliberately omitted. See TestPOST_Comment_XSSEscape.
+var markdownRenderer = goldmark.New(
+	goldmark.WithExtensions(extension.GFM),
+	goldmark.WithRendererOptions(
+		html.WithXHTML(),
+	),
+)
+
+// renderMarkdown converts a raw comment body to safe HTML. Returns the raw
+// body wrapped in a <p> on goldmark error so the UI always has something to
+// display.
+func renderMarkdown(src string) string {
+	var buf bytes.Buffer
+	if err := markdownRenderer.Convert([]byte(src), &buf); err != nil {
+		return "<p>" + escapeHTML(src) + "</p>"
+	}
+	return buf.String()
+}
+
+// escapeHTML is a tiny helper for the renderMarkdown fallback path.
+func escapeHTML(s string) string {
+	r := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		`"`, "&quot;",
+		"'", "&#39;",
+	)
+	return r.Replace(s)
+}
 
 // M2-T5 — HTTP surface for comments. Thin wrapper over comments.Store;
 // mirrors the MCP surface in parallel task M2-T4. Error codes match the
@@ -35,6 +73,7 @@ type commentView struct {
 	Author        string  `json:"author"`
 	Type          string  `json:"type"`
 	Body          string  `json:"body"`
+	BodyHTML      string  `json:"body_html"`
 	CreatedAt     int64   `json:"created_at"`
 	CreatedAtISO  string  `json:"created_at_iso"`
 	UpdatedAt     *int64  `json:"updated_at,omitempty"`
@@ -50,6 +89,7 @@ func toCommentView(c comments.Comment) commentView {
 		Author:       c.Author,
 		Type:         string(c.Type),
 		Body:         c.Body,
+		BodyHTML:     renderMarkdown(c.Body),
 		CreatedAt:    c.CreatedAt.Unix(),
 		CreatedAtISO: c.CreatedAt.UTC().Format(time.RFC3339),
 		ParentID:     c.ParentID,
@@ -293,6 +333,15 @@ func deleteComment(store *comments.Store) http.HandlerFunc {
 	}
 }
 
+// listCommentTypes serves GET /api/comments/types — the canonical Registry()
+// order from internal/comments. M3 UI consumes this to populate the filter
+// dropdown + add form type select so new types appear automatically.
+func listCommentTypes() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, comments.Registry())
+	}
+}
+
 // commentScopeRoutes pairs a URL-plural segment with its TargetType so the
 // registration loop stays declarative.
 var commentScopeRoutes = []struct {
@@ -311,6 +360,7 @@ func registerCommentsRoutes(api *mux.Router, store *comments.Store) {
 		api.HandleFunc(path, listComments(store, s.target)).Methods("GET")
 		api.HandleFunc(path, addComment(store, s.target)).Methods("POST")
 	}
+	api.HandleFunc("/comments/types", listCommentTypes()).Methods("GET")
 	api.HandleFunc("/comments/{id}", editComment(store)).Methods("PATCH")
 	api.HandleFunc("/comments/{id}", deleteComment(store)).Methods("DELETE")
 }

--- a/internal/web/handlers_comments_test.go
+++ b/internal/web/handlers_comments_test.go
@@ -1,0 +1,425 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"database/sql"
+
+	"github.com/gorilla/mux"
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
+)
+
+// ---- harness ----------------------------------------------------------------
+
+type commentsTestEnv struct {
+	store  *comments.Store
+	server *httptest.Server
+}
+
+func newCommentsTestEnv(t *testing.T) *commentsTestEnv {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "comments.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		t.Fatalf("set WAL: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
+		t.Fatalf("busy_timeout: %v", err)
+	}
+	if err := comments.InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	store := comments.NewStore(db)
+
+	r := mux.NewRouter()
+	api := r.PathPrefix("/api").Subrouter()
+	registerCommentsRoutes(api, store)
+
+	srv := httptest.NewServer(r)
+	t.Cleanup(func() {
+		srv.Close()
+		db.Close()
+	})
+	return &commentsTestEnv{store: store, server: srv}
+}
+
+func (e *commentsTestEnv) do(t *testing.T, method, path string, body any) (*http.Response, []byte) {
+	t.Helper()
+	var buf io.Reader
+	if body != nil {
+		switch v := body.(type) {
+		case []byte:
+			buf = bytes.NewReader(v)
+		default:
+			b, err := json.Marshal(body)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			buf = bytes.NewReader(b)
+		}
+	}
+	req, err := http.NewRequest(method, e.server.URL+path, buf)
+	if err != nil {
+		t.Fatalf("req: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp, out
+}
+
+func decodeErr(t *testing.T, body []byte) map[string]string {
+	t.Helper()
+	var m map[string]string
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("decode error body: %v raw=%s", err, body)
+	}
+	return m
+}
+
+func decodeComment(t *testing.T, body []byte) commentView {
+	t.Helper()
+	var v commentView
+	if err := json.Unmarshal(body, &v); err != nil {
+		t.Fatalf("decode comment: %v raw=%s", err, body)
+	}
+	return v
+}
+
+func decodeList(t *testing.T, body []byte) []commentView {
+	t.Helper()
+	var v listCommentsResponse
+	if err := json.Unmarshal(body, &v); err != nil {
+		t.Fatalf("decode list: %v raw=%s", err, body)
+	}
+	return v.Comments
+}
+
+// ---- POST -------------------------------------------------------------------
+
+func TestPOST_AddComment_ProductScope(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "POST", "/api/products/p1/comments", addCommentRequest{
+		Author: "alice",
+		Type:   string(comments.TypeUserNote),
+		Body:   "hello",
+	})
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, body)
+	}
+	c := decodeComment(t, body)
+	if c.ID == "" || c.TargetType != "product" || c.TargetID != "p1" ||
+		c.Author != "alice" || c.Type != "user_note" || c.Body != "hello" {
+		t.Fatalf("bad comment: %+v", c)
+	}
+	if c.CreatedAt == 0 || c.CreatedAtISO == "" {
+		t.Fatalf("missing timestamps: %+v", c)
+	}
+	if c.UpdatedAt != nil || c.UpdatedAtISO != "" {
+		t.Fatalf("unexpected updated fields on create: %+v", c)
+	}
+}
+
+func TestPOST_AddComment_ManifestScope(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "POST", "/api/manifests/m1/comments", addCommentRequest{
+		Author: "bob", Type: string(comments.TypeDecision), Body: "chose plan X",
+	})
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, body)
+	}
+	c := decodeComment(t, body)
+	if c.TargetType != "manifest" || c.TargetID != "m1" || c.Type != "decision" {
+		t.Fatalf("bad comment: %+v", c)
+	}
+}
+
+func TestPOST_AddComment_TaskScope(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "POST", "/api/tasks/t1/comments", addCommentRequest{
+		Author: "carol", Type: string(comments.TypeExecutionReview), Body: "ran fine",
+	})
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, body)
+	}
+	c := decodeComment(t, body)
+	if c.TargetType != "task" || c.Type != "execution_review" {
+		t.Fatalf("bad comment: %+v", c)
+	}
+}
+
+func TestPOST_RejectsEmptyBody(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "POST", "/api/products/p1/comments", addCommentRequest{
+		Author: "alice", Type: string(comments.TypeUserNote), Body: "   ",
+	})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, body)
+	}
+	if got := decodeErr(t, body)["code"]; got != "empty_body" {
+		t.Fatalf("code: got %q", got)
+	}
+}
+
+func TestPOST_RejectsUnknownType(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "POST", "/api/products/p1/comments", addCommentRequest{
+		Author: "alice", Type: "not_a_type", Body: "hi",
+	})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, body)
+	}
+	if got := decodeErr(t, body)["code"]; got != "unknown_type" {
+		t.Fatalf("code: got %q", got)
+	}
+}
+
+func TestPOST_RejectsEmptyAuthor(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "POST", "/api/products/p1/comments", addCommentRequest{
+		Author: "", Type: string(comments.TypeUserNote), Body: "hi",
+	})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, body)
+	}
+	if got := decodeErr(t, body)["code"]; got != "empty_author" {
+		t.Fatalf("code: got %q", got)
+	}
+}
+
+// ---- GET --------------------------------------------------------------------
+
+func TestGET_ListComments_NewestFirst(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	// Insert three comments directly; store assigns UUID v7 ids (monotonic).
+	for i, body := range []string{"first", "second", "third"} {
+		if _, err := env.store.Add(t.Context(), comments.TargetProduct, "p1",
+			"alice", comments.TypeUserNote, body); err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+	}
+	resp, body := env.do(t, "GET", "/api/products/p1/comments", nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+	list := decodeList(t, body)
+	if len(list) != 3 {
+		t.Fatalf("len: got %d", len(list))
+	}
+	// Newest-first: "third", "second", "first".
+	if list[0].Body != "third" || list[2].Body != "first" {
+		t.Fatalf("order: got %+v", list)
+	}
+}
+
+func TestGET_ListComments_TypeFilter(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	_, _ = env.store.Add(t.Context(), comments.TargetProduct, "p1", "a",
+		comments.TypeUserNote, "u1")
+	_, _ = env.store.Add(t.Context(), comments.TargetProduct, "p1", "a",
+		comments.TypeDecision, "d1")
+	resp, body := env.do(t, "GET", "/api/products/p1/comments?type=decision", nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+	list := decodeList(t, body)
+	if len(list) != 1 || list[0].Type != "decision" {
+		t.Fatalf("filter: got %+v", list)
+	}
+}
+
+func TestGET_ListComments_LimitAndCap(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	for i := 0; i < 5; i++ {
+		_, _ = env.store.Add(t.Context(), comments.TargetProduct, "p1", "a",
+			comments.TypeUserNote, fmt.Sprintf("n%d", i))
+	}
+	resp, body := env.do(t, "GET", "/api/products/p1/comments?limit=2", nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+	if list := decodeList(t, body); len(list) != 2 {
+		t.Fatalf("limit=2: got %d", len(list))
+	}
+	// limit=2000 should be capped at 1000 — store caps; endpoint must not
+	// reject the value. Only 5 rows exist so we just confirm 200 + 5 rows.
+	resp, body = env.do(t, "GET", "/api/products/p1/comments?limit=2000", nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+	if list := decodeList(t, body); len(list) != 5 {
+		t.Fatalf("limit=2000 cap: got %d want 5", len(list))
+	}
+}
+
+func TestGET_ListComments_InvalidLimit(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "GET", "/api/products/p1/comments?limit=abc", nil)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, body)
+	}
+}
+
+func TestGET_ListComments_InvalidType(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "GET", "/api/products/p1/comments?type=foo", nil)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+	if got := decodeErr(t, body)["code"]; got != "unknown_type" {
+		t.Fatalf("code: got %q", got)
+	}
+}
+
+func TestGET_ListComments_ScopeIsolation(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	_, _ = env.store.Add(t.Context(), comments.TargetProduct, "X", "a",
+		comments.TypeUserNote, "product-X")
+	resp, body := env.do(t, "GET", "/api/tasks/X/comments", nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+	if list := decodeList(t, body); len(list) != 0 {
+		t.Fatalf("expected empty list on task/X: got %+v", list)
+	}
+}
+
+// ---- PATCH ------------------------------------------------------------------
+
+func TestPATCH_EditComment(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	c, err := env.store.Add(t.Context(), comments.TargetProduct, "p1",
+		"alice", comments.TypeUserNote, "original")
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	resp, body := env.do(t, "PATCH", "/api/comments/"+c.ID, editCommentRequest{Body: "edited"})
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, body)
+	}
+	out := decodeComment(t, body)
+	if out.Body != "edited" {
+		t.Fatalf("body: got %q", out.Body)
+	}
+	if out.UpdatedAt == nil || out.UpdatedAtISO == "" {
+		t.Fatalf("updated_at fields not set: %+v", out)
+	}
+}
+
+func TestPATCH_NotFound(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "PATCH", "/api/comments/missing-id",
+		editCommentRequest{Body: "x"})
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+	if got := decodeErr(t, body)["code"]; got != "not_found" {
+		t.Fatalf("code: got %q", got)
+	}
+}
+
+func TestPATCH_EmptyBody(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	c, _ := env.store.Add(t.Context(), comments.TargetProduct, "p1", "a",
+		comments.TypeUserNote, "orig")
+	resp, body := env.do(t, "PATCH", "/api/comments/"+c.ID, editCommentRequest{Body: "   "})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+	if got := decodeErr(t, body)["code"]; got != "empty_body" {
+		t.Fatalf("code: got %q", got)
+	}
+}
+
+// ---- DELETE -----------------------------------------------------------------
+
+func TestDELETE_Idempotent(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	c, _ := env.store.Add(t.Context(), comments.TargetProduct, "p1", "a",
+		comments.TypeUserNote, "x")
+	for i := 0; i < 2; i++ {
+		resp, body := env.do(t, "DELETE", "/api/comments/"+c.ID, nil)
+		if resp.StatusCode != 200 {
+			t.Fatalf("iter %d: got %d body=%s", i, resp.StatusCode, body)
+		}
+	}
+}
+
+// ---- body size --------------------------------------------------------------
+
+func TestPOST_BodyTooLarge(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	huge := strings.Repeat("a", commentMaxBodyBytes+1024)
+	resp, body := env.do(t, "POST", "/api/products/p1/comments",
+		[]byte(`{"author":"a","type":"user_note","body":"`+huge+`"}`))
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, body)
+	}
+	if got := decodeErr(t, body)["code"]; got != "body_too_large" {
+		t.Fatalf("code: got %q", got)
+	}
+}
+
+// ---- route wiring -----------------------------------------------------------
+
+// TestRoutes_AllCommentEndpointsRegistered enforces that the registration
+// function exposes every URL + method the spec requires.
+func TestRoutes_AllCommentEndpointsRegistered(t *testing.T) {
+	r := mux.NewRouter()
+	api := r.PathPrefix("/api").Subrouter()
+	registerCommentsRoutes(api, nil)
+
+	want := map[string]string{
+		"GET /api/products/{id}/comments":   "",
+		"POST /api/products/{id}/comments":  "",
+		"GET /api/manifests/{id}/comments":  "",
+		"POST /api/manifests/{id}/comments": "",
+		"GET /api/tasks/{id}/comments":      "",
+		"POST /api/tasks/{id}/comments":     "",
+		"PATCH /api/comments/{id}":          "",
+		"DELETE /api/comments/{id}":         "",
+	}
+	if err := r.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
+		pathTmpl, err := route.GetPathTemplate()
+		if err != nil {
+			return nil
+		}
+		methods, _ := route.GetMethods()
+		for _, m := range methods {
+			key := m + " " + pathTmpl
+			if _, ok := want[key]; ok {
+				want[key] = "seen"
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	for k, v := range want {
+		if v != "seen" {
+			t.Errorf("route missing: %s", k)
+		}
+	}
+}

--- a/internal/web/handlers_comments_test.go
+++ b/internal/web/handlers_comments_test.go
@@ -382,6 +382,116 @@ func TestPOST_BodyTooLarge(t *testing.T) {
 	}
 }
 
+// ---- body_html (M3-T6) ------------------------------------------------------
+
+func TestPOST_Comment_BodyHTMLParagraph(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "POST", "/api/products/p1/comments", addCommentRequest{
+		Author: "alice", Type: string(comments.TypeUserNote), Body: "hello **world**",
+	})
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: %d body=%s", resp.StatusCode, body)
+	}
+	c := decodeComment(t, body)
+	if !strings.Contains(c.BodyHTML, "<p>") || !strings.Contains(c.BodyHTML, "<strong>world</strong>") {
+		t.Fatalf("body_html missing markdown rendering: %q", c.BodyHTML)
+	}
+}
+
+func TestPOST_Comment_BodyHTMLCodeBlock(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	src := "```\nfmt.Println(\"hi\")\n```"
+	resp, body := env.do(t, "POST", "/api/products/p1/comments", addCommentRequest{
+		Author: "a", Type: string(comments.TypeUserNote), Body: src,
+	})
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: %d body=%s", resp.StatusCode, body)
+	}
+	c := decodeComment(t, body)
+	if !strings.Contains(c.BodyHTML, "<pre>") || !strings.Contains(c.BodyHTML, "<code>") {
+		t.Fatalf("code block not rendered: %q", c.BodyHTML)
+	}
+}
+
+func TestPOST_Comment_BodyHTMLGFMTable(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	src := "| a | b |\n| - | - |\n| 1 | 2 |"
+	resp, body := env.do(t, "POST", "/api/products/p1/comments", addCommentRequest{
+		Author: "a", Type: string(comments.TypeUserNote), Body: src,
+	})
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: %d body=%s", resp.StatusCode, body)
+	}
+	c := decodeComment(t, body)
+	if !strings.Contains(c.BodyHTML, "<table>") {
+		t.Fatalf("GFM table not rendered: %q", c.BodyHTML)
+	}
+}
+
+// TestPOST_Comment_XSSEscape is the acceptance-criteria XSS test: raw
+// <script> in body must be escaped in body_html.
+func TestPOST_Comment_XSSEscape(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "POST", "/api/products/p1/comments", addCommentRequest{
+		Author: "a", Type: string(comments.TypeUserNote),
+		Body: "<script>alert(1)</script>",
+	})
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: %d body=%s", resp.StatusCode, body)
+	}
+	c := decodeComment(t, body)
+	// goldmark with WithUnsafe() OFF drops raw HTML entirely (replaces with
+	// an "<!-- raw HTML omitted -->" comment). The security property we
+	// enforce: no executable <script> tag survives into body_html.
+	if strings.Contains(c.BodyHTML, "<script>") {
+		t.Fatalf("raw <script> tag leaked into body_html: %q", c.BodyHTML)
+	}
+	if strings.Contains(c.BodyHTML, "alert(1)") {
+		t.Fatalf("script payload leaked into body_html: %q", c.BodyHTML)
+	}
+}
+
+// TestPOST_Comment_EscapedAngleBrackets verifies that when angle brackets
+// appear in prose (outside an HTML-looking tag), goldmark escapes them so
+// the UI renders them as text rather than HTML.
+func TestPOST_Comment_EscapedAngleBrackets(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "POST", "/api/products/p1/comments", addCommentRequest{
+		Author: "a", Type: string(comments.TypeUserNote),
+		Body: "use the `<T>` type param",
+	})
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: %d body=%s", resp.StatusCode, body)
+	}
+	c := decodeComment(t, body)
+	if !strings.Contains(c.BodyHTML, "&lt;T&gt;") {
+		t.Fatalf("expected escaped brackets in body_html: %q", c.BodyHTML)
+	}
+}
+
+// ---- /api/comments/types (M3-T6) --------------------------------------------
+
+func TestGET_CommentsTypes(t *testing.T) {
+	env := newCommentsTestEnv(t)
+	resp, body := env.do(t, "GET", "/api/comments/types", nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: %d body=%s", resp.StatusCode, body)
+	}
+	var got []comments.CommentTypeInfo
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode: %v body=%s", err, body)
+	}
+	want := comments.Registry()
+	if len(got) != len(want) {
+		t.Fatalf("len: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Type != want[i].Type || got[i].Label != want[i].Label {
+			t.Fatalf("entry %d: got %+v want %+v", i, got[i], want[i])
+		}
+	}
+}
+
 // ---- route wiring -----------------------------------------------------------
 
 // TestRoutes_AllCommentEndpointsRegistered enforces that the registration
@@ -400,6 +510,7 @@ func TestRoutes_AllCommentEndpointsRegistered(t *testing.T) {
 		"POST /api/tasks/{id}/comments":     "",
 		"PATCH /api/comments/{id}":          "",
 		"DELETE /api/comments/{id}":         "",
+		"GET /api/comments/types":           "",
 	}
 	if err := r.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
 		pathTmpl, err := route.GetPathTemplate()

--- a/internal/web/ui/components/comments.js
+++ b/internal/web/ui/components/comments.js
@@ -1,0 +1,254 @@
+// OpenPraxis — Entity Comments component (M3-T6)
+//
+// Shared UI for product, manifest, and task detail views. Consumes the
+// HTTP surface shipped by M2-T5 + the /api/comments/types endpoint added
+// in M3-T6. Markdown is rendered server-side (goldmark); we inject
+// response.body_html directly into the DOM.
+//
+// Integration (M3-T7/T8) calls:
+//   OL.renderCommentsSection(containerEl, { type: 'product'|'manifest'|'task', id: '<id>' })
+
+(function(OL) {
+  'use strict';
+
+  var fetchJSON = OL.fetchJSON, esc = OL.esc, timeAgo = OL.timeAgo;
+
+  // --- type catalog cache (static per server process) --------------------
+  var _typesCache = null;
+  function loadTypes() {
+    if (_typesCache) return Promise.resolve(_typesCache);
+    return fetchJSON('/api/comments/types').then(function(data) {
+      _typesCache = Array.isArray(data) ? data : [];
+      return _typesCache;
+    }).catch(function() {
+      // Fallback — keep the dropdown usable even if the endpoint 500s.
+      _typesCache = [
+        { type: 'user_note', label: 'Note' },
+        { type: 'execution_review', label: 'Execution Review' },
+        { type: 'watcher_finding', label: 'Watcher Finding' },
+        { type: 'agent_note', label: 'Agent Note' },
+        { type: 'decision', label: 'Decision' },
+        { type: 'link', label: 'Link' },
+      ];
+      return _typesCache;
+    });
+  }
+  OL.invalidateCommentTypesCache = function() { _typesCache = null; };
+
+  // --- current user (best-effort) ----------------------------------------
+  // Used to decide whether to expose edit/delete buttons. Falls back to
+  // showing controls for all comments — M3 does not wire up auth UI and
+  // the server is the source of truth for authorization.
+  function currentAuthor() {
+    return (OL.currentUser && OL.currentUser()) || '';
+  }
+
+  // --- rendering ---------------------------------------------------------
+
+  function renderAddForm(scope, types) {
+    var opts = types.map(function(t) {
+      var sel = t.type === 'user_note' ? ' selected' : '';
+      return '<option value="' + esc(t.type) + '"' + sel + '>' + esc(t.label) + '</option>';
+    }).join('');
+    return (
+      '<form class="comment-add-form" data-scope-type="' + esc(scope.type) + '" data-scope-id="' + esc(scope.id) + '">' +
+        '<textarea class="comment-add-body" placeholder="Add a comment… (Markdown supported)" required></textarea>' +
+        '<div class="comment-add-row">' +
+          '<select class="comment-add-type">' + opts + '</select>' +
+          '<button type="submit" class="comment-add-submit">Post</button>' +
+        '</div>' +
+        '<div class="comment-add-error" hidden></div>' +
+      '</form>'
+    );
+  }
+
+  function renderFilter(types, currentFilter) {
+    var opts = ['<option value="">All</option>'];
+    types.forEach(function(t) {
+      var sel = t.type === currentFilter ? ' selected' : '';
+      opts.push('<option value="' + esc(t.type) + '"' + sel + '>' + esc(t.label) + '</option>');
+    });
+    return (
+      '<div class="comment-filter-row">' +
+        '<label class="comment-filter-label">Filter:</label>' +
+        '<select class="comment-filter">' + opts.join('') + '</select>' +
+      '</div>'
+    );
+  }
+
+  function renderComment(c) {
+    var typeClass = 'comment-type-' + esc(c.type);
+    var iso = c.updated_at_iso || c.created_at_iso;
+    var relTime = timeAgo(iso) + (c.updated_at_iso ? ' (edited)' : '');
+    var me = currentAuthor();
+    var canModify = !me || me === c.author;
+    var controls = '';
+    if (canModify) {
+      controls = (
+        '<div class="comment-controls">' +
+          '<button type="button" class="comment-edit" data-id="' + esc(c.id) + '" title="Edit">✎</button>' +
+          '<button type="button" class="comment-delete" data-id="' + esc(c.id) + '" title="Delete">🗑</button>' +
+        '</div>'
+      );
+    }
+    // body_html is goldmark-rendered (raw HTML escaped, GFM extensions on);
+    // safe to innerHTML-inject.
+    return (
+      '<div class="comment-card" data-id="' + esc(c.id) + '" data-type="' + esc(c.type) + '">' +
+        '<div class="comment-header">' +
+          '<span class="comment-author">' + esc(c.author) + '</span>' +
+          '<span class="comment-type-badge ' + typeClass + '">' + esc(c.type) + '</span>' +
+          '<span class="comment-time" title="' + esc(iso) + '">' + esc(relTime) + '</span>' +
+          controls +
+        '</div>' +
+        '<div class="comment-body">' + (c.body_html || esc(c.body) || '') + '</div>' +
+      '</div>'
+    );
+  }
+
+  function renderStream(comments) {
+    if (!comments.length) {
+      return '<div class="comment-empty">No comments yet</div>';
+    }
+    return '<div class="comment-stream">' + comments.map(renderComment).join('') + '</div>';
+  }
+
+  // --- entry point -------------------------------------------------------
+
+  OL.renderCommentsSection = function(containerEl, scope) {
+    if (!containerEl || !scope || !scope.type || !scope.id) return;
+    containerEl.innerHTML = '<div class="comment-section-loading">Loading comments…</div>';
+
+    var state = { scope: scope, types: [], comments: [], filter: '' };
+
+    function url(path) {
+      return '/api/' + scope.type + 's/' + encodeURIComponent(scope.id) + '/comments' + (path || '');
+    }
+
+    function fetchList() {
+      var q = state.filter ? '?limit=50&type=' + encodeURIComponent(state.filter) : '?limit=50';
+      return fetchJSON(url(q)).then(function(resp) {
+        state.comments = (resp && resp.comments) || [];
+      });
+    }
+
+    function paint() {
+      containerEl.innerHTML = (
+        '<div class="comment-section">' +
+          '<div class="comment-section-header">Comments</div>' +
+          renderAddForm(state.scope, state.types) +
+          renderFilter(state.types, state.filter) +
+          '<div class="comment-section-stream">' + renderStream(state.comments) + '</div>' +
+        '</div>'
+      );
+      bind();
+    }
+
+    function showAddError(msg) {
+      var el = containerEl.querySelector('.comment-add-error');
+      if (!el) return;
+      if (!msg) { el.hidden = true; el.textContent = ''; return; }
+      el.hidden = false;
+      el.textContent = msg;
+    }
+
+    function bind() {
+      var form = containerEl.querySelector('.comment-add-form');
+      if (form) {
+        form.onsubmit = function(ev) {
+          ev.preventDefault();
+          showAddError('');
+          var body = form.querySelector('.comment-add-body').value;
+          var type = form.querySelector('.comment-add-type').value;
+          var author = currentAuthor() || 'user';
+          fetch(url(), {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({ author: author, type: type, body: body }),
+          }).then(function(resp) {
+            return resp.json().then(function(data) { return { ok: resp.ok, data: data }; });
+          }).then(function(r) {
+            if (!r.ok) {
+              var code = (r.data && r.data.code) || '';
+              var msg = (r.data && r.data.error) || 'Failed to post comment';
+              if (code === 'empty_body') msg = 'Comment body is required';
+              showAddError(msg);
+              return;
+            }
+            // Prepend on success.
+            state.comments.unshift(r.data);
+            form.querySelector('.comment-add-body').value = '';
+            var streamEl = containerEl.querySelector('.comment-section-stream');
+            if (streamEl) streamEl.innerHTML = renderStream(state.comments);
+            bindStreamHandlers();
+          }).catch(function(e) {
+            showAddError(String(e && e.message || e));
+          });
+        };
+      }
+
+      var filterEl = containerEl.querySelector('.comment-filter');
+      if (filterEl) {
+        filterEl.onchange = function() {
+          state.filter = filterEl.value;
+          fetchList().then(function() {
+            var streamEl = containerEl.querySelector('.comment-section-stream');
+            if (streamEl) streamEl.innerHTML = renderStream(state.comments);
+            bindStreamHandlers();
+          });
+        };
+      }
+
+      bindStreamHandlers();
+    }
+
+    function bindStreamHandlers() {
+      var stream = containerEl.querySelector('.comment-section-stream');
+      if (!stream) return;
+      stream.onclick = function(ev) {
+        var delBtn = ev.target.closest('.comment-delete');
+        var editBtn = ev.target.closest('.comment-edit');
+        if (delBtn) {
+          var id = delBtn.getAttribute('data-id');
+          if (!confirm('Delete this comment?')) return;
+          fetch('/api/comments/' + encodeURIComponent(id), { method: 'DELETE' })
+            .then(function(resp) {
+              if (!resp.ok) throw new Error('delete failed');
+              state.comments = state.comments.filter(function(c) { return c.id !== id; });
+              stream.innerHTML = renderStream(state.comments);
+              bindStreamHandlers();
+            }).catch(function(e) { alert(e.message || e); });
+          return;
+        }
+        if (editBtn) {
+          var eid = editBtn.getAttribute('data-id');
+          var existing = state.comments.find(function(c) { return c.id === eid; });
+          if (!existing) return;
+          var next = prompt('Edit comment:', existing.body);
+          if (next == null || next === existing.body) return;
+          fetch('/api/comments/' + encodeURIComponent(eid), {
+            method: 'PATCH',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({ body: next }),
+          }).then(function(resp) {
+            return resp.json().then(function(data) { return { ok: resp.ok, data: data }; });
+          }).then(function(r) {
+            if (!r.ok) throw new Error((r.data && r.data.error) || 'edit failed');
+            state.comments = state.comments.map(function(c) { return c.id === eid ? r.data : c; });
+            stream.innerHTML = renderStream(state.comments);
+            bindStreamHandlers();
+          }).catch(function(e) { alert(e.message || e); });
+        }
+      };
+    }
+
+    // Initial load: types + comments in parallel.
+    Promise.all([loadTypes(), fetchList()]).then(function(res) {
+      state.types = res[0] || [];
+      paint();
+    }).catch(function(e) {
+      containerEl.innerHTML = '<div class="comment-section-error">Failed to load comments: ' + esc(e.message || String(e)) + '</div>';
+    });
+  };
+
+})(window.OL);

--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -738,6 +738,7 @@
   <script src="/tree.js"></script>
   <script src="/lifecycle.js"></script>
   <script src="/components/knobs.js"></script>
+  <script src="/components/comments.js"></script>
   <script src="/views/overview.js"></script>
   <script src="/views/memories.js"></script>
   <script src="/views/conversations.js"></script>

--- a/internal/web/ui/style.css
+++ b/internal/web/ui/style.css
@@ -1291,3 +1291,51 @@ body {
   .knob-row-meta { padding-left: 0; }
   .knob-label { min-width: 0; }
 }
+
+/* === Entity Comments (M3-T6) — rendered by OL.renderCommentsSection === */
+.comment-section { margin-top: 16px; padding: 12px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-secondary); }
+.comment-section-header { font-weight: 600; margin-bottom: 12px; color: var(--text-primary); font-size: 13px; }
+.comment-section-loading { color: var(--text-muted); font-size: 12px; padding: 8px 0; }
+.comment-section-error { color: var(--red); font-size: 12px; padding: 8px 0; }
+.comment-section-stream { margin-top: 8px; }
+
+.comment-add-form { display: flex; flex-direction: column; gap: 6px; margin-bottom: 12px; }
+.comment-add-body { min-height: 80px; resize: vertical; background: var(--bg-input); border: 1px solid var(--border); color: var(--text-primary); padding: 8px; border-radius: 4px; font-size: 12px; font-family: var(--font-mono); }
+.comment-add-row { display: flex; gap: 8px; align-items: center; }
+.comment-add-type { background: var(--bg-input); border: 1px solid var(--border); color: var(--text-primary); padding: 4px 8px; border-radius: 3px; font-size: 12px; font-family: var(--font-mono); }
+.comment-add-submit { background: var(--accent); color: #fff; border: none; padding: 4px 14px; border-radius: 3px; font-size: 12px; cursor: pointer; font-weight: 600; }
+.comment-add-submit:hover { background: var(--accent-hover); }
+.comment-add-error { color: var(--red); font-size: 11px; padding: 4px 0; }
+
+.comment-filter-row { display: flex; gap: 8px; align-items: center; margin-bottom: 8px; font-size: 11px; color: var(--text-muted); }
+.comment-filter-label { font-size: 11px; }
+.comment-filter { background: var(--bg-input); border: 1px solid var(--border); color: var(--text-primary); padding: 2px 6px; border-radius: 3px; font-size: 11px; font-family: var(--font-mono); }
+
+.comment-empty { color: var(--text-muted); font-size: 12px; padding: 12px 0; text-align: center; font-style: italic; }
+
+.comment-card { border: 1px solid var(--border); border-radius: 6px; padding: 10px; margin-bottom: 8px; background: var(--bg-secondary); }
+.comment-header { display: flex; gap: 8px; align-items: center; margin-bottom: 6px; font-size: 11px; }
+.comment-author { color: var(--text-primary); font-weight: 600; }
+.comment-time { color: var(--text-muted); }
+.comment-controls { margin-left: auto; display: flex; gap: 4px; }
+.comment-controls button { background: transparent; border: none; color: var(--text-muted); cursor: pointer; font-size: 12px; padding: 2px 4px; border-radius: 3px; }
+.comment-controls button:hover { color: var(--text-primary); background: var(--bg-input); }
+.comment-type-badge { padding: 2px 8px; border-radius: 3px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; border: 1px solid currentColor; }
+.comment-type-execution_review { color: var(--accent); }
+.comment-type-user_note        { color: var(--green); }
+.comment-type-watcher_finding  { color: var(--yellow); }
+.comment-type-agent_note       { color: var(--accent); }
+.comment-type-decision         { color: var(--green); }
+.comment-type-link             { color: var(--text-muted); }
+.comment-type-review_rejection { color: var(--red); }
+.comment-type-review_approval  { color: var(--green); }
+.comment-body { font-size: 12px; line-height: 1.5; color: var(--text-primary); }
+.comment-body p { margin: 0 0 6px 0; }
+.comment-body p:last-child { margin-bottom: 0; }
+.comment-body pre, .comment-body code { background: var(--bg-primary); padding: 2px 4px; border-radius: 3px; font-family: var(--font-mono); }
+.comment-body pre { padding: 8px; overflow-x: auto; }
+.comment-body pre code { background: transparent; padding: 0; }
+.comment-body table { border-collapse: collapse; margin: 4px 0; }
+.comment-body th, .comment-body td { border: 1px solid var(--border); padding: 4px 8px; }
+.comment-body a { color: var(--accent); }
+.comment-body ul, .comment-body ol { margin: 4px 0 6px 20px; padding: 0; }


### PR DESCRIPTION
## Summary

Part 3 of 4 on Entity Comments (M3-T6). Delivers the server-side markdown pipeline plus the shared UI component that M3-T7/T8 will drop into the task, manifest, and product detail views.

- `handlers_comments.go`: `commentView` gains a `body_html` field rendered via `goldmark` (GFM enabled, `WithUnsafe()` **off**). Rendered at response time — nothing is persisted.
- `GET /api/comments/types`: returns `comments.Registry()` in canonical order; UI consumes it to populate the add-form type select + filter dropdown so newly added types surface automatically.
- `internal/web/ui/components/comments.js`: exports `OL.renderCommentsSection(containerEl, { type, id })`. Add form above a newest-first stream, inline edit (prompt) and delete (confirm), filter dropdown, empty state, error surfacing.
- `style.css`: `.comment-card` / `.comment-type-*` tokens use existing CSS variables only — no new design tokens.
- `index.html`: loads `/components/comments.js` alongside `/components/knobs.js`.

## Decisions carried from the manifest

- Markdown renders server-side (goldmark). UI injects `body_html` directly.
- `html.WithUnsafe()` is deliberately off — raw HTML in source becomes a `<!-- raw HTML omitted -->` comment (no escaping syntax needed because the tag is dropped entirely). The XSS test locks that behaviour in.
- Delete/edit buttons show when `OL.currentUser()` is unset (no auth UI in M3) so operators aren't blocked; the server is still the authorization source of truth.

## Tests

- `TestPOST_Comment_BodyHTMLParagraph` — `**bold**` → `<strong>`
- `TestPOST_Comment_BodyHTMLCodeBlock` — fenced blocks render `<pre><code>`
- `TestPOST_Comment_BodyHTMLGFMTable` — GFM tables render `<table>`
- `TestPOST_Comment_XSSEscape` — raw `<script>alert(1)</script>` body → no `<script>` and no `alert(1)` in `body_html`
- `TestPOST_Comment_EscapedAngleBrackets` — `` `<T>` `` in prose → `&lt;T&gt;`
- `TestGET_CommentsTypes` — endpoint returns `Registry()` order + labels
- `TestRoutes_AllCommentEndpointsRegistered` — now asserts `GET /api/comments/types` is wired

## Acceptance notes

- Memory note `/project/openpraxis/entity-comments/m3-t6-complete` — **not written**: this session's MCP permissions weren't granted (`visceral_rules`/`visceral_confirm`/`memory_store` all denied). Rules were still applied from the task prompt; the 13 rules were acknowledged in-conversation. Recommend creating the memory note via a follow-up OpenPraxis MCP call from a session with permissions.
- Dogfood execution_review comment on this task — deferred to the reviewer: the autonomous worktree session cannot post to a running OpenPraxis peer without MCP permissions. After merge, posting an `execution_review` via `POST /api/tasks/<this-task-id>/comments` is a real live test.

## Test plan

- [ ] `go test ./internal/web/...` passes locally (confirmed)
- [ ] `go vet ./...` clean (confirmed)
- [ ] Manual: open product/manifest/task detail view after M3-T7/T8 wires this in — add, edit, delete, filter
- [ ] Manual: XSS smoke — post a `<script>alert(1)</script>` body and confirm no alert fires in the browser