### PR TITLE
feat(mcp+ui): task_update MCP + robust click-to-edit for manifest/task

### DIFF
--- a/internal/mcp/tools_task.go
+++ b/internal/mcp/tools_task.go
@@ -53,6 +53,16 @@ func (s *Server) registerTaskTools() {
 	)
 
 	s.mcp.AddTool(
+		mcplib.NewTool("task_update",
+			mcplib.WithDescription("Update a task's title and/or description. At least one of title or description must be provided. Accepts marker or full UUID."),
+			mcplib.WithString("id", mcplib.Required(), mcplib.Description("Task ID or 8-char marker")),
+			mcplib.WithString("title", mcplib.Description("New title (optional)")),
+			mcplib.WithString("description", mcplib.Description("New description (optional)")),
+		),
+		s.handleTaskUpdate,
+	)
+
+	s.mcp.AddTool(
 		mcplib.NewTool("task_cancel",
 			mcplib.WithDescription("Cancel a scheduled or running task."),
 			mcplib.WithString("id", mcplib.Required(), mcplib.Description("Task ID or marker")),
@@ -341,6 +351,50 @@ func (s *Server) handleTaskStart(ctx context.Context, req mcplib.CallToolRequest
 	}
 
 	return textResult(fmt.Sprintf("Task [%s] scheduled: %s (schedule: %s)", t.Marker, t.Title, schedule)), nil
+}
+
+func (s *Server) handleTaskUpdate(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := args(req)
+	id := argStr(a, "id")
+	if id == "" {
+		return errResult("id is required"), nil
+	}
+
+	t, err := s.node.Tasks.Get(id)
+	if err != nil {
+		return errResult("get task: %v", err), nil
+	}
+	if t == nil {
+		return errResult("task not found: %s", id), nil
+	}
+
+	// Map-presence check distinguishes "not provided" from "empty string".
+	// The store's Update takes *string so callers can explicitly clear a
+	// field — but the MCP surface only allows updates, not clears, and
+	// requires at least one of title/description.
+	var titlePtr, descPtr *string
+	if _, ok := a["title"]; ok {
+		v := argStr(a, "title")
+		titlePtr = &v
+	}
+	if _, ok := a["description"]; ok {
+		v := argStr(a, "description")
+		descPtr = &v
+	}
+	if titlePtr == nil && descPtr == nil {
+		return errResult("at least one of title or description is required"), nil
+	}
+
+	updated, err := s.node.Tasks.Update(t.ID, titlePtr, descPtr)
+	if err != nil {
+		return errResult("update task: %v", err), nil
+	}
+	if updated == nil {
+		return errResult("task not found after update: %s", id), nil
+	}
+
+	return textResult(fmt.Sprintf("Task [%s] updated: %s\nDescription: %s",
+		updated.Marker, updated.Title, updated.Description)), nil
 }
 
 func (s *Server) handleTaskCancel(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {

--- a/internal/mcp/tools_task_test.go
+++ b/internal/mcp/tools_task_test.go
@@ -1,0 +1,148 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestTaskUpdate_TitleOnly — happy path, title replaced, description preserved.
+func TestTaskUpdate_TitleOnly(t *testing.T) {
+	s, _ := newTestServerWithAllStores(t)
+	tk, err := s.node.Tasks.Create("", "original title", "original desc", "once", "claude-code", "", "", "")
+	if err != nil {
+		t.Fatalf("Create task: %v", err)
+	}
+
+	res, err := s.handleTaskUpdate(context.Background(), buildReq(map[string]any{
+		"id":    tk.ID,
+		"title": "new title",
+	}))
+	if err != nil {
+		t.Fatalf("handleTaskUpdate: %v", err)
+	}
+	if isErrResult(res) {
+		t.Fatalf("unexpected tool error: %q", toolResultText(res))
+	}
+
+	got, _ := s.node.Tasks.Get(tk.ID)
+	if got.Title != "new title" {
+		t.Errorf("title not updated: got %q want %q", got.Title, "new title")
+	}
+	if got.Description != "original desc" {
+		t.Errorf("description clobbered: got %q want %q", got.Description, "original desc")
+	}
+}
+
+// TestTaskUpdate_DescriptionOnly — title preserved, description replaced.
+func TestTaskUpdate_DescriptionOnly(t *testing.T) {
+	s, _ := newTestServerWithAllStores(t)
+	tk, _ := s.node.Tasks.Create("", "keep title", "old desc", "once", "claude-code", "", "", "")
+
+	res, err := s.handleTaskUpdate(context.Background(), buildReq(map[string]any{
+		"id":          tk.ID,
+		"description": "new desc",
+	}))
+	if err != nil {
+		t.Fatalf("handleTaskUpdate: %v", err)
+	}
+	if isErrResult(res) {
+		t.Fatalf("unexpected tool error: %q", toolResultText(res))
+	}
+
+	got, _ := s.node.Tasks.Get(tk.ID)
+	if got.Title != "keep title" {
+		t.Errorf("title clobbered: got %q", got.Title)
+	}
+	if got.Description != "new desc" {
+		t.Errorf("description not updated: got %q", got.Description)
+	}
+}
+
+// TestTaskUpdate_BothFields — both fields updated in a single call.
+func TestTaskUpdate_BothFields(t *testing.T) {
+	s, _ := newTestServerWithAllStores(t)
+	tk, _ := s.node.Tasks.Create("", "a", "b", "once", "claude-code", "", "", "")
+
+	res, _ := s.handleTaskUpdate(context.Background(), buildReq(map[string]any{
+		"id":          tk.ID,
+		"title":       "A",
+		"description": "B",
+	}))
+	if isErrResult(res) {
+		t.Fatalf("unexpected tool error: %q", toolResultText(res))
+	}
+
+	got, _ := s.node.Tasks.Get(tk.ID)
+	if got.Title != "A" || got.Description != "B" {
+		t.Errorf("both fields not updated: title=%q desc=%q", got.Title, got.Description)
+	}
+}
+
+// TestTaskUpdate_MarkerResolved — agent passes the 8-char marker, handler
+// resolves to full UUID before update.
+func TestTaskUpdate_MarkerResolved(t *testing.T) {
+	s, _ := newTestServerWithAllStores(t)
+	tk, _ := s.node.Tasks.Create("", "by marker", "d", "once", "claude-code", "", "", "")
+
+	shortMarker := tk.ID[:8]
+	res, err := s.handleTaskUpdate(context.Background(), buildReq(map[string]any{
+		"id":    shortMarker,
+		"title": "updated via marker",
+	}))
+	if err != nil {
+		t.Fatalf("handleTaskUpdate: %v", err)
+	}
+	if isErrResult(res) {
+		t.Fatalf("unexpected tool error: %q", toolResultText(res))
+	}
+
+	got, _ := s.node.Tasks.Get(tk.ID)
+	if got.Title != "updated via marker" {
+		t.Errorf("marker path did not resolve: got %q", got.Title)
+	}
+}
+
+// TestTaskUpdate_RejectsNoFields — empty update is a user error, not a no-op.
+func TestTaskUpdate_RejectsNoFields(t *testing.T) {
+	s, _ := newTestServerWithAllStores(t)
+	tk, _ := s.node.Tasks.Create("", "x", "y", "once", "claude-code", "", "", "")
+
+	res, _ := s.handleTaskUpdate(context.Background(), buildReq(map[string]any{
+		"id": tk.ID,
+	}))
+	if !isErrResult(res) {
+		t.Fatalf("expected empty-fields rejection, got %q", toolResultText(res))
+	}
+	if !strings.Contains(toolResultText(res), "at least one") {
+		t.Errorf("unexpected error text: %q", toolResultText(res))
+	}
+}
+
+// TestTaskUpdate_NonExistent — clean not-found error.
+func TestTaskUpdate_NonExistent(t *testing.T) {
+	s, _ := newTestServerWithAllStores(t)
+
+	res, _ := s.handleTaskUpdate(context.Background(), buildReq(map[string]any{
+		"id":    "deadbeef-nope",
+		"title": "x",
+	}))
+	if !isErrResult(res) {
+		t.Fatalf("expected not-found error, got %q", toolResultText(res))
+	}
+	if !strings.Contains(toolResultText(res), "not found") {
+		t.Errorf("expected 'not found' in error, got %q", toolResultText(res))
+	}
+}
+
+// TestTaskUpdate_MissingID — id is required.
+func TestTaskUpdate_MissingID(t *testing.T) {
+	s, _ := newTestServerWithAllStores(t)
+
+	res, _ := s.handleTaskUpdate(context.Background(), buildReq(map[string]any{
+		"title": "x",
+	}))
+	if !isErrResult(res) {
+		t.Fatalf("expected id-required error, got %q", toolResultText(res))
+	}
+}

--- a/internal/web/ui/style.css
+++ b/internal/web/ui/style.css
@@ -852,7 +852,8 @@ body {
   color: var(--text-primary);
 }
 
-.manifest-editable:hover {
+.manifest-editable:hover,
+.task-editable:hover {
   background: var(--bg-secondary);
   outline: 1px dashed var(--border);
 }

--- a/internal/web/ui/views/manifests.js
+++ b/internal/web/ui/views/manifests.js
@@ -599,7 +599,10 @@
         });
       });
 
-      // Inline edit: Title (click to edit)
+      // Inline edit: Title (click to edit).
+      // commitEdit dedupes blur+Enter double-fires (browser fires blur when
+      // the input is removed from the DOM after save, which would otherwise
+      // trigger a second PUT with stale data).
       const titleSpan = document.getElementById('manifest-edit-title');
       if (titleSpan) {
         OL.onView(titleSpan, 'click', () => {
@@ -611,24 +614,37 @@
           titleSpan.replaceWith(input);
           input.focus();
           input.select();
-          const save = async () => {
+          let committed = false;
+          const commit = async (cancel) => {
+            if (committed) return;
+            committed = true;
             const val = input.value.trim();
-            if (val && val !== m.title) {
-              await fetch('/api/manifests/' + m.id, {
-                method: 'PUT',
-                headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({title: val})
-              });
-              OL.loadManifests();
+            if (!cancel && val && val !== m.title) {
+              try {
+                const res = await fetch('/api/manifests/' + m.id, {
+                  method: 'PUT',
+                  headers: {'Content-Type': 'application/json'},
+                  body: JSON.stringify({title: val})
+                });
+                if (!res.ok) {
+                  console.error('Manifest title PUT failed:', res.status, await res.text().catch(() => ''));
+                }
+                OL.loadManifests();
+              } catch (err) {
+                console.error('Manifest title save failed:', err);
+              }
             }
             OL.loadManifest(m.id);
           };
-          OL.onView(input, 'blur', save);
-          OL.onView(input, 'keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); save(); } if (e.key === 'Escape') OL.loadManifest(m.id); });
+          OL.onView(input, 'blur', () => commit(false));
+          OL.onView(input, 'keydown', (e) => {
+            if (e.key === 'Enter') { e.preventDefault(); commit(false); }
+            else if (e.key === 'Escape') { e.preventDefault(); commit(true); }
+          });
         });
       }
 
-      // Inline edit: Description (click to edit)
+      // Inline edit: Description (click to edit). Same dedupe guard as title.
       const descEl = document.getElementById('manifest-edit-desc');
       if (descEl) {
         OL.onView(descEl, 'click', () => {
@@ -640,20 +656,33 @@
           input.placeholder = 'Enter description...';
           descEl.replaceWith(input);
           input.focus();
-          const save = async () => {
+          let committed = false;
+          const commit = async (cancel) => {
+            if (committed) return;
+            committed = true;
             const val = input.value.trim();
-            if (val !== (m.description || '')) {
-              await fetch('/api/manifests/' + m.id, {
-                method: 'PUT',
-                headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({description: val})
-              });
-              OL.loadManifests();
+            if (!cancel && val !== (m.description || '')) {
+              try {
+                const res = await fetch('/api/manifests/' + m.id, {
+                  method: 'PUT',
+                  headers: {'Content-Type': 'application/json'},
+                  body: JSON.stringify({description: val})
+                });
+                if (!res.ok) {
+                  console.error('Manifest desc PUT failed:', res.status, await res.text().catch(() => ''));
+                }
+                OL.loadManifests();
+              } catch (err) {
+                console.error('Manifest desc save failed:', err);
+              }
             }
             OL.loadManifest(m.id);
           };
-          OL.onView(input, 'blur', save);
-          OL.onView(input, 'keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); save(); } if (e.key === 'Escape') OL.loadManifest(m.id); });
+          OL.onView(input, 'blur', () => commit(false));
+          OL.onView(input, 'keydown', (e) => {
+            if (e.key === 'Enter') { e.preventDefault(); commit(false); }
+            else if (e.key === 'Escape') { e.preventDefault(); commit(true); }
+          });
         });
       }
 
@@ -705,12 +734,19 @@
         });
         OL.onView(document.getElementById('manifest-content-save'), 'click', async () => {
           const val = document.getElementById('manifest-content-textarea').value;
-          await fetch('/api/manifests/' + m.id, {
-            method: 'PUT',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({content: val})
-          });
-          OL.loadManifests();
+          try {
+            const res = await fetch('/api/manifests/' + m.id, {
+              method: 'PUT',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({content: val})
+            });
+            if (!res.ok) {
+              console.error('Manifest content PUT failed:', res.status, await res.text().catch(() => ''));
+            }
+            OL.loadManifests();
+          } catch (err) {
+            console.error('Manifest content save failed:', err);
+          }
           OL.loadManifest(m.id);
         });
       }

--- a/internal/web/ui/views/tasks.js
+++ b/internal/web/ui/views/tasks.js
@@ -351,7 +351,7 @@
           <!-- 1. HEADER BAR -->
           <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
             <span class="session-uuid" style="font-size:14px">${esc(t.marker)}</span>
-            <span style="flex:1;font-size:15px;font-weight:600;color:var(--text-primary)">${esc(t.title)}</span>
+            <span id="task-edit-title" class="task-editable" style="flex:1;font-size:15px;font-weight:600;color:var(--text-primary);cursor:pointer;border-radius:4px;padding:2px 4px" title="Click to edit title">${esc(t.title)}</span>
             <span style="color:${statusColor};font-weight:700;font-size:13px;text-transform:uppercase;padding:3px 10px;border:2px solid ${statusColor};border-radius:4px" title="${esc(statusRender.label)}">${statusRender.icon} ${esc(t.status)}</span>
             ${needsExecReview ? `<a href="#task-comments-mount" onclick="var el=document.getElementById('task-comments-mount');if(el)el.scrollIntoView({behavior:'smooth'});return false;" style="color:var(--yellow);font-weight:700;font-size:11px;text-transform:uppercase;padding:3px 8px;border:2px solid var(--yellow);border-radius:4px;text-decoration:none;cursor:pointer" title="Task completed but no agent-authored execution_review comment was posted. Click to jump to the comments section.">&#9888; No execution review</a>` : ''}
           </div>
@@ -559,6 +559,52 @@
           setTimeout(() => OL.loadManifest(mid), 300);
         });
       });
+
+      // Inline edit: Task title (click to edit). Mirrors the manifest title
+      // pattern — click swaps the span for an <input>, Enter commits via
+      // PATCH /api/tasks/:id, Esc cancels. commit() is idempotent so the
+      // blur fired when the input is removed from the DOM after save
+      // doesn't trigger a second PATCH.
+      const taskTitleSpan = document.getElementById('task-edit-title');
+      if (taskTitleSpan) {
+        OL.onView(taskTitleSpan, 'click', () => {
+          const input = document.createElement('input');
+          input.type = 'text';
+          input.value = t.title;
+          input.className = 'conv-search';
+          input.style.cssText = 'flex:1;font-size:15px;font-weight:600;padding:2px 4px';
+          taskTitleSpan.replaceWith(input);
+          input.focus();
+          input.select();
+          let committed = false;
+          const commit = async (cancel) => {
+            if (committed) return;
+            committed = true;
+            const val = input.value.trim();
+            if (!cancel && val && val !== t.title) {
+              try {
+                const res = await fetch('/api/tasks/' + t.id, {
+                  method: 'PATCH',
+                  headers: {'Content-Type': 'application/json'},
+                  body: JSON.stringify({title: val})
+                });
+                if (!res.ok) {
+                  console.error('Task title PATCH failed:', res.status, await res.text().catch(() => ''));
+                }
+                if (OL.loadTasks) OL.loadTasks();
+              } catch (err) {
+                console.error('Task title save failed:', err);
+              }
+            }
+            OL.loadTaskDetail(t.id);
+          };
+          OL.onView(input, 'blur', () => commit(false));
+          OL.onView(input, 'keydown', (e) => {
+            if (e.key === 'Enter') { e.preventDefault(); commit(false); }
+            else if (e.key === 'Escape') { e.preventDefault(); commit(true); }
+          });
+        });
+      }
 
       // Action cross-links
       bodyEl.querySelectorAll('.action-link').forEach(el => {


### PR DESCRIPTION
## Summary
- M1: ships `mcp__openpraxis__task_update` (title/description, marker-resolved, rejects empty updates) with 7 tests in `internal/mcp/tools_task_test.go`.
- M2: manifest title/description/content click-to-edit hardened — dedupe flag on commit to prevent blur-after-save double-PUT, surface HTTP failures to the console instead of silently reloading stale state, clean Escape path.
- M3: task detail panel title is now click-to-edit, mirroring the manifest pattern. Enter commits via PATCH `/api/tasks/:id`, Esc cancels. Task description (Instructions) edit path untouched.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all green (see run in CI)
- [ ] Dashboard: click manifest title → edit → Enter → persists across refresh
- [ ] Dashboard: click manifest description → edit → Enter → persists across refresh
- [ ] Dashboard: click task detail title → edit → Enter → persists across refresh
- [ ] MCP: `task_update id=<marker> title="x"` then `task_get <marker>` shows new title

🤖 Generated with [Claude Code](https://claude.com/claude-code)