### PR TITLE
feat(ui): M3+M5/T4 — shared per-tab search input with 250ms debounce

### DIFF
--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -234,6 +234,7 @@
 
       <div id="view-memories" class="view">
         <div class="tab-hint">Memories grouped by peer node, then by session. Click a memory to see its full content. Click <span class="btn-copy-inline">&#x2398;</span> to copy a reference you can paste into Claude.</div>
+        <div id="memories-search-mount"></div>
         <div class="memories-layout">
           <div class="memory-tree-panel">
             <div class="panel-header">Peers &amp; Memories</div>
@@ -252,6 +253,7 @@
 
       <div id="view-products" class="view">
         <div class="tab-hint">Products group related manifests under one initiative. Click a product to see its linked manifests, total cost, and tasks.</div>
+        <div id="products-search-mount"></div>
         <div class="manifests-layout">
           <div class="manifest-list-panel">
             <div class="panel-header">Peers &amp; Products</div>
@@ -270,9 +272,8 @@
 
       <div id="view-manifests" class="view">
         <div class="tab-hint">Manifests grouped by peer node. Shared across all peers and sessions. Tell Claude: <em>"create a manifest for the auth module, reference ENG-1234"</em></div>
-        <div style="display:flex;gap:8px;margin-bottom:16px">
-          <input type="text" id="manifest-search-input" class="conv-search" placeholder="Search manifests by keyword, Jira ref, or tag..." style="flex:1" />
-          <button id="manifest-search-btn" class="btn-search">Search</button>
+        <div style="display:flex;gap:8px;margin-bottom:16px;align-items:flex-start">
+          <div id="manifest-search-mount" style="flex:1"></div>
           <button id="manifest-new-btn" class="btn-search btn-action">+ New Manifest</button>
         </div>
         <div class="manifests-layout">
@@ -293,6 +294,7 @@
 
       <div id="view-ideas" class="view">
         <div class="tab-hint">Ideas grouped by peer node. Add ideas from the dashboard or tell Claude: <em>"save idea: separate the serve and mcp binaries so restarts don't kill sessions"</em></div>
+        <div id="ideas-search-mount"></div>
         <div class="manifests-layout">
           <div class="manifest-list-panel">
             <div class="panel-header">Peers &amp; Ideas</div>
@@ -323,6 +325,7 @@
 
       <div id="view-tasks" class="view">
         <div class="tab-hint">Scheduled tasks execute against manifests on a timer. Create a task, point it at a manifest, set the schedule, and start it.</div>
+        <div id="tasks-search-mount"></div>
         <div class="panel" id="tasks-running-panel" style="display:none;margin-bottom:16px;border-left:3px solid var(--green)">
           <div class="panel-header" style="background:rgba(0,217,126,0.05)">
             Running Now
@@ -527,10 +530,7 @@
 
       <div id="view-conversations" class="view">
         <div class="tab-hint">Conversations grouped by peer node. Click a conversation to see all turns. Click <span class="btn-copy-inline">&#x2398;</span> on any turn to copy a reference &mdash; paste it into Claude and it will review that exact exchange.</div>
-        <div class="conv-header">
-          <input type="text" id="conv-search-input" class="conv-search" placeholder="Search conversations by topic..." />
-          <button id="conv-search-btn" class="btn-search">Search</button>
-        </div>
+        <div id="conv-search-mount"></div>
         <div class="conv-layout">
           <div class="conv-list-panel">
             <div class="panel-header">Peers &amp; Conversations</div>
@@ -549,6 +549,7 @@
 
       <div id="view-actions" class="view">
         <div class="tab-hint">Complete audit log of every tool call, grouped by peer node and session. Every file read, edit, bash command, and their results.</div>
+        <div id="actions-search-mount"></div>
         <div class="conv-layout">
           <div class="conv-list-panel">
             <div class="panel-header">Peers &amp; Actions</div>
@@ -740,6 +741,7 @@
   <script src="/lifecycle.js"></script>
   <script src="/components/knobs.js"></script>
   <script src="/components/comments.js"></script>
+  <script src="/views/search.js"></script>
   <script src="/views/overview.js"></script>
   <script src="/views/memories.js"></script>
   <script src="/views/conversations.js"></script>

--- a/internal/web/ui/views/actions.js
+++ b/internal/web/ui/views/actions.js
@@ -2,8 +2,39 @@
   'use strict';
   var fetchJSON = OL.fetchJSON, esc = OL.esc, formatTime = OL.formatTime;
 
+  function renderActionSearchList(el, actions) {
+    if (!actions || !actions.length) {
+      el.innerHTML = '<div class="empty-state">No actions found</div>';
+      return;
+    }
+    el.innerHTML = actions.map(function(a) {
+      var input = a.tool_input ? (a.tool_input.length > 60 ? a.tool_input.substring(0, 60) + '...' : a.tool_input) : '';
+      return '<div class="tree-node peer-leaf clickable" data-action-id="' + esc(a.id) + '" role="button" tabindex="0" ' +
+        'onclick="OL.loadActionDetail(\'' + esc(a.id) + '\')" ' +
+        'onkeydown="if(event.key===\'Enter\'||event.key===\' \'){event.preventDefault();this.click()}">' +
+        '<span class="badge type badge-sm">' + esc(a.tool_name) + '</span>' +
+        '<span style="font-size:11px;color:var(--text-primary);flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + esc(input) + '</span>' +
+        '<span style="color:var(--text-muted);font-size:10px">' + formatTime(a.created_at) + '</span>' +
+      '</div>';
+    }).join('');
+  }
+
   OL.loadActions = async function() {
     const el = document.getElementById('actions-tree');
+
+    const mount = document.getElementById('actions-search-mount');
+    if (mount && OL.mountSearchInput) {
+      OL.mountSearchInput(mount, {
+        placeholder: 'Search actions by id, tool name, or keyword...',
+        onSearch: async function(q) {
+          const results = await fetchJSON('/api/actions/search?q=' + encodeURIComponent(q));
+          renderActionSearchList(el, results || []);
+          return (results || []).length;
+        },
+        onClear: function() { OL.loadActions(); }
+      });
+    }
+
     try {
       const peerGroups = await fetchJSON('/api/actions/by-peer');
       if (!peerGroups || !peerGroups.length) {

--- a/internal/web/ui/views/conversations.js
+++ b/internal/web/ui/views/conversations.js
@@ -2,14 +2,26 @@
   'use strict';
   var fetchJSON = OL.fetchJSON, esc = OL.esc, formatTime = OL.formatTime, formatModel = OL.formatModel;
   function setupConvSearch() {
-    var input = document.getElementById('conv-search-input');
-    var btn = document.getElementById('conv-search-btn');
-    if (btn) {
-      OL.onView(btn, 'click', function() { searchConversations(input.value); });
-      OL.onView(input, 'keypress', function(e) {
-        if (e.key === 'Enter') searchConversations(input.value);
-      });
-    }
+    var mount = document.getElementById('conv-search-mount');
+    if (!mount || !OL.mountSearchInput) return;
+    OL.mountSearchInput(mount, {
+      placeholder: 'Search conversations by id, marker, or keyword...',
+      onSearch: async function(q) {
+        var resp = await fetch('/api/conversations/search?q=' + encodeURIComponent(q));
+        var results = await resp.json();
+        var convos = (results || []).map(function(r) {
+          return {
+            id: r.conversation.id,
+            title: r.conversation.title + (typeof r.score === 'number' ? ' (' + r.score.toFixed(2) + ')' : ''),
+            agent: r.conversation.agent,
+            turn_count: r.conversation.turn_count
+          };
+        });
+        renderConversationSearchResults(convos);
+        return convos.length;
+      },
+      onClear: function() { OL.loadConversations(); }
+    });
   }
 
   OL.loadConversations = async function() {
@@ -182,32 +194,5 @@
     });
   };
 
-  async function searchConversations(query) {
-    if (!query.trim()) {
-      OL.loadConversations();
-      return;
-    }
-    try {
-      var resp = await fetch('/api/conversations/search', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({query: query, limit: 20})
-      });
-      var results = await resp.json();
-      var convos = (results || []).map(function(r) {
-        return {
-          id: r.conversation.id,
-          title: r.conversation.title + ' (' + r.score.toFixed(2) + ')',
-          agent: r.conversation.agent,
-          turn_count: r.conversation.turn_count
-        };
-      });
-      renderConversationSearchResults(convos);
-    } catch (e) {
-      console.error('Search conversations failed:', e);
-    }
-  }
-
-  OL.searchConversations = searchConversations;
   OL.renderConversationSearchResults = renderConversationSearchResults;
 })(window.OL);

--- a/internal/web/ui/views/ideas.js
+++ b/internal/web/ui/views/ideas.js
@@ -3,11 +3,46 @@
   var fetchJSON = OL.fetchJSON, esc = OL.esc;
   var _pendingIdeaId = null;
 
+  function renderIdeaSearchList(el, ideas) {
+    if (!ideas || !ideas.length) {
+      el.innerHTML = '<div class="empty-state" style="padding:16px">No ideas found</div>';
+      return;
+    }
+    el.innerHTML = ideas.map(function(i) {
+      var prioClass = i.priority === 'critical' || i.priority === 'high' ? 'high' :
+        i.priority === 'low' ? 'low' : 'medium';
+      return '<div class="manifest-item clickable" data-id="' + esc(i.id) + '" role="button" tabindex="0" ' +
+        'onclick="OL.loadIdea(\'' + esc(i.id) + '\')" ' +
+        'onkeydown="if(event.key===\'Enter\'||event.key===\' \'){event.preventDefault();this.click()}">' +
+        '<div style="display:flex;align-items:center;gap:6px;margin-bottom:4px">' +
+          '<span class="amnesia-score ' + prioClass + ' badge-sm">' + esc(i.priority) + '</span>' +
+          '<span class="session-uuid">' + esc(i.marker) + '</span>' +
+          '<span class="badge">' + esc(i.status) + '</span>' +
+        '</div>' +
+        '<div class="manifest-item-title">' + esc(i.title) + '</div>' +
+        (i.description ? '<div style="font-size:12px;color:var(--text-secondary)">' + esc(i.description) + '</div>' : '') +
+      '</div>';
+    }).join('');
+  }
+
   OL.loadIdeas = async function() {
     var el = document.getElementById('ideas-list');
     var btn = document.getElementById('idea-add-btn');
     var titleInput = document.getElementById('idea-title');
     var prioritySelect = document.getElementById('idea-priority');
+
+    var mount = document.getElementById('ideas-search-mount');
+    if (mount && OL.mountSearchInput) {
+      OL.mountSearchInput(mount, {
+        placeholder: 'Search ideas by id, marker, or keyword...',
+        onSearch: async function(q) {
+          var results = await fetchJSON('/api/ideas/search?q=' + encodeURIComponent(q));
+          renderIdeaSearchList(el, results || []);
+          return (results || []).length;
+        },
+        onClear: function() { OL.loadIdeas(); }
+      });
+    }
 
     btn.onclick = async function() {
       var title = titleInput.value.trim();

--- a/internal/web/ui/views/manifests.js
+++ b/internal/web/ui/views/manifests.js
@@ -4,13 +4,22 @@
 
   OL.loadManifests = async function() {
     const el = document.getElementById('manifest-list');
-    const searchInput = document.getElementById('manifest-search-input');
-    const searchBtn = document.getElementById('manifest-search-btn');
     const newBtn = document.getElementById('manifest-new-btn');
 
-    searchBtn.onclick = () => searchManifests(searchInput.value);
-    searchInput.onkeypress = (e) => { if (e.key === 'Enter') searchManifests(searchInput.value); };
     if (newBtn) newBtn.onclick = () => OL.createManifest();
+
+    const mount = document.getElementById('manifest-search-mount');
+    if (mount && OL.mountSearchInput) {
+      OL.mountSearchInput(mount, {
+        placeholder: 'Search manifests by id, marker, Jira ref, tag, or keyword...',
+        onSearch: async function(q) {
+          const results = await fetchJSON('/api/manifests/search?q=' + encodeURIComponent(q));
+          renderManifestList(el, results || []);
+          return (results || []).length;
+        },
+        onClear: function() { OL.loadManifests(); }
+      });
+    }
 
     try {
       var results = await Promise.all([
@@ -90,22 +99,6 @@
       console.error('Load manifests failed:', e);
     }
   };
-
-  async function searchManifests(query) {
-    if (!query.trim()) { OL.loadManifests(); return; }
-    const el = document.getElementById('manifest-list');
-    try {
-      const resp = await fetch('/api/manifests/search', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({query})
-      });
-      const manifests = await resp.json();
-      renderManifestList(el, manifests || []);
-    } catch (e) {
-      console.error('Search manifests failed:', e);
-    }
-  }
 
   function renderManifestList(el, manifests) {
     if (!manifests || !manifests.length) {

--- a/internal/web/ui/views/memories.js
+++ b/internal/web/ui/views/memories.js
@@ -2,7 +2,40 @@
   'use strict';
   var fetchJSON = OL.fetchJSON, esc = OL.esc, formatTime = OL.formatTime;
 
+  function renderMemorySearchList(el, results) {
+    if (!results || !results.length) {
+      el.innerHTML = '<div class="empty-state">No memories found</div>';
+      return;
+    }
+    el.innerHTML = results.map(function(r) {
+      var m = r.memory || r;
+      var score = (typeof r.score === 'number') ? r.score : null;
+      var preview = (m.l0 || m.l1 || '').substring(0, 80);
+      return '<div class="tree-node peer-leaf clickable" data-memory-id="' + esc(m.id) + '" ' +
+        'role="button" tabindex="0" ' +
+        'onclick="OL.loadMemoryPeerDetail(\'' + esc(m.id) + '\')" ' +
+        'onkeydown="if(event.key===\'Enter\'||event.key===\' \'){event.preventDefault();this.click()}">' +
+        '<span class="session-uuid">' + esc(m.marker || (m.id ? m.id.substring(0,12) : '')) + '</span>' +
+        (score != null ? '<span class="badge badge-sm" style="color:var(--accent)">' + score.toFixed(2) + '</span>' : '') +
+        '<span style="font-size:12px;color:var(--text-primary);flex:1">' + esc(preview) + '</span>' +
+      '</div>';
+    }).join('');
+  }
+
   OL.loadMemoryPeerTree = async function() {
+    var mount = document.getElementById('memories-search-mount');
+    var tree = document.getElementById('memory-peer-tree');
+    if (mount && OL.mountSearchInput) {
+      OL.mountSearchInput(mount, {
+        placeholder: 'Search memories by id, marker, path, or keyword...',
+        onSearch: async function(q) {
+          var results = await fetchJSON('/api/memories/search?q=' + encodeURIComponent(q));
+          renderMemorySearchList(tree, results || []);
+          return (results || []).length;
+        },
+        onClear: function() { OL.loadMemoryPeerTree(); }
+      });
+    }
     try {
       var peerGroups = await fetchJSON('/api/memories/by-peer');
       var el = document.getElementById('memory-peer-tree');

--- a/internal/web/ui/views/products.js
+++ b/internal/web/ui/views/products.js
@@ -2,8 +2,49 @@
   'use strict';
   var fetchJSON = OL.fetchJSON, esc = OL.esc, formatTime = OL.formatTime;
 
+  function renderProductSearchList(el, products) {
+    if (!products || !products.length) {
+      el.innerHTML = '<div class="empty-state" style="padding:16px">No products found</div>';
+      return;
+    }
+    el.innerHTML = products.map(function(p) {
+      var statusColors = {open:'var(--green)',closed:'var(--text-muted)',draft:'var(--yellow)',archive:'var(--red)'};
+      var color = statusColors[p.status] || 'var(--text-muted)';
+      var meta = [];
+      if (p.total_manifests > 0) meta.push(p.total_manifests + ' manifests');
+      if (p.total_tasks > 0) meta.push(p.total_tasks + ' tasks');
+      if (p.total_cost > 0) meta.push('$' + p.total_cost.toFixed(2));
+      return '<div class="manifest-item clickable" data-product-id="' + esc(p.id) + '" role="button" tabindex="0" ' +
+        'onclick="OL.loadProductDetail(\'' + esc(p.id) + '\')" ' +
+        'onkeydown="if(event.key===\'Enter\'||event.key===\' \'){event.preventDefault();this.click()}">' +
+        '<div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">' +
+          '<span class="status-dot" style="background:' + color + '"></span>' +
+          '<span class="session-uuid">' + esc(p.marker) + '</span>' +
+          '<span class="badge" style="color:' + color + '">' + esc(p.status) + '</span>' +
+        '</div>' +
+        '<div class="manifest-item-title">' + esc(p.title) + '</div>' +
+        (p.description ? '<div style="font-size:12px;color:var(--text-secondary)">' + esc(p.description) + '</div>' : '') +
+        (meta.length ? '<div style="font-size:11px;color:var(--text-muted);margin-top:4px">' + meta.join(' &middot; ') + '</div>' : '') +
+      '</div>';
+    }).join('');
+  }
+
   OL.loadProducts = async function() {
     var el = document.getElementById('products-list');
+
+    var mount = document.getElementById('products-search-mount');
+    if (mount && OL.mountSearchInput) {
+      OL.mountSearchInput(mount, {
+        placeholder: 'Search products by id, marker, tag, or keyword...',
+        onSearch: async function(q) {
+          var results = await fetchJSON('/api/products/search?q=' + encodeURIComponent(q));
+          renderProductSearchList(el, results || []);
+          return (results || []).length;
+        },
+        onClear: function() { OL.loadProducts(); }
+      });
+    }
+
     try {
       var peerGroups = await fetchJSON('/api/products/by-peer');
 

--- a/internal/web/ui/views/search.js
+++ b/internal/web/ui/views/search.js
@@ -1,0 +1,101 @@
+// Shared per-tab search input — manifest 019daafb-b5e M3+M5.
+// Renders a debounced <input> + clear-X + results-count badge into `container`.
+// Each tab owns its own onSearch / onClear callbacks; this component only
+// handles UI + debounce + cancel-on-new-input. 250 ms is locked by M5.
+(function(OL) {
+  'use strict';
+
+  OL.mountSearchInput = function(container, opts) {
+    opts = opts || {};
+    var placeholder = opts.placeholder || 'Search...';
+    var debounceMs  = opts.debounceMs != null ? opts.debounceMs : 250;
+    var ariaLabel   = opts.ariaLabel || placeholder;
+
+    container.innerHTML =
+      '<div class="ol-search" style="display:flex;align-items:center;gap:8px;margin-bottom:12px">' +
+        '<div style="position:relative;flex:1">' +
+          '<input type="text" class="ol-search-input conv-search" ' +
+            'placeholder="' + OL.esc(placeholder) + '" ' +
+            'aria-label="' + OL.esc(ariaLabel) + '" ' +
+            'style="width:100%;padding-right:28px" />' +
+          '<button type="button" class="ol-search-clear" aria-label="Clear search" ' +
+            'style="display:none;position:absolute;right:6px;top:50%;transform:translateY(-50%);' +
+            'background:none;border:none;color:var(--text-muted);font-size:18px;cursor:pointer;' +
+            'padding:0 4px;line-height:1">&times;</button>' +
+        '</div>' +
+        '<span class="ol-search-count" ' +
+          'style="display:none;font-size:11px;color:var(--text-muted);' +
+          'font-family:var(--font-mono);white-space:nowrap"></span>' +
+      '</div>';
+
+    var input   = container.querySelector('.ol-search-input');
+    var clearEl = container.querySelector('.ol-search-clear');
+    var countEl = container.querySelector('.ol-search-count');
+    var timer   = null;
+    var lastQ   = '';
+
+    function setCount(n) {
+      if (n == null || n < 0) {
+        countEl.style.display = 'none';
+        countEl.textContent = '';
+        return;
+      }
+      countEl.style.display = '';
+      countEl.textContent = n + (n === 1 ? ' result' : ' results');
+    }
+
+    function restore() {
+      lastQ = '';
+      setCount(null);
+      if (typeof opts.onClear === 'function') opts.onClear();
+    }
+
+    function fire(q) {
+      if (!q) { restore(); return; }
+      if (typeof opts.onSearch !== 'function') return;
+      lastQ = q;
+      Promise.resolve(opts.onSearch(q)).then(function(n) {
+        if (q !== lastQ) return; // stale — a newer query has taken over
+        if (typeof n === 'number') setCount(n);
+      }).catch(function(err) {
+        console.error('Search failed:', err);
+      });
+    }
+
+    function doClear() {
+      input.value = '';
+      if (timer) { clearTimeout(timer); timer = null; }
+      clearEl.style.display = 'none';
+      restore();
+      input.focus();
+    }
+
+    OL.onView(input, 'input', function() {
+      var q = input.value.trim();
+      clearEl.style.display = q ? '' : 'none';
+      if (timer) { clearTimeout(timer); timer = null; }
+      if (!q) { restore(); return; }
+      timer = setTimeout(function() { timer = null; fire(q); }, debounceMs);
+    });
+
+    OL.onView(input, 'keydown', function(e) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (timer) { clearTimeout(timer); timer = null; }
+        fire(input.value.trim());
+      } else if (e.key === 'Escape') {
+        doClear();
+      }
+    });
+
+    OL.onView(clearEl, 'click', doClear);
+
+    return {
+      setCount: setCount,
+      clear: doClear,
+      focus: function() { input.focus(); },
+      value: function() { return input.value.trim(); }
+    };
+  };
+
+})(window.OL);

--- a/internal/web/ui/views/tasks.js
+++ b/internal/web/ui/views/tasks.js
@@ -69,11 +69,53 @@
   };
 
   // --- Tasks ---
+  function renderTaskSearchList(el, tasks) {
+    if (!tasks || !tasks.length) {
+      el.innerHTML = '<div class="empty-state" style="padding:16px">No tasks found</div>';
+      return;
+    }
+    el.innerHTML = tasks.map(function(t) {
+      var render = OL.getStatusRender(t.status);
+      var meta = [];
+      if (t.run_count > 0) meta.push(t.run_count + ' runs');
+      if (t.total_turns > 0) meta.push(t.total_turns + ' turns');
+      if (t.total_cost > 0) meta.push('$' + t.total_cost.toFixed(2));
+      if (t.schedule) meta.push(esc(t.schedule));
+      return '<div class="amnesia-item ' + render.cssClass + ' clickable" data-id="' + esc(t.id) + '" ' +
+        'role="button" tabindex="0" ' +
+        'onclick="OL.loadTaskDetail(\'' + esc(t.id) + '\')" ' +
+        'onkeydown="if(event.key===\'Enter\'||event.key===\' \'){event.preventDefault();this.click()}">' +
+        '<div class="amnesia-header">' +
+          '<span class="status-dot" style="background:' + render.color + '"></span>' +
+          '<span class="amnesia-status-label" style="color:' + render.color + ';font-weight:600">' +
+            render.icon + ' ' + esc(t.status) +
+          '</span>' +
+          '<span class="session-uuid">' + esc(t.marker) + '</span>' +
+        '</div>' +
+        '<div class="amnesia-rule">' + esc(t.title) + '</div>' +
+        (meta.length ? '<div class="amnesia-action">' + meta.join(' &middot; ') + '</div>' : '') +
+      '</div>';
+    }).join('');
+  }
+
   OL.loadTasks = async function() {
     const el = document.getElementById('tasks-list');
     const newBtn = document.getElementById('task-new-btn');
 
     newBtn.onclick = () => OL.showTaskCreateForm();
+
+    const mount = document.getElementById('tasks-search-mount');
+    if (mount && OL.mountSearchInput) {
+      OL.mountSearchInput(mount, {
+        placeholder: 'Search tasks by id, marker, title, or keyword...',
+        onSearch: async function(q) {
+          const results = await fetchJSON('/api/tasks/search?q=' + encodeURIComponent(q));
+          renderTaskSearchList(el, results || []);
+          return (results || []).length;
+        },
+        onClear: function() { OL.loadTasks(); }
+      });
+    }
 
     // Status styling comes from OL.getStatusRender (task-status.js).
     // Never add an inline map here — adding a status in status.go


### PR DESCRIPTION
## Summary

- New `OL.mountSearchInput` shared component in `internal/web/ui/views/search.js`: `<input>` + clear-X + results-count badge, 250 ms debounce with cancel-on-new-input and stale-response guard. Enter fires immediately; Escape clears.
- Wired into all seven list tabs (products, manifests, tasks, memories, ideas, conversations, actions) via dedicated `*-search-mount` divs in `index.html`. Each tab passes its own `onSearch(q)` → `GET /api/<type>/search?q=` + flat renderer, and `onClear()` → reload full tree.
- Retired legacy `#manifest-search-input`/`#manifest-search-btn` and `#conv-search-input`/`#conv-search-btn` + their JS search functions. In-context `tc-manifest-search` picker untouched per spec.

Manifest: `019daafb-b5e` M3 (per-tab input UX) + M5 (250 ms debounce locked).

## Test plan

- [ ] `go build ./...` (green)
- [ ] `go test ./internal/web/ -run 'Tests*Search'` (green — existing T3 handler tests)
- [ ] Dashboard loads, each tab shows its search input above the list
- [ ] Typing a UUID / marker into any tab returns the matching entity of that type
- [ ] Typing a keyword returns matches; clear-X and empty input restore the full list
- [ ] Results-count badge reflects response length

🤖 Generated with [Claude Code](https://claude.com/claude-code)