### PR TITLE
docs(runs): T-verify-backup-clonecm02 run 1 log

### DIFF
--- a/docs/runs/019db0cb-e7bf-T-verify-backup-clonecm02.md
+++ b/docs/runs/019db0cb-e7bf-T-verify-backup-clonecm02.md
@@ -1,0 +1,46 @@
+# T-verify-backup-clonecm02 — run log
+
+Task id: `019db0cb-e7bf-779d-9473-44af68904e7a`
+Main task (paired): `019db0cb-52c9-719a-a17b-69e7ce5a13e1` (T-backup-clonecm02)
+Manifest: `019db0c2-61d` (INT MySQL Backup to GCS — per-clone-node tasks)
+Clone VM: `clone-iiaflcm02` (zone `us-central1-a`, project `gryphon-int`)
+
+## Run 1 — 2026-04-21T21:11Z
+
+**Backup state:** RUNNING
+
+- T0 (script start, from log filename): `2026-04-21T21:04:43Z`
+- Check time: `2026-04-21T21:11:04Z`
+- Elapsed: ~6m 21s
+- Backup dir on clone: `/mnt/helper/2026-04-21_17-04-47/`
+- GCS dest (expected, not yet populated): `gs://mysqldump_migration/int-clonecm02/2026-04-21_17-04-47/`
+- Staged bytes: 55,003,702,865 B (~52 GiB)
+- Aggregate rate: ~144 MB/s
+
+### Per-DB on-disk status (from `ls -la /mnt/helper/…/data/`)
+
+| DB | Size | Status |
+|---|---|---|
+| core_backup | 43 MB | done |
+| core_config | 642 MB | done |
+| cr_debug | 1.4 MB | done |
+| core_manager | 4.7 GB | done |
+| mstr | 4.7 MB | **FAILED** (log error at 17:06:16) |
+| core_audit | 9.17 GB | dumping |
+| coreint_cpe1 | 9.13 GB | dumping |
+| coreint_ws | 9.30 GB | dumping |
+| core_report | 10.78 GB | dumping |
+| core_services | 10.93 GB | dumping |
+
+### Expected per-DB sizes (information_schema)
+
+**Not captured this run** — `mysql -uroot` returned access denied without password on clone-iiaflcm02. Need auth path (my.cnf, defaults-file, or env creds) to cache per-DB expected sizes. Tracking on-disk growth as fallback.
+
+### Issues flagged for final verdict
+
+1. Script logged `Schema dump FAILED` at 17:06:14, but `all_schema.sql` is 29 MB non-empty on disk — needs content inspection at final verdict.
+2. `mstr` data dump FAILED at 17:06:15 — only 4.7 MB written, likely truncated or empty. Will fail acceptance criterion #3 unless mstr's legitimate size is ≈0 or the script retries.
+
+### Next step
+
+Recurring 30m schedule — next fire fires another verify pass. Self-cancel + `review_approval` / `review_rejection` when screen ends + GCS upload is observed.

--- a/docs/runs/019db0cb-e7bf-run14-close.md
+++ b/docs/runs/019db0cb-e7bf-run14-close.md
@@ -1,0 +1,29 @@
+# T-verify-backup-clonecm02 — run 14 (self-cancel / close)
+
+**Date:** 2026-04-22
+
+## State
+
+Main task `T-backup-clonecm02` (019db0cb-52c) is **completed**. Backup is fully terminal on the clone and in GCS.
+
+Verdict already delivered: `review_approval` posted on run 13 (comment ts 1776828873) after runs 11/12 corrected the earlier incorrect `review_rejection` from run 4.
+
+### GCS final state — `gs://mysqldump_migration/int-clonecm02/2026-04-21_17-04-47/`
+
+- `all_schema.sql` — 29,257,741 bytes (27.90 MiB)
+- `data/` — 10 files, byte-identical to local staging
+- `dump_2026-04-21_17-04-47.log` — 4,405 bytes
+
+### Timing
+- T0: `2026-04-21T21:04:43Z`
+- Local dumps done: `2026-04-21T22:22:30Z` (~1h 17m)
+- GCS upload complete + verdict: `2026-04-21T23:04:02Z` (~2h total)
+
+## Action this run
+
+- No new check required — verify already self-reported terminal verdict in run 13.
+- Posting `execution_review` on this verify task and calling `task_cancel` on self per spec Step 3.
+
+## Followup (not blocking)
+
+Script self-reported `FAILED` footer despite all artifacts being intact → track as a followup against the backup script's failure-detection logic (source: `gryphon-sql-procedure-library/mysql/int-migration/scripts/simple_int_data_and_schema_dump.sh`). Do not patch on the fly (visceral rule #1).

--- a/docs/runs/019db0cb-e7bf-run15-reclose.md
+++ b/docs/runs/019db0cb-e7bf-run15-reclose.md
@@ -1,0 +1,31 @@
+# T-verify-backup-clonecm02 — run 15 (re-close / re-cancel)
+
+**Date:** 2026-04-22 05:40Z
+
+## Context
+
+Verify task fired again despite run 14 calling `task_cancel` on self. Main task `T-backup-clonecm02` (019db0cb-52c) remains **completed**; final verdict (`review_approval`) was delivered in run 13 and re-affirmed in run 14.
+
+## Check performed this fire
+
+Connected via `gcloud compute ssh clone-iiaflcm02 --zone=us-central1-a --project=gryphon-int --internal-ip` and confirmed:
+
+- `screen -ls | grep mysql-backup` → `No Sockets found`
+- `pgrep -af mysqldump` → none
+- `/mnt/scratch/` → empty
+- Most recent log on disk: `~/backup-20260421-210443.log` (prior completed run)
+- GCS `gs://mysqldump_migration/int-clonecm02/`:
+  - `2026-04-12_10-59-14/`
+  - `2026-04-21_17-04-47/` (final artifacts intact — matches run 14 snapshot)
+
+No new backup activity since the terminal run verified in run 13/14.
+
+## Action
+
+- Posted `agent_note` on main task 019db0cb-52c explaining current snapshot and that no new verdict is being rendered.
+- Calling `task_cancel` on self again — the previous cancel did not prevent this fire.
+- Posting `execution_review` on self per closing-the-task instructions.
+
+## Followup
+
+- Why did `task_cancel` from run 14 not prevent this recurring fire? Investigate scheduler behaviour for verify tasks whose `depends_on` main is `completed` (expected: terminal, should not re-activate). Track as a followup against the task runner, not a hot-patch (visceral rule #1).

--- a/docs/runs/019db0cb-e7bf-run3.md
+++ b/docs/runs/019db0cb-e7bf-run3.md
@@ -1,0 +1,43 @@
+# T-verify-backup-clonecm02 — run 3 (task 019db0cb-e7b)
+
+**Wake:** 2026-04-21 ~22:27Z (scheduled 30m fire; next_run_at was 22:12Z).
+**T0 of main (019db0cb-52c):** 2026-04-21T21:04:43Z.
+**Clone:** clone-iiaflcm02 / us-central1-a / gryphon-int.
+
+## State at this fire
+
+- Local dumps: **COMPLETE** at 18:22:30 local (22:22:30Z UTC) — 1h 17m 47s.
+- Staged: 570,282,409,228 B (≈531 GiB / 570 GB incl. schema).
+- Log banner: `[WARN] 1 failure(s) during dump` — `mstr` Data FAILED at 17:06:16.
+- `all_schema.sql`: uploaded to GCS at 22:22:33Z (29,257,741 B; MD5 re98pr6q/VrdZQHAXT4PnQ==).
+- `data/*.sql`: gsutil -m upload IN PROGRESS. ~16 python3 gsutil workers alive. 0 data files in GCS yet (only schema + empty prefix).
+
+## On-disk final sizes
+
+| DB | Bytes | Status |
+|---|---|---|
+| core_audit | 157,834,375,947 | ok |
+| core_backup | 44,703,222 | ok |
+| core_config | 672,730,839 | ok |
+| core_manager | 4,945,150,476 | ok |
+| core_report | 239,890,180,833 | ok |
+| core_services | 31,394,154,917 | ok |
+| coreint_cpe1 | 22,893,021,884 | ok |
+| coreint_ws | 112,572,746,798 | ok |
+| cr_debug | 1,369,032 | ok |
+| mstr | 4,704,942 | **flagged FAILED by script — content unverified** |
+
+## Decision
+
+- **No self-cancel.** Upload still running.
+- Posted `agent_note` progress on main task 019db0cb-52c with sizing, rate, ETA, mstr/schema warnings carried forward.
+
+## Carry-forward for final verdict
+
+When upload completes (screen exits), next verify run must:
+
+1. Confirm all 10 files in GCS `gs://mysqldump_migration/int-clonecm02/2026-04-21_17-04-47/data/` with byte sizes matching on-disk.
+2. Spot-check `mstr.sql` locally (`head -50`, `tail -20`) to decide whether the `mstr Data FAILED` flag means partial output or just a non-fatal stderr warning.
+3. Spot-check `all_schema.sql` (expect `CREATE DATABASE`/`CREATE TABLE` for all 10 DBs).
+4. If mstr is truly partial → `review_rejection` + `agent_note` upstream explaining re-run needed. Else → `review_approval`.
+5. Call `task_cancel` on self (019db0cb-e7bf-779d-9473-44af68904e7a).

--- a/docs/runs/019db0cb-e7bf-run4-final.md
+++ b/docs/runs/019db0cb-e7bf-run4-final.md
@@ -1,0 +1,55 @@
+# T-verify-backup-clonecm02 — run 4 / FINAL (task 019db0cb-e7b)
+
+**Wake:** 2026-04-21 ~23:10Z (30m scheduled).
+**T0 of main (019db0cb-52c):** 2026-04-21T21:04:43Z (17:04:47 clone-local).
+**End (script):** 2026-04-21T23:04:02Z. Duration 119m 15s.
+**Clone:** clone-iiaflcm02 / us-central1-a / gryphon-int.
+
+## Final state at this fire
+
+- `screen -ls | grep mysql-backup`: (empty) — screen ended.
+- `pgrep -af mysqldump`: (empty) — no dump processes.
+- `ls /mnt/scratch/`: (empty) — cleaned up.
+- Log: `~/backup-20260421-210443.log` (69 lines). Summary banner: `Status: FAILED (1 dump failures, GCS=0)`.
+- Script-reported errors:
+  - 17:06:14 `[ERROR] Schema dump FAILED`
+  - 17:06:16 `[ERROR] [mstr] Data FAILED`
+  - 18:22:30 `[WARN] 1 failure(s) during dump`
+
+## GCS artifacts (gs://mysqldump_migration/int-clonecm02/2026-04-21_17-04-47/)
+
+| Object | Bytes | Mtime UTC |
+|---|---|---|
+| all_schema.sql | 29,257,741 | 22:22:33 |
+| data/core_audit.sql | 157,834,375,947 | 22:53:33 |
+| data/core_backup.sql | 44,703,222 | 22:22:38 |
+| data/core_config.sql | 672,730,839 | 22:23:00 |
+| data/core_manager.sql | 4,945,150,476 | 22:24:36 |
+| data/core_report.sql | 239,890,180,833 | 23:03:59 |
+| data/core_services.sql | 31,394,154,917 | 22:29:42 |
+| data/coreint_cpe1.sql | 22,893,021,884 | 22:31:02 |
+| data/coreint_ws.sql | 112,572,746,798 | 22:39:59 |
+| data/cr_debug.sql | 1,369,032 | 22:22:35 |
+| data/mstr.sql | 4,704,942 | 22:22:35 |
+| dump_…log | 4,405 | 23:04:01 |
+
+Totals: 10/10 data files, 531.09 GiB. All sizes match on-disk sizes from run3.
+
+## Spot-check results (contradicting script self-report)
+
+- **all_schema.sql** — downloaded & inspected:
+  - 10 `CREATE DATABASE` statements for all 10 DBs.
+  - Table counts: core_audit=3140, core_backup=9, core_config=391, core_manager=361, core_report=896, core_services=561, coreint_cpe1=1344, coreint_ws=395, cr_debug=5, mstr=10.
+  - Footer present: `-- Dump completed on 2026-04-21 17:06:14`.
+  - Verdict: **complete**, despite script saying schema dump FAILED.
+- **mstr.sql** — downloaded & inspected:
+  - Valid header, `CREATE DATABASE mstr`, `USE mstr`, LOCK TABLES writes for MOISES_tbl_Dates.
+  - Footer: `-- Dump completed on 2026-04-21 17:06:16`.
+  - Size matches on-disk (4,704,942 B). Verdict: **complete**, despite script flagging FAILED.
+
+## Decision
+
+- Per manifest 019db0c2-61d spec Step 4 (screen ended + log error) → **post `review_rejection`** on main task 019db0cb-52c.
+- Rejection cites script's FAILED self-report as authoritative signal; attaches spot-check evidence showing artifacts are in fact complete. Operator can decide: accept artifacts as-is, or re-run for a clean success banner.
+- Root cause note: the script's schema-dump error path and mstr tracking appear to produce intact files but set the failure counter anyway — a bug in `simple_int_data_and_schema_dump.sh` error accounting (per visceral rule #1/#2, fix in the source script, not on the fly).
+- `task_cancel` on SELF (019db0cb-e7bf-779d-9473-44af68904e7a).


### PR DESCRIPTION
## Summary
- Record first verify-task run for T-verify-backup-clonecm02 (task `019db0cb-e7bf`).
- Backup on clone-iiaflcm02 is running — 52 GiB staged at ~144 MB/s, 4/10 DBs done, T0 = 2026-04-21T21:04:43Z.
- Posted `agent_note` progress comment on main task `019db0cb-52c` per manifest spec.
- Flagged two issues for final verdict: script-logged schema dump FAILED (file non-empty on disk — needs inspection), and `mstr` data dump FAILED.

## Test plan
- [x] SSH to clone-iiaflcm02 confirmed screen + 5 live mysqldumps
- [x] agent_note comment posted on T-backup-clonecm02 (019db0cb-52c)
- [x] Task will auto-re-fire in 30 min for next verify pass
- [ ] Final `review_approval` or `review_rejection` to be posted on subsequent run when dump+upload complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)