### PR TITLE
fix(mcp): resolve comment_add target_id to full UUID — stop orphaning reviews

### DIFF
--- a/internal/mcp/tools_comments.go
+++ b/internal/mcp/tools_comments.go
@@ -12,6 +12,13 @@ import (
 // handleCommentAdd posts a comment on a product, manifest, or task.
 // Matches the HTTP addComment handler in internal/web/handlers_comments.go:246
 // so MCP and HTTP paths stay behaviorally identical.
+//
+// target_id is accepted as either the full UUID or a short marker (first
+// 8-12 chars). The handler resolves to the full UUID before insert so the
+// dashboard — which queries by full UUID — always finds the comment. Agents
+// that interpolate the short marker from the runner prompt stop orphaning
+// rows. Non-existent target_ids return a clean error rather than silently
+// writing a dangling row.
 func (s *Server) handleCommentAdd(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	a := args(req)
 	targetType := argStr(a, "target_type")
@@ -30,11 +37,65 @@ func (s *Server) handleCommentAdd(ctx context.Context, req mcplib.CallToolReques
 		return errResult("validate: %v", err), nil
 	}
 
-	c, err := s.node.Comments.Add(ctx, target, targetID, author, ct, body)
+	resolvedID, err := s.resolveCommentTarget(target, targetID)
+	if err != nil {
+		return errResult("%v", err), nil
+	}
+
+	c, err := s.node.Comments.Add(ctx, target, resolvedID, author, ct, body)
 	if err != nil {
 		return errResult("add comment: %v", err), nil
 	}
 
 	return textResult(fmt.Sprintf("Comment added [%s] on %s %s by %s (type=%s)",
 		c.ID, c.TargetType, c.TargetID, c.Author, c.Type)), nil
+}
+
+// resolveCommentTarget canonicalizes a short-marker or full-UUID target_id
+// into the full 36-char UUID by looking it up in the respective entity store.
+// Returns an error if the target does not exist. Safe to pass a full UUID —
+// each entity's Get method accepts either form via id = ? OR id LIKE ?.
+//
+// When a store is not wired (e.g. tests with a minimal Node), the raw id is
+// returned unchanged so tool registration still works.
+func (s *Server) resolveCommentTarget(target comments.TargetType, raw string) (string, error) {
+	switch target {
+	case comments.TargetTask:
+		if s.node.Tasks == nil {
+			return raw, nil
+		}
+		t, err := s.node.Tasks.Get(raw)
+		if err != nil {
+			return "", fmt.Errorf("resolve target task %q: %w", raw, err)
+		}
+		if t == nil {
+			return "", fmt.Errorf("target task not found: %s", raw)
+		}
+		return t.ID, nil
+	case comments.TargetManifest:
+		if s.node.Manifests == nil {
+			return raw, nil
+		}
+		m, err := s.node.Manifests.Get(raw)
+		if err != nil {
+			return "", fmt.Errorf("resolve target manifest %q: %w", raw, err)
+		}
+		if m == nil {
+			return "", fmt.Errorf("target manifest not found: %s", raw)
+		}
+		return m.ID, nil
+	case comments.TargetProduct:
+		if s.node.Products == nil {
+			return raw, nil
+		}
+		p, err := s.node.Products.Get(raw)
+		if err != nil {
+			return "", fmt.Errorf("resolve target product %q: %w", raw, err)
+		}
+		if p == nil {
+			return "", fmt.Errorf("target product not found: %s", raw)
+		}
+		return p.ID, nil
+	}
+	return raw, nil
 }

--- a/internal/mcp/tools_comments_test.go
+++ b/internal/mcp/tools_comments_test.go
@@ -7,7 +7,10 @@ import (
 	"testing"
 
 	"github.com/k8nstantin/OpenPraxis/internal/comments"
+	"github.com/k8nstantin/OpenPraxis/internal/manifest"
 	"github.com/k8nstantin/OpenPraxis/internal/node"
+	"github.com/k8nstantin/OpenPraxis/internal/product"
+	"github.com/k8nstantin/OpenPraxis/internal/task"
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	_ "github.com/mattn/go-sqlite3"
@@ -120,4 +123,135 @@ func isErrResult(r *mcplib.CallToolResult) bool {
 		return false
 	}
 	return r.IsError
+}
+
+// newTestServerWithAllStores wires Comments + Tasks + Manifests + Products so
+// the resolveCommentTarget path can look up targets by marker or full UUID.
+func newTestServerWithAllStores(t *testing.T) (*Server, *sql.DB) {
+	t.Helper()
+	dsn := "file::memory:?cache=shared&_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	if err := comments.InitSchema(db); err != nil {
+		t.Fatalf("InitSchema comments: %v", err)
+	}
+	tasks, err := task.NewStore(db)
+	if err != nil {
+		t.Fatalf("NewStore tasks: %v", err)
+	}
+	manifests, err := manifest.NewStore(db)
+	if err != nil {
+		t.Fatalf("NewStore manifests: %v", err)
+	}
+	products, err := product.NewStore(db)
+	if err != nil {
+		t.Fatalf("NewStore products: %v", err)
+	}
+
+	n := &node.Node{
+		Comments:  comments.NewStore(db),
+		Tasks:     tasks,
+		Manifests: manifests,
+		Products:  products,
+	}
+	return &Server{node: n}, db
+}
+
+// TestCommentAdd_ResolvesShortMarker_Task — the core bug this PR fixes.
+// Agent interpolates the 12-char marker from the runner prompt; handler
+// MUST canonicalize to the full UUID before insert so the dashboard (which
+// queries by full UUID) finds the comment.
+func TestCommentAdd_ResolvesShortMarker_Task(t *testing.T) {
+	s, _ := newTestServerWithAllStores(t)
+
+	// Seed a task. Store.Create returns the full UUID.
+	tk, err := s.node.Tasks.Create("", "Example task", "desc", "once", "claude-code", "", "", "")
+	if err != nil {
+		t.Fatalf("Create task: %v", err)
+	}
+	if len(tk.ID) != 36 {
+		t.Fatalf("expected 36-char UUID, got %q (len=%d)", tk.ID, len(tk.ID))
+	}
+
+	// Agent passes the 12-char marker — classic runner-prompt interpolation.
+	shortMarker := tk.ID[:12]
+	res, err := s.handleCommentAdd(context.Background(), buildReq(map[string]any{
+		"target_type": "task",
+		"target_id":   shortMarker,
+		"author":      "agent",
+		"type":        "review_approval",
+		"body":        "**APPROVE** — posted with short marker target_id",
+	}))
+	if err != nil {
+		t.Fatalf("handleCommentAdd: %v", err)
+	}
+	if isErrResult(res) {
+		t.Fatalf("unexpected tool error: %q", toolResultText(res))
+	}
+
+	// The comment row MUST have target_id = the full UUID, not the short marker.
+	cs, err := s.node.Comments.List(context.Background(),
+		comments.TargetTask, tk.ID, 10, nil)
+	if err != nil {
+		t.Fatalf("ListByTarget full UUID: %v", err)
+	}
+	if len(cs) != 1 {
+		t.Fatalf("expected 1 comment on full UUID, got %d", len(cs))
+	}
+	if cs[0].TargetID != tk.ID {
+		t.Fatalf("target_id not canonicalized: got %q, want %q", cs[0].TargetID, tk.ID)
+	}
+
+	// And crucially the short-marker lookup must return zero — no orphan.
+	orphans, err := s.node.Comments.List(context.Background(),
+		comments.TargetTask, shortMarker, 10, nil)
+	if err != nil {
+		t.Fatalf("ListByTarget short: %v", err)
+	}
+	if len(orphans) != 0 {
+		t.Fatalf("expected 0 orphans on short marker, got %d", len(orphans))
+	}
+}
+
+func TestCommentAdd_FullUUIDPassthrough_Task(t *testing.T) {
+	s, _ := newTestServerWithAllStores(t)
+	tk, _ := s.node.Tasks.Create("", "Task", "desc", "once", "claude-code", "", "", "")
+
+	res, _ := s.handleCommentAdd(context.Background(), buildReq(map[string]any{
+		"target_type": "task",
+		"target_id":   tk.ID, // full UUID
+		"author":      "agent",
+		"type":        "execution_review",
+		"body":        "x",
+	}))
+	if isErrResult(res) {
+		t.Fatalf("full-UUID should pass through: %q", toolResultText(res))
+	}
+	cs, _ := s.node.Comments.List(context.Background(),
+		comments.TargetTask, tk.ID, 10, nil)
+	if len(cs) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(cs))
+	}
+}
+
+func TestCommentAdd_RejectsNonExistentTarget_Task(t *testing.T) {
+	s, _ := newTestServerWithAllStores(t)
+
+	res, _ := s.handleCommentAdd(context.Background(), buildReq(map[string]any{
+		"target_type": "task",
+		"target_id":   "deadbeef-nope",
+		"author":      "agent",
+		"type":        "execution_review",
+		"body":        "x",
+	}))
+	if !isErrResult(res) {
+		t.Fatalf("expected not-found error, got %q", toolResultText(res))
+	}
+	if !strings.Contains(toolResultText(res), "not found") {
+		t.Fatalf("expected 'not found' in error, got %q", toolResultText(res))
+	}
 }


### PR DESCRIPTION
## Summary

Every review task in today's Per-Tab Search chain posted its `review_approval` comment with `target_id` set to the 12-char short marker (e.g. `019dab07-0bd`) because the runner prompt interpolates `Task.Marker`, the agent passes that literal into `mcp__openpraxis__comment_add`, and the handler wrote it verbatim. The dashboard queries by full UUID (`019dab07-0bdb-7079-a048-490236423ef7`), so every review comment was invisible. Each round required a manual SQL `UPDATE` migration.

## Fix

Resolve `target_id` to the full 36-char UUID at the MCP handler boundary before calling `comments.Store.Add`. Non-existent targets now return a clean error rather than silently writing a dangling row.

- `internal/mcp/tools_comments.go`: new `resolveCommentTarget` helper walks `Tasks` / `Manifests` / `Products` stores. `nil` stores short-circuit to the raw id (test-friendly).
- `internal/mcp/tools_comments_test.go`: 3 new tests.

## Test plan

- [x] `go build ./...` green
- [x] `go vet ./...` green
- [x] `go test ./internal/mcp/...` — 7/7 PASS (4 existing + 3 new):
  - `TestCommentAdd_ResolvesShortMarker_Task` — core bug repro
  - `TestCommentAdd_FullUUIDPassthrough_Task` — no regression for full UUIDs
  - `TestCommentAdd_RejectsNonExistentTarget_Task` — clean error on bogus id
- [ ] Post-merge live: next review task in any chain posts `review_approval` with full UUID, comment appears in dashboard without SQL migration.

## Addresses

Issue #130 bullets B3 (agent fabricated target_ids) and B4 (short-marker lookups silently fail). Root-cause equivalent for the HTTP `addComment` handler at `internal/web/handlers_comments.go:246` is left for a follow-up — same one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)