### PR TITLE
fix(ui): debounce WebSocket-driven refreshAll to 500ms

### DIFF
--- a/internal/web/ui/app.js
+++ b/internal/web/ui/app.js
@@ -256,11 +256,25 @@
     };
   }
 
+  // Debounced refresh — collapse bursts of WebSocket events into one fetch
+  // cascade. A running agent can fire 20-50 events in quick succession (each
+  // tool call + hook + cost record); pre-debounce every event triggered 10
+  // sequential fetchJSON calls in refreshAll(), drowning the browser. 500ms
+  // trailing-edge is imperceptible to the user and caps refresh rate at 2Hz.
+  var refreshDebounceTimer = null;
+  function refreshAllDebounced() {
+    if (refreshDebounceTimer) return;
+    refreshDebounceTimer = setTimeout(function() {
+      refreshDebounceTimer = null;
+      refreshAll();
+    }, 500);
+  }
+
   function handleEvent(event) {
     if (event.event === 'stats_update') {
       OL.updateMetrics(event.data);
     } else {
-      refreshAll();
+      refreshAllDebounced();
     }
   }
 


### PR DESCRIPTION
## Summary

`app.js` `handleEvent` called `refreshAll()` on every non-`stats_update` WebSocket message. `refreshAll()` does 10 sequential `fetchJSON` calls. A running agent fires 20–50 events per minute (tool calls, hooks, cost records), each triggering a full 10-fetch cascade. Browser event loop drowns, dashboard becomes unclickable for the duration of the task run. Observed live on task 019dab05-7fb (T2 in the Per-Tab Search chain).

## Fix

Trailing-edge debounce at 500ms. First event schedules the cascade 500ms out; subsequent events inside that window are dropped. Cap: max 2 refresh cycles per second. Direct `stats_update` path unchanged — metrics still real-time via in-place DOM updates.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [ ] Post-merge: resume T2, confirm dashboard stays interactive.