### PR TITLE
fix(admin): sweep legacy short-marker comment orphans

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
+	"github.com/k8nstantin/OpenPraxis/internal/config"
+	"github.com/k8nstantin/OpenPraxis/internal/node"
+
+	"github.com/spf13/cobra"
+)
+
+var adminCmd = &cobra.Command{
+	Use:   "admin",
+	Short: "Operator-only maintenance commands",
+}
+
+var migrateCommentOrphansApply bool
+
+var migrateCommentOrphansCmd = &cobra.Command{
+	Use:   "migrate-comment-orphans",
+	Short: "Rewrite short-marker comment target_ids to full UUIDs",
+	Long: `Scans the comments table for rows whose target_id is a short
+marker (length < 36). For each row, looks up the canonical full UUID via
+the product/manifest/task stores (which accept marker OR full id). Rows
+whose target cannot be resolved are logged and left alone — nothing is
+deleted. Dry-run by default; pass --apply to actually write.
+
+Motivation: before PRs #136 (MCP comment_add) and #139 (HTTP comment
+handler) landed, both paths stored target_id verbatim, so comments
+posted with short markers became invisible to the dashboard (which
+queries by full UUID). This command sweeps the legacy rows.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		})))
+
+		cfg, err := config.Load(cfgFile)
+		if err != nil {
+			return fmt.Errorf("load config: %w", err)
+		}
+		n, err := node.New(cfg)
+		if err != nil {
+			return fmt.Errorf("init node: %w", err)
+		}
+		defer n.Close()
+
+		resolver := &nodeTargetResolver{n: n}
+		report, err := comments.SweepOrphans(context.Background(), n.Index.DB(), resolver, !migrateCommentOrphansApply)
+		if err != nil {
+			return fmt.Errorf("sweep: %w", err)
+		}
+
+		mode := "dry-run"
+		if migrateCommentOrphansApply {
+			mode = "apply"
+		}
+		fmt.Printf("orphan comment sweep (%s)\n", mode)
+		fmt.Printf("  scanned:      %d\n", report.Scanned)
+		fmt.Printf("  migrated:     %d\n", report.Migrated)
+		fmt.Printf("  unresolvable: %d\n", report.Unresolvable)
+		if len(report.ByTargetType) > 0 {
+			fmt.Printf("  by target_type:\n")
+			for _, tt := range []string{"product", "manifest", "task"} {
+				if c := report.ByTargetType[tt]; c > 0 {
+					fmt.Printf("    %-9s %d\n", tt+":", c)
+				}
+			}
+		}
+		if !migrateCommentOrphansApply && report.Migrated > 0 {
+			fmt.Printf("\n(dry-run — re-run with --apply to write changes)\n")
+		}
+		return nil
+	},
+}
+
+// nodeTargetResolver adapts node.Node to comments.TargetResolver by
+// dispatching to the product/manifest/task store Get methods. Each of
+// those stores already accepts a marker prefix OR a full UUID via the
+// `id = ? OR id LIKE ?` query form, so short markers resolve naturally.
+type nodeTargetResolver struct{ n *node.Node }
+
+func (r *nodeTargetResolver) Resolve(ctx context.Context, t comments.TargetType, id string) (string, error) {
+	switch t {
+	case comments.TargetTask:
+		tk, err := r.n.Tasks.Get(id)
+		if err != nil || tk == nil {
+			return "", nil
+		}
+		return tk.ID, nil
+	case comments.TargetManifest:
+		m, err := r.n.Manifests.Get(id)
+		if err != nil || m == nil {
+			return "", nil
+		}
+		return m.ID, nil
+	case comments.TargetProduct:
+		p, err := r.n.Products.Get(id)
+		if err != nil || p == nil {
+			return "", nil
+		}
+		return p.ID, nil
+	}
+	return "", nil
+}
+
+func init() {
+	migrateCommentOrphansCmd.Flags().BoolVar(&migrateCommentOrphansApply, "apply", false, "actually write UPDATEs (default: dry-run)")
+	adminCmd.AddCommand(migrateCommentOrphansCmd)
+	rootCmd.AddCommand(adminCmd)
+}

--- a/internal/comments/orphan_sweep.go
+++ b/internal/comments/orphan_sweep.go
@@ -1,0 +1,85 @@
+package comments
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+)
+
+// TargetResolver resolves a (target_type, raw target_id) pair — where the
+// raw id may be a short marker prefix — to the canonical full UUID. An
+// empty string return means the target entity does not exist (orphan).
+//
+// The sweep uses this to migrate pre-#136/#139 short-marker comment rows.
+// Kept as an interface here so the comments package stays free of an
+// internal/node import (node already imports comments — reversing would
+// cycle).
+type TargetResolver interface {
+	Resolve(ctx context.Context, target TargetType, id string) (string, error)
+}
+
+// SweepReport summarises a SweepOrphans run.
+type SweepReport struct {
+	Scanned      int
+	Migrated     int
+	Unresolvable int
+	ByTargetType map[string]int
+}
+
+// SweepOrphans finds comments whose target_id is a short marker (length < 36)
+// and, for each, resolves the real full UUID via the provided TargetResolver.
+// Resolvable rows are updated to the full UUID; unresolvable rows are logged
+// and left alone (operator-investigable). If dryRun is true, no UPDATEs run —
+// the report still reflects what would have been migrated.
+func SweepOrphans(ctx context.Context, db *sql.DB, r TargetResolver, dryRun bool) (SweepReport, error) {
+	report := SweepReport{ByTargetType: map[string]int{}}
+
+	rows, err := db.QueryContext(ctx,
+		`SELECT id, target_type, target_id FROM comments WHERE length(target_id) < 36`)
+	if err != nil {
+		return report, fmt.Errorf("orphan sweep: scan: %w", err)
+	}
+	defer rows.Close()
+
+	type row struct{ id, tt, tid string }
+	var found []row
+	for rows.Next() {
+		var x row
+		if err := rows.Scan(&x.id, &x.tt, &x.tid); err != nil {
+			return report, fmt.Errorf("orphan sweep: scan row: %w", err)
+		}
+		found = append(found, x)
+	}
+	if err := rows.Err(); err != nil {
+		return report, fmt.Errorf("orphan sweep: rows err: %w", err)
+	}
+	report.Scanned = len(found)
+
+	for _, x := range found {
+		full, rerr := r.Resolve(ctx, TargetType(x.tt), x.tid)
+		if rerr != nil || full == "" {
+			report.Unresolvable++
+			slog.Error("orphan comment unresolvable",
+				"comment_id", x.id,
+				"target_type", x.tt,
+				"target_id", x.tid,
+				"err", rerr,
+			)
+			continue
+		}
+		if full == x.tid {
+			// Already full (shouldn't happen given the length filter, but guard anyway).
+			continue
+		}
+		if !dryRun {
+			if _, err := db.ExecContext(ctx,
+				`UPDATE comments SET target_id = ? WHERE id = ?`, full, x.id); err != nil {
+				return report, fmt.Errorf("orphan sweep: update %s: %w", x.id, err)
+			}
+		}
+		report.Migrated++
+		report.ByTargetType[x.tt]++
+	}
+	return report, nil
+}

--- a/internal/comments/orphan_sweep_test.go
+++ b/internal/comments/orphan_sweep_test.go
@@ -1,0 +1,148 @@
+package comments
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// stubResolver implements TargetResolver using two maps keyed by target_type
+// then short-marker prefix → full UUID. Unknown keys return "".
+type stubResolver struct {
+	full map[TargetType]map[string]string
+}
+
+func (r *stubResolver) Resolve(ctx context.Context, t TargetType, id string) (string, error) {
+	inner, ok := r.full[t]
+	if !ok {
+		return "", nil
+	}
+	return inner[id], nil
+}
+
+// seedOrphan inserts a comment row with an arbitrary target_id (may be short).
+func seedOrphan(t *testing.T, db *sql.DB, target TargetType, targetID string) string {
+	t.Helper()
+	id, err := uuid.NewV7()
+	if err != nil {
+		t.Fatalf("uuid: %v", err)
+	}
+	_, err = db.Exec(
+		`INSERT INTO comments (id, target_type, target_id, author, type, body, created_at)
+		 VALUES (?, ?, ?, 'agent', 'user_note', 'body', ?)`,
+		id.String(), string(target), targetID, time.Now().Unix(),
+	)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	return id.String()
+}
+
+func TestSweepOrphans_DryRunReportsButDoesNotWrite(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	fullTaskA := "019dafbc-31c0-7000-8000-000000000001"
+	fullManB := "019dafe2-5030-7000-8000-000000000002"
+
+	shortTaskA := fullTaskA[:12]
+	shortManB := fullManB[:12]
+
+	cA := seedOrphan(t, db, TargetTask, shortTaskA)
+	cB := seedOrphan(t, db, TargetManifest, shortManB)
+	cGhost := seedOrphan(t, db, TargetTask, "deadbeefcafe")
+
+	// Also seed a non-orphan (full UUID length) row that should be skipped.
+	_ = seedOrphan(t, db, TargetProduct, "019dabbf-2df0-7000-8000-000000000003")
+
+	r := &stubResolver{full: map[TargetType]map[string]string{
+		TargetTask:     {shortTaskA: fullTaskA},
+		TargetManifest: {shortManB: fullManB},
+	}}
+
+	rep, err := SweepOrphans(ctx, db, r, true)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if rep.Scanned != 3 {
+		t.Fatalf("scanned: want 3, got %d", rep.Scanned)
+	}
+	if rep.Migrated != 2 {
+		t.Fatalf("migrated: want 2, got %d", rep.Migrated)
+	}
+	if rep.Unresolvable != 1 {
+		t.Fatalf("unresolvable: want 1, got %d", rep.Unresolvable)
+	}
+	if rep.ByTargetType["task"] != 1 || rep.ByTargetType["manifest"] != 1 {
+		t.Fatalf("by-type: %+v", rep.ByTargetType)
+	}
+
+	// Verify nothing actually changed on disk.
+	for _, id := range []string{cA, cB, cGhost} {
+		var got string
+		if err := db.QueryRow(`SELECT target_id FROM comments WHERE id = ?`, id).Scan(&got); err != nil {
+			t.Fatalf("query %s: %v", id, err)
+		}
+		if len(got) >= 36 {
+			t.Fatalf("dry-run mutated row %s: %s", id, got)
+		}
+	}
+}
+
+func TestSweepOrphans_ApplyMigratesResolvableOnly(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	fullTaskA := "019dafbc-31c0-7000-8000-000000000001"
+	fullManB := "019dafe2-5030-7000-8000-000000000002"
+	shortTaskA := fullTaskA[:12]
+	shortManB := fullManB[:12]
+	ghost := "deadbeefcafe"
+
+	cA := seedOrphan(t, db, TargetTask, shortTaskA)
+	cB := seedOrphan(t, db, TargetManifest, shortManB)
+	cGhost := seedOrphan(t, db, TargetTask, ghost)
+
+	r := &stubResolver{full: map[TargetType]map[string]string{
+		TargetTask:     {shortTaskA: fullTaskA},
+		TargetManifest: {shortManB: fullManB},
+	}}
+
+	rep, err := SweepOrphans(ctx, db, r, false)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if rep.Migrated != 2 || rep.Unresolvable != 1 {
+		t.Fatalf("report: %+v", rep)
+	}
+
+	check := func(id, want string) {
+		t.Helper()
+		var got string
+		if err := db.QueryRow(`SELECT target_id FROM comments WHERE id = ?`, id).Scan(&got); err != nil {
+			t.Fatalf("query %s: %v", id, err)
+		}
+		if got != want {
+			t.Fatalf("row %s: want target_id=%q, got %q", id, want, got)
+		}
+	}
+	check(cA, fullTaskA)
+	check(cB, fullManB)
+	check(cGhost, ghost) // unresolvable left alone
+
+	// Second run: everything resolvable is now length==36, so only the
+	// ghost is rescanned and still unresolvable; no new migrations.
+	rep2, err := SweepOrphans(ctx, db, r, false)
+	if err != nil {
+		t.Fatalf("sweep 2: %v", err)
+	}
+	if rep2.Migrated != 0 {
+		t.Fatalf("idempotency: expected 0 migrated on 2nd run, got %d", rep2.Migrated)
+	}
+	if rep2.Scanned != 1 || rep2.Unresolvable != 1 {
+		t.Fatalf("idempotency: expected 1 scanned/1 unresolvable on 2nd run, got %+v", rep2)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `openpraxis admin migrate-comment-orphans [--apply]` to rewrite pre-#136/#139 comments whose `target_id` was stored as a short marker prefix — these rows are invisible to the dashboard, which queries by full UUID.
- `internal/comments.SweepOrphans` scans `comments WHERE length(target_id) < 36`, resolves each via a `TargetResolver` (adapter dispatches to Products/Manifests/Tasks `Get`, which already accept marker OR full id), UPDATEs resolvable rows, logs unresolvable rows, never deletes.
- Dry-run default; `--apply` writes. Idempotent — second `--apply` migrates 0.

## Context
Fresh writes were fixed by PR #136 (MCP `comment_add`) and PR #139 (HTTP comment handler). This closes the loop by sweeping the historical rows those PRs left behind. Closes remaining ghost-data from #130 B3/B4.

Manifest: `019dafe2-503` (Historical orphan comment sweep). Product: `019dabbf-2df` OpenPraxis Entity ID Resolution.

## Design note
`comments.TargetResolver` is an interface rather than a direct `*node.Node` — `internal/node` already imports `internal/comments` (for review adapters), so reversing would cycle. The `nodeTargetResolver` adapter lives in `cmd/admin.go`.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/comments/...` green (new tests cover dry-run read-only, --apply migrates resolvable + preserves unresolvable, idempotency)
- [x] Live dry-run against real node DB found 5 orphans (all task comments, all resolvable, 0 unresolvable)
- [ ] Operator runs `./openpraxis admin migrate-comment-orphans --apply` and hard-refreshes dashboard — historical review comments should render on task detail panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)