### PR TITLE
feat(comments): wire OL.renderCommentsSection into task detail view (M3-T7)

### DIFF
--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>OpenPraxis</title>
   <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/components/comments.css">
   <script src="https://cdn.jsdelivr.net/npm/cytoscape@3.30.4/dist/cytoscape.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dagre@0.8.5/dist/dagre.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/cytoscape-dagre@2.5.0/cytoscape-dagre.js"></script>
@@ -738,6 +739,7 @@
   <script src="/tree.js"></script>
   <script src="/lifecycle.js"></script>
   <script src="/components/knobs.js"></script>
+  <script src="/components/comments.js"></script>
   <script src="/views/overview.js"></script>
   <script src="/views/memories.js"></script>
   <script src="/views/conversations.js"></script>

--- a/internal/web/ui/views/tasks.js
+++ b/internal/web/ui/views/tasks.js
@@ -438,6 +438,9 @@
           <!-- EXECUTION CONTROLS -->
           <div id="task-knobs-mount" style="margin-top:16px"></div>
 
+          <!-- COMMENTS -->
+          <div id="task-comments-mount" style="margin-top:16px"></div>
+
           <!-- 5. LIVE OUTPUT (if running/paused) -->
           ${isRunningOrPaused ? `
             <div style="margin-bottom:12px;border-left:3px solid ${t.status === 'paused' ? 'var(--yellow)' : 'var(--green)'};padding-left:10px">
@@ -479,6 +482,11 @@
       const knobMount = document.getElementById('task-knobs-mount');
       if (knobMount && OL.renderKnobSection) {
         OL.renderKnobSection(knobMount, { type: 'task', id: t.id });
+      }
+
+      const commentsMount = document.getElementById('task-comments-mount');
+      if (commentsMount && OL.renderCommentsSection) {
+        OL.renderCommentsSection(commentsMount, { type: 'task', id: t.id });
       }
 
       // Manifest cross-link — fetch title + wire click


### PR DESCRIPTION
Closes #108 (retroactive issue).

Wires the \`OL.renderCommentsSection\` component (shipped in #107) into the task detail view so every task gets its comments stream.

**Single commit, +10 lines across 2 files** — same scope as the spec: \`internal/web/ui/index.html\` registers the component's JS + CSS assets; \`internal/web/ui/views/tasks.js\` adds a \`#task-comments-mount\` div in the detail panel and calls \`OL.renderCommentsSection\` against it, guarded by \`if (OL.renderCommentsSection)\` for safe degradation.

## Note on review order

M3-T7 ran in parallel with M3-T6's first (no-op) pass because \`ActivateDependents\` fires on the parent task reaching \`completed\` — and M3-T6's first pass was falsely marked completed. The original PR #106 on this branch was closed because it referenced code that hadn't landed yet (the component from #107 was still being re-run). Now that #107 is merged to main, this PR's reference is valid.

## Test plan

- [x] \`go build\`, \`go vet\`, \`go test ./...\` all green — no Go code changed
- [ ] Manual browser test after merge: open a task detail; confirm comments section renders below execution controls; post + edit + delete a comment; confirm filter works

🤖 Generated with [Claude Code](https://claude.com/claude-code)