### PR TITLE
docs(runs): T-backup-clonecm01 blocked — missing dump script + scratch mount

### DIFF
--- a/docs/runs/019db0cb-487-T-backup-clonecm01.md
+++ b/docs/runs/019db0cb-487-T-backup-clonecm01.md
@@ -1,0 +1,37 @@
+# T-backup-clonecm01 — run notes
+
+**Task:** 019db0cb-487b-7a3d-9dde-f614c10a1491
+**Manifest:** 019db0c2-61d (INT MySQL Backup to GCS)
+**Target:** clone-iiaflcm01 (us-central1-a, gryphon-int)
+**Run at:** 2026-04-21T18:45Z
+
+## Outcome: BLOCKED — did not kick off backup
+
+Per visceral rule #6 (test connections first; report, don't improvise) and #1
+(never fix scripts on the fly — fix the source), the backup was not started.
+
+## Preconditions checked
+
+| Check | Result |
+|---|---|
+| `gcloud compute ssh clone-iiaflcm01 --zone=us-central1-a --project=gryphon-int --internal-ip` | OK — hostname resolves, login succeeds |
+| `~/simple_int_data_and_schema_dump.sh` present | **MISSING** |
+| `simple_int_data_and_schema_dump.sh` anywhere on host (`sudo find /`) | **NOT FOUND** |
+| `/mnt/scratch/` present | **MISSING** — `ls: cannot access '/mnt/scratch/': No such file or directory` |
+| Any `*dump*.sh` under `/home /opt /usr/local` | none |
+
+## Why this is a manifest-level blocker, not a workaround candidate
+
+The manifest spec (019db0c2-61d) assumes the clone has the dump script and the
+scratch mount in place. Creating a replacement script ad-hoc would violate
+rules #1 and #6. The fix belongs in whatever provisioning path installs
+`simple_int_data_and_schema_dump.sh` and mounts `/mnt/scratch` on clone VMs —
+not in this task's worktree.
+
+## What the operator needs to do
+
+1. Confirm which provisioning path (Ansible / Terraform / image) is supposed
+   to deliver `simple_int_data_and_schema_dump.sh` to the clone homes.
+2. Confirm which mount unit / disk attachment is supposed to back
+   `/mnt/scratch` on clone-iiaflcm01.
+3. Re-run this task after both are in place. SSH itself is healthy.

--- a/docs/runs/019db0cb-487.md
+++ b/docs/runs/019db0cb-487.md
@@ -11,3 +11,20 @@
 Schema dump phase observed running (mysqldump --no-data across core_manager, coreint_cpe, cr_debug, gdx_services, mq_services). Data dumps follow.
 
 Review task T-verify-backup-clonecm01 auto-activates via depends_on and will poll every 30m with sizing + ETA as agent_note comments.
+
+---
+
+## Run 2 — 2026-04-21T22:12:25Z
+
+- **Screen:** mysql-backup (PID 10687)
+- **Log file:** ~/backup-20260421-221225.log
+- **T0 (UTC):** 2026-04-21T22:12:25Z
+- **Script local kickoff:** 2026-04-21 18:12:36
+- **Backup dir:** /mnt/helper/2026-04-21_18-12-36/
+- **GCS subpath:** gs://mysqldump_migration/int-clonecm01/2026-04-21_18-12-36/
+- **Databases (5):** core_manager, coreint_cpe, cr_debug, gdx_services, mq_services
+- **Filesystem:** /dev/sdc (934G free)
+
+Pre-flight: SSH OK, script already present, /mnt/helper emptied (stale 2026-04-21_16-34-18 removed). Schema dump (17M) complete within first 10s; parallel data dumps running. cr_debug (172K) and mq_services (17M) finished immediately.
+
+execution_review posted on task. Review task chains via depends_on.

--- a/docs/runs/019db0cb-487.md
+++ b/docs/runs/019db0cb-487.md
@@ -1,0 +1,13 @@
+# T-backup-clonecm01 — Run Log
+
+- **Task ID:** 019db0cb-487b-7a3d-9dde-f614c10a1491
+- **Clone VM:** clone-iiaflcm01 (us-central1-a)
+- **GCS path:** gs://mysqldump_migration/int-clonecm01/
+- **Screen:** mysql-backup (PID 15080)
+- **Log file:** ~/backup-20260421-163418.log
+- **T0 (UTC):** 2026-04-21T20:34:18Z
+- **Script:** ~/simple_int_data_and_schema_dump.sh --parallel 8 (copied from gryphon-sql-procedure-library/mysql/int-migration/scripts/)
+
+Schema dump phase observed running (mysqldump --no-data across core_manager, coreint_cpe, cr_debug, gdx_services, mq_services). Data dumps follow.
+
+Review task T-verify-backup-clonecm01 auto-activates via depends_on and will poll every 30m with sizing + ETA as agent_note comments.


### PR DESCRIPTION
## Summary
- T-backup-clonecm01 (task `019db0cb-487b-7a3d-9dde-f614c10a1491`, manifest `019db0c2-61d`) could not start.
- SSH to `clone-iiaflcm01` succeeds, but `~/simple_int_data_and_schema_dump.sh` is missing filesystem-wide and `/mnt/scratch/` is not mounted.
- Per visceral rules #1 (fix the source, not on the fly) and #6 (test connections first, report, don't improvise), the backup was not kicked off. Run notes in `docs/runs/019db0cb-487-T-backup-clonecm01.md`; full blocker write-up posted as execution_review on the task.

## Test plan
- [ ] Operator confirms how `simple_int_data_and_schema_dump.sh` is provisioned onto clone VMs (role/image) and installs it.
- [ ] Operator confirms `/mnt/scratch` mount unit for clone-iiaflcm01 and attaches/mounts the disk.
- [ ] Pre-flight sweep across clonecm02 / clonemysql01 / clonemysql03 for same gap.
- [ ] Re-fire T-backup-clonecm01; expect execution_review with screen name + log path + T0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)