### PR TITLE
fix(watcher): remove gatekeeper path — observer-only, as agreed

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -223,31 +223,17 @@ var serveCmd = &cobra.Command{
 						status, actionCount, costUSD,
 					)
 
-					// If audit failed and original was "completed", downgrade the task
-					finalStatus := status
-					if audit.Status == "failed" && status == "completed" {
-						if err := n.Tasks.UpdateStatus(t.ID, "failed"); err != nil {
-							slog.Error("update task status to failed after audit", "error", err)
-						}
-						finalStatus = "failed"
-						slog.Warn("watcher downgraded task", "marker", t.Marker, "from", "completed", "to", "failed",
-							"git_passed", audit.GitPassed, "build_passed", audit.BuildPassed, "manifest_score", audit.ManifestScore*100)
-					}
-
-					// Activate dependents ONLY after the audit verdict is known.
-					// Gating here (instead of the runner) prevents the race where a
-					// task the runner marked "completed" gets downgraded by the
-					// watcher but its dependents have already been scheduled.
-					if finalStatus == "completed" || finalStatus == "max_turns" {
+					// Watcher is observer-only: audit records + finding comments
+					// surface signal on the task, but never mutate task state or
+					// gate dependents. The paired review task is the sole decision
+					// point for downstream activation.
+					if status == "completed" || status == "max_turns" {
 						activated, actErr := n.Tasks.ActivateDependents(t.ID)
 						if actErr != nil {
 							slog.Error("activate dependents failed", "marker", t.Marker, "error", actErr)
 						} else if activated > 0 {
-							slog.Info("activated dependent tasks after audit", "marker", t.Marker, "count", activated)
+							slog.Info("activated dependent tasks", "marker", t.Marker, "count", activated)
 						}
-					} else {
-						slog.Info("skipping dependent activation — task did not pass audit",
-							"marker", t.Marker, "final_status", finalStatus)
 					}
 
 					hub.Broadcast(web.Event{Type: "watcher_audit", Data: map[string]string{

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -172,8 +172,10 @@ func gitFailureBody(g GitResult) string {
 	if branch == "" {
 		branch = "(unresolved)"
 	}
-	return fmt.Sprintf("### Git gate failed\n"+
-		"No commits on branch %s. Watcher cannot verify work. Task auto-downgraded to failed.\n\n"+
+	return fmt.Sprintf("### Git gate observation\n"+
+		"No commits on branch %s. Watcher cannot verify code-change work against git. "+
+		"This is informational only — task state and downstream activation are unaffected; "+
+		"the paired review task decides the outcome.\n\n"+
 		"**Branch:** %s\n"+
 		"**Expected commits:** ≥1\n"+
 		"**Actual:** %d",
@@ -181,7 +183,7 @@ func gitFailureBody(g GitResult) string {
 }
 
 func buildFailureBody(b BuildResult) string {
-	return fmt.Sprintf("### Build gate failed\n\n```\n%s\n```", lastNLines(b.Output, 40))
+	return fmt.Sprintf("### Build gate observation\n\nBuild check failed — informational only; paired review task decides outcome.\n\n```\n%s\n```", lastNLines(b.Output, 40))
 }
 
 func manifestFailureBody(m ManifestResult) string {
@@ -196,7 +198,7 @@ func manifestFailureBody(m ManifestResult) string {
 	}
 
 	var sb strings.Builder
-	sb.WriteString("### Manifest gate failed\n\n")
+	sb.WriteString("### Manifest gate observation\n\nManifest deliverable check failed — informational only; paired review task decides outcome.\n\n")
 	if len(missing) == 0 {
 		sb.WriteString("Deliverables missing: (none identified individually)\n")
 	} else {

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -217,8 +217,8 @@ func TestWatcher_Gate1_Fail_PostsComment(t *testing.T) {
 		t.Fatalf("expected GitPassed=false, got true (reason=%s)", audit.GitDetails.Reason)
 	}
 	c := assertOneWatcherFinding(t, store, "task-gate1")
-	if !strings.Contains(c.Body, "Git gate failed") {
-		t.Fatalf("body missing 'Git gate failed':\n%s", c.Body)
+	if !strings.Contains(c.Body, "Git gate observation") {
+		t.Fatalf("body missing 'Git gate observation':\n%s", c.Body)
 	}
 	if !strings.Contains(c.Body, "openpraxis/gate1fail") {
 		t.Fatalf("body missing branch name:\n%s", c.Body)
@@ -240,8 +240,8 @@ func TestWatcher_Gate2_Fail_PostsComment(t *testing.T) {
 		t.Fatalf("expected BuildPassed=false, got true")
 	}
 	c := assertOneWatcherFinding(t, store, "task-gate2")
-	if !strings.Contains(c.Body, "Build gate failed") {
-		t.Fatalf("body missing 'Build gate failed':\n%s", c.Body)
+	if !strings.Contains(c.Body, "Build gate observation") {
+		t.Fatalf("body missing 'Build gate observation':\n%s", c.Body)
 	}
 	if !strings.Contains(c.Body, "```") {
 		t.Fatalf("body missing fenced code block:\n%s", c.Body)
@@ -268,8 +268,8 @@ func TestWatcher_Gate3_Fail_PostsComment(t *testing.T) {
 			audit.ManifestScore, audit.ManifestDetails.Reason)
 	}
 	c := assertOneWatcherFinding(t, store, "task-gate3")
-	if !strings.Contains(c.Body, "Manifest gate failed") {
-		t.Fatalf("body missing 'Manifest gate failed':\n%s", c.Body)
+	if !strings.Contains(c.Body, "Manifest gate observation") {
+		t.Fatalf("body missing 'Manifest gate observation':\n%s", c.Body)
 	}
 	if !strings.Contains(c.Body, "internal/missing/thing.go") {
 		t.Fatalf("body missing missing-deliverable bullet:\n%s", c.Body)


### PR DESCRIPTION
## Summary
- PR #111 gave the watcher the ability to post \`watcher_finding\` comments but never removed its teeth
- \`cmd/serve.go\` was still calling \`UpdateStatus(failed)\` when the audit verdict was \"failed\" and gating \`ActivateDependents\` on the post-audit finalStatus
- Real-world symptom: an ops task that kicks off a backup in a detached screen (no local commits, so Git gate fails) was getting auto-downgraded to \`failed\`, and its paired review task stayed \`waiting\` because dependent activation was blocked
- Paired review task is the sole decision point for downstream activation. Watcher is signal, not control.

## Changes
- \`cmd/serve.go\`: drop the downgrade branch and the final-status gate. \`ActivateDependents\` now fires on \`completed\` / \`max_turns\` regardless of audit verdict. Audit record + finding comments still post.
- \`internal/watcher/watcher.go\`: gate-failure bodies reworded from \"gate failed\" to \"gate observation\" and explicitly say \"informational only — paired review task decides outcome.\"
- \`internal/watcher/watcher_test.go\`: assertions updated to the new wording.

## Repro (before fix)
1. Create an ops-style task that SSHes to a remote node, fires something in a detached screen, and exits — no local commits
2. Pair it with a verify task via \`depends_on\`
3. Fire the main. Agent exits \`completed\`. Watcher's Git gate fails. Task downgraded to \`failed\`. Verify stays \`waiting\`. Cross-chain dead.

## After fix
1. Same task lifecycle. Task stays \`completed\`. Watcher still posts a \`watcher_finding\` comment (observer signal).
2. Verify activates via \`depends_on\`. Normal flow.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./internal/watcher/... ./internal/task/...\`
- [ ] Manual: fire the remaining paired-main tasks in the INT MySQL manifests; confirm each verify auto-activates even when the main makes no local commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)