### PR TITLE
fix(ui): stop task-detail flicker on task completion (#115)

### DIFF
--- a/internal/web/ui/views/tasks.js
+++ b/internal/web/ui/views/tasks.js
@@ -616,8 +616,15 @@
             if (data && data.running) {
               OL.viewTimeout(pollOutput, 2000);
             } else {
-              // Task finished — reload full detail
-              OL.loadTaskDetail(t.id);
+              // Task finished — DO NOT full-reload the detail. That used
+              // to cause flicker: the tasks.status column lags the
+              // /output endpoint's running flag, so loadTaskDetail
+              // re-rendered with isRunningOrPaused=true, which restarted
+              // pollOutput, which saw running=false again, and the
+              // whole detail panel flickered at poll cadence. Instead
+              // we just stop polling and refresh the task list so the
+              // row's status updates naturally; a manual click into
+              // the task brings in the freshly-completed detail.
               OL.loadTasks();
             }
           } catch (e) {}


### PR DESCRIPTION
Closes #115.

## What

\`loadTaskDetail\` kicks off a \`pollOutput\` loop for running/paused tasks. The old pollOutput called \`OL.loadTaskDetail(t.id)\` on poll-finish (\`data.running === false\`) to refresh the whole panel. But the \`tasks.status\` column lags the \`/output\` endpoint's \`running\` flag — at poll-finish the DB still reports \`status=running\`, so \`loadTaskDetail\` re-rendered with \`isRunningOrPaused=true\`, restarted pollOutput, got \`running=false\` again, and flickered the detail panel at 2-second cadence.

## Fix

Don't call \`loadTaskDetail\` on poll-finish. Just refresh the task list (\`OL.loadTasks()\`) so the row's status color updates naturally. The detail panel keeps showing the last polled output; a manual click back into the task picks up the freshly-completed detail without the race.

+8 lines of comment explaining why, so the next contributor doesn't "fix" it back to the racy version.

## Test plan

- [x] Verified live during Entity Comments M4-T10 execution (2026-04-20). Operator confirmed flicker is gone.
- [ ] No JS test harness in the repo; manual verification only.

## Related

Unrelated but adjacent bug from the same session: **#114** — \`SetDependency\` + \`FlipManifestBlockedTasks\` + \`FlipProductBlockedTasks\` forget to set \`next_run_at\` when flipping to scheduled, so the scheduler never picks up those tasks. Worth fixing together if you want to pair them in a combined PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)