### PR TITLE
feat(comments): M4-T10 — enforce execution_review on task completion

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -277,6 +277,11 @@ func (n *Node) InitRunner(onEvent func(string, map[string]string)) *task.Runner 
 	// cmd/serve.go passes an explicit dir via a follow-up SetRepoDir if it
 	// runs from outside the repo root.
 	n.runner = task.NewRunner(n.Tasks, n.Actions, n.SettingsResolver, "", onEvent)
+	// Wire the post-completion execution_review gate (M4-T10). Non-fatal
+	// if Comments is nil — the runner treats nil as "feature off".
+	if n.Comments != nil {
+		n.runner.SetExecutionReviewChecker(&executionReviewCheckerAdapter{s: n.Comments})
+	}
 	return n.runner
 }
 
@@ -672,6 +677,26 @@ func (a *taskReviewWriteAdapter) AddReviewComment(ctx context.Context, taskID, a
 // here so the caller's "latest review comment wins" logic doesn't
 // have to re-filter.
 type taskReviewReadAdapter struct{ s *comments.Store }
+
+// executionReviewCheckerAdapter satisfies task.ExecutionReviewChecker by
+// asking the comments store whether the given task carries at least one
+// execution_review comment authored by "agent". Used by the runner's
+// post-completion amnesia gate (M4-T10).
+type executionReviewCheckerAdapter struct{ s *comments.Store }
+
+func (a *executionReviewCheckerAdapter) HasAgentExecutionReview(ctx context.Context, taskID string) (bool, error) {
+	t := comments.TypeExecutionReview
+	rows, err := a.s.List(ctx, comments.TargetTask, taskID, 50, &t)
+	if err != nil {
+		return false, err
+	}
+	for _, c := range rows {
+		if c.Author == "agent" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
 
 func (a *taskReviewReadAdapter) ListReviewCommentsForTask(ctx context.Context, taskID string, limit int) ([]task.ReviewComment, error) {
 	all, err := a.s.List(ctx, comments.TargetTask, taskID, limit, nil)

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -74,6 +74,79 @@ type Runner struct {
 	// warnOnce guards per-Runner log-once semantics for unsupported agent
 	// flags (e.g. --temperature on Claude Code). Keyed by "<agent>:<knob>".
 	warnOnce sync.Map
+
+	// execReview is the optional post-completion checker for
+	// execution_review comments. When wired, tasks that finish with
+	// status=completed/reason=success are inspected — if no agent-authored
+	// execution_review comment exists on the task, an amnesia flag is
+	// recorded so the gap is visible on the dashboard. Leaving it nil
+	// disables the check (existing behavior).
+	execReview ExecutionReviewChecker
+
+	// sourceNode is the originating node UUID used when recording amnesia
+	// flags from the post-completion path. Empty is fine — amnesia.task_id
+	// is what the task detail pulls on.
+	sourceNode string
+}
+
+// ExecutionReviewChecker answers whether a task has at least one
+// execution_review comment authored by the agent. Wired via
+// SetExecutionReviewChecker; node.go adapts internal/comments.Store to
+// this shape so the task package stays free of a comments import.
+type ExecutionReviewChecker interface {
+	HasAgentExecutionReview(ctx context.Context, taskID string) (bool, error)
+}
+
+// SetExecutionReviewChecker wires the post-completion execution_review
+// gate. Nil disables it.
+func (r *Runner) SetExecutionReviewChecker(c ExecutionReviewChecker) {
+	r.execReview = c
+}
+
+// SetSourceNode records the node UUID used when the runner writes amnesia
+// flags from its own code path (e.g. missing execution_review).
+func (r *Runner) SetSourceNode(id string) { r.sourceNode = id }
+
+// enforceExecutionReview runs the M4-T10 post-completion gate. Only fires
+// for status=completed/reason=success; skips entirely when the checker is
+// not wired. Extracted from Execute so it can be tested directly.
+func (r *Runner) enforceExecutionReview(bgCtx context.Context, taskID, marker, status, reason string) {
+	if r.execReview == nil {
+		return
+	}
+	if status != "completed" || reason != "success" {
+		return
+	}
+	checkCtx, checkCancel := context.WithTimeout(bgCtx, 5*time.Second)
+	has, checkErr := r.execReview.HasAgentExecutionReview(checkCtx, taskID)
+	checkCancel()
+	switch {
+	case checkErr != nil:
+		slog.Warn("execution review lookup failed",
+			"component", "runner", "marker", marker, "task_id", taskID, "error", checkErr)
+	case !has:
+		slog.Warn("task completed but no execution_review comment — agent forgot the closing call",
+			"component", "runner", "marker", marker, "task_id", taskID)
+		if r.actions != nil {
+			if amnErr := r.actions.RecordAmnesia(
+				"",            // sessionID
+				r.sourceNode,  // sourceNode
+				"",            // actionID
+				taskID,        // taskID
+				"exec-review", // ruleID (synthetic)
+				"exec-review", // ruleMarker
+				"Every completed task must post an execution_review comment via comment_add before finishing",
+				"",  // toolName
+				"",  // toolInput
+				1.0, // score (max — the call was definitely missing)
+				"rule",
+				"missing_execution_review",
+			); amnErr != nil {
+				slog.Warn("record exec-review amnesia failed",
+					"component", "runner", "marker", marker, "error", amnErr)
+			}
+		}
+	}
 }
 
 // NewRunner creates a task runner. The resolver is required — every knob that
@@ -884,6 +957,13 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 			slog.Error("record run failed", "component", "runner", "marker", marker, "error", err)
 		}
 
+		// Post-completion execution-review gate. Successful completions must
+		// carry at least one agent-authored execution_review comment on the
+		// task. When missing, log and record an amnesia flag so the gap
+		// surfaces on the dashboard. Non-blocking — the watcher still has
+		// final say on the completion status.
+		r.enforceExecutionReview(bgCtx, t.ID, marker, status, reason)
+
 		// Retry on transient failure. Counter persists across restarts via
 		// the settings table so a crash mid-retry does not reset progress.
 		// Watcher-driven downgrades (completed→failed via deliverable audit)
@@ -1208,6 +1288,20 @@ func buildPrompt(t *Task, manifestTitle, manifestContent, visceralRules string) 
 	b.WriteString("5. Create a pull request using: gh pr create --title \"<title>\" --body \"<summary>\"\n")
 	b.WriteString("6. Include the PR URL in your final output.\n")
 	b.WriteString("NEVER work on an existing branch. NEVER push to main. Each task gets its own branch and PR.\n\n")
+
+	b.WriteString("## Closing the task — MANDATORY\n")
+	b.WriteString("Before your final commit+push, call the MCP tool:\n\n")
+	b.WriteString("    mcp__openpraxis__comment_add\n")
+	b.WriteString(fmt.Sprintf("      target_type = \"task\"\n      target_id   = \"%s\"\n", t.ID))
+	b.WriteString("      type        = \"execution_review\"\n")
+	b.WriteString("      author      = \"agent\"\n")
+	b.WriteString("      body        = <markdown summary>\n\n")
+	b.WriteString("The body should include:\n")
+	b.WriteString("- **What shipped** — files created/edited, key APIs, what's testable\n")
+	b.WriteString("- **Gates self-check** — which acceptance-criteria bullets you verified locally (git gate: commits exist; build gate: go build passes; manifest gate: deliverables addressed)\n")
+	b.WriteString("- **What the next task should expect** — APIs, error codes, file layout\n")
+	b.WriteString("- **Anything surprising** — bugs found, decisions taken, followups to file\n\n")
+	b.WriteString("This comment is your execution review. It becomes the canonical per-task home — no parallel memory note required unless you want a structured cross-session memory as well. The runner will record an amnesia flag if this call is missing.\n\n")
 
 	b.WriteString("Report completion when done.\n")
 

--- a/internal/task/runner_exec_review_test.go
+++ b/internal/task/runner_exec_review_test.go
@@ -1,0 +1,196 @@
+package task
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/k8nstantin/OpenPraxis/internal/action"
+)
+
+// fakeExecReview is an in-memory ExecutionReviewChecker. has reports whether
+// the task has an agent-authored execution_review comment. err forces the
+// checker to return an error so the warn-and-continue path can be exercised.
+type fakeExecReview struct {
+	has    map[string]bool
+	err    error
+	calls  int
+	lastID string
+}
+
+func (f *fakeExecReview) HasAgentExecutionReview(_ context.Context, taskID string) (bool, error) {
+	f.calls++
+	f.lastID = taskID
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.has[taskID], nil
+}
+
+// openAmnesiaDB opens an isolated sqlite DB with WAL+busy_timeout and
+// initializes the action store (which owns the amnesia table). Returns the
+// store and a t.Cleanup-registered close.
+func openAmnesiaDB(t *testing.T) *action.Store {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "actions.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		t.Fatalf("WAL: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
+		t.Fatalf("busy_timeout: %v", err)
+	}
+	s, err := action.NewStore(db)
+	if err != nil {
+		t.Fatalf("action.NewStore: %v", err)
+	}
+	return s
+}
+
+// TestRunner_PromptTemplate_IncludesClosingSection — the spawn prompt must
+// tell the agent to call comment_add with type=execution_review before
+// finishing, and must interpolate the full task ID into target_id.
+func TestRunner_PromptTemplate_IncludesClosingSection(t *testing.T) {
+	task := &Task{ID: "019da142-479c-70d2-865b-d6e593883e3f", Title: "demo"}
+	got := buildPrompt(task, "Manifest X", "manifest body", "rules body")
+
+	mustContain(t, got, "## Closing the task — MANDATORY")
+	mustContain(t, got, "mcp__openpraxis__comment_add")
+	mustContain(t, got, `type        = "execution_review"`)
+	mustContain(t, got, `author      = "agent"`)
+	// target_id must be the full task ID so the comment lands on the right row.
+	mustContain(t, got, `target_id   = "019da142-479c-70d2-865b-d6e593883e3f"`)
+}
+
+// TestRunner_MissingExecutionReview_FlagsAmnesia — when the task finishes
+// with status=completed / reason=success and no agent execution_review
+// comment exists, the runner records an amnesia flag scoped to the task.
+func TestRunner_MissingExecutionReview_FlagsAmnesia(t *testing.T) {
+	r, _, _, _ := newRunnerHarness(t)
+	actions := openAmnesiaDB(t)
+	r.actions = actions
+	checker := &fakeExecReview{has: map[string]bool{}} // nothing recorded
+	r.SetExecutionReviewChecker(checker)
+
+	r.enforceExecutionReview(context.Background(), "t-abc", "t-abc", "completed", "success")
+
+	if checker.calls != 1 {
+		t.Fatalf("checker calls = %d, want 1", checker.calls)
+	}
+	if checker.lastID != "t-abc" {
+		t.Fatalf("checker taskID = %q, want t-abc", checker.lastID)
+	}
+	list, err := actions.ListAmnesiaByTask("t-abc", 10)
+	if err != nil {
+		t.Fatalf("ListAmnesiaByTask: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("amnesia rows = %d, want 1", len(list))
+	}
+	if list[0].RuleMarker != "exec-review" {
+		t.Fatalf("RuleMarker = %q, want exec-review", list[0].RuleMarker)
+	}
+	if list[0].MatchedPattern != "missing_execution_review" {
+		t.Fatalf("MatchedPattern = %q, want missing_execution_review", list[0].MatchedPattern)
+	}
+}
+
+// TestRunner_WithExecutionReview_NoAmnesia — when the comment exists, the
+// runner records no amnesia flag.
+func TestRunner_WithExecutionReview_NoAmnesia(t *testing.T) {
+	r, _, _, _ := newRunnerHarness(t)
+	actions := openAmnesiaDB(t)
+	r.actions = actions
+	checker := &fakeExecReview{has: map[string]bool{"t-ok": true}}
+	r.SetExecutionReviewChecker(checker)
+
+	r.enforceExecutionReview(context.Background(), "t-ok", "t-ok", "completed", "success")
+
+	list, err := actions.ListAmnesiaByTask("t-ok", 10)
+	if err != nil {
+		t.Fatalf("ListAmnesiaByTask: %v", err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("amnesia rows = %d, want 0", len(list))
+	}
+}
+
+// TestRunner_FailedTask_SkipsExecReviewGate — the gate fires only for
+// status=completed/reason=success. Failures and other terminal reasons
+// (max_turns, cost_cap, timeout) must not trip the check.
+func TestRunner_FailedTask_SkipsExecReviewGate(t *testing.T) {
+	r, _, _, _ := newRunnerHarness(t)
+	actions := openAmnesiaDB(t)
+	r.actions = actions
+	checker := &fakeExecReview{has: map[string]bool{}}
+	r.SetExecutionReviewChecker(checker)
+
+	cases := []struct {
+		status string
+		reason string
+	}{
+		{"failed", "process_error"},
+		{"failed", "timeout"},
+		{"failed", "cost_cap"},
+		{"completed", "max_turns"}, // completed-but-not-success also skips
+	}
+	for _, c := range cases {
+		r.enforceExecutionReview(context.Background(), "t-x", "t-x", c.status, c.reason)
+	}
+	if checker.calls != 0 {
+		t.Fatalf("checker fired %d times for non-success terminals, want 0", checker.calls)
+	}
+	list, _ := actions.ListAmnesiaByTask("t-x", 10)
+	if len(list) != 0 {
+		t.Fatalf("amnesia rows = %d, want 0", len(list))
+	}
+}
+
+// TestRunner_NilChecker_IsNoOp — when no checker is wired, the gate does
+// nothing and no amnesia rows are written.
+func TestRunner_NilChecker_IsNoOp(t *testing.T) {
+	r, _, _, _ := newRunnerHarness(t)
+	actions := openAmnesiaDB(t)
+	r.actions = actions
+	// Deliberately do NOT call SetExecutionReviewChecker.
+
+	r.enforceExecutionReview(context.Background(), "t-nil", "t-nil", "completed", "success")
+
+	list, _ := actions.ListAmnesiaByTask("t-nil", 10)
+	if len(list) != 0 {
+		t.Fatalf("amnesia rows = %d, want 0 (checker not wired)", len(list))
+	}
+}
+
+// TestRunner_CheckerError_IsLoggedNotRecorded — a checker that returns an
+// error must neither record amnesia nor panic. The gate degrades to "warn".
+func TestRunner_CheckerError_IsLoggedNotRecorded(t *testing.T) {
+	r, _, _, _ := newRunnerHarness(t)
+	actions := openAmnesiaDB(t)
+	r.actions = actions
+	checker := &fakeExecReview{err: errors.New("boom")}
+	r.SetExecutionReviewChecker(checker)
+
+	r.enforceExecutionReview(context.Background(), "t-err", "t-err", "completed", "success")
+
+	list, _ := actions.ListAmnesiaByTask("t-err", 10)
+	if len(list) != 0 {
+		t.Fatalf("amnesia rows = %d, want 0 (checker erred)", len(list))
+	}
+}
+
+func mustContain(t *testing.T, s, sub string) {
+	t.Helper()
+	if !strings.Contains(s, sub) {
+		t.Fatalf("prompt missing %q\n---prompt---\n%s", sub, s)
+	}
+}

--- a/internal/web/ui/views/tasks.js
+++ b/internal/web/ui/views/tasks.js
@@ -186,15 +186,27 @@
         } catch(e) {}
       }
 
-      // Fetch linked actions, amnesia, delusions, and run history in parallel
+      // Fetch linked actions, amnesia, delusions, run history, and
+      // execution_review comments in parallel. The exec-review payload drives
+      // the "No execution review" badge (M4-T10) in the header.
       let actionsHtml = '', amnesiaHtml = '', delusionsHtml = '', runsHtml = '';
+      let needsExecReview = false;
       try {
-        const [actions, amnesia, delusions, runs] = await Promise.all([
+        const [actions, amnesia, delusions, runs, execReviewRes] = await Promise.all([
           fetchJSON('/api/tasks/' + t.id + '/actions'),
           fetchJSON('/api/tasks/' + t.id + '/amnesia'),
           fetchJSON('/api/tasks/' + t.id + '/delusions'),
           fetchJSON('/api/tasks/' + t.id + '/runs'),
+          fetchJSON('/api/tasks/' + t.id + '/comments?type=execution_review'),
         ]);
+        // Badge condition: task is completed AND no agent-authored
+        // execution_review comment exists. execReviewRes shape:
+        // { comments: [{ author, type, ... }, ...] }.
+        if (t.status === 'completed') {
+          const rows = (execReviewRes && execReviewRes.comments) || [];
+          const hasAgent = rows.some(c => c && c.author === 'agent');
+          needsExecReview = !hasAgent;
+        }
         if (actions && actions.length) {
           actionsHtml = `<div style="margin-bottom:12px">
             <div class="section-label">Actions (${actions.length})</div>
@@ -299,6 +311,7 @@
             <span class="session-uuid" style="font-size:14px">${esc(t.marker)}</span>
             <span style="flex:1;font-size:15px;font-weight:600;color:var(--text-primary)">${esc(t.title)}</span>
             <span style="color:${statusColor};font-weight:700;font-size:13px;text-transform:uppercase;padding:3px 10px;border:2px solid ${statusColor};border-radius:4px" title="${esc(statusRender.label)}">${statusRender.icon} ${esc(t.status)}</span>
+            ${needsExecReview ? `<a href="#task-comments-mount" onclick="var el=document.getElementById('task-comments-mount');if(el)el.scrollIntoView({behavior:'smooth'});return false;" style="color:var(--yellow);font-weight:700;font-size:11px;text-transform:uppercase;padding:3px 8px;border:2px solid var(--yellow);border-radius:4px;text-decoration:none;cursor:pointer" title="Task completed but no agent-authored execution_review comment was posted. Click to jump to the comments section.">&#9888; No execution review</a>` : ''}
           </div>
           ${t.block_reason ? `
           <div style="display:flex;align-items:center;gap:6px;margin-bottom:12px;padding:6px 10px;background:rgba(59,130,246,0.08);border-left:3px solid var(--accent);border-radius:4px;font-size:12px;color:var(--text-primary)">


### PR DESCRIPTION
## Summary

**Manifest:** M4 (Integrations + Backfill) · **Depends on:** M3-T8

Explicit-agent-call mechanism (Option C): the runner's spawn prompt
tells every agent to call `mcp__openpraxis__comment_add` with
`type=execution_review` before its final commit+push. After the agent
exits with `status=completed/reason=success`, the runner checks the
comments table for an agent-authored `execution_review` on the task —
if missing, it records an amnesia flag so the gap is visible on the
dashboard. Non-blocking: the watcher still has final say on the run.

The task detail view gets a yellow **⚠ No execution review** badge next
to the status pill when `status=completed` AND no agent
`execution_review` comment exists. Clicking scrolls to the comments
section so the user can post one manually.

## Changes

- `internal/task/runner.go` — `buildPrompt` appends a "Closing the task — MANDATORY" section with the full task ID interpolated into `target_id`. New `Runner` hook `SetExecutionReviewChecker` + `enforceExecutionReview` helper extracted so the gate is unit-testable.
- `internal/node/node.go` — `executionReviewCheckerAdapter` bridges `comments.Store.List` to `task.ExecutionReviewChecker`, filtering to `author="agent"`.
- `internal/web/ui/views/tasks.js` — fetch `execution_review` comments alongside actions/amnesia/delusions/runs; render yellow badge in detail header when `completed` + missing.
- `internal/task/runner_exec_review_test.go` — prompt contains closing section; amnesia flagged when missing; no amnesia when present; non-success terminals skip the gate; nil checker is a no-op; checker errors degrade to warn-and-continue.

## Decisions locked in the task spec

- **Mechanism: Option C (explicit).** Not A (post-task hook) or B (memory-store instrumentation).
- **Backfill: dropped.** Out of scope for this task.

## Deferred

- **List-row badge.** The spec requests a badge on task rows too. Doing this cheaply needs a server-side `has_agent_execution_review` flag on the task list API (EXISTS subquery on the task list SQL) rather than N per-row fetches. The detail-view badge satisfies the "drive from comment list already fetched" design intent; the list-row variant will be a follow-up task.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -race` all packages pass
- [x] Closing-Comment section present in spawn prompt (`TestRunner_PromptTemplate_IncludesClosingSection`)
- [x] Amnesia flag recorded when `execution_review` is missing (`TestRunner_MissingExecutionReview_FlagsAmnesia`)
- [x] No amnesia flag when `execution_review` is present (`TestRunner_WithExecutionReview_NoAmnesia`)
- [x] Gate skips for failed/max_turns/timeout/cost_cap (`TestRunner_FailedTask_SkipsExecReviewGate`)
- [x] Nil checker is a no-op (`TestRunner_NilChecker_IsNoOp`)
- [x] Checker errors do not panic or flag (`TestRunner_CheckerError_IsLoggedNotRecorded`)
- [ ] Manual UI check: complete a task without posting `execution_review`, verify the yellow badge appears; post one, verify the badge clears
- [x] Dogfood: THIS task's own `execution_review` comment posted on task `019da142-479c-70d2-865b-d6e593883e3f` using the feature itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)