### PR TITLE
feat(mcp): add comment_add tool — unblock runner closing step

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -318,6 +318,20 @@ func (s *Server) registerTools() {
 		),
 		s.handleMarkerDone,
 	)
+
+	// --- Comment tools ---
+
+	s.mcp.AddTool(
+		mcplib.NewTool("comment_add",
+			mcplib.WithDescription("Post a comment on a product, manifest, or task. Mirrors POST /api/{products|manifests|tasks}/{id}/comments. The runner's closing step uses this to record the execution_review."),
+			mcplib.WithString("target_type", mcplib.Required(), mcplib.Description("'product', 'manifest', or 'task'")),
+			mcplib.WithString("target_id", mcplib.Required(), mcplib.Description("ID of the entity to comment on")),
+			mcplib.WithString("author", mcplib.Required(), mcplib.Description("Author name — e.g. 'agent', 'claude-code', 'operator'")),
+			mcplib.WithString("type", mcplib.Required(), mcplib.Description("Comment type: 'execution_review', 'user_note', 'watcher_finding', 'agent_note', 'decision', 'link', 'review_rejection', 'review_approval'")),
+			mcplib.WithString("body", mcplib.Required(), mcplib.Description("Markdown comment body")),
+		),
+		s.handleCommentAdd,
+	)
 }
 
 func textResult(text string) *mcplib.CallToolResult {

--- a/internal/mcp/tools_comments.go
+++ b/internal/mcp/tools_comments.go
@@ -1,0 +1,40 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+)
+
+// handleCommentAdd posts a comment on a product, manifest, or task.
+// Matches the HTTP addComment handler in internal/web/handlers_comments.go:246
+// so MCP and HTTP paths stay behaviorally identical.
+func (s *Server) handleCommentAdd(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := args(req)
+	targetType := argStr(a, "target_type")
+	targetID := argStr(a, "target_id")
+	author := argStr(a, "author")
+	cType := argStr(a, "type")
+	body := argStr(a, "body")
+
+	if s.node.Comments == nil {
+		return errResult("comments store not initialised"), nil
+	}
+
+	target := comments.TargetType(targetType)
+	ct := comments.CommentType(cType)
+	if err := comments.ValidateAdd(target, targetID, author, ct, body); err != nil {
+		return errResult("validate: %v", err), nil
+	}
+
+	c, err := s.node.Comments.Add(ctx, target, targetID, author, ct, body)
+	if err != nil {
+		return errResult("add comment: %v", err), nil
+	}
+
+	return textResult(fmt.Sprintf("Comment added [%s] on %s %s by %s (type=%s)",
+		c.ID, c.TargetType, c.TargetID, c.Author, c.Type)), nil
+}

--- a/internal/mcp/tools_comments_test.go
+++ b/internal/mcp/tools_comments_test.go
@@ -1,0 +1,123 @@
+package mcp
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
+	"github.com/k8nstantin/OpenPraxis/internal/node"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func newTestServerWithComments(t *testing.T) *Server {
+	t.Helper()
+	dsn := "file::memory:?cache=shared&_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	if err := comments.InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	return &Server{node: &node.Node{Comments: comments.NewStore(db)}}
+}
+
+func buildReq(argMap map[string]any) mcplib.CallToolRequest {
+	return mcplib.CallToolRequest{
+		Params: mcplib.CallToolParams{Arguments: argMap},
+	}
+}
+
+func TestCommentAdd_HappyPath_Task(t *testing.T) {
+	s := newTestServerWithComments(t)
+	res, err := s.handleCommentAdd(context.Background(), buildReq(map[string]any{
+		"target_type": "task",
+		"target_id":   "019dab05-5da9-7f0b-b5c2-6f4920c91a69",
+		"author":      "agent",
+		"type":        "execution_review",
+		"body":        "test body — what shipped, gates self-check, followups",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if res == nil {
+		t.Fatalf("nil result")
+	}
+	got := toolResultText(res)
+	if !strings.Contains(got, "Comment added") {
+		t.Errorf("expected success message, got %q", got)
+	}
+	if !strings.Contains(got, "task") || !strings.Contains(got, "execution_review") {
+		t.Errorf("expected target/type echoed, got %q", got)
+	}
+}
+
+func TestCommentAdd_RejectsUnknownType(t *testing.T) {
+	s := newTestServerWithComments(t)
+	res, err := s.handleCommentAdd(context.Background(), buildReq(map[string]any{
+		"target_type": "task",
+		"target_id":   "t1",
+		"author":      "agent",
+		"type":        "not_a_real_type",
+		"body":        "x",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !isErrResult(res) {
+		t.Fatalf("expected tool error, got %q", toolResultText(res))
+	}
+}
+
+func TestCommentAdd_RejectsUnknownTargetType(t *testing.T) {
+	s := newTestServerWithComments(t)
+	res, _ := s.handleCommentAdd(context.Background(), buildReq(map[string]any{
+		"target_type": "peer",
+		"target_id":   "p1",
+		"author":      "agent",
+		"type":        "execution_review",
+		"body":        "x",
+	}))
+	if !isErrResult(res) {
+		t.Fatalf("expected target_type rejection, got %q", toolResultText(res))
+	}
+}
+
+func TestCommentAdd_RejectsEmptyBody(t *testing.T) {
+	s := newTestServerWithComments(t)
+	res, _ := s.handleCommentAdd(context.Background(), buildReq(map[string]any{
+		"target_type": "task",
+		"target_id":   "t1",
+		"author":      "agent",
+		"type":        "execution_review",
+		"body":        "",
+	}))
+	if !isErrResult(res) {
+		t.Fatalf("expected empty-body rejection, got %q", toolResultText(res))
+	}
+}
+
+func toolResultText(r *mcplib.CallToolResult) string {
+	if r == nil {
+		return ""
+	}
+	for _, c := range r.Content {
+		if tc, ok := c.(mcplib.TextContent); ok {
+			return tc.Text
+		}
+	}
+	return ""
+}
+
+func isErrResult(r *mcplib.CallToolResult) bool {
+	if r == nil {
+		return false
+	}
+	return r.IsError
+}


### PR DESCRIPTION
## Summary

The runner's task-prompt template (shipped in M4-T10 / PR #118) instructs every spawned agent to call `mcp__openpraxis__comment_add` in its mandatory closing step, but the tool was never registered. Every task hung or failed on the closing call — compounded by anthropics/claude-code#40207 (SIGTERM-MCP-stdio bug), leaving tasks in `failed` state and blocking dependent chains via `depends_on`.

Just hit it on task chain under product [`019daaf5-5c4`](http://localhost:8765/#view-products/019daaf5-5c4): T1R (`019dab05-5da`) did all its real work (PR #122 + review_approval comment on T1) then hung in the closing MCP call, locking the dashboard until the stuck claude subprocess was killed.

## Changes

- `internal/mcp/tools_comments.go` — `handleCommentAdd`, mirrors the HTTP `addComment` in `handlers_comments.go:246`. Validates via `comments.ValidateAdd`, writes via `comments.Store.Add`, echoes the new comment id.
- `internal/mcp/server.go` — registers `comment_add` with 5 required args: `target_type`, `target_id`, `author`, `type`, `body`.
- `internal/mcp/tools_comments_test.go` — 4 tests (happy path on a task, unknown type, unknown target_type, empty body). All green.

Implements the MCP surface originally scoped in task `019d9beb-25c` (M2-T4 "Entity Comments — MCP tools", still pending). Does not touch HTTP endpoints, the watcher comment hook, or the runner prompt.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/mcp/... -run TestCommentAdd` — 4/4 PASS
- [ ] Post-merge: rebuild + restart serve, re-run task `019dab05-5da` and confirm it completes the closing MCP call without hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)