### PR TITLE
feat(search): M1/T2 — Search(q, limit) for task/product/idea/action stores

### DIFF
--- a/internal/action/search.go
+++ b/internal/action/search.go
@@ -1,0 +1,27 @@
+package action
+
+import "strings"
+
+// Search finds actions matching a query. Supports id match (LIKE on the
+// integer id cast to text in SQLite) plus keyword substring in
+// tool_name, tool_input, and tool_response. Mirrors manifest.Store.Search
+// shape per 019daafb-b5e M1 — single OR-set LIKE, trim + empty-check
+// guard to avoid `%%` matching every row.
+func (s *Store) Search(query string, limit int) ([]Action, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, nil
+	}
+	pattern := "%" + q + "%"
+	rows, err := s.db.Query(`SELECT id, session_id, source_node, task_id, tool_name, tool_input, tool_response, cwd, created_at
+		FROM actions WHERE CAST(id AS TEXT) LIKE ? OR tool_name LIKE ? OR tool_input LIKE ? OR tool_response LIKE ?
+		ORDER BY created_at DESC LIMIT ?`, pattern, pattern, pattern, pattern, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanActions(rows)
+}

--- a/internal/action/search_test.go
+++ b/internal/action/search_test.go
@@ -1,0 +1,121 @@
+package action
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func openSearchTestStore(t *testing.T) *Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "s.db") + "?_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	s, err := NewStore(db)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return s
+}
+
+func containsToolName(as []Action, name string) bool {
+	for _, a := range as {
+		if a.ToolName == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSearch_Keyword(t *testing.T) {
+	s := openSearchTestStore(t)
+	if _, err := s.RecordForTask("t1", "node", "Alpha_widget", "in", "out", "/cwd"); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if _, err := s.RecordForTask("t2", "node", "Beta_gizmo", "in", "out", "/cwd"); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+
+	res, err := s.Search("widget", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if !containsToolName(res, "Alpha_widget") || containsToolName(res, "Beta_gizmo") {
+		t.Fatalf("keyword mismatch: got %+v", res)
+	}
+}
+
+func TestSearch_IDExact(t *testing.T) {
+	s := openSearchTestStore(t)
+	id, err := s.RecordForTask("t1", "node", "Tool", "in", "out", "/cwd")
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	_, _ = s.RecordForTask("t2", "node", "Other", "in", "out", "/cwd")
+
+	res, err := s.Search(fmt.Sprintf("%d", id), 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	// id match may return both rows if the substring appears in other
+	// auto-ids; require the exact target to be present.
+	found := false
+	for _, a := range res {
+		if a.ID == fmt.Sprintf("%d", id) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("id-exact wanted id=%d, got %+v", id, res)
+	}
+}
+
+func TestSearch_IDPrefix(t *testing.T) {
+	s := openSearchTestStore(t)
+	// Create enough rows so ids have a leading digit pattern we can
+	// prefix-match. SQLite INTEGER PK starts at 1.
+	for i := 0; i < 5; i++ {
+		if _, err := s.RecordForTask("t", "node", "Tool", "in", "out", "/cwd"); err != nil {
+			t.Fatalf("record: %v", err)
+		}
+	}
+	res, err := s.Search("1", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) == 0 {
+		t.Fatalf("id-prefix '1' should match at least id=1, got empty")
+	}
+}
+
+func TestSearch_Unknown(t *testing.T) {
+	s := openSearchTestStore(t)
+	_, _ = s.RecordForTask("t1", "node", "Tool", "in", "out", "/cwd")
+
+	res, err := s.Search("no-such-thing-xyz-987", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("unknown should be empty, got %+v", res)
+	}
+}
+
+func TestSearch_EmptyQuery(t *testing.T) {
+	s := openSearchTestStore(t)
+	_, _ = s.RecordForTask("t1", "node", "Tool", "in", "out", "/cwd")
+
+	res, err := s.Search("  ", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("empty query should be empty, got %+v", res)
+	}
+}

--- a/internal/idea/search.go
+++ b/internal/idea/search.go
@@ -1,0 +1,36 @@
+package idea
+
+import "strings"
+
+// Search finds ideas matching a query. Supports id-exact, id-prefix
+// (marker or UUID prefix), id-substring, and keyword substring in
+// title/description/tags. Mirrors manifest.Store.Search shape per
+// 019daafb-b5e M1.
+func (s *Store) Search(query string, limit int) ([]*Idea, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, nil
+	}
+	pattern := "%" + q + "%"
+	rows, err := s.db.Query(`SELECT id, title, description, status, priority, tags, author, source_node, project_id, created_at, updated_at
+		FROM ideas WHERE deleted_at = '' AND (id LIKE ? OR title LIKE ? OR description LIKE ? OR tags LIKE ?)
+		ORDER BY CASE status WHEN 'draft' THEN 0 WHEN 'open' THEN 1 WHEN 'closed' THEN 2 WHEN 'archive' THEN 3 ELSE 4 END, updated_at DESC LIMIT ?`,
+		pattern, pattern, pattern, pattern, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []*Idea
+	for rows.Next() {
+		i, err := scanIdeaRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, i)
+	}
+	return results, rows.Err()
+}

--- a/internal/idea/search_test.go
+++ b/internal/idea/search_test.go
@@ -1,0 +1,101 @@
+package idea
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func openSearchTestStore(t *testing.T) *Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "s.db") + "?_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	s, err := NewStore(db)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return s
+}
+
+func containsIdea(is []*Idea, id string) bool {
+	for _, i := range is {
+		if i.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSearch_Keyword(t *testing.T) {
+	s := openSearchTestStore(t)
+	a, _ := s.Create("Alpha widget", "", "open", "medium", "author", "node", "", nil)
+	b, _ := s.Create("Beta gizmo", "", "open", "medium", "author", "node", "", nil)
+
+	res, err := s.Search("widget", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if !containsIdea(res, a.ID) || containsIdea(res, b.ID) {
+		t.Fatalf("keyword mismatch: got %+v", res)
+	}
+}
+
+func TestSearch_IDExact(t *testing.T) {
+	s := openSearchTestStore(t)
+	a, _ := s.Create("A", "", "open", "medium", "author", "node", "", nil)
+	_, _ = s.Create("B", "", "open", "medium", "author", "node", "", nil)
+
+	res, err := s.Search(a.ID, 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) != 1 || res[0].ID != a.ID {
+		t.Fatalf("id-exact wanted [%s], got %+v", a.ID, res)
+	}
+}
+
+func TestSearch_IDPrefix(t *testing.T) {
+	s := openSearchTestStore(t)
+	a, _ := s.Create("A", "", "open", "medium", "author", "node", "", nil)
+	_, _ = s.Create("B", "", "open", "medium", "author", "node", "", nil)
+
+	res, err := s.Search(a.Marker, 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if !containsIdea(res, a.ID) {
+		t.Fatalf("id-prefix missing %s: got %+v", a.ID, res)
+	}
+}
+
+func TestSearch_Unknown(t *testing.T) {
+	s := openSearchTestStore(t)
+	_, _ = s.Create("A", "", "open", "medium", "author", "node", "", nil)
+
+	res, err := s.Search("no-such-thing-xyz-987", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("unknown should be empty, got %+v", res)
+	}
+}
+
+func TestSearch_EmptyQuery(t *testing.T) {
+	s := openSearchTestStore(t)
+	_, _ = s.Create("A", "", "open", "medium", "author", "node", "", nil)
+
+	res, err := s.Search("  ", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("empty query should be empty, got %+v", res)
+	}
+}

--- a/internal/product/search.go
+++ b/internal/product/search.go
@@ -1,0 +1,37 @@
+package product
+
+import "strings"
+
+// Search finds products matching a query. Supports id-exact, id-prefix
+// (marker or UUID prefix), id-substring, and keyword substring in
+// title/description/tags. Mirrors manifest.Store.Search shape per
+// 019daafb-b5e M1.
+func (s *Store) Search(query string, limit int) ([]*Product, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, nil
+	}
+	pattern := "%" + q + "%"
+	rows, err := s.db.Query(`SELECT id, title, description, status, source_node, tags, created_at, updated_at
+		FROM products WHERE deleted_at = '' AND (id LIKE ? OR title LIKE ? OR description LIKE ? OR tags LIKE ?)
+		ORDER BY CASE status WHEN 'draft' THEN 0 WHEN 'open' THEN 1 WHEN 'closed' THEN 2 WHEN 'archive' THEN 3 ELSE 4 END, updated_at DESC LIMIT ?`,
+		pattern, pattern, pattern, pattern, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []*Product
+	for rows.Next() {
+		p, err := scanProductRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, p)
+	}
+	s.EnrichWithCosts(results)
+	return results, rows.Err()
+}

--- a/internal/product/search_test.go
+++ b/internal/product/search_test.go
@@ -1,0 +1,115 @@
+package product
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func openSearchTestStore(t *testing.T) *Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "s.db") + "?_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	s, err := NewStore(db)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return s
+}
+
+func containsProduct(ps []*Product, id string) bool {
+	for _, p := range ps {
+		if p.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSearch_Keyword(t *testing.T) {
+	s := openSearchTestStore(t)
+	a, _ := s.Create("Alpha widget", "", "open", "node", nil)
+	b, _ := s.Create("Beta gizmo", "", "open", "node", nil)
+
+	res, err := s.Search("widget", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if !containsProduct(res, a.ID) || containsProduct(res, b.ID) {
+		t.Fatalf("keyword mismatch: got %+v", res)
+	}
+}
+
+func TestSearch_IDExact(t *testing.T) {
+	s := openSearchTestStore(t)
+	a, _ := s.Create("A", "", "open", "node", nil)
+	_, _ = s.Create("B", "", "open", "node", nil)
+
+	res, err := s.Search(a.ID, 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) != 1 || res[0].ID != a.ID {
+		t.Fatalf("id-exact wanted [%s], got %+v", a.ID, res)
+	}
+}
+
+func TestSearch_IDPrefix(t *testing.T) {
+	s := openSearchTestStore(t)
+	a, _ := s.Create("A", "", "open", "node", nil)
+	_, _ = s.Create("B", "", "open", "node", nil)
+
+	res, err := s.Search(a.Marker, 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if !containsProduct(res, a.ID) {
+		t.Fatalf("id-prefix missing %s: got %+v", a.ID, res)
+	}
+}
+
+func TestSearch_Unknown(t *testing.T) {
+	s := openSearchTestStore(t)
+	_, _ = s.Create("A", "", "open", "node", nil)
+
+	res, err := s.Search("no-such-thing-xyz-987", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("unknown should be empty, got %+v", res)
+	}
+}
+
+func TestSearch_EmptyQuery(t *testing.T) {
+	s := openSearchTestStore(t)
+	_, _ = s.Create("A", "", "open", "node", nil)
+
+	res, err := s.Search("  ", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("empty query should be empty, got %+v", res)
+	}
+}
+
+func TestSearch_Tag(t *testing.T) {
+	s := openSearchTestStore(t)
+	a, _ := s.Create("A", "", "open", "node", []string{"alpha-tag"})
+	_, _ = s.Create("B", "", "open", "node", []string{"beta-tag"})
+
+	res, err := s.Search("alpha-tag", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if !containsProduct(res, a.ID) {
+		t.Fatalf("tag match missing %s: got %+v", a.ID, res)
+	}
+}

--- a/internal/task/search.go
+++ b/internal/task/search.go
@@ -1,0 +1,28 @@
+package task
+
+import "strings"
+
+// Search finds tasks matching a query. Supports id-exact, id-prefix
+// (marker or UUID prefix), id-substring, and keyword substring in
+// title/description. Mirrors manifest.Store.Search (see 019daafb-b5e
+// M1 per-entity scoped search) — the shape is a single LIKE OR-set
+// because the sibling ladder in internal/memory is only warranted where
+// semantic fallback and path lookups live.
+func (s *Store) Search(query string, limit int) ([]*Task, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, nil
+	}
+	pattern := "%" + q + "%"
+	rows, err := s.db.Query(`SELECT `+taskColumns+`
+		FROM tasks WHERE deleted_at = '' AND (id LIKE ? OR title LIKE ? OR description LIKE ?)
+		ORDER BY updated_at DESC LIMIT ?`, pattern, pattern, pattern, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanTasks(rows)
+}

--- a/internal/task/search_test.go
+++ b/internal/task/search_test.go
@@ -1,0 +1,80 @@
+package task
+
+import "testing"
+
+func containsTask(ts []*Task, id string) bool {
+	for _, t := range ts {
+		if t.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSearch_Keyword(t *testing.T) {
+	s := openRepoTestStore(t)
+	a, _ := s.Create("", "Alpha widget", "", "once", "claude-code", "node", "test", "")
+	b, _ := s.Create("", "Beta gizmo", "", "once", "claude-code", "node", "test", "")
+
+	res, err := s.Search("widget", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if !containsTask(res, a.ID) || containsTask(res, b.ID) {
+		t.Fatalf("keyword mismatch: got %+v", res)
+	}
+}
+
+func TestSearch_IDExact(t *testing.T) {
+	s := openRepoTestStore(t)
+	a, _ := s.Create("", "A", "", "once", "claude-code", "node", "test", "")
+	_, _ = s.Create("", "B", "", "once", "claude-code", "node", "test", "")
+
+	res, err := s.Search(a.ID, 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) != 1 || res[0].ID != a.ID {
+		t.Fatalf("id-exact wanted [%s], got %+v", a.ID, res)
+	}
+}
+
+func TestSearch_IDPrefix(t *testing.T) {
+	s := openRepoTestStore(t)
+	a, _ := s.Create("", "A", "", "once", "claude-code", "node", "test", "")
+	_, _ = s.Create("", "B", "", "once", "claude-code", "node", "test", "")
+
+	res, err := s.Search(a.ID[:12], 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if !containsTask(res, a.ID) {
+		t.Fatalf("id-prefix missing %s: got %+v", a.ID, res)
+	}
+}
+
+func TestSearch_Unknown(t *testing.T) {
+	s := openRepoTestStore(t)
+	_, _ = s.Create("", "A", "", "once", "claude-code", "node", "test", "")
+
+	res, err := s.Search("no-such-thing-xyz-987", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("unknown should be empty, got %+v", res)
+	}
+}
+
+func TestSearch_EmptyQuery(t *testing.T) {
+	s := openRepoTestStore(t)
+	_, _ = s.Create("", "A", "", "once", "claude-code", "node", "test", "")
+
+	res, err := s.Search("   ", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("empty query should be empty, got %+v", res)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Search(query, limit)` to `internal/task`, `internal/product`, `internal/idea`, `internal/action` stores.
- Mirrors manifest.Store.Search (PR #121) shape: trim + empty-check guard, single LIKE OR-set across `id` + content columns.
- Each store ships with unit tests covering id-exact, id-prefix (marker), keyword, unknown, and empty-query.
- No HTTP endpoints wired — that's M1/T3.

## Manifest
019daafb-b5e — Per-Tab Search, M1/T2 (task `019dab05-7fbf`).

## Contract per store
- Single query string; trim + empty-check returns `nil, nil` so a bare `%%` cannot match every row.
- `id LIKE ?` included in the OR-set, so typing a UUID, UUID-prefix, or marker returns the entity.
- Keyword fallback LIKEs on title/description (+ tags where the type has them).
- Actions use `CAST(id AS TEXT) LIKE ?` since `actions.id` is an INTEGER PK.
- Default limit = 50 per the manifest contract.
- WAL sqlite is inherited from the shared DB connection (visceral rule #10).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/task/ ./internal/product/ ./internal/idea/ ./internal/action/ -count=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)