### PR TITLE
fix(manifest): M6/T1 — search matches id/marker, not just content

### DIFF
--- a/internal/manifest/search_test.go
+++ b/internal/manifest/search_test.go
@@ -1,0 +1,109 @@
+package manifest
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func openSearchTestStore(t *testing.T) *Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "s.db") + "?_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	s, err := NewStore(db)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return s
+}
+
+func contains(ms []*Manifest, id string) bool {
+	for _, m := range ms {
+		if m.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSearch_Keyword covers the existing behavior: LIKE match on
+// title/description/content/jira_refs/tags.
+func TestSearch_Keyword(t *testing.T) {
+	s := openSearchTestStore(t)
+	a, _ := s.Create("Alpha widget", "", "", "open", "t", "node", "", "", nil, nil)
+	b, _ := s.Create("Beta gizmo", "", "", "open", "t", "node", "", "", nil, nil)
+
+	res, err := s.Search("widget", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if !contains(res, a.ID) || contains(res, b.ID) {
+		t.Fatalf("keyword match mismatch: got %+v", res)
+	}
+}
+
+// TestSearch_IDExact — full UUID returns the exact manifest.
+func TestSearch_IDExact(t *testing.T) {
+	s := openSearchTestStore(t)
+	a, _ := s.Create("A", "", "", "open", "t", "node", "", "", nil, nil)
+	_, _ = s.Create("B", "", "", "open", "t", "node", "", "", nil, nil)
+
+	res, err := s.Search(a.ID, 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) != 1 || res[0].ID != a.ID {
+		t.Fatalf("id-exact match wanted [%s], got %+v", a.ID, res)
+	}
+}
+
+// TestSearch_IDPrefix — marker (id[:12]) returns the owning manifest.
+// This is the bread-and-butter scoped-id-search case from manifest M6.
+func TestSearch_IDPrefix(t *testing.T) {
+	s := openSearchTestStore(t)
+	a, _ := s.Create("A", "", "", "open", "t", "node", "", "", nil, nil)
+	_, _ = s.Create("B", "", "", "open", "t", "node", "", "", nil, nil)
+
+	res, err := s.Search(a.Marker, 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if !contains(res, a.ID) {
+		t.Fatalf("id-prefix match missing manifest %s: got %+v", a.ID, res)
+	}
+}
+
+// TestSearch_Unknown — unknown marker / unknown keyword returns empty.
+func TestSearch_Unknown(t *testing.T) {
+	s := openSearchTestStore(t)
+	_, _ = s.Create("A", "", "", "open", "t", "node", "", "", nil, nil)
+
+	res, err := s.Search("no-such-thing-12345", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("unknown query should return empty, got %+v", res)
+	}
+}
+
+// TestSearch_EmptyQuery — empty/whitespace returns nil without hitting
+// the DB with a degenerate `%%` pattern that would match every row.
+func TestSearch_EmptyQuery(t *testing.T) {
+	s := openSearchTestStore(t)
+	_, _ = s.Create("A", "", "", "open", "t", "node", "", "", nil, nil)
+
+	res, err := s.Search("   ", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("empty query should return empty, got %+v", res)
+	}
+}

--- a/internal/manifest/store.go
+++ b/internal/manifest/store.go
@@ -276,15 +276,23 @@ func (s *Store) List(status string, limit int) ([]*Manifest, error) {
 	return results, rows.Err()
 }
 
-// Search finds manifests by keyword in title, description, or content.
+// Search finds manifests matching a query. Supports id-exact, id-prefix
+// (marker or UUID prefix), id-substring, and keyword substring in
+// title/description/content/jira_refs/tags. Previously this only
+// matched content fields, so typing a marker returned zero results —
+// see manifest 019daafb-b5e M6 for the root-cause write-up.
 func (s *Store) Search(query string, limit int) ([]*Manifest, error) {
 	if limit <= 0 {
 		limit = 20
 	}
-	pattern := "%" + query + "%"
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, nil
+	}
+	pattern := "%" + q + "%"
 	rows, err := s.db.Query(`SELECT id, title, description, content, status, jira_refs, tags, author, source_node, project_id, depends_on, version, created_at, updated_at
-		FROM manifests WHERE deleted_at = '' AND (title LIKE ? OR description LIKE ? OR content LIKE ? OR jira_refs LIKE ? OR tags LIKE ?)
-		ORDER BY CASE status WHEN 'draft' THEN 0 WHEN 'open' THEN 1 WHEN 'closed' THEN 2 WHEN 'archive' THEN 3 ELSE 4 END, updated_at DESC LIMIT ?`, pattern, pattern, pattern, pattern, pattern, limit)
+		FROM manifests WHERE deleted_at = '' AND (id LIKE ? OR title LIKE ? OR description LIKE ? OR content LIKE ? OR jira_refs LIKE ? OR tags LIKE ?)
+		ORDER BY CASE status WHEN 'draft' THEN 0 WHEN 'open' THEN 1 WHEN 'closed' THEN 2 WHEN 'archive' THEN 3 ELSE 4 END, updated_at DESC LIMIT ?`, pattern, pattern, pattern, pattern, pattern, pattern, limit)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Root-cause fix for the broken Manifests-tab search bar. `Store.Search` only LIKE-matched title/description/content/jira_refs/tags, so typing a marker (`id[:12]`) or any UUID prefix returned zero hits.
- Added `id LIKE ?` to the OR set, so the single `%q%` pattern now covers id-exact, id-prefix, id-substring, and keyword.
- Trim + short-circuit empty queries so a `%%` pattern can't match every row.
- New `internal/manifest/search_test.go` covers id-exact, id-prefix (marker), keyword, unknown, empty.

Scope is manifest search only — per manifest `019daafb-b5e` M6. Adding GET aliases / other entity stores is M1/M2 and not part of this task.

## Test plan
- [x] `go build ./...` green
- [x] `go vet ./...` green
- [x] `go test ./internal/manifest/` green (5 new tests pass)
- [x] `go test ./internal/web/` green (no regressions in handler)
- [ ] Manual: type a marker into the Manifests-tab search bar and confirm it returns the matching manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)