### PR TITLE
fix(api): normalize /api/<type>/search response shape — flat arrays, [] on empty

### DIFF
--- a/internal/web/handlers_search.go
+++ b/internal/web/handlers_search.go
@@ -3,8 +3,14 @@ package web
 import (
 	"net/http"
 	"strconv"
+	"time"
 
+	"github.com/k8nstantin/OpenPraxis/internal/action"
+	"github.com/k8nstantin/OpenPraxis/internal/idea"
+	"github.com/k8nstantin/OpenPraxis/internal/memory"
 	"github.com/k8nstantin/OpenPraxis/internal/node"
+	"github.com/k8nstantin/OpenPraxis/internal/product"
+	"github.com/k8nstantin/OpenPraxis/internal/task"
 )
 
 // GET-alias helpers for per-tab scoped search. See manifest 019daafb-b5e M2.
@@ -12,6 +18,12 @@ import (
 // stay untouched for MCP/programmatic consumers — these additive GET
 // handlers let the frontend use a uniform `GET /api/<type>/search?q=&limit=`
 // call across every tab.
+//
+// Response-shape contract (manifest 019dac18-638): every GET /api/<type>/search
+// returns a flat [] of entities matching the list endpoint's shape, and never
+// `null` on empty — the frontend can render results without unwrapping.
+// Scored/semantic data is still available via POST, or via `?scored=true` on
+// the memories/conversations GET endpoints.
 
 func parseSearchParams(r *http.Request) (string, int) {
 	q := r.URL.Query().Get("q")
@@ -27,11 +39,19 @@ func parseSearchParams(r *http.Request) (string, int) {
 	return q, limit
 }
 
+// scoreRef surfaces score/distance alongside the unwrapped entity list when
+// a caller opts in via `?scored=true`.
+type scoreRef struct {
+	ID       string  `json:"id"`
+	Score    float64 `json:"score"`
+	Distance float64 `json:"distance"`
+}
+
 func apiMemoriesSearchGET(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		q, limit := parseSearchParams(r)
 		if q == "" {
-			writeJSON(w, []any{})
+			writeJSON(w, []memory.Memory{})
 			return
 		}
 		scope := r.URL.Query().Get("scope")
@@ -42,7 +62,17 @@ func apiMemoriesSearchGET(n *node.Node) http.HandlerFunc {
 			writeError(w, err.Error(), 500)
 			return
 		}
-		writeJSON(w, results)
+		items := make([]memory.Memory, 0, len(results))
+		scores := make([]scoreRef, 0, len(results))
+		for _, sr := range results {
+			items = append(items, sr.Memory)
+			scores = append(scores, scoreRef{ID: sr.Memory.ID, Score: sr.Score, Distance: sr.Distance})
+		}
+		if r.URL.Query().Get("scored") == "true" {
+			writeJSON(w, map[string]any{"items": items, "scores": scores})
+			return
+		}
+		writeJSON(w, items)
 	}
 }
 
@@ -50,7 +80,7 @@ func apiManifestsSearchGET(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		q, limit := parseSearchParams(r)
 		if q == "" {
-			writeJSON(w, []any{})
+			writeJSON(w, []enrichedManifest{})
 			return
 		}
 		results, err := n.Manifests.Search(q, limit)
@@ -62,11 +92,27 @@ func apiManifestsSearchGET(n *node.Node) http.HandlerFunc {
 	}
 }
 
+// conversationSearchItem mirrors the slim shape returned by
+// /api/conversations (apiConversations) — id, title, summary, agent, project,
+// tags, turn_count, created_at, updated_at. Turns are intentionally omitted;
+// detail view /api/conversations/{id} exposes them.
+type conversationSearchItem struct {
+	ID        string   `json:"id"`
+	Title     string   `json:"title"`
+	Summary   string   `json:"summary"`
+	Agent     string   `json:"agent"`
+	Project   string   `json:"project"`
+	Tags      []string `json:"tags"`
+	TurnCount int      `json:"turn_count"`
+	CreatedAt string   `json:"created_at"`
+	UpdatedAt string   `json:"updated_at"`
+}
+
 func apiConversationsSearchGET(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		q, limit := parseSearchParams(r)
 		if q == "" {
-			writeJSON(w, []any{})
+			writeJSON(w, []conversationSearchItem{})
 			return
 		}
 		agent := r.URL.Query().Get("agent")
@@ -76,7 +122,32 @@ func apiConversationsSearchGET(n *node.Node) http.HandlerFunc {
 			writeError(w, err.Error(), 500)
 			return
 		}
-		writeJSON(w, results)
+		items := make([]conversationSearchItem, 0, len(results))
+		scores := make([]scoreRef, 0, len(results))
+		for _, sr := range results {
+			c := sr.Conversation
+			turnCount := c.TurnCount
+			if turnCount == 0 && len(c.Turns) > 0 {
+				turnCount = len(c.Turns)
+			}
+			items = append(items, conversationSearchItem{
+				ID:        c.ID,
+				Title:     c.Title,
+				Summary:   c.Summary,
+				Agent:     c.Agent,
+				Project:   c.Project,
+				Tags:      c.Tags,
+				TurnCount: turnCount,
+				CreatedAt: c.CreatedAt.UTC().Format(time.RFC3339),
+				UpdatedAt: c.UpdatedAt.UTC().Format(time.RFC3339),
+			})
+			scores = append(scores, scoreRef{ID: c.ID, Score: sr.Score, Distance: sr.Distance})
+		}
+		if r.URL.Query().Get("scored") == "true" {
+			writeJSON(w, map[string]any{"items": items, "scores": scores})
+			return
+		}
+		writeJSON(w, items)
 	}
 }
 
@@ -84,13 +155,16 @@ func apiTasksSearch(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		q, limit := parseSearchParams(r)
 		if q == "" {
-			writeJSON(w, []any{})
+			writeJSON(w, []*task.Task{})
 			return
 		}
 		results, err := n.Tasks.Search(q, limit)
 		if err != nil {
 			writeError(w, err.Error(), 500)
 			return
+		}
+		if results == nil {
+			results = []*task.Task{}
 		}
 		writeJSON(w, results)
 	}
@@ -100,13 +174,16 @@ func apiProductsSearch(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		q, limit := parseSearchParams(r)
 		if q == "" {
-			writeJSON(w, []any{})
+			writeJSON(w, []*product.Product{})
 			return
 		}
 		results, err := n.Products.Search(q, limit)
 		if err != nil {
 			writeError(w, err.Error(), 500)
 			return
+		}
+		if results == nil {
+			results = []*product.Product{}
 		}
 		writeJSON(w, results)
 	}
@@ -116,13 +193,16 @@ func apiIdeasSearch(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		q, limit := parseSearchParams(r)
 		if q == "" {
-			writeJSON(w, []any{})
+			writeJSON(w, []*idea.Idea{})
 			return
 		}
 		results, err := n.Ideas.Search(q, limit)
 		if err != nil {
 			writeError(w, err.Error(), 500)
 			return
+		}
+		if results == nil {
+			results = []*idea.Idea{}
 		}
 		writeJSON(w, results)
 	}
@@ -132,13 +212,16 @@ func apiActionsSearch(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		q, limit := parseSearchParams(r)
 		if q == "" {
-			writeJSON(w, []any{})
+			writeJSON(w, []action.Action{})
 			return
 		}
 		results, err := n.Actions.Search(q, limit)
 		if err != nil {
 			writeError(w, err.Error(), 500)
 			return
+		}
+		if results == nil {
+			results = []action.Action{}
 		}
 		writeJSON(w, results)
 	}

--- a/internal/web/handlers_search_test.go
+++ b/internal/web/handlers_search_test.go
@@ -190,6 +190,81 @@ func TestActionsSearch_Keyword(t *testing.T) {
 	}
 }
 
+// The following tests enforce the response-shape contract from manifest
+// 019dac18-638: every GET /api/<type>/search returns a flat JSON array and
+// never `null` on empty. They use raw-bytes comparison because nil slices
+// marshal to "null" while empty slices marshal to "[]" — and the frontend
+// can't distinguish those without guarding every caller.
+
+func TestTasksSearch_EmptyResultIsArrayNotNull(t *testing.T) {
+	n := newSearchNode(t)
+	rec := doGET(t, apiTasksSearch(n), "/api/tasks/search?q=zzz_no_such_task")
+	if rec.Code != 200 {
+		t.Fatalf("status %d", rec.Code)
+	}
+	if body := rec.Body.String(); body != "[]" && body != "[]\n" {
+		t.Fatalf("want `[]`, got %q", body)
+	}
+}
+
+func TestProductsSearch_EmptyResultIsArrayNotNull(t *testing.T) {
+	n := newSearchNode(t)
+	rec := doGET(t, apiProductsSearch(n), "/api/products/search?q=zzz_no_such_product")
+	if rec.Code != 200 {
+		t.Fatalf("status %d", rec.Code)
+	}
+	if body := rec.Body.String(); body != "[]" && body != "[]\n" {
+		t.Fatalf("want `[]`, got %q", body)
+	}
+}
+
+func TestIdeasSearch_EmptyResultIsArrayNotNull(t *testing.T) {
+	n := newSearchNode(t)
+	rec := doGET(t, apiIdeasSearch(n), "/api/ideas/search?q=zzz_no_such_idea")
+	if rec.Code != 200 {
+		t.Fatalf("status %d", rec.Code)
+	}
+	if body := rec.Body.String(); body != "[]" && body != "[]\n" {
+		t.Fatalf("want `[]`, got %q", body)
+	}
+}
+
+func TestActionsSearch_EmptyResultIsArrayNotNull(t *testing.T) {
+	n := newSearchNode(t)
+	rec := doGET(t, apiActionsSearch(n), "/api/actions/search?q=zzz_no_such_action")
+	if rec.Code != 200 {
+		t.Fatalf("status %d", rec.Code)
+	}
+	if body := rec.Body.String(); body != "[]" && body != "[]\n" {
+		t.Fatalf("want `[]`, got %q", body)
+	}
+}
+
+// TestTasksSearch_ShapeMatchesListEndpoint asserts that a successful task
+// search returns entities flat (no outer {task: ...} wrapper), so that the
+// frontend can render `r.id`/`r.title` directly.
+func TestTasksSearch_ShapeMatchesListEndpoint(t *testing.T) {
+	n := newSearchNode(t)
+	a, _ := n.Tasks.Create("", "shape-alpha", "desc", "once", "claude-code", n.PeerID(), "test", "")
+	rec := doGET(t, apiTasksSearch(n), "/api/tasks/search?q=shape-alpha")
+	if rec.Code != 200 {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var raw []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode: %v body=%s", err, rec.Body.String())
+	}
+	if len(raw) != 1 {
+		t.Fatalf("want 1 result, got %d", len(raw))
+	}
+	if _, wrapped := raw[0]["task"]; wrapped {
+		t.Fatalf("search result is wrapped under 'task' key; want flat: %+v", raw[0])
+	}
+	if id, _ := raw[0]["id"].(string); id != a.ID {
+		t.Fatalf("want id=%s, got %+v", a.ID, raw[0])
+	}
+}
+
 func TestParseSearchParams_LimitAndAlias(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/x/search?query=hello&limit=7", nil)
 	q, lim := parseSearchParams(req)

--- a/internal/web/ui/views/conversations.js
+++ b/internal/web/ui/views/conversations.js
@@ -9,12 +9,12 @@
       onSearch: async function(q) {
         var resp = await fetch('/api/conversations/search?q=' + encodeURIComponent(q));
         var results = await resp.json();
-        var convos = (results || []).map(function(r) {
+        var convos = (results || []).map(function(c) {
           return {
-            id: r.conversation.id,
-            title: r.conversation.title + (typeof r.score === 'number' ? ' (' + r.score.toFixed(2) + ')' : ''),
-            agent: r.conversation.agent,
-            turn_count: r.conversation.turn_count
+            id: c.id,
+            title: c.title,
+            agent: c.agent,
+            turn_count: c.turn_count
           };
         });
         renderConversationSearchResults(convos);

--- a/internal/web/ui/views/memories.js
+++ b/internal/web/ui/views/memories.js
@@ -8,7 +8,7 @@
       return;
     }
     el.innerHTML = results.map(function(r) {
-      var m = r.memory || r;
+      var m = r;
       var score = (typeof r.score === 'number') ? r.score : null;
       var preview = (m.l0 || m.l1 || '').substring(0, 80);
       return '<div class="tree-node peer-leaf clickable" data-memory-id="' + esc(m.id) + '" ' +


### PR DESCRIPTION
## Summary

Per manifest `019dac18-638`, normalize `GET /api/<type>/search` response shape across every entity type so the frontend can render results without per-endpoint unwrapping.

- **memories/search (GET)**: unwrap `memory.SearchResult` → `[]memory.Memory`. POST stays scored/wrapped (backward-compat for MCP). Opt-in `?scored=true` surfaces `{items, scores}` on GET.
- **conversations/search (GET)**: unwrap, drop `turns` array, compute `turn_count`. Shape now matches `/api/conversations` slim list. Fixes the blank-search-results bug where `r.conversation.turn_count` was `undefined` because the backend sent `turns: [...]`, not `turn_count`.
- **tasks / products / ideas / actions / manifests (GET)**: initialize slice literals so empty results marshal as `[]`, not `null` — closes T3R Nit #1 from PR #129.
- Frontend: drop the now-dead unwrap in `conversations.js:12-19` and `memories.js:11`.
- Tests: extend `handlers_search_test.go` with `empty-result-is-[]-not-null` and `shape-matches-list-endpoint` assertions.

## Test plan

- [x] `go build ./...` — green
- [x] `go vet ./...` — green
- [x] `go test ./...` — all packages green (web suite includes new shape tests)
- [ ] Live: conversations tab search returns rendered items (title + agent + turn count), no `undefined` text
- [ ] Live: tasks/products/ideas/actions/manifests search with no matches renders \"empty\" state (never throws on `null.length`)
- [ ] Live: POST `/api/memories/search` and `/api/conversations/search` still return scored wrapped results for MCP callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)