### PR TITLE
feat(settings): default_model is a KnobEnum — dropdown of the Claude family

### DIFF
--- a/internal/settings/catalog.go
+++ b/internal/settings/catalog.go
@@ -55,7 +55,12 @@ func Catalog() []KnobDef {
 		{Key: "temperature", Type: KnobFloat, SliderMin: f(0), SliderMax: f(2), SliderStep: f(0.05), Default: 0.2, Description: "LLM sampling temperature"},
 		{Key: "reasoning_effort", Type: KnobEnum, EnumValues: []string{"minimal", "low", "medium", "high"}, Default: "medium", Description: "Thinking budget for reasoning models"},
 		{Key: "default_agent", Type: KnobEnum, EnumValues: []string{"claude-code", "codex", "cursor", "windsurf"}, Default: "claude-code", Description: "Agent runtime"},
-		{Key: "default_model", Type: KnobString, Default: "", Description: "Model ID (agent-dependent)"},
+		{Key: "default_model", Type: KnobEnum, EnumValues: []string{
+			"",                   // empty = let the agent runtime choose its own default
+			"claude-opus-4-7",    // Opus 4.7 — highest capability, 1M context
+			"claude-sonnet-4-6",  // Sonnet 4.6 — balanced
+			"claude-haiku-4-5",   // Haiku 4.5 — fast / cheap
+		}, Default: "", Description: "Model ID passed to the agent as --model. Empty = agent default."},
 		{Key: "retry_on_failure", Type: KnobInt, SliderMin: f(0), SliderMax: f(10), SliderStep: f(1), Default: 0, Description: "Auto-retry count"},
 		{Key: "approval_mode", Type: KnobEnum, EnumValues: []string{"auto", "manual", "on-failure"}, Default: "auto", Description: "Codex approval mode"},
 		{Key: "allowed_tools", Type: KnobMultiselect, Default: []string{

--- a/internal/settings/catalog_test.go
+++ b/internal/settings/catalog_test.go
@@ -150,13 +150,20 @@ func TestValidateValue_FloatKnob_AcceptsAny(t *testing.T) {
 	}
 }
 
-func TestValidateValue_StringKnob_AcceptsString(t *testing.T) {
-	warnings, err := ValidateValue("default_model", `"gpt-5"`)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestValidateValue_ModelKnob_AcceptsKnownModel(t *testing.T) {
+	// default_model moved from KnobString to KnobEnum so the UI can render a
+	// dropdown of the Claude family. Empty string remains valid ("agent default").
+	for _, v := range []string{`""`, `"claude-opus-4-7"`, `"claude-sonnet-4-6"`, `"claude-haiku-4-5"`} {
+		if _, err := ValidateValue("default_model", v); err != nil {
+			t.Errorf("unexpected error for %s: %v", v, err)
+		}
 	}
-	if len(warnings) != 0 {
-		t.Fatalf("unexpected warnings: %v", warnings)
+}
+
+func TestValidateValue_ModelKnob_RejectsUnknown(t *testing.T) {
+	_, err := ValidateValue("default_model", `"gpt-5"`)
+	if err == nil {
+		t.Fatalf("expected enum rejection for unknown model, got nil")
 	}
 }
 


### PR DESCRIPTION
## Summary
- \`default_model\` was a free-form \`KnobString\`. UI rendered a text input; nothing stopped typos or stale IDs from being saved
- Changed to \`KnobEnum\` with the Claude family listed: \"\", \`claude-opus-4-7\`, \`claude-sonnet-4-6\`, \`claude-haiku-4-5\`
- Empty string stays valid and means \"let the agent runtime pick its default\"

## Why now
Operator needs to select model (Opus / Sonnet / Haiku) per product / manifest / task scope to route compute — e.g. long-horizon backup verifies on Sonnet, expensive design work on Opus. Dropdown removes the typo surface and matches what's already in the catalog.

## What else
- Runner already reads \`default_model\` and passes \`--model\` when non-empty (\`runner.go:593\`). No change needed.
- UI already renders \`KnobEnum\` as \`<select>\` (\`components/knobs.js:168\`). No change needed.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./internal/settings/...\` — new tests for known/unknown models
- [ ] Manual: open a task's knob editor, confirm default_model is a dropdown with 4 options; set one, restart agent, confirm it's invoked with \`--model <id>\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)