### PR TITLE
fix(task): allow mcp__openpraxis__comment_add in runner default toolset

### DIFF
--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -319,6 +319,9 @@ func defaultAllowedTools() []string {
 		"mcp__openpraxis__settings_get",
 		"mcp__openpraxis__settings_resolve",
 		"mcp__openpraxis__settings_catalog",
+		// comment_add is referenced in the runner's mandatory closing
+		// prompt — every task must be able to post its execution_review.
+		"mcp__openpraxis__comment_add",
 	}
 }
 


### PR DESCRIPTION
## Summary

PR #123 registered the `comment_add` MCP tool but did not add it to `defaultAllowedTools` in `internal/task/runner.go`. Every spawned agent is told in its mandatory closing prompt to call `comment_add`, then gets "tool not in allowlist" from Claude Code. The closing `execution_review` comment never gets written.

Observed on task `019dab05-5da` (T1R in the Per-Tab Search chain): completed with the chain rolling forward, but zero `execution_review` comments on itself. Its `review_approval` comments on the reviewed task `019dab05-3ab` were posted via `curl` inside the task body (allowed per visceral rule #4), so the reviewed-task audit trail is fine. Only the self-closing comment is missing.

## Change

```go
// internal/task/runner.go defaultAllowedTools()
  "mcp__openpraxis__settings_catalog",
+ // comment_add is referenced in the runner's mandatory closing
+ // prompt — every task must be able to post its execution_review.
+ "mcp__openpraxis__comment_add",
```

One line + comment.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/task/...` green (6.9s)
- [ ] Post-merge: rebuild + restart serve, watch the next task in the chain (T2 `019dab05-7fb` is running now — may still spawn under the old list since its subprocess cmdline was built at spawn; T2R will be the first test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)