### PR TITLE
fix(scheduler): set next_run_at when flipping tasks to scheduled (#114, closes #103)

### DIFF
--- a/internal/task/manifest_activation.go
+++ b/internal/task/manifest_activation.go
@@ -61,13 +61,27 @@ func (s *Store) FlipManifestBlockedTasks(ctx context.Context, manifestID string,
 	// walker and the chain doesn't advance on manifest close. Drop
 	// the legacy clause in a follow-up once DB is known-clean.
 	now := time.Now().UTC().Format(time.RFC3339)
+	// next_run_at must be set when flipping to scheduled — the
+	// scheduler's dequeue query requires next_run_at != ''. Bug #114:
+	// without this, tasks flipped by the propagation walker land
+	// scheduled-but-uncallable, which presented as #103 ("manifest-
+	// close propagation doesn't activate downstream tasks"). The
+	// propagation DID fire; the flipped rows were just invisible to
+	// the scheduler because next_run_at was empty.
+	//
+	// For the rehab path (newStatus=pending) next_run_at stays empty —
+	// pending tasks never auto-fire by design.
+	nextRunAt := ""
+	if newStatus == StatusScheduled {
+		nextRunAt = now
+	}
 	res, err := s.db.ExecContext(ctx,
 		`UPDATE tasks
-		 SET status = ?, block_reason = '', updated_at = ?
+		 SET status = ?, block_reason = '', next_run_at = ?, updated_at = ?
 		 WHERE manifest_id = ? AND status = 'waiting'
 		   AND (block_reason LIKE ? OR block_reason LIKE ?)
 		   AND deleted_at = ''`,
-		string(newStatus), now, manifestID,
+		string(newStatus), nextRunAt, now, manifestID,
 		manifestBlockPrefix+"%", legacyManifestBlockPrefix+"%")
 	if err != nil {
 		return 0, fmt.Errorf("flip manifest-blocked tasks: %w", err)

--- a/internal/task/next_run_at_regression_test.go
+++ b/internal/task/next_run_at_regression_test.go
@@ -1,0 +1,147 @@
+package task
+
+import (
+	"context"
+	"testing"
+)
+
+// readNextRunAt pulls the raw tasks.next_run_at column for a given id. We
+// go direct to the DB rather than via scanTask because scanTask projects
+// through the standard column list and we care about this specific field.
+func readNextRunAt(t *testing.T, s *Store, id string) string {
+	t.Helper()
+	var next string
+	if err := s.db.QueryRow(`SELECT next_run_at FROM tasks WHERE id = ?`, id).Scan(&next); err != nil {
+		t.Fatalf("read next_run_at for %s: %v", id, err)
+	}
+	return next
+}
+
+// TestSetDependency_SchedulesTaskSetsNextRunAt — regression for #114.
+// When SetDependency detects the parent is completed it flips the task
+// to StatusScheduled. Prior to this fix the UPDATE wrote only the
+// status column, leaving next_run_at empty and the task invisible to
+// the scheduler's dequeue query. This test asserts the column is
+// populated on the scheduled-land path.
+func TestSetDependency_SchedulesTaskSetsNextRunAt(t *testing.T) {
+	s := openRepoTestStore(t)
+	parent, _ := s.Create("", "parent", "", "once", "claude-code", "node", "t", "")
+	if _, err := s.db.Exec(`UPDATE tasks SET status='completed' WHERE id = ?`, parent.ID); err != nil {
+		t.Fatalf("force parent completed: %v", err)
+	}
+	child, _ := s.Create("", "child", "", "once", "claude-code", "node", "t", "")
+	// Force child back to pending so SetDependency's parent-completed
+	// path takes the scheduled branch (Create would have already
+	// scheduled it given the parent is completed; we want to exercise
+	// the SetDependency path explicitly).
+	if _, err := s.db.Exec(`UPDATE tasks SET status='pending', depends_on='' WHERE id = ?`, child.ID); err != nil {
+		t.Fatalf("reset child: %v", err)
+	}
+
+	if err := s.SetDependency(child.ID, parent.ID); err != nil {
+		t.Fatalf("SetDependency: %v", err)
+	}
+	if got := readStatus(t, s, child.ID); got != "scheduled" {
+		t.Fatalf("status = %q, want scheduled", got)
+	}
+	if got := readNextRunAt(t, s, child.ID); got == "" {
+		t.Fatalf("next_run_at is empty; scheduler would never pick this task up (bug #114 regression)")
+	}
+}
+
+// TestSetDependency_ClearPath_LeavesNextRunAtEmpty — symmetric check:
+// when SetDependency clears a dep and the task ends up in pending
+// (because it was waiting), next_run_at must NOT be populated. Pending
+// tasks never auto-fire by design; filling next_run_at would turn a
+// rehabbed dep-removed task into an auto-firing one.
+func TestSetDependency_ClearPath_LeavesNextRunAtEmpty(t *testing.T) {
+	s := openRepoTestStore(t)
+	parent, _ := s.Create("", "parent", "", "once", "claude-code", "node", "t", "")
+	child, _ := s.Create("", "child", "", "once", "claude-code", "node", "t", parent.ID)
+
+	if got := readStatus(t, s, child.ID); got != "waiting" {
+		t.Fatalf("setup: child = %q, want waiting", got)
+	}
+	if err := s.SetDependency(child.ID, ""); err != nil {
+		t.Fatalf("SetDependency clear: %v", err)
+	}
+	if got := readStatus(t, s, child.ID); got != "pending" {
+		t.Fatalf("status = %q, want pending after clear", got)
+	}
+	if got := readNextRunAt(t, s, child.ID); got != "" {
+		t.Errorf("next_run_at = %q, want empty (pending tasks must not auto-fire)", got)
+	}
+}
+
+// TestFlipManifestBlockedTasks_ScheduledSetsNextRunAt — regression for
+// #114 / root-cause-of-#103. When the manifest-close propagation
+// walker flips waiting tasks to scheduled, the UPDATE must populate
+// next_run_at so the scheduler actually picks them up.
+func TestFlipManifestBlockedTasks_ScheduledSetsNextRunAt(t *testing.T) {
+	s := openRepoTestStore(t)
+	blocked := seedWaitingBlockedByManifest(t, s, "mf-prop", "the-task", "mf-prop")
+
+	n, err := s.FlipManifestBlockedTasks(context.Background(), "mf-prop", StatusScheduled)
+	if err != nil {
+		t.Fatalf("FlipManifestBlockedTasks: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("flipped %d rows, want 1", n)
+	}
+	if got := readStatus(t, s, blocked); got != "scheduled" {
+		t.Fatalf("status = %q, want scheduled", got)
+	}
+	if got := readNextRunAt(t, s, blocked); got == "" {
+		t.Fatalf("next_run_at is empty after scheduled flip; this is the #103 root cause")
+	}
+}
+
+// TestFlipManifestBlockedTasks_PendingLeavesNextRunAtEmpty — the
+// Option B rehab path (dep removed → tasks flip to pending) must
+// NOT set next_run_at. Symmetric to TestSetDependency_ClearPath.
+func TestFlipManifestBlockedTasks_PendingLeavesNextRunAtEmpty(t *testing.T) {
+	s := openRepoTestStore(t)
+	blocked := seedWaitingBlockedByManifest(t, s, "mf-reh", "the-task", "mf-reh")
+
+	n, err := s.FlipManifestBlockedTasks(context.Background(), "mf-reh", StatusPending)
+	if err != nil {
+		t.Fatalf("FlipManifestBlockedTasks: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("flipped %d rows, want 1", n)
+	}
+	if got := readStatus(t, s, blocked); got != "pending" {
+		t.Fatalf("status = %q, want pending", got)
+	}
+	if got := readNextRunAt(t, s, blocked); got != "" {
+		t.Errorf("next_run_at = %q, want empty on pending rehab path", got)
+	}
+}
+
+// TestFlipProductBlockedTasks_ScheduledSetsNextRunAt — same regression
+// check at the product tier. The product-close propagation walker
+// also needs next_run_at populated when flipping to scheduled.
+func TestFlipProductBlockedTasks_ScheduledSetsNextRunAt(t *testing.T) {
+	s := openRepoTestStore(t)
+	seedManifestForProduct(t, s, "mf-P", "prod-P")
+	tsk, _ := s.Create("mf-P", "blocked", "", "once", "claude-code", "node", "t", "")
+	if _, err := s.db.Exec(
+		`UPDATE tasks SET status='waiting', block_reason=? WHERE id=?`,
+		"product not satisfied — blocked by: other", tsk.ID); err != nil {
+		t.Fatalf("force waiting: %v", err)
+	}
+
+	n, err := s.FlipProductBlockedTasks(context.Background(), "prod-P", StatusScheduled)
+	if err != nil {
+		t.Fatalf("FlipProductBlockedTasks: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("flipped %d rows, want 1", n)
+	}
+	if got := readStatus(t, s, tsk.ID); got != "scheduled" {
+		t.Fatalf("status = %q, want scheduled", got)
+	}
+	if got := readNextRunAt(t, s, tsk.ID); got == "" {
+		t.Fatalf("next_run_at is empty after product-flip; scheduler would never pick this up")
+	}
+}

--- a/internal/task/product_activation.go
+++ b/internal/task/product_activation.go
@@ -53,9 +53,16 @@ func (s *Store) FlipProductBlockedTasks(ctx context.Context, productID string, n
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339)
+	// next_run_at must be set when flipping to scheduled; see #114 +
+	// the matching fix in FlipManifestBlockedTasks. Pending path
+	// keeps it empty (pending tasks never auto-fire).
+	nextRunAt := ""
+	if newStatus == StatusScheduled {
+		nextRunAt = now
+	}
 	res, err := s.db.ExecContext(ctx,
 		`UPDATE tasks
-		 SET status = ?, block_reason = '', updated_at = ?
+		 SET status = ?, block_reason = '', next_run_at = ?, updated_at = ?
 		 WHERE id IN (
 		   SELECT t.id FROM tasks t
 		   JOIN manifests m ON m.id = t.manifest_id
@@ -65,7 +72,7 @@ func (s *Store) FlipProductBlockedTasks(ctx context.Context, productID string, n
 		     AND t.deleted_at = ''
 		     AND m.deleted_at = ''
 		 )`,
-		string(newStatus), now, productID, productBlockPrefix+"%")
+		string(newStatus), nextRunAt, now, productID, productBlockPrefix+"%")
 	if err != nil {
 		return 0, fmt.Errorf("flip product-blocked tasks: %w", err)
 	}

--- a/internal/task/repository.go
+++ b/internal/task/repository.go
@@ -408,9 +408,18 @@ func (s *Store) SetDependencyWithAudit(id, dependsOn, changedBy, reason string) 
 	if err := s.writeSCDDepRow(fullID, parentID, now, changedBy, reason); err != nil {
 		return err
 	}
+	// When deriveDepState returns StatusScheduled (parent already
+	// completed), set next_run_at too — the scheduler's dequeue query
+	// requires next_run_at != ''. Bug #114: previously this UPDATE
+	// wrote only the status column, leaving the task armed-but-
+	// uncallable ("scheduled but never picked up").
+	nextRunAt := ""
+	if nextStatus == string(StatusScheduled) {
+		nextRunAt = now
+	}
 	_, err := s.db.Exec(
-		`UPDATE tasks SET depends_on = ?, status = ?, block_reason = ?, updated_at = ? WHERE id = ?`,
-		parentID, nextStatus, blockReason, now, fullID)
+		`UPDATE tasks SET depends_on = ?, status = ?, block_reason = ?, next_run_at = ?, updated_at = ? WHERE id = ?`,
+		parentID, nextStatus, blockReason, nextRunAt, now, fullID)
 	return err
 }
 


### PR DESCRIPTION
Closes #114. Also closes #103 as a root-cause duplicate.

## TL;DR

Three code paths flipped tasks to \`scheduled\` via raw UPDATE without populating \`next_run_at\`. The scheduler's dequeue query requires \`next_run_at != ''\`, so flipped tasks were armed-but-invisible. Fixes the missing column at all three sites + regression-tests each one.

## Affected paths

- \`task.Store.SetDependency\` parent-completed branch (from #87)
- \`task.Store.FlipManifestBlockedTasks\` (from #78 propagation walker)
- \`task.Store.FlipProductBlockedTasks\` (from #92 propagation walker)

## Root cause of #103

Closing a manifest fired the terminal-transition handler, which called \`PropagateManifestClosed\`, which walked dependents + flipped blocked tasks — but those flipped tasks had \`next_run_at=''\`. Scheduler dequeue filter rejected them. Operators saw tasks "still waiting" despite the close event and concluded propagation didn't work. It did. The flip just wasn't complete.

## Test plan

- [x] 5 regression tests in \`internal/task/next_run_at_regression_test.go\` — one per path + symmetric checks that pending-path keeps next_run_at empty (pending must never auto-fire).
- [x] \`go test ./...\` full suite green
- [x] \`go build\`, \`go vet\` clean
- [ ] Post-merge verification: close a manifest with a known dependent waiting task; observe scheduler dispatches it within the next tick (no manual SQL intervention needed).

## Invariants preserved

- Pending-path UPDATEs (Option B rehab after dep removal) deliberately leave \`next_run_at=''\` — pending tasks never auto-fire; populating would convert operator-removed-dep tasks into auto-burning-budget tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)