### PR TITLE
fix(mcp): widen task_get depends_on display from 8 to 14 chars

### DIFF
--- a/internal/mcp/tools_task.go
+++ b/internal/mcp/tools_task.go
@@ -268,7 +268,11 @@ func (s *Server) handleTaskGet(ctx context.Context, req mcplib.CallToolRequest) 
 		output += fmt.Sprintf("Description: %s\n", t.Description)
 	}
 	if t.DependsOn != "" {
-		output += fmt.Sprintf("Depends on: %s\n", t.DependsOn[:min(8, len(t.DependsOn))])
+		// Show 14 chars, not 8 — UUIDv7 tasks created in the same millisecond
+		// share an 8-char time prefix, so truncating to 8 made every chained
+		// review look like it pointed at the same parent. 14 chars extends past
+		// the collision window and keeps the output unambiguous.
+		output += fmt.Sprintf("Depends on: %s\n", t.DependsOn[:min(14, len(t.DependsOn))])
 	}
 	output += fmt.Sprintf("Runs: %d\n", t.RunCount)
 	output += fmt.Sprintf("Created: %s | Updated: %s\n", t.CreatedAt.Format("2006-01-02 15:04"), t.UpdatedAt.Format("2006-01-02 15:04"))


### PR DESCRIPTION
## Summary
- `handleTaskGet` truncated the `Depends on:` line to 8 chars
- UUIDv7 tasks created in the same millisecond share an 8-char time prefix, so every chained review looked like it pointed at the same parent even though the stored `depends_on` values were distinct
- Widen the display to 14 chars — extends past the UUIDv7 time-prefix collision window and matches the marker format used elsewhere in the output

Hit in today's INT MySQL backup/restore task wiring: 8 main tasks created within the same millisecond all shared the prefix `019db0cb`, so every paired verify task displayed `Depends on: 019db0cb` and looked wrongly cross-chained. Underlying data was correct; only the `task_get` formatter was lying.

## Test plan
- [x] `go build ./...` passes
- [ ] Manual: call `task_get` on a chained verify task, confirm `Depends on:` now shows 14 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)