### PR TITLE
chore(release): v0.3.0 — version bump + ldflags fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 .PHONY: build clean run test help
 
-VERSION ?= 2.0.0
+VERSION ?= 0.3.0
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-LDFLAGS = -ldflags "-X openpraxis/cmd.Version=$(VERSION) \
-	-X openpraxis/cmd.GitCommit=$(GIT_COMMIT) \
-	-X openpraxis/cmd.BuildDate=$(BUILD_DATE)"
+LDFLAGS = -ldflags "-X github.com/k8nstantin/OpenPraxis/cmd.Version=$(VERSION) \
+	-X github.com/k8nstantin/OpenPraxis/cmd.GitCommit=$(GIT_COMMIT) \
+	-X github.com/k8nstantin/OpenPraxis/cmd.BuildDate=$(BUILD_DATE)"
 
 build:
 	go mod tidy

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/mark3labs/mcp-go v0.48.0
 	github.com/mattn/go-sqlite3 v1.14.42
 	github.com/spf13/cobra v1.10.2
+	github.com/yuin/goldmark v1.8.2
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -23,7 +24,6 @@ require (
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	github.com/yuin/goldmark v1.8.2 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect


### PR DESCRIPTION
## Summary

- Bump Makefile `VERSION` 2.0.0 → 0.3.0 for the v0.3.0 tag
- Fix ldflags module path so `VERSION` actually reaches the binary (was targeting stale `openpraxis/cmd.Version` — module is `github.com/k8nstantin/OpenPraxis/cmd`). v0.2.0 shipped reporting a pseudo-version from `debug.BuildInfo` for this reason.
- `go mod tidy`: goldmark moved indirect → direct (shipped in the comments markdown-render path this cycle)

## Test plan

- [x] `make build` succeeds
- [x] `./openpraxis version` reports `openpraxis 0.3.0 (commit: ..., built: ...)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)