### PR TITLE
feat(search): keyword-first pagination + <mark> highlights for conversations & actions

### DIFF
--- a/internal/action/search.go
+++ b/internal/action/search.go
@@ -8,20 +8,47 @@ import "strings"
 // shape per 019daafb-b5e M1 — single OR-set LIKE, trim + empty-check
 // guard to avoid `%%` matching every row.
 func (s *Store) Search(query string, limit int) ([]Action, error) {
+	items, _, err := s.SearchPaged(query, limit, 0)
+	return items, err
+}
+
+// SearchPaged is Search plus offset + total. Returns the paged slice and the
+// total match count so the caller can drive infinite-scroll pagination
+// without a second COUNT query round-trip. Empty query returns (nil, 0, nil).
+func (s *Store) SearchPaged(query string, limit, offset int) ([]Action, int, error) {
 	if limit <= 0 {
 		limit = 50
 	}
+	if offset < 0 {
+		offset = 0
+	}
 	q := strings.TrimSpace(query)
 	if q == "" {
-		return nil, nil
+		return nil, 0, nil
 	}
 	pattern := "%" + q + "%"
-	rows, err := s.db.Query(`SELECT id, session_id, source_node, task_id, tool_name, tool_input, tool_response, cwd, created_at
-		FROM actions WHERE CAST(id AS TEXT) LIKE ? OR tool_name LIKE ? OR tool_input LIKE ? OR tool_response LIKE ?
-		ORDER BY created_at DESC LIMIT ?`, pattern, pattern, pattern, pattern, limit)
+
+	var total int
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM actions
+		  WHERE CAST(id AS TEXT) LIKE ? OR tool_name LIKE ? OR tool_input LIKE ? OR tool_response LIKE ?`,
+		pattern, pattern, pattern, pattern,
+	).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	rows, err := s.db.Query(
+		`SELECT id, session_id, source_node, task_id, tool_name, tool_input, tool_response, cwd, created_at
+		   FROM actions
+		  WHERE CAST(id AS TEXT) LIKE ? OR tool_name LIKE ? OR tool_input LIKE ? OR tool_response LIKE ?
+		  ORDER BY created_at DESC
+		  LIMIT ? OFFSET ?`,
+		pattern, pattern, pattern, pattern, limit, offset,
+	)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer rows.Close()
-	return scanActions(rows)
+	items, err := scanActions(rows)
+	return items, total, err
 }

--- a/internal/conversation/store.go
+++ b/internal/conversation/store.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"strings"
 	"time"
 
 	sqlite_vec "github.com/asg017/sqlite-vec-go-bindings/cgo"
@@ -297,6 +298,60 @@ func (s *Store) Count() (int, error) {
 	var count int
 	err := s.db.QueryRow(`SELECT COUNT(*) FROM conversations`).Scan(&count)
 	return count, err
+}
+
+// SearchKeyword performs a literal (LIKE) keyword search across title,
+// summary, and the raw turns blob. Returns the paged slice plus the total
+// match count so the caller can drive infinite-scroll pagination without a
+// second COUNT query round-trip. Empty query returns (nil, 0, nil).
+//
+// This complements Search (semantic) — both are run in parallel by the
+// /api/conversations/search handler, with keyword hits surfaced first and
+// semantic hits appended as a "related by meaning" tail only on page 0.
+func (s *Store) SearchKeyword(query string, limit, offset int) ([]*Conversation, int, error) {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, 0, nil
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	pattern := "%" + q + "%"
+
+	var total int
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM conversations WHERE title LIKE ? OR summary LIKE ? OR turns LIKE ?`,
+		pattern, pattern, pattern,
+	).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("keyword count: %w", err)
+	}
+
+	rows, err := s.db.Query(
+		`SELECT id, title, summary, agent, project, tags, turns, turn_count, source_node,
+		        created_at, updated_at, accessed_at, access_count
+		   FROM conversations
+		  WHERE title LIKE ? OR summary LIKE ? OR turns LIKE ?
+		  ORDER BY updated_at DESC
+		  LIMIT ? OFFSET ?`,
+		pattern, pattern, pattern, limit, offset,
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("keyword query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*Conversation
+	for rows.Next() {
+		c, err := scanConversationRows(rows)
+		if err != nil {
+			return nil, 0, err
+		}
+		out = append(out, c)
+	}
+	return out, total, rows.Err()
 }
 
 // TouchAccess updates accessed_at and increments access_count.

--- a/internal/web/handlers_search.go
+++ b/internal/web/handlers_search.go
@@ -3,9 +3,11 @@ package web
 import (
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/k8nstantin/OpenPraxis/internal/action"
+	"github.com/k8nstantin/OpenPraxis/internal/conversation"
 	"github.com/k8nstantin/OpenPraxis/internal/idea"
 	"github.com/k8nstantin/OpenPraxis/internal/memory"
 	"github.com/k8nstantin/OpenPraxis/internal/node"
@@ -26,17 +28,30 @@ import (
 // the memories/conversations GET endpoints.
 
 func parseSearchParams(r *http.Request) (string, int) {
-	q := r.URL.Query().Get("q")
-	if q == "" {
-		q = r.URL.Query().Get("query")
+	q, limit, _ := parseSearchParamsPaged(r)
+	return q, limit
+}
+
+// parseSearchParamsPaged adds offset support for endpoints that drive
+// infinite scroll (conversations, actions). Other endpoints stay on the
+// non-paged helper for backwards compatibility with their bare-array shape.
+func parseSearchParamsPaged(r *http.Request) (query string, limit, offset int) {
+	query = r.URL.Query().Get("q")
+	if query == "" {
+		query = r.URL.Query().Get("query")
 	}
-	limit := 50
+	limit = 50
 	if ls := r.URL.Query().Get("limit"); ls != "" {
 		if n, err := strconv.Atoi(ls); err == nil && n > 0 {
 			limit = n
 		}
 	}
-	return q, limit
+	if os := r.URL.Query().Get("offset"); os != "" {
+		if n, err := strconv.Atoi(os); err == nil && n >= 0 {
+			offset = n
+		}
+	}
+	return query, limit, offset
 }
 
 // scoreRef surfaces score/distance alongside the unwrapped entity list when
@@ -96,58 +111,133 @@ func apiManifestsSearchGET(n *node.Node) http.HandlerFunc {
 // /api/conversations (apiConversations) — id, title, summary, agent, project,
 // tags, turn_count, created_at, updated_at. Turns are intentionally omitted;
 // detail view /api/conversations/{id} exposes them.
+//
+// SnippetHTML carries a pre-rendered fragment of matched text with the
+// query wrapped in <mark>. Safe for innerHTML: caller-supplied text is
+// escaped, only the <mark> tags are literal. MatchType is "keyword" or
+// "semantic".
 type conversationSearchItem struct {
-	ID        string   `json:"id"`
-	Title     string   `json:"title"`
-	Summary   string   `json:"summary"`
-	Agent     string   `json:"agent"`
-	Project   string   `json:"project"`
-	Tags      []string `json:"tags"`
-	TurnCount int      `json:"turn_count"`
-	CreatedAt string   `json:"created_at"`
-	UpdatedAt string   `json:"updated_at"`
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	Summary     string   `json:"summary"`
+	Agent       string   `json:"agent"`
+	Project     string   `json:"project"`
+	Tags        []string `json:"tags"`
+	TurnCount   int      `json:"turn_count"`
+	CreatedAt   string   `json:"created_at"`
+	UpdatedAt   string   `json:"updated_at"`
+	SnippetHTML string   `json:"snippet_html,omitempty"`
+	MatchType   string   `json:"match_type,omitempty"`
+}
+
+// searchEnvelope is the paginated response shape used by the
+// infinite-scroll endpoints (conversations, actions). Keyword hits go in
+// Items and are pageable via Offset/Limit; Semantic is populated only on
+// page 0 and holds semantic-overlay hits that did not already appear in the
+// keyword set, for a "related by meaning" tail in the UI.
+type searchEnvelope[T any] struct {
+	Items    []T  `json:"items"`
+	Total    int  `json:"total"`
+	Offset   int  `json:"offset"`
+	Limit    int  `json:"limit"`
+	Semantic []T  `json:"semantic,omitempty"`
+	HasMore  bool `json:"has_more"`
+}
+
+// turnsText joins turn content for snippet extraction. Kept simple — the
+// snippet helper scans linearly so concatenation cost is O(total chars) and
+// we read only what we need once.
+func turnsText(turns []conversation.Turn) string {
+	if len(turns) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for i, t := range turns {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(t.Content)
+	}
+	return sb.String()
+}
+
+func conversationItem(c *conversation.Conversation, snippet, matchType string) conversationSearchItem {
+	turnCount := c.TurnCount
+	if turnCount == 0 && len(c.Turns) > 0 {
+		turnCount = len(c.Turns)
+	}
+	return conversationSearchItem{
+		ID:          c.ID,
+		Title:       c.Title,
+		Summary:     c.Summary,
+		Agent:       c.Agent,
+		Project:     c.Project,
+		Tags:        c.Tags,
+		TurnCount:   turnCount,
+		CreatedAt:   c.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:   c.UpdatedAt.UTC().Format(time.RFC3339),
+		SnippetHTML: snippet,
+		MatchType:   matchType,
+	}
 }
 
 func apiConversationsSearchGET(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		q, limit := parseSearchParams(r)
+		q, limit, offset := parseSearchParamsPaged(r)
+		emptyEnv := searchEnvelope[conversationSearchItem]{
+			Items: []conversationSearchItem{}, Total: 0, Offset: offset, Limit: limit,
+		}
 		if q == "" {
-			writeJSON(w, []conversationSearchItem{})
+			writeJSON(w, emptyEnv)
 			return
 		}
 		agent := r.URL.Query().Get("agent")
 		project := r.URL.Query().Get("project")
-		results, err := n.SearchConversations(r.Context(), q, limit, agent, project)
+
+		// Keyword hits — pageable.
+		kwRows, kwTotal, err := n.Conversations.SearchKeyword(q, limit, offset)
 		if err != nil {
 			writeError(w, err.Error(), 500)
 			return
 		}
-		items := make([]conversationSearchItem, 0, len(results))
-		scores := make([]scoreRef, 0, len(results))
-		for _, sr := range results {
-			c := sr.Conversation
-			turnCount := c.TurnCount
-			if turnCount == 0 && len(c.Turns) > 0 {
-				turnCount = len(c.Turns)
+		items := make([]conversationSearchItem, 0, len(kwRows))
+		seen := make(map[string]struct{}, len(kwRows))
+		for _, c := range kwRows {
+			if agent != "" && c.Agent != agent {
+				continue
 			}
-			items = append(items, conversationSearchItem{
-				ID:        c.ID,
-				Title:     c.Title,
-				Summary:   c.Summary,
-				Agent:     c.Agent,
-				Project:   c.Project,
-				Tags:      c.Tags,
-				TurnCount: turnCount,
-				CreatedAt: c.CreatedAt.UTC().Format(time.RFC3339),
-				UpdatedAt: c.UpdatedAt.UTC().Format(time.RFC3339),
-			})
-			scores = append(scores, scoreRef{ID: c.ID, Score: sr.Score, Distance: sr.Distance})
+			if project != "" && c.Project != project {
+				continue
+			}
+			snippet := highlightSnippet(q, c.Summary, c.Title, turnsText(c.Turns))
+			items = append(items, conversationItem(c, snippet, "keyword"))
+			seen[c.ID] = struct{}{}
 		}
-		if r.URL.Query().Get("scored") == "true" {
-			writeJSON(w, map[string]any{"items": items, "scores": scores})
-			return
+
+		env := searchEnvelope[conversationSearchItem]{
+			Items:   items,
+			Total:   kwTotal,
+			Offset:  offset,
+			Limit:   limit,
+			HasMore: offset+len(items) < kwTotal,
 		}
-		writeJSON(w, items)
+
+		// Semantic overlay — only on page 0. Capped at 10 extra results.
+		if offset == 0 {
+			semResults, semErr := n.SearchConversations(r.Context(), q, 10, agent, project)
+			if semErr == nil {
+				for _, sr := range semResults {
+					if _, dup := seen[sr.Conversation.ID]; dup {
+						continue
+					}
+					c := sr.Conversation
+					snippet := highlightSnippet(q, c.Summary, c.Title, turnsText(c.Turns))
+					env.Semantic = append(env.Semantic, conversationItem(&c, snippet, "semantic"))
+				}
+			}
+		}
+
+		writeJSON(w, env)
 	}
 }
 
@@ -208,21 +298,38 @@ func apiIdeasSearch(n *node.Node) http.HandlerFunc {
 	}
 }
 
+// actionSearchItem is the shape delivered by the paged actions search.
+// Embeds the full action record and adds SnippetHTML for the UI — that way
+// detail-view expectations (tool_name, tool_input, tool_response, etc.)
+// stay identical to the existing /api/actions payloads.
+type actionSearchItem struct {
+	action.Action
+	SnippetHTML string `json:"snippet_html,omitempty"`
+}
+
 func apiActionsSearch(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		q, limit := parseSearchParams(r)
+		q, limit, offset := parseSearchParamsPaged(r)
+		env := searchEnvelope[actionSearchItem]{
+			Items: []actionSearchItem{}, Total: 0, Offset: offset, Limit: limit,
+		}
 		if q == "" {
-			writeJSON(w, []action.Action{})
+			writeJSON(w, env)
 			return
 		}
-		results, err := n.Actions.Search(q, limit)
+		results, total, err := n.Actions.SearchPaged(q, limit, offset)
 		if err != nil {
 			writeError(w, err.Error(), 500)
 			return
 		}
-		if results == nil {
-			results = []action.Action{}
+		items := make([]actionSearchItem, 0, len(results))
+		for _, a := range results {
+			snippet := highlightSnippet(q, a.ToolInput, a.ToolResponse, a.ToolName)
+			items = append(items, actionSearchItem{Action: a, SnippetHTML: snippet})
 		}
-		writeJSON(w, results)
+		env.Items = items
+		env.Total = total
+		env.HasMore = offset+len(items) < total
+		writeJSON(w, env)
 	}
 }

--- a/internal/web/handlers_search_test.go
+++ b/internal/web/handlers_search_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/k8nstantin/OpenPraxis/internal/action"
@@ -183,10 +184,23 @@ func TestActionsSearch_Keyword(t *testing.T) {
 	if rec.Code != 200 {
 		t.Fatalf("status %d body=%s", rec.Code, rec.Body.String())
 	}
-	var got []action.Action
-	_ = json.Unmarshal(rec.Body.Bytes(), &got)
-	if len(got) != 1 || got[0].ToolName != "zebra_tool" {
-		t.Fatalf("keyword: want zebra_tool, got %+v", got)
+	// Envelope shape per pagination + snippet support: { items, total, offset, limit, has_more }.
+	var env struct {
+		Items []struct {
+			action.Action
+			SnippetHTML string `json:"snippet_html"`
+		} `json:"items"`
+		Total   int  `json:"total"`
+		HasMore bool `json:"has_more"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, rec.Body.String())
+	}
+	if env.Total != 1 || len(env.Items) != 1 || env.Items[0].ToolName != "zebra_tool" {
+		t.Fatalf("keyword: want zebra_tool, got total=%d items=%+v", env.Total, env.Items)
+	}
+	if !strings.Contains(env.Items[0].SnippetHTML, "<mark>") {
+		t.Fatalf("expected <mark>-wrapped snippet, got %q", env.Items[0].SnippetHTML)
 	}
 }
 
@@ -229,14 +243,28 @@ func TestIdeasSearch_EmptyResultIsArrayNotNull(t *testing.T) {
 	}
 }
 
-func TestActionsSearch_EmptyResultIsArrayNotNull(t *testing.T) {
+func TestActionsSearch_EmptyResultIsEnvelope(t *testing.T) {
+	// Actions search moved to the paginated envelope shape so the UI can
+	// drive infinite scroll. Empty result is still well-formed: items=[]
+	// rather than a bare JSON array.
 	n := newSearchNode(t)
 	rec := doGET(t, apiActionsSearch(n), "/api/actions/search?q=zzz_no_such_action")
 	if rec.Code != 200 {
 		t.Fatalf("status %d", rec.Code)
 	}
-	if body := rec.Body.String(); body != "[]" && body != "[]\n" {
-		t.Fatalf("want `[]`, got %q", body)
+	var env struct {
+		Items   []any `json:"items"`
+		Total   int   `json:"total"`
+		HasMore bool  `json:"has_more"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, rec.Body.String())
+	}
+	if env.Total != 0 || len(env.Items) != 0 || env.HasMore {
+		t.Fatalf("want empty envelope, got %+v", env)
+	}
+	if env.Items == nil {
+		t.Fatalf("items must be [] not null")
 	}
 }
 

--- a/internal/web/snippet.go
+++ b/internal/web/snippet.go
@@ -1,0 +1,69 @@
+package web
+
+import (
+	"html"
+	"strings"
+)
+
+// highlightSnippet finds the first case-insensitive occurrence of q in any of
+// the provided text fields, returns an HTML snippet with ~80 chars of context
+// on each side, and wraps the match with <mark>...</mark>. Non-match text is
+// HTML-escaped so it is safe to render with innerHTML.
+//
+// Fallback when q matches nothing in any field: returns the first 160 chars of
+// the first non-empty field, HTML-escaped, without any <mark>. Returns empty
+// string only when every field is empty.
+//
+// Note: text args are scanned in order, so pass the field you'd prefer to
+// snippet from first (e.g. summary before raw turns blob).
+func highlightSnippet(q string, texts ...string) string {
+	q = strings.TrimSpace(q)
+	for _, text := range texts {
+		if text == "" {
+			continue
+		}
+		idx := caseInsensitiveIndex(text, q)
+		if q == "" || idx < 0 {
+			continue
+		}
+		start := idx - 80
+		if start < 0 {
+			start = 0
+		}
+		end := idx + len(q) + 80
+		if end > len(text) {
+			end = len(text)
+		}
+		prefix := ""
+		if start > 0 {
+			prefix = "…"
+		}
+		suffix := ""
+		if end < len(text) {
+			suffix = "…"
+		}
+		before := html.EscapeString(text[start:idx])
+		match := html.EscapeString(text[idx : idx+len(q)])
+		after := html.EscapeString(text[idx+len(q) : end])
+		return prefix + before + "<mark>" + match + "</mark>" + after + suffix
+	}
+	// No literal match — fall back to the first non-empty field truncated.
+	for _, text := range texts {
+		if text == "" {
+			continue
+		}
+		trimmed := text
+		if len(trimmed) > 160 {
+			trimmed = trimmed[:160] + "…"
+		}
+		return html.EscapeString(trimmed)
+	}
+	return ""
+}
+
+func caseInsensitiveIndex(haystack, needle string) int {
+	if needle == "" {
+		return -1
+	}
+	return strings.Index(strings.ToLower(haystack), strings.ToLower(needle))
+}

--- a/internal/web/ui/style.css
+++ b/internal/web/ui/style.css
@@ -695,6 +695,28 @@ body {
   gap: 8px;
 }
 
+/* Search snippet row — shown under .conv-item-meta when the server
+   returns a snippet_html. Two lines max; escaped text + <mark> tags. */
+.conv-item-snippet {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 4px;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.conv-item-snippet mark,
+.search-header mark,
+mark {
+  background: var(--accent, #ffd400);
+  color: #111;
+  padding: 0 2px;
+  border-radius: 2px;
+}
+
 .conv-item-agent {
   color: var(--accent);
   font-weight: 500;

--- a/internal/web/ui/views/actions.js
+++ b/internal/web/ui/views/actions.js
@@ -2,21 +2,103 @@
   'use strict';
   var fetchJSON = OL.fetchJSON, esc = OL.esc, formatTime = OL.formatTime;
 
-  function renderActionSearchList(el, actions) {
-    if (!actions || !actions.length) {
-      el.innerHTML = '<div class="empty-state">No actions found</div>';
-      return;
-    }
-    el.innerHTML = actions.map(function(a) {
-      var input = a.tool_input ? (a.tool_input.length > 60 ? a.tool_input.substring(0, 60) + '...' : a.tool_input) : '';
-      return '<div class="tree-node peer-leaf clickable" data-action-id="' + esc(a.id) + '" role="button" tabindex="0" ' +
-        'onclick="OL.loadActionDetail(\'' + esc(a.id) + '\')" ' +
-        'onkeydown="if(event.key===\'Enter\'||event.key===\' \'){event.preventDefault();this.click()}">' +
-        '<span class="badge type badge-sm">' + esc(a.tool_name) + '</span>' +
-        '<span style="font-size:11px;color:var(--text-primary);flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + esc(input) + '</span>' +
-        '<span style="color:var(--text-muted);font-size:10px">' + formatTime(a.created_at) + '</span>' +
+  // Infinite-scroll state for the actions search. Reset on every new query.
+  var actSearch = {
+    query: '',
+    offset: 0,
+    limit: 50,
+    total: 0,
+    hasMore: false,
+    loading: false,
+    scrollHandler: null
+  };
+
+  function renderActionSearchRow(a) {
+    var snippet = a.snippet_html ? '<div class="conv-item-snippet" style="margin-top:4px">' + a.snippet_html + '</div>' : '';
+    return '<div class="tree-node peer-leaf clickable" data-action-id="' + esc(a.id) + '" role="button" tabindex="0" ' +
+      'onclick="OL.loadActionDetail(\'' + esc(a.id) + '\')" ' +
+      'onkeydown="if(event.key===\'Enter\'||event.key===\' \'){event.preventDefault();this.click()}">' +
+      '<div style="flex:1;overflow:hidden">' +
+        '<div style="display:flex;align-items:center;gap:6px">' +
+          '<span class="badge type badge-sm">' + esc(a.tool_name) + '</span>' +
+          '<span style="color:var(--text-muted);font-size:10px">' + formatTime(a.created_at) + '</span>' +
+        '</div>' +
+        snippet +
+      '</div>' +
+    '</div>';
+  }
+
+  function renderActionSearchEnvelope(env, append) {
+    var el = document.getElementById('actions-tree');
+    if (!el) return;
+    var items = env.items || [];
+    var total = env.total || 0;
+
+    if (!append) {
+      if (!items.length) {
+        el.innerHTML = '<div class="empty-state">No actions found</div>';
+        return;
+      }
+      var html = '<div class="search-header" style="padding:6px 8px;font-size:11px;color:var(--text-muted)">' +
+        esc(String(items.length)) + ' of ' + esc(String(total)) + ' match' + (total === 1 ? '' : 'es') +
       '</div>';
-    }).join('');
+      html += '<div class="actions-search-list">' + items.map(renderActionSearchRow).join('') + '</div>';
+      el.innerHTML = html;
+    } else {
+      var list = el.querySelector('.actions-search-list');
+      if (list && items.length) {
+        list.insertAdjacentHTML('beforeend', items.map(renderActionSearchRow).join(''));
+      }
+      var header = el.querySelector('.search-header');
+      if (header) {
+        var rendered = el.querySelectorAll('.actions-search-list .peer-leaf').length;
+        header.textContent = rendered + ' of ' + total + ' match' + (total === 1 ? '' : 'es');
+      }
+    }
+  }
+
+  async function fetchActionSearchPage(q, offset, limit) {
+    var url = '/api/actions/search?q=' + encodeURIComponent(q) +
+              '&offset=' + offset + '&limit=' + limit;
+    var resp = await fetch(url);
+    var env = await resp.json();
+    actSearch.total = env.total || 0;
+    actSearch.offset = (env.offset || 0) + (env.items || []).length;
+    actSearch.hasMore = !!env.has_more;
+    return env;
+  }
+
+  function wireActionSearchScroll() {
+    detachActionSearchScroll();
+    var el = document.getElementById('actions-tree');
+    if (!el) return;
+    actSearch.scrollHandler = function() {
+      if (actSearch.loading || !actSearch.hasMore) return;
+      var threshold = 80;
+      if (el.scrollTop + el.clientHeight + threshold >= el.scrollHeight) {
+        loadMoreActionSearch();
+      }
+    };
+    el.addEventListener('scroll', actSearch.scrollHandler);
+  }
+
+  function detachActionSearchScroll() {
+    var el = document.getElementById('actions-tree');
+    if (el && actSearch.scrollHandler) {
+      el.removeEventListener('scroll', actSearch.scrollHandler);
+    }
+    actSearch.scrollHandler = null;
+  }
+
+  async function loadMoreActionSearch() {
+    if (actSearch.loading || !actSearch.hasMore) return;
+    actSearch.loading = true;
+    try {
+      var env = await fetchActionSearchPage(actSearch.query, actSearch.offset, actSearch.limit);
+      renderActionSearchEnvelope(env, /*append=*/ true);
+    } finally {
+      actSearch.loading = false;
+    }
   }
 
   OL.loadActions = async function() {
@@ -27,11 +109,19 @@
       OL.mountSearchInput(mount, {
         placeholder: 'Search actions by id, tool name, or keyword...',
         onSearch: async function(q) {
-          const results = await fetchJSON('/api/actions/search?q=' + encodeURIComponent(q));
-          renderActionSearchList(el, results || []);
-          return (results || []).length;
+          actSearch.query = q;
+          actSearch.offset = 0;
+          actSearch.total = 0;
+          actSearch.hasMore = false;
+          var env = await fetchActionSearchPage(q, 0, actSearch.limit);
+          renderActionSearchEnvelope(env, /*append=*/ false);
+          wireActionSearchScroll();
+          return (env.items || []).length;
         },
-        onClear: function() { OL.loadActions(); }
+        onClear: function() {
+          detachActionSearchScroll();
+          OL.loadActions();
+        }
       });
     }
 

--- a/internal/web/ui/views/conversations.js
+++ b/internal/web/ui/views/conversations.js
@@ -1,27 +1,83 @@
 (function(OL) {
   'use strict';
   var fetchJSON = OL.fetchJSON, esc = OL.esc, formatTime = OL.formatTime, formatModel = OL.formatModel;
+
+  // Infinite-scroll state for the conversations keyword search. Reset on
+  // every new query via onSearch, appended to on scroll-bottom.
+  var convSearch = {
+    query: '',
+    offset: 0,
+    limit: 50,
+    total: 0,
+    hasMore: false,
+    loading: false,
+    scrollHandler: null
+  };
+
   function setupConvSearch() {
     var mount = document.getElementById('conv-search-mount');
     if (!mount || !OL.mountSearchInput) return;
     OL.mountSearchInput(mount, {
       placeholder: 'Search conversations by id, marker, or keyword...',
       onSearch: async function(q) {
-        var resp = await fetch('/api/conversations/search?q=' + encodeURIComponent(q));
-        var results = await resp.json();
-        var convos = (results || []).map(function(c) {
-          return {
-            id: c.id,
-            title: c.title,
-            agent: c.agent,
-            turn_count: c.turn_count
-          };
-        });
-        renderConversationSearchResults(convos);
-        return convos.length;
+        convSearch.query = q;
+        convSearch.offset = 0;
+        convSearch.total = 0;
+        convSearch.hasMore = false;
+        var env = await fetchConvSearchPage(q, 0, convSearch.limit);
+        renderConversationSearchEnvelope(env, /*append=*/ false);
+        wireConvSearchScroll();
+        return (env.items || []).length + (env.semantic || []).length;
       },
-      onClear: function() { OL.loadConversations(); }
+      onClear: function() {
+        detachConvSearchScroll();
+        OL.loadConversations();
+      }
     });
+  }
+
+  async function fetchConvSearchPage(q, offset, limit) {
+    var url = '/api/conversations/search?q=' + encodeURIComponent(q) +
+              '&offset=' + offset + '&limit=' + limit;
+    var resp = await fetch(url);
+    var env = await resp.json();
+    convSearch.total = env.total || 0;
+    convSearch.offset = (env.offset || 0) + (env.items || []).length;
+    convSearch.hasMore = !!env.has_more;
+    return env;
+  }
+
+  function wireConvSearchScroll() {
+    detachConvSearchScroll();
+    var el = document.getElementById('conv-list');
+    if (!el) return;
+    convSearch.scrollHandler = function() {
+      if (convSearch.loading || !convSearch.hasMore) return;
+      var threshold = 80; // px from bottom
+      if (el.scrollTop + el.clientHeight + threshold >= el.scrollHeight) {
+        loadMoreConvSearch();
+      }
+    };
+    el.addEventListener('scroll', convSearch.scrollHandler);
+  }
+
+  function detachConvSearchScroll() {
+    var el = document.getElementById('conv-list');
+    if (el && convSearch.scrollHandler) {
+      el.removeEventListener('scroll', convSearch.scrollHandler);
+    }
+    convSearch.scrollHandler = null;
+  }
+
+  async function loadMoreConvSearch() {
+    if (convSearch.loading || !convSearch.hasMore) return;
+    convSearch.loading = true;
+    try {
+      var env = await fetchConvSearchPage(convSearch.query, convSearch.offset, convSearch.limit);
+      renderConversationSearchEnvelope(env, /*append=*/ true);
+    } finally {
+      convSearch.loading = false;
+    }
   }
 
   OL.loadConversations = async function() {
@@ -91,22 +147,71 @@
     }
   };
 
-  function renderConversationSearchResults(convos) {
+  // renderConversationSearchItem builds one row. snippet_html is already
+  // HTML-escaped on the server with only <mark> tags literal, so it is
+  // safe to interpolate directly.
+  function renderConversationSearchItem(c) {
+    var snippet = c.snippet_html ? '<div class="conv-item-snippet">' + c.snippet_html + '</div>' : '';
+    return '<div class="conv-item" data-id="' + esc(c.id) + '" role="button" tabindex="0">' +
+      '<div class="conv-item-title">' + esc(c.title) + '</div>' +
+      '<div class="conv-item-meta">' +
+        '<span class="conv-item-agent">' + esc(c.agent || 'unknown') + '</span>' +
+        '<span>' + (c.turn_count || 0) + ' turns</span>' +
+      '</div>' +
+      snippet +
+    '</div>';
+  }
+
+  // renderConversationSearchEnvelope handles both initial render and
+  // append-on-scroll. Initial render draws keyword results plus an optional
+  // "Related by meaning" tail from env.semantic (page 0 only). Append adds
+  // only new keyword items.
+  function renderConversationSearchEnvelope(env, append) {
     var el = document.getElementById('conv-list');
-    if (!convos.length) {
-      el.innerHTML = '<div class="empty-state">No conversations found</div>';
-      return;
-    }
-    el.innerHTML = convos.map(function(c) {
-      return '<div class="conv-item" data-id="' + esc(c.id) + '" role="button" tabindex="0">' +
-        '<div class="conv-item-title">' + esc(c.title) + '</div>' +
-        '<div class="conv-item-meta">' +
-          '<span class="conv-item-agent">' + esc(c.agent || 'unknown') + '</span>' +
-          '<span>' + c.turn_count + ' turns</span>' +
-        '</div>' +
+    if (!el) return;
+    var keywordItems = env.items || [];
+    var semanticItems = env.semantic || [];
+    var total = env.total || 0;
+
+    if (!append) {
+      if (!keywordItems.length && !semanticItems.length) {
+        el.innerHTML = '<div class="empty-state">No conversations found</div>';
+        return;
+      }
+      var html = '<div class="search-header" style="padding:6px 8px;font-size:11px;color:var(--text-muted)">' +
+        esc(String(keywordItems.length)) + ' of ' + esc(String(total)) + ' keyword match' + (total === 1 ? '' : 'es') +
       '</div>';
-    }).join('');
+      html += '<div class="conv-search-keyword-list">' +
+        keywordItems.map(renderConversationSearchItem).join('') +
+      '</div>';
+      if (semanticItems.length) {
+        html += '<div class="search-header" style="padding:6px 8px;font-size:11px;color:var(--text-muted);border-top:1px solid var(--border);margin-top:4px">' +
+          'Related by meaning (' + esc(String(semanticItems.length)) + ')' +
+        '</div>';
+        html += '<div class="conv-search-semantic-list">' +
+          semanticItems.map(renderConversationSearchItem).join('') +
+        '</div>';
+      }
+      el.innerHTML = html;
+    } else {
+      var kwList = el.querySelector('.conv-search-keyword-list');
+      if (kwList && keywordItems.length) {
+        kwList.insertAdjacentHTML('beforeend', keywordItems.map(renderConversationSearchItem).join(''));
+      }
+      var header = el.querySelector('.search-header');
+      if (header) {
+        var rendered = el.querySelectorAll('.conv-search-keyword-list .conv-item').length;
+        header.textContent = rendered + ' of ' + total + ' keyword match' + (total === 1 ? '' : 'es');
+      }
+    }
+
+    wireConvItemClicks(el);
+  }
+
+  function wireConvItemClicks(el) {
     el.querySelectorAll('.conv-item').forEach(function(item) {
+      if (item.dataset.wired === '1') return;
+      item.dataset.wired = '1';
       var handler = function() {
         el.querySelectorAll('.conv-item').forEach(function(i) { i.classList.remove('active'); });
         item.classList.add('active');
@@ -117,6 +222,12 @@
         if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handler(); }
       });
     });
+  }
+
+  // Back-compat shim: older call sites may still invoke this with a bare
+  // array of conversations. Map to the envelope renderer.
+  function renderConversationSearchResults(convos) {
+    renderConversationSearchEnvelope({ items: convos || [], total: (convos || []).length }, false);
   }
 
   // Expose to onclick


### PR DESCRIPTION
## Summary
- Conversations + actions search were one-shot (limit=50, no pagination) and rendered raw records with no indication where the query hit
- Switched both to an envelope response \`{items, total, offset, limit, has_more, semantic?}\` with per-item \`snippet_html\` containing the match wrapped in \`<mark>\`
- Conversations run **keyword (paged)** first, then overlay a capped **\"Related by meaning\"** semantic tail on page 0 (deduped against keyword ids)
- UI renders initial page + appends on scroll-near-bottom; no re-render, no jump

## Why
User workflow was \"search the full history for a keyword\" — semantic-only recall was fuzzy and the UI silently capped at 50. Now you can keyword-filter the whole archive with pagination, still get semantic suggestions where they help.

## Scope (explicit)
- **Changed**: \`/api/conversations/search\`, \`/api/actions/search\` (GET)
- **Unchanged**: memories / manifests / tasks / products / ideas search endpoints — already work for users

## Files
- \`internal/web/snippet.go\` — new \`highlightSnippet\` helper (case-insensitive, ~80 chars context, HTML-escapes non-match, wraps match with \`<mark>\`, falls back to first 160 chars on no-match)
- \`internal/conversation/store.go\` — new \`SearchKeyword(q, limit, offset) (items, total, err)\` over title/summary/turns
- \`internal/action/search.go\` — new \`SearchPaged(q, limit, offset) (items, total, err)\`; old \`Search\` kept as a shim
- \`internal/web/handlers_search.go\` — envelope shape for both endpoints; conversations merge keyword + semantic (page 0 only)
- \`internal/web/ui/views/conversations.js\`, \`actions.js\` — infinite scroll state machine (offset tracking, append-only, scroll-to-bottom trigger, detach on clear); separate sections for keyword vs. \"Related by meaning\"
- \`internal/web/ui/style.css\` — \`.conv-item-snippet\` (2-line clamp) + global \`<mark>\` styling

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./internal/web/... ./internal/conversation/... ./internal/action/...\`
- [ ] Manual: search \"backup\" on Conversations tab, scroll — verify pagination appends, keyword stays highlighted, \"Related by meaning\" shows on first page only
- [ ] Manual: search \"mysqldump\" on Actions tab, scroll — verify pagination, snippet shows \`<mark>mysqldump</mark>\` inside the tool_input fragment

🤖 Generated with [Claude Code](https://claude.com/claude-code)