### PR TITLE
fix(settings): catalog default allowed_tools includes runner MCP tools

### DIFF
--- a/internal/settings/catalog.go
+++ b/internal/settings/catalog.go
@@ -58,7 +58,24 @@ func Catalog() []KnobDef {
 		{Key: "default_model", Type: KnobString, Default: "", Description: "Model ID (agent-dependent)"},
 		{Key: "retry_on_failure", Type: KnobInt, SliderMin: f(0), SliderMax: f(10), SliderStep: f(1), Default: 0, Description: "Auto-retry count"},
 		{Key: "approval_mode", Type: KnobEnum, EnumValues: []string{"auto", "manual", "on-failure"}, Default: "auto", Description: "Codex approval mode"},
-		{Key: "allowed_tools", Type: KnobMultiselect, Default: []string{"Bash", "Read", "Write", "Edit", "Glob", "Grep"}, Description: "Tool allowlist for agent"},
+		{Key: "allowed_tools", Type: KnobMultiselect, Default: []string{
+			"Bash", "Read", "Write", "Edit", "Glob", "Grep",
+			// MCP tools the runner's prompt template instructs agents to call.
+			// Must stay in sync with internal/task/runner.go:defaultAllowedTools.
+			// Missing any of these silently denies the agent — it can't post its
+			// closing execution_review, load visceral rules, or read settings.
+			"mcp__openpraxis__memory_store",
+			"mcp__openpraxis__memory_search",
+			"mcp__openpraxis__memory_recall",
+			"mcp__openpraxis__visceral_rules",
+			"mcp__openpraxis__visceral_confirm",
+			"mcp__openpraxis__manifest_get",
+			"mcp__openpraxis__conversation_save",
+			"mcp__openpraxis__settings_get",
+			"mcp__openpraxis__settings_resolve",
+			"mcp__openpraxis__settings_catalog",
+			"mcp__openpraxis__comment_add",
+		}, Description: "Tool allowlist for agent. Includes MCP tools the runner prompts reference; removing any breaks the corresponding closing step."},
 	}
 }
 


### PR DESCRIPTION
## Summary

The catalog default for \`allowed_tools\` was the 6-tool core list with no MCP tools. Because the catalog default wins over \`runner.go:defaultAllowedTools\` (which only fires when the resolver returns empty), every new product inherited the broken default and agents couldn't call \`mcp__openpraxis__comment_add\`, \`visceral_rules\`, \`settings_get\`, etc.

Observed today: task \`019dafbc-31c\` (under fresh Watcher Observer product \`019dafba-3b9\`) completed with zero \`execution_review\` comments because \`comment_add\` was denied by the 6-tool allowlist. Same pattern repeats on every new product until the operator manually sets \`allowed_tools\` at product scope.

This is issue #130 B2: PR #124 added \`comment_add\` to \`defaultAllowedTools\` in runner.go but that was dead code — the catalog default shadows it.

## Fix

Catalog default now lists every MCP tool the runner's prompt template references, matching \`runner.go:defaultAllowedTools\` 1:1. New products inherit the working list by default. Operators with explicit overrides are unaffected — their override still wins.

## Test plan

- [x] \`go build ./...\` green
- [x] \`go vet ./...\` green
- [x] \`go test ./internal/settings/...\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)