### PR TITLE
feat(watcher): auto-post watcher_finding comments on gate failures (M4-T9)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -179,6 +179,7 @@ var serveCmd = &cobra.Command{
 		// Watcher — independent server-side task audit
 		cwd, _ := os.Getwd()
 		taskWatcher := watcher.New(n.Watcher, cwd, "go build ./...", cfg.Node.PeerID())
+		taskWatcher.SetCommentPoster(n.Comments)
 
 		runner := n.InitRunner(func(event string, data map[string]string) {
 			hub.Broadcast(web.Event{Type: event, Data: data})

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -1,6 +1,7 @@
 package watcher
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os/exec"
@@ -9,7 +10,18 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
 )
+
+// CommentPoster is the minimal subset of *comments.Store the watcher calls to
+// auto-post watcher_finding comments on gate decisions. Declared as an
+// interface so tests can inject a broken implementation and verify the audit
+// path does not fail on comment-write errors.
+type CommentPoster interface {
+	Add(ctx context.Context, target comments.TargetType, targetID, author string,
+		cType comments.CommentType, body string) (comments.Comment, error)
+}
 
 // Watcher is the independent server-side task execution auditor.
 // It runs OUTSIDE the agent session — the agent cannot access, override, or skip it.
@@ -18,6 +30,7 @@ type Watcher struct {
 	repoDir    string // git repo root
 	buildCmd   string // build command (e.g. "go build ./...")
 	sourceNode string
+	comments   CommentPoster
 }
 
 // New creates a watcher.
@@ -32,6 +45,11 @@ func New(store *Store, repoDir, buildCmd, sourceNode string) *Watcher {
 		sourceNode: sourceNode,
 	}
 }
+
+// SetCommentPoster wires a comments store so gate-failure decisions auto-post
+// watcher_finding comments on the audited task. A nil poster disables the
+// feature (existing behavior).
+func (w *Watcher) SetCommentPoster(p CommentPoster) { w.comments = p }
 
 // AuditTask runs all three gates on a completed task.
 // This is called by the task runner AFTER the agent claims completion.
@@ -111,7 +129,106 @@ func (w *Watcher) AuditTask(taskID, taskMarker, taskTitle, manifestID, manifestT
 		slog.Error("failed to store audit", "component", "watcher", "error", err)
 	}
 
+	// Post watcher_finding comments on gate failures. All-pass posts nothing
+	// (the green status badge on the task card already communicates). Comment
+	// write errors are logged and swallowed — an audit never fails because a
+	// comment failed to write.
+	w.postFindings(taskID, audit)
+
 	return audit
+}
+
+// postFindings writes one watcher_finding comment per failed gate. Safe to
+// call with a nil comment poster (feature disabled).
+func (w *Watcher) postFindings(taskID string, audit *Audit) {
+	if w.comments == nil || taskID == "" {
+		return
+	}
+
+	var bodies []string
+	if !audit.GitPassed {
+		bodies = append(bodies, gitFailureBody(audit.GitDetails))
+	}
+	if !audit.BuildPassed {
+		bodies = append(bodies, buildFailureBody(audit.BuildDetails))
+	}
+	if !audit.ManifestPassed {
+		bodies = append(bodies, manifestFailureBody(audit.ManifestDetails))
+	}
+
+	for _, body := range bodies {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_, err := w.comments.Add(ctx, comments.TargetTask, taskID, "watcher", comments.TypeWatcherFinding, body)
+		cancel()
+		if err != nil {
+			slog.Warn("watcher failed to post finding comment",
+				"component", "watcher", "task", taskID, "error", err)
+		}
+	}
+}
+
+func gitFailureBody(g GitResult) string {
+	branch := g.Branch
+	if branch == "" {
+		branch = "(unresolved)"
+	}
+	return fmt.Sprintf("### Git gate failed\n"+
+		"No commits on branch %s. Watcher cannot verify work. Task auto-downgraded to failed.\n\n"+
+		"**Branch:** %s\n"+
+		"**Expected commits:** ≥1\n"+
+		"**Actual:** %d",
+		branch, branch, g.CommitCount)
+}
+
+func buildFailureBody(b BuildResult) string {
+	return fmt.Sprintf("### Build gate failed\n\n```\n%s\n```", lastNLines(b.Output, 40))
+}
+
+func manifestFailureBody(m ManifestResult) string {
+	var missing, found []string
+	for _, d := range m.Deliverables {
+		switch d.Status {
+		case "missing":
+			missing = append(missing, d.Item)
+		case "done", "partial":
+			found = append(found, d.Item)
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString("### Manifest gate failed\n\n")
+	if len(missing) == 0 {
+		sb.WriteString("Deliverables missing: (none identified individually)\n")
+	} else {
+		sb.WriteString("Deliverables missing:\n")
+		for _, item := range missing {
+			sb.WriteString("- ")
+			sb.WriteString(item)
+			sb.WriteString("\n")
+		}
+	}
+	if len(found) > 0 {
+		sb.WriteString("\nDeliverables found in diff:\n")
+		for _, item := range found {
+			sb.WriteString("- ")
+			sb.WriteString(item)
+			sb.WriteString("\n")
+		}
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+// lastNLines returns the trailing n non-empty-trimmed lines of s, preserving
+// original order. If s has fewer than n lines, all of s is returned.
+func lastNLines(s string, n int) string {
+	if s == "" {
+		return ""
+	}
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) <= n {
+		return strings.Join(lines, "\n")
+	}
+	return strings.Join(lines[len(lines)-n:], "\n")
 }
 
 // resolveTaskBranch finds the branch this task committed on. Accepts either

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1,10 +1,20 @@
 package watcher
 
 import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/yuin/goldmark"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
 )
 
 // initTestRepo creates a temp git repo with an initial commit on main. Every
@@ -101,6 +111,245 @@ func TestResolveTaskBranch_NoFalsePrefixMatch(t *testing.T) {
 	w := New(nil, dir, "", "node")
 	if got, ok := w.resolveTaskBranch("abc"); ok {
 		t.Fatalf("resolveTaskBranch matched %q for unrelated prefix", got)
+	}
+}
+
+// openCommentsStore returns a comments.Store backed by a fresh sqlite DB in
+// t.TempDir() with WAL + busy_timeout pragmas applied (visceral rule #10).
+func openCommentsStore(t *testing.T) (*comments.Store, *sql.DB) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "comments.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		t.Fatalf("set WAL: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
+		t.Fatalf("set busy_timeout: %v", err)
+	}
+	if err := comments.InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	return comments.NewStore(db), db
+}
+
+// newAuditStore returns a watcher Store backed by a fresh sqlite DB so
+// AuditTask can persist audits during integration tests.
+func newAuditStore(t *testing.T) *Store {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "audits.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open audit db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	s, err := NewStore(db)
+	if err != nil {
+		t.Fatalf("audit NewStore: %v", err)
+	}
+	return s
+}
+
+// brokenPoster always errors, used to verify audit does not fail when comment
+// write fails (acceptance criterion).
+type brokenPoster struct{ calls int }
+
+func (b *brokenPoster) Add(_ context.Context, _ comments.TargetType, _, _ string,
+	_ comments.CommentType, _ string) (comments.Comment, error) {
+	b.calls++
+	return comments.Comment{}, errors.New("comments: store unavailable")
+}
+
+// emptyBranch creates a branch at the same commit as main — branch exists but
+// has zero commits relative to base, which is what Gate 1 keys on.
+func emptyBranch(t *testing.T, dir, branch string) {
+	t.Helper()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("checkout", "-q", "-b", branch)
+	run("checkout", "-q", "main")
+}
+
+func listTaskComments(t *testing.T, store *comments.Store, taskID string) []comments.Comment {
+	t.Helper()
+	out, err := store.List(context.Background(), comments.TargetTask, taskID, 100, nil)
+	if err != nil {
+		t.Fatalf("list comments: %v", err)
+	}
+	return out
+}
+
+func assertOneWatcherFinding(t *testing.T, store *comments.Store, taskID string) comments.Comment {
+	t.Helper()
+	cs := listTaskComments(t, store, taskID)
+	if len(cs) != 1 {
+		t.Fatalf("expected 1 comment on task %s, got %d", taskID, len(cs))
+	}
+	c := cs[0]
+	if c.Type != comments.TypeWatcherFinding {
+		t.Fatalf("expected type %q, got %q", comments.TypeWatcherFinding, c.Type)
+	}
+	if c.Author != "watcher" {
+		t.Fatalf("expected author %q, got %q", "watcher", c.Author)
+	}
+	return c
+}
+
+func TestWatcher_Gate1_Fail_PostsComment(t *testing.T) {
+	dir := initTestRepo(t)
+	// Branch exists but has zero commits vs main — Gate 1 fails.
+	emptyBranch(t, dir, "openpraxis/gate1fail")
+
+	store, _ := openCommentsStore(t)
+	w := New(newAuditStore(t), dir, "true", "node")
+	w.SetCommentPoster(store)
+
+	audit := w.AuditTask("task-gate1", "gate1fail", "T", "", "", "", "completed", 0, 0)
+	if audit.GitPassed {
+		t.Fatalf("expected GitPassed=false, got true (reason=%s)", audit.GitDetails.Reason)
+	}
+	c := assertOneWatcherFinding(t, store, "task-gate1")
+	if !strings.Contains(c.Body, "Git gate failed") {
+		t.Fatalf("body missing 'Git gate failed':\n%s", c.Body)
+	}
+	if !strings.Contains(c.Body, "openpraxis/gate1fail") {
+		t.Fatalf("body missing branch name:\n%s", c.Body)
+	}
+}
+
+func TestWatcher_Gate2_Fail_PostsComment(t *testing.T) {
+	dir := initTestRepo(t)
+	commitOnBranch(t, dir, "openpraxis/gate2fail", "work.go")
+
+	store, _ := openCommentsStore(t)
+	// buildCmd=false always exits non-zero; no build output required for body
+	// check — failed-build body wraps whatever output the gate captured.
+	w := New(newAuditStore(t), dir, "false", "node")
+	w.SetCommentPoster(store)
+
+	audit := w.AuditTask("task-gate2", "gate2fail", "T", "", "", "", "completed", 0, 0)
+	if audit.BuildPassed {
+		t.Fatalf("expected BuildPassed=false, got true")
+	}
+	c := assertOneWatcherFinding(t, store, "task-gate2")
+	if !strings.Contains(c.Body, "Build gate failed") {
+		t.Fatalf("body missing 'Build gate failed':\n%s", c.Body)
+	}
+	if !strings.Contains(c.Body, "```") {
+		t.Fatalf("body missing fenced code block:\n%s", c.Body)
+	}
+}
+
+func TestWatcher_Gate3_Fail_PostsComment(t *testing.T) {
+	dir := initTestRepo(t)
+	commitOnBranch(t, dir, "openpraxis/gate3fail", "unrelated.txt")
+
+	store, _ := openCommentsStore(t)
+	w := New(newAuditStore(t), dir, "true", "node")
+	w.SetCommentPoster(store)
+
+	// Manifest mentions deliverables that will NOT appear in the diff.
+	// extractDeliverables keys on `backtick-paths` in bullet lines.
+	manifest := "## Scope\n\n" +
+		"- `internal/missing/thing.go`\n" +
+		"- `internal/missing/other.go`\n"
+
+	audit := w.AuditTask("task-gate3", "gate3fail", "T", "m", "M", manifest, "completed", 0, 0)
+	if audit.ManifestPassed {
+		t.Fatalf("expected ManifestPassed=false, got true (score=%v, reason=%s)",
+			audit.ManifestScore, audit.ManifestDetails.Reason)
+	}
+	c := assertOneWatcherFinding(t, store, "task-gate3")
+	if !strings.Contains(c.Body, "Manifest gate failed") {
+		t.Fatalf("body missing 'Manifest gate failed':\n%s", c.Body)
+	}
+	if !strings.Contains(c.Body, "internal/missing/thing.go") {
+		t.Fatalf("body missing missing-deliverable bullet:\n%s", c.Body)
+	}
+}
+
+func TestWatcher_AllPass_NoComment(t *testing.T) {
+	dir := initTestRepo(t)
+	commitOnBranch(t, dir, "openpraxis/allpass", "work.go")
+
+	store, _ := openCommentsStore(t)
+	w := New(newAuditStore(t), dir, "true", "node")
+	w.SetCommentPoster(store)
+
+	audit := w.AuditTask("task-allpass", "allpass", "T", "", "", "", "completed", 0, 0)
+	if audit.Status != "passed" {
+		t.Fatalf("expected status=passed, got %q (git=%v build=%v manifest=%v)",
+			audit.Status, audit.GitPassed, audit.BuildPassed, audit.ManifestPassed)
+	}
+	if cs := listTaskComments(t, store, "task-allpass"); len(cs) != 0 {
+		t.Fatalf("expected 0 comments on all-pass, got %d", len(cs))
+	}
+}
+
+func TestWatcher_CommentWriteFailure_DoesNotBlockAudit(t *testing.T) {
+	dir := initTestRepo(t)
+	emptyBranch(t, dir, "openpraxis/brokencomments")
+
+	auditStore := newAuditStore(t)
+	broken := &brokenPoster{}
+	w := New(auditStore, dir, "true", "node")
+	w.SetCommentPoster(broken)
+
+	audit := w.AuditTask("task-broken", "brokencomments", "T", "", "", "", "completed", 0, 0)
+	if audit == nil {
+		t.Fatal("audit is nil — broken comment store must not stop the audit path")
+	}
+	if audit.Status != "failed" {
+		t.Fatalf("expected status=failed on git gate fail, got %q", audit.Status)
+	}
+	// Audit must still be persisted even though the comment write failed.
+	stored, err := auditStore.GetByTask("task-broken")
+	if err != nil || stored == nil {
+		t.Fatalf("audit not persisted: err=%v stored=%v", err, stored)
+	}
+	if broken.calls == 0 {
+		t.Fatal("expected poster.Add to be called at least once")
+	}
+}
+
+func TestWatcher_BodyFormat_Markdown(t *testing.T) {
+	// Build fake audit results covering all three failure bodies and confirm
+	// goldmark renders them without errors (i.e. they are well-formed).
+	bodies := []string{
+		gitFailureBody(GitResult{Branch: "openpraxis/xyz", CommitCount: 0}),
+		buildFailureBody(BuildResult{Output: "pkg/foo.go:1: undefined: Bar"}),
+		manifestFailureBody(ManifestResult{Deliverables: []Deliverable{
+			{Item: "internal/a.go", Status: "missing"},
+			{Item: "internal/b.go", Status: "done"},
+		}}),
+	}
+	for i, body := range bodies {
+		var buf bytes.Buffer
+		if err := goldmark.New().Convert([]byte(body), &buf); err != nil {
+			t.Fatalf("body %d goldmark convert: %v\nbody:\n%s", i, err, body)
+		}
+		rendered := buf.String()
+		if !strings.Contains(rendered, "<h3>") {
+			t.Fatalf("body %d missing rendered <h3>:\n%s", i, rendered)
+		}
+	}
+	// The build body specifically must include a fenced code block that
+	// renders to <pre><code>.
+	buildBody := bodies[1]
+	var buf bytes.Buffer
+	if err := goldmark.New().Convert([]byte(buildBody), &buf); err != nil {
+		t.Fatalf("build body convert: %v", err)
+	}
+	if !strings.Contains(buf.String(), "<pre>") {
+		t.Fatalf("build body missing <pre> render:\n%s", buf.String())
 	}
 }
 

--- a/internal/web/handlers_watcher.go
+++ b/internal/web/handlers_watcher.go
@@ -102,6 +102,7 @@ func apiWatcherTrigger(n *node.Node) http.HandlerFunc {
 		// Create the watcher and run audit
 		cwd, _ := os.Getwd()
 		taskWatcher := watcher.New(n.Watcher, cwd, "go build ./...", n.PeerID())
+		taskWatcher.SetCommentPoster(n.Comments)
 		audit := taskWatcher.AuditTask(
 			t.ID, t.Marker, t.Title,
 			t.ManifestID, manifestTitle, manifestContent,


### PR DESCRIPTION
## Summary
- Watcher auto-posts `watcher_finding` comments on failed gates (git / build / manifest); all-pass posts nothing
- `CommentPoster` interface injected into watcher so `*comments.Store` (or a broken fake) can be swapped
- Comment writes are best-effort: 5s timeout, errors logged and swallowed — an audit never fails because a comment failed to write

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/watcher/...` passes
- [x] `go test -race ./internal/watcher/...` passes
- [x] Covered: Gate 1 / 2 / 3 failure → comment posted with markdown body; all-pass → no comment; broken poster → audit still persists; goldmark renders all three bodies without error

## Notes
- Manifest M4 · Task M4-T9 · Branch `openpraxis/019da141-b2b`
- Wire-up: `cmd/serve.go` and `internal/web/handlers_watcher.go` both call `taskWatcher.SetCommentPoster(n.Comments)` after construction
- Comment author: `"watcher"`, type: `watcher_finding`, target: `task`
- Dogfood end-to-end UI screenshot not captured in this automated run — recommend a manual dogfood before closing the acceptance checkbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)