### PR TITLE
fix(web): resolve HTTP comment target_id to full UUID — kill short-marker orphans

### DIFF
--- a/internal/web/handlers_comments.go
+++ b/internal/web/handlers_comments.go
@@ -210,14 +210,82 @@ type editCommentRequest struct {
 	Body string `json:"body"`
 }
 
+// TargetResolver canonicalizes a target_id from the URL path into the full
+// UUID by looking up the entity. Accepts short markers (8-12 char prefixes)
+// as well as full UUIDs. Returns an error if the target does not exist.
+//
+// Tests can pass a passthrough resolver (returns raw as-is) when entity
+// stores are not wired; production uses nodeTargetResolver.
+type TargetResolver func(target comments.TargetType, raw string) (string, error)
+
+// passthroughResolver is the no-op TargetResolver for tests that don't wire
+// real entity stores. Accepts whatever id the caller passes.
+func passthroughResolver(_ comments.TargetType, raw string) (string, error) {
+	return raw, nil
+}
+
+// nodeTargetResolver builds a TargetResolver backed by the node's entity
+// stores. Each store's Get accepts marker or full UUID via `id = ? OR id LIKE ?`.
+func nodeTargetResolver(n *node.Node) TargetResolver {
+	return func(target comments.TargetType, raw string) (string, error) {
+		switch target {
+		case comments.TargetTask:
+			if n.Tasks == nil {
+				return raw, nil
+			}
+			t, err := n.Tasks.Get(raw)
+			if err != nil {
+				return "", fmt.Errorf("resolve target task %q: %w", raw, err)
+			}
+			if t == nil {
+				return "", fmt.Errorf("target task not found: %s", raw)
+			}
+			return t.ID, nil
+		case comments.TargetManifest:
+			if n.Manifests == nil {
+				return raw, nil
+			}
+			m, err := n.Manifests.Get(raw)
+			if err != nil {
+				return "", fmt.Errorf("resolve target manifest %q: %w", raw, err)
+			}
+			if m == nil {
+				return "", fmt.Errorf("target manifest not found: %s", raw)
+			}
+			return m.ID, nil
+		case comments.TargetProduct:
+			if n.Products == nil {
+				return raw, nil
+			}
+			p, err := n.Products.Get(raw)
+			if err != nil {
+				return "", fmt.Errorf("resolve target product %q: %w", raw, err)
+			}
+			if p == nil {
+				return "", fmt.Errorf("target product not found: %s", raw)
+			}
+			return p.ID, nil
+		}
+		return raw, nil
+	}
+}
+
 // listComments is the shared handler body for
 // GET /api/{products|manifests|tasks}/{id}/comments.
-func listComments(store *comments.Store, target comments.TargetType) http.HandlerFunc {
+//
+// Resolves the URL {id} to full UUID so short markers find the same
+// target_id rows that MCP comment_add (also resolved) wrote.
+func listComments(store *comments.Store, target comments.TargetType, resolve TargetResolver) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		id := mux.Vars(r)["id"]
-		if id == "" {
+		rawID := mux.Vars(r)["id"]
+		if rawID == "" {
 			writeCommentError(w, "empty_target_id",
 				comments.ErrEmptyTargetID.Error(), http.StatusBadRequest)
+			return
+		}
+		id, err := resolve(target, rawID)
+		if err != nil {
+			writeCommentError(w, "target_not_found", err.Error(), http.StatusNotFound)
 			return
 		}
 		limit, ok := parseLimit(w, r)
@@ -243,12 +311,20 @@ func listComments(store *comments.Store, target comments.TargetType) http.Handle
 
 // addComment is the shared handler body for
 // POST /api/{products|manifests|tasks}/{id}/comments.
-func addComment(store *comments.Store, target comments.TargetType) http.HandlerFunc {
+//
+// Resolves the URL {id} to full UUID before insert so comments posted via
+// HTTP never orphan on a short-marker target_id.
+func addComment(store *comments.Store, target comments.TargetType, resolve TargetResolver) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		id := mux.Vars(r)["id"]
-		if id == "" {
+		rawID := mux.Vars(r)["id"]
+		if rawID == "" {
 			writeCommentError(w, "empty_target_id",
 				comments.ErrEmptyTargetID.Error(), http.StatusBadRequest)
+			return
+		}
+		id, err := resolve(target, rawID)
+		if err != nil {
+			writeCommentError(w, "target_not_found", err.Error(), http.StatusNotFound)
 			return
 		}
 		var req addCommentRequest
@@ -353,12 +429,17 @@ var commentScopeRoutes = []struct {
 	{"tasks", comments.TargetTask},
 }
 
-// registerCommentsRoutes attaches the 8 comment endpoints to /api.
-func registerCommentsRoutes(api *mux.Router, store *comments.Store) {
+// registerCommentsRoutes attaches the 8 comment endpoints to /api using the
+// given TargetResolver. Tests pass passthroughResolver; production wires
+// nodeTargetResolver via registerCommentsRoutesFromNode.
+func registerCommentsRoutes(api *mux.Router, store *comments.Store, resolve TargetResolver) {
+	if resolve == nil {
+		resolve = passthroughResolver
+	}
 	for _, s := range commentScopeRoutes {
 		path := "/" + s.segment + "/{id}/comments"
-		api.HandleFunc(path, listComments(store, s.target)).Methods("GET")
-		api.HandleFunc(path, addComment(store, s.target)).Methods("POST")
+		api.HandleFunc(path, listComments(store, s.target, resolve)).Methods("GET")
+		api.HandleFunc(path, addComment(store, s.target, resolve)).Methods("POST")
 	}
 	api.HandleFunc("/comments/types", listCommentTypes()).Methods("GET")
 	api.HandleFunc("/comments/{id}", editComment(store)).Methods("PATCH")
@@ -366,7 +447,8 @@ func registerCommentsRoutes(api *mux.Router, store *comments.Store) {
 }
 
 // registerCommentsRoutesFromNode is the production entry point. Keeps the
-// wire-up in handler.go a single line.
+// wire-up in handler.go a single line. Uses nodeTargetResolver so every
+// HTTP comment call canonicalizes target_id to full UUID before insert/read.
 func registerCommentsRoutesFromNode(api *mux.Router, n *node.Node) {
-	registerCommentsRoutes(api, n.Comments)
+	registerCommentsRoutes(api, n.Comments, nodeTargetResolver(n))
 }

--- a/internal/web/handlers_comments_resolve_test.go
+++ b/internal/web/handlers_comments_resolve_test.go
@@ -1,0 +1,146 @@
+package web
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
+	"github.com/k8nstantin/OpenPraxis/internal/manifest"
+	"github.com/k8nstantin/OpenPraxis/internal/node"
+	"github.com/k8nstantin/OpenPraxis/internal/product"
+	"github.com/k8nstantin/OpenPraxis/internal/task"
+
+	"github.com/gorilla/mux"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// TestAddComment_ResolvesShortMarker — the bug this PR fixes. HTTP POST to
+// /api/tasks/<short-marker>/comments MUST write target_id = full UUID,
+// matching what MCP comment_add already does after PR #136.
+func TestAddComment_ResolvesShortMarker_Task(t *testing.T) {
+	n, tasks, commentsStore := setupResolveTestNode(t)
+
+	tk, err := tasks.Create("", "Example task", "desc", "once", "claude-code", "", "", "")
+	if err != nil {
+		t.Fatalf("Create task: %v", err)
+	}
+	if len(tk.ID) != 36 {
+		t.Fatalf("expected 36-char UUID, got %q", tk.ID)
+	}
+	shortMarker := tk.ID[:12]
+
+	api := mux.NewRouter().PathPrefix("/api").Subrouter()
+	registerCommentsRoutesFromNode(api, n)
+
+	body := `{"author":"operator","type":"user_note","body":"posted via short marker"}`
+	req := httptest.NewRequest("POST", "/api/tasks/"+shortMarker+"/comments", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	api.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var view commentView
+	if err := json.Unmarshal(rec.Body.Bytes(), &view); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if view.TargetID != tk.ID {
+		t.Fatalf("target_id not canonicalized: got %q, want %q", view.TargetID, tk.ID)
+	}
+
+	cs, err := commentsStore.List(req.Context(), comments.TargetTask, tk.ID, 10, nil)
+	if err != nil {
+		t.Fatalf("List full UUID: %v", err)
+	}
+	if len(cs) != 1 {
+		t.Fatalf("expected 1 comment on full UUID, got %d", len(cs))
+	}
+	orphans, _ := commentsStore.List(req.Context(), comments.TargetTask, shortMarker, 10, nil)
+	if len(orphans) != 0 {
+		t.Fatalf("expected 0 orphans on short marker, got %d", len(orphans))
+	}
+}
+
+func TestListComments_ResolvesShortMarker_Task(t *testing.T) {
+	n, tasks, commentsStore := setupResolveTestNode(t)
+	tk, _ := tasks.Create("", "Example", "desc", "once", "claude-code", "", "", "")
+
+	if _, err := commentsStore.Add(t.Context(), comments.TargetTask, tk.ID, "operator",
+		comments.TypeUserNote, "seeded"); err != nil {
+		t.Fatalf("seed comment: %v", err)
+	}
+
+	api := mux.NewRouter().PathPrefix("/api").Subrouter()
+	registerCommentsRoutesFromNode(api, n)
+
+	req := httptest.NewRequest("GET", "/api/tasks/"+tk.ID[:8]+"/comments", nil)
+	rec := httptest.NewRecorder()
+	api.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var out listCommentsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Comments) != 1 {
+		t.Fatalf("expected 1 comment via short marker, got %d", len(out.Comments))
+	}
+}
+
+func TestAddComment_RejectsNonExistentTarget_Task(t *testing.T) {
+	n, _, _ := setupResolveTestNode(t)
+	api := mux.NewRouter().PathPrefix("/api").Subrouter()
+	registerCommentsRoutesFromNode(api, n)
+
+	body := `{"author":"op","type":"user_note","body":"x"}`
+	req := httptest.NewRequest("POST", "/api/tasks/deadbeef-nope/comments", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	api.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for nonexistent target, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func setupResolveTestNode(t *testing.T) (*node.Node, *task.Store, *comments.Store) {
+	t.Helper()
+	dsn := "file::memory:?cache=shared&_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	if err := comments.InitSchema(db); err != nil {
+		t.Fatalf("InitSchema comments: %v", err)
+	}
+	tasks, err := task.NewStore(db)
+	if err != nil {
+		t.Fatalf("NewStore tasks: %v", err)
+	}
+	manifests, err := manifest.NewStore(db)
+	if err != nil {
+		t.Fatalf("NewStore manifests: %v", err)
+	}
+	products, err := product.NewStore(db)
+	if err != nil {
+		t.Fatalf("NewStore products: %v", err)
+	}
+	cs := comments.NewStore(db)
+
+	return &node.Node{
+		Comments:  cs,
+		Tasks:     tasks,
+		Manifests: manifests,
+		Products:  products,
+	}, tasks, cs
+}

--- a/internal/web/handlers_comments_test.go
+++ b/internal/web/handlers_comments_test.go
@@ -46,7 +46,7 @@ func newCommentsTestEnv(t *testing.T) *commentsTestEnv {
 
 	r := mux.NewRouter()
 	api := r.PathPrefix("/api").Subrouter()
-	registerCommentsRoutes(api, store)
+	registerCommentsRoutes(api, store, nil)
 
 	srv := httptest.NewServer(r)
 	t.Cleanup(func() {
@@ -499,7 +499,7 @@ func TestGET_CommentsTypes(t *testing.T) {
 func TestRoutes_AllCommentEndpointsRegistered(t *testing.T) {
 	r := mux.NewRouter()
 	api := r.PathPrefix("/api").Subrouter()
-	registerCommentsRoutes(api, nil)
+	registerCommentsRoutes(api, nil, nil)
 
 	want := map[string]string{
 		"GET /api/products/{id}/comments":   "",


### PR DESCRIPTION
## Summary

PR #136 fixed MCP \`comment_add\` short→full resolution. HTTP \`POST /api/{products|manifests|tasks}/{id}/comments\` still stored \`target_id\` literally — operators (or dashboard code) posting via a short marker created orphan comments invisible to the dashboard which queries by full UUID.

Root cause is the same class of bug as issue #130 B3/B4: UUID v7 is the authoritative identifier, shortened markers are display only, but several call sites let the short form leak into stored data. This PR plugs the HTTP comment endpoints.

## Fix

- New \`TargetResolver\` func type in \`internal/web/handlers_comments.go\`.
- \`addComment\` and \`listComments\` accept it alongside store + target; they canonicalize URL \`{id}\` before calling the store.
- \`nodeTargetResolver\` looks up \`n.Tasks\`/\`n.Manifests\`/\`n.Products\` via their \`Get(id)\` (already accepts marker or full).
- Nonexistent target returns 404 instead of silently orphaning.
- Tests: new \`handlers_comments_resolve_test.go\` covers short-marker resolve on POST + GET, and rejection on nonexistent target. Existing tests updated to pass \`nil\` resolver (passthrough).

## Test plan

- [x] \`go build ./...\` green
- [x] \`go vet ./...\` green
- [x] \`go test ./internal/web/... -run Comment\` — 20+ PASS including 3 new

Closes issue #130 B3/B4 HTTP-side. MCP-side done in PR #136. Catalog allowlist fixed in PR #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)