### PR TITLE
docs(readme): marketing-first landing — features on top, positioning vs OpenClaw, changelog out

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ One Go binary. No cloud. No monthly bill surprise. You set the daily budget; the
   <img src="docs/images/overview.png" alt="OpenPraxis dashboard — Cost Today $16.24 / $100, 438 turns, 147 tasks, tasks-today ranked by cost" width="100%" />
 </p>
 
+> **The shift.** Chat wrappers hand you a black box: you press run, you hope, and you meet the bill at the end of the month. OpenPraxis inverts that — every turn captured as it happens, aggregated upward, and surfaced on a single dashboard. Cost is a first-class metric on the task, the manifest, the product, and the day. Activity is a first-class record: every prompt, every tool input, every tool result, every acknowledgement of a rule. Independent evaluation is non-negotiable: the watcher audits every completed task and posts findings the agent cannot delete.
+>
+> **The result is cost control by construction.** You set a daily budget, you see spend accrue against it live, and runaway sessions can't hide behind a finished status.
+
 ## Why OpenPraxis
 
 - **You already pay for agents — start seeing where the money goes.** Spend surfaces on the task, the manifest, the product, and the day, live, in one place.
@@ -46,6 +50,66 @@ OpenPraxis is not a consumer chat wrapper. If you are looking to route inbound W
 
 Short version: **OpenPraxis captures what the agent did and what it cost, every turn, forever.** That's the core. Everything else — specs, review workflows, peer sync, the DAG viewer — is in service of that capture loop.
 
+## The Hierarchy — Product → Manifest → Task
+
+**One organizational model, used everywhere.** OpenPraxis orchestrates work as a three-level hierarchy borrowed from how actual engineering teams already think. Everything — cost, turns, status, settings, review verdicts — cascades up or down this spine.
+
+```
+ Peer  (your machine, identified by UUID v7 + MAC fingerprint)
+   │
+   ├──  Product            — an initiative / product line
+   │      │                  tags · status · cost rollup · DAG root
+   │      │
+   │      ├──  Manifest    — a versioned spec, markdown with deliverables
+   │      │      │           depends_on other manifests (build order)
+   │      │      │           jira_refs · status · linked ideas · comments
+   │      │      │
+   │      │      ├──  Task — a scheduled unit of work, executes an agent
+   │      │      │     │    depends_on other tasks · schedule (once / 5m / at:)
+   │      │      │     │    status, cost, turns, run_count, branch · comments
+   │      │      │     │
+   │      │      │     ├──  Run — one execution attempt, captures agent I/O
+   │      │      │     │     │   started_at / completed_at · cost · exit code
+   │      │      │     │     │
+   │      │      │     │     └──  Action — one tool call (Bash, Read, Edit, …)
+   │      │      │     │           tool_name · tool_input · tool_response · cwd
+   │      │      │
+   │      │      └──  Review Task — paired via depends_on, auto-activates
+   │      │            posts review_approval / review_rejection on parent
+   │      │
+   │      └──  More manifests … chained by manifest depends_on
+   │
+   └──  More products …
+```
+
+### Why a hierarchy
+
+- **Organization matches reality.** Initiatives have specs. Specs have work items. Work items have runs. Runs have tool calls. The model holds all the way down.
+- **Aggregation is free.** Cost and turns roll up at every level with no manual bookkeeping — drill from _"my product cost me $12"_ → _"this manifest accounted for $8"_ → _"this one task is $6"_ → _"this one agent turn burned $3"_ → _"here's the exact prompt and tool call"._
+- **Settings cascade.** 12 execution knobs resolve via `task → manifest → product → system`. Set `max_turns=100` once at the product, every task under it inherits. Override for one hard manifest. Override again for one risky task. The resolver walks the chain on every read.
+- **Dependencies at every layer.** Products depend on products. Manifests depend on manifests (build order). Tasks depend on tasks (run order + paired reviews). The same `depends_on` primitive powers all three — and the scheduler blocks dependents until prerequisites are terminal.
+- **Reviews ride the same chain.** The review-task pattern pairs every main task with a verify task via `depends_on`; when main completes, review auto-activates, polls real-world state, and posts the canonical verdict. No watcher can override it; no review agent can impersonate the watcher.
+
+## The DAG — your shop floor, at a glance
+
+**The hierarchy isn't just a data model — it's a picture.** Every product renders as an interactive Directed Acyclic Graph. You see the whole build plan at once: what's done, what's running, what's blocked, what's next, where the money went, and exactly which task implements which line of which spec.
+
+<p align="center">
+  <img src="docs/images/product-dag-openpraxis.png" alt="Product DAG — product at top, manifests as blue-edged nodes, task chains below, status-colored, interactive" width="100%" />
+</p>
+
+- **Purple product node** at the top — the initiative.
+- **Manifest nodes** linked by blue manifest-dep edges — the build order.
+- **Task nodes** under each manifest linked by yellow task-dep edges — the execution chain.
+- **Ownership edges** (dashed) from manifest to each root task — the "I belong to this spec" relationship.
+- **Status colours** — green done, grey pending, red failed, amber in flight. One glance tells you where the build is.
+- **Any shape, no custom code.** Linear 12-task chain (like the ELS product: `T1 → T1R → T2 → T2R → … → T6R`)? Renders top-to-bottom. Eight independent pairs (like INT MySQL backup/verify)? Renders as eight parallel short columns. Multi-parent fan-in? Dagre figures it out. Empty manifest? Graceful. The renderer takes the edge set and delegates layout to [dagre](https://github.com/dagrejs/dagre) ([PR #158](https://github.com/k8nstantin/OpenPraxis/pull/158)); we don't do arithmetic on positions anymore.
+- **Click any node to drill in.** Purple → product detail. Blue → manifest detail. Chain node → task detail with live output. `#view-products/<id>/dag` is shareable.
+- **Locally bundled.** Cytoscape + dagre + cytoscape-dagre are served from `/vendor/` on the same Go binary ([PR #159](https://github.com/k8nstantin/OpenPraxis/pull/159)). The DAG works offline, air-gapped, no CDN risk.
+- **Contract-tested at the API level.** `TestProductHierarchy_EmptyProduct / _LinearChain / _ParallelPairs` locks the `/api/products/:id/hierarchy` payload dagre rides on so a new DAG shape can't silently break the renderer ([PR #160](https://github.com/k8nstantin/OpenPraxis/pull/160)).
+
+**Why it matters.** A spec without a picture is a PDF nobody reads. A DAG without real numbers is a toy. OpenPraxis combines both — you see the plan _and_ the current cost, status, run count, and cost-per-turn of every node in it, live, in one view.
+
 ## Features
 
 - **Spec-driven task orchestration** — `Product → Manifest → Task → Run → Action` hierarchy; every layer aggregates cost, turns, and status from its children.
@@ -65,7 +129,7 @@ Short version: **OpenPraxis captures what the agent did and what it cost, every 
 
 ## Table of contents
 
-- [Why OpenPraxis](#why-openpraxis) · [Where OpenPraxis fits](#where-openpraxis-fits) · [Features](#features)
+- [Why OpenPraxis](#why-openpraxis) · [Where OpenPraxis fits](#where-openpraxis-fits) · [The Hierarchy](#the-hierarchy--product--manifest--task) · [The DAG](#the-dag--your-shop-floor-at-a-glance) · [Features](#features)
 - [See it in action](#see-it-in-action)
   - [Dashboard — cost today vs. budget, tasks ranked by spend](#dashboard--cost-today-vs-budget-tasks-ranked-by-spend)
   - [Live tool output — watch the agent work, turn by turn](#live-tool-output--watch-the-agent-work-turn-by-turn)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,29 @@ One Go binary. No cloud. No monthly bill surprise. You set the daily budget; the
 - **You already fix the same bug twice — stop.** Semantic memory with 768-dim embeddings recalls decisions, patterns, and constraints across sessions, agents, and machines.
 - **You don't trust an agent to grade itself — don't have to.** A separate watcher audits every completed task against git, build, and the manifest deliverables, and posts findings as first-class comments.
 
+## Where OpenPraxis fits
+
+**If an AI model is a CNC machine, OpenPraxis is the factory.** The model cuts metal; OpenPraxis is everything around it: the specs (manifests), the work orders (tasks), the shop floor (execution engine), the time clock (cost + turn tracking), the QA station (watcher), the archive (memory), and the shift log (activity feed). One developer with OpenPraxis runs an engineering shop, not a chat thread.
+
+**Professional AI development tool — not a consumer agent-message manager.** OpenPraxis lives on the builder's side of the tool: every action an agent takes is captured, every dollar is attributed, every rule is enforceable, every decision is auditable months later. It is purpose-built for the person who has to justify the AI bill, defend the merges, and find out what the agent actually did on Tuesday.
+
+OpenPraxis is not a consumer chat wrapper. If you are looking to route inbound WhatsApp / iMessage / Telegram messages to a local assistant, OpenPraxis isn't the tool — [OpenClaw](https://github.com/openclaw/openclaw) or a similar assistant gateway is. OpenPraxis starts where the build request starts and ends where the commit lands.
+
+| | OpenPraxis | Consumer agent-message managers (e.g. OpenClaw) |
+|---|---|---|
+| **Domain** | AI-assisted software development | Local personal assistant over chat/voice |
+| **Front door** | Manifests + scheduled tasks written by a developer | Inbound messages on WhatsApp, iMessage, Telegram, Signal, Slack, Discord, ... |
+| **Output** | Commits, branches, PRs, dashboard state | Reply messages in the source channel + voice + canvas |
+| **Unit of work** | A task that runs an agent session against a spec | A conversation turn in a messaging thread |
+| **Isolation** | One agent per task, in its own git worktree | One agent per channel / account / workspace |
+| **Cost model** | Per-task, per-turn, per-day, per-product spend — first-class metric | Not a first-class surface |
+| **Audit model** | Independent watcher + typed review comments + execution_review retrospectives | Conversation history |
+| **Ideal user** | Professional developer / team with AI spend to justify and merges to defend | Power user who wants a private assistant across their chat apps |
+| **Persistence** | SQLite + WAL + `sqlite-vec` semantic search | JSON config + workspace dirs |
+| **Primary language** | Go (single binary) | TypeScript / Node.js |
+
+Short version: **OpenPraxis captures what the agent did and what it cost, every turn, forever.** That's the core. Everything else — specs, review workflows, peer sync, the DAG viewer — is in service of that capture loop.
+
 ## Features
 
 - **Spec-driven task orchestration** — `Product → Manifest → Task → Run → Action` hierarchy; every layer aggregates cost, turns, and status from its children.
@@ -42,7 +65,7 @@ One Go binary. No cloud. No monthly bill surprise. You set the daily budget; the
 
 ## Table of contents
 
-- [Why OpenPraxis](#why-openpraxis) · [Features](#features)
+- [Why OpenPraxis](#why-openpraxis) · [Where OpenPraxis fits](#where-openpraxis-fits) · [Features](#features)
 - [See it in action](#see-it-in-action)
   - [Dashboard — cost today vs. budget, tasks ranked by spend](#dashboard--cost-today-vs-budget-tasks-ranked-by-spend)
   - [Live tool output — watch the agent work, turn by turn](#live-tool-output--watch-the-agent-work-turn-by-turn)

--- a/README.md
+++ b/README.md
@@ -6,13 +6,43 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Release](https://img.shields.io/github/v/release/k8nstantin/OpenPraxis?include_prereleases&sort=semver)](https://github.com/k8nstantin/OpenPraxis/releases)
 
-**Spec-driven development platform for autonomous coding agents.** Define products, write specs, and let independent agent sessions build them — with persistent memory, compliance enforcement, and independent execution auditing.
+### Ship software with autonomous coding agents — without losing the plot.
 
-OpenPraxis is the operating system between you and your coding agents. It manages the full lifecycle: ideas become specs, specs become tasks, tasks execute autonomously, a watcher audits the output, and everything persists across sessions, agents, and machines.
+**OpenPraxis is the operating system between you and your coding agents.** Write a spec, hand it to an agent, walk away — and come back to a dashboard that shows you every turn, every tool call, every dollar spent, every rule acknowledged, every commit landed, audited by an independent watcher your agent can't silence. **All local. All persistent. Peer-to-peer across your machines.**
+
+One Go binary. No cloud. No monthly bill surprise. You set the daily budget; the runner clamps against it; runaway agents can't hide.
+
+<p align="center">
+  <img src="docs/images/overview.png" alt="OpenPraxis dashboard — Cost Today $16.24 / $100, 438 turns, 147 tasks, tasks-today ranked by cost" width="100%" />
+</p>
+
+## Why OpenPraxis
+
+- **You already pay for agents — start seeing where the money goes.** Spend surfaces on the task, the manifest, the product, and the day, live, in one place.
+- **You already write specs — stop copy-pasting them into every chat.** Manifests are versioned, searchable, and injected into every agent session automatically.
+- **You already fix the same bug twice — stop.** Semantic memory with 768-dim embeddings recalls decisions, patterns, and constraints across sessions, agents, and machines.
+- **You don't trust an agent to grade itself — don't have to.** A separate watcher audits every completed task against git, build, and the manifest deliverables, and posts findings as first-class comments.
+
+## Features
+
+- **Spec-driven task orchestration** — `Product → Manifest → Task → Run → Action` hierarchy; every layer aggregates cost, turns, and status from its children.
+- **Autonomous agent sessions** — tasks spawn Claude Code / Cursor / Codex subprocesses in isolated git worktrees off fresh `origin/main`, with the manifest spec, visceral rules, and relevant memories injected as context.
+- **Cost as a first-class metric** — live spend per task, per turn, per day, rolled up to the product. Hard daily budget enforced as a visceral rule.
+- **Hierarchical execution controls** — 12 knobs (`max_turns`, `temperature`, `default_model`, `max_cost_usd`, …) inherit through `task → manifest → product → system` scope with one-click override + reset.
+- **Independent observer** — a separate watcher runs three gates (git, build, manifest-deliverables) on every completed task and posts findings as comments; the paired review task owns the verdict.
+- **Review workflow with typed comments** — every entity has a comment thread; `review_approval` / `review_rejection` / `execution_review` / `agent_note` / `watcher_finding` are first-class types with enforcement at both the MCP and HTTP boundaries.
+- **Visceral rules + amnesia detection** — non-negotiable operating constraints every agent must acknowledge; violations auto-flagged on the dashboard.
+- **Semantic + keyword search** — `sqlite-vec` 768-dim embeddings over memories, conversations, actions; keyword-first paginated results with `<mark>`-highlighted snippets and optional "Related by meaning" tail.
+- **Interactive DAG visualization** — cytoscape + dagre renders product hierarchy; edges derived from real `depends_on`, layout computed by dagre, assets bundled locally (no CDN).
+- **Peer-to-peer sync** — mDNS discovery + Automerge CRDT replicates memories, conversations, manifests, and visceral rules across machines on the LAN.
+- **Single-binary distribution** — one Go build, `go:embed`-ded dashboard, no npm, no separate frontend deploy.
+- **55 MCP tools** — full programmatic surface for agents: products, manifests, tasks, memory, comments, reviews, settings, visceral rules, ideas, markers, peers.
+- **17-tab operator dashboard** — overview, memories, conversations, actions, amnesia, visceral, ideas, products, manifests, tasks, chat, delusions, watcher, peers, activity, recall, settings.
+- **Mobile peer app** — React Native / Expo companion that acts as a full OpenPraxis peer from your phone, syncing over LAN.
 
 ## Table of contents
 
-- [What's new (April 2026)](#whats-new-april-2026)
+- [Why OpenPraxis](#why-openpraxis) · [Features](#features)
 - [See it in action](#see-it-in-action)
   - [Dashboard — cost today vs. budget, tasks ranked by spend](#dashboard--cost-today-vs-budget-tasks-ranked-by-spend)
   - [Live tool output — watch the agent work, turn by turn](#live-tool-output--watch-the-agent-work-turn-by-turn)
@@ -42,34 +72,8 @@ OpenPraxis is the operating system between you and your coding agents. It manage
 
 **Deeper references:**
 - [Execution Controls — all 12 knobs in detail](docs/execution-controls.md)
-
-## What's new (April 2026)
-
-Landed on main this week:
-
-**Reliability**
-- **Watcher is observer-only (#149).** Removed the gatekeeper path that was mutating task state + blocking `ActivateDependents` on gate failure. Audits still run; findings post as `watcher_finding` comments; the paired review task owns the verdict. Fixes the "ops-task with 0 commits auto-downgraded to failed" bug that stranded INT MySQL backup chains.
-- **Task `depends_on` display widened 8 → 14 chars (#145).** UUIDv7 tasks created in the same millisecond share an 8-char time prefix, so the old `task_get` output rendered every child as if it pointed at the same parent. Now unambiguous.
-- **Scheduler cleanup rule for cancelled recurring tasks.** `task_cancel` on a task with `schedule: 30m` is now durable: status flips to `cancelled`, schedule collapses to `once`, `next_run_at` clears, so the runner can't re-fire it. (Operational tooling, not a PR — directly applied.)
-
-**DAG renderer — one-and-done**
-- **Dagre layout (#158).** Deleted 80+ lines of hand-rolled column/row arithmetic + manual topo sort + per-manifest DFS. Replaced with `layout: { name: 'dagre', rankDir: 'TB', ... }`. Any DAG shape — linear chain, independent pairs, multi-parent fan-in, empty manifests — now renders correctly with no layout-specific code.
-- **Edges from real `depends_on` (#146, kept through #158).** Product → manifest (ownership), manifest → manifest (explicit deps), parent-task → child-task (`depends_on`), manifest → task (ownership for in-manifest roots).
-- **Local vendor bundle (#159).** Cytoscape + dagre + cytoscape-dagre pinned and served from `/vendor/`, not a CDN. Dashboard works offline; no silent break when jsdelivr hiccups.
-- **Extract + contract test (#160).** Diagram code moved out of the 900-line `products.js` into `views/product-dag.js`. Added `TestProductHierarchy_EmptyProduct / _LinearChain / _ParallelPairs` in `handlers_product_hierarchy_test.go` so the API contract dagre rides on is locked at build time.
-
-**Search**
-- **Keyword-first search for conversations + actions (#152).** New envelope response `{ items, total, offset, limit, has_more, semantic? }`. Infinite scroll appends pages. `<mark>`-highlighted snippets around the first literal match, 80 chars of context each side. Conversations get an optional "Related by meaning" semantic tail on page 0 (capped at 10, deduped). Actions stay keyword-only (already LIKE-based).
-
-**Execution controls**
-- **Model selector is an enum (#151).** `default_model` moved from free-form string to `KnobEnum` with the Claude family (`""` agent default, `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`). Dashboard renders as a `<select>`; typos rejected at validation.
-
-**Comments + target resolution**
-- **Short-marker target IDs resolve everywhere.** `comment_add` + HTTP comment endpoints accept 8–12 char markers or full UUIDs; both paths canonicalize via the entity stores before writing (PR #136, PR #139). Sweep migration for legacy short-marker orphans shipped as `openpraxis admin migrate-comment-orphans` (PR #141).
-- **`execution_review` enforcement (PR #118).** Task completion blocked unless the agent posted its post-run retrospective.
-
-**Branding**
-- **OpenPraxis mark (#161).** Sidebar glyph swapped for a transparent 256×256 PNG served from `/assets/`. Favicon + apple-touch-icon wired at the same path.
+- [Workflow Engine — DAG, states, activation model, review loop, SCD principle](docs/workflow-engine.md)
+- [Changelog — April 2026 release notes](docs/changelog.md)
 
 ## See it in action
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,37 @@
+# Changelog
+
+Moved out of the main README to keep the landing page focused on what OpenPraxis **is** rather than what just changed. See the ["Changelog" link in the README](../README.md#deeper-references) to land here from the top of the repo.
+
+## April 2026
+
+Landed on `main` between 2026-04-20 and 2026-04-22.
+
+### Reliability
+
+- **Watcher is observer-only ([#149](https://github.com/k8nstantin/OpenPraxis/pull/149)).** Removed the gatekeeper path that was mutating task state + blocking `ActivateDependents` on gate failure. Audits still run; findings post as `watcher_finding` comments; the paired review task owns the verdict. Fixes the "ops-task with zero commits auto-downgraded to failed" bug that stranded INT MySQL backup chains.
+- **Task `depends_on` display widened 8 → 14 chars ([#145](https://github.com/k8nstantin/OpenPraxis/pull/145)).** UUIDv7 tasks created in the same millisecond share an 8-char time prefix, so the old `task_get` output rendered every child as if it pointed at the same parent. Now unambiguous.
+- **Scheduler cleanup rule for cancelled recurring tasks.** `task_cancel` on a task with `schedule: 30m` is now durable: status flips to `cancelled`, schedule collapses to `once`, `next_run_at` clears, so the runner can't re-fire it. (Operational tooling, not a PR — directly applied.)
+
+### DAG renderer — one-and-done
+
+- **Dagre layout ([#158](https://github.com/k8nstantin/OpenPraxis/pull/158)).** Deleted 80+ lines of hand-rolled column/row arithmetic + manual topo sort + per-manifest DFS. Replaced with `layout: { name: 'dagre', rankDir: 'TB', ... }`. Any DAG shape — linear chain, independent pairs, multi-parent fan-in, empty manifests — now renders correctly with no layout-specific code.
+- **Edges from real `depends_on` ([#146](https://github.com/k8nstantin/OpenPraxis/pull/146), kept through #158).** Product → manifest (ownership), manifest → manifest (explicit deps), parent-task → child-task (`depends_on`), manifest → task (ownership for in-manifest roots).
+- **Local vendor bundle ([#159](https://github.com/k8nstantin/OpenPraxis/pull/159)).** Cytoscape + dagre + cytoscape-dagre pinned and served from `/vendor/`, not a CDN. Dashboard works offline; no silent break when a CDN hiccups.
+- **Extract + contract test ([#160](https://github.com/k8nstantin/OpenPraxis/pull/160)).** Diagram code moved out of the 900-line `products.js` into `views/product-dag.js`. Added `TestProductHierarchy_EmptyProduct / _LinearChain / _ParallelPairs` in `handlers_product_hierarchy_test.go` so the API contract dagre rides on is locked at build time.
+
+### Search
+
+- **Keyword-first search for conversations + actions ([#152](https://github.com/k8nstantin/OpenPraxis/pull/152)).** New envelope response `{ items, total, offset, limit, has_more, semantic? }`. Infinite scroll appends pages. `<mark>`-highlighted snippets around the first literal match, 80 chars of context each side. Conversations get an optional "Related by meaning" semantic tail on page 0 (capped at 10, deduped). Actions stay keyword-only (already LIKE-based).
+
+### Execution controls
+
+- **Model selector is an enum ([#151](https://github.com/k8nstantin/OpenPraxis/pull/151)).** `default_model` moved from free-form string to `KnobEnum` with the Claude family (`""` agent default, `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`). Dashboard renders as a `<select>`; typos rejected at validation.
+
+### Comments + target resolution
+
+- **Short-marker target IDs resolve everywhere.** `comment_add` + HTTP comment endpoints accept 8–12 char markers or full UUIDs; both paths canonicalize via the entity stores before writing ([#136](https://github.com/k8nstantin/OpenPraxis/pull/136), [#139](https://github.com/k8nstantin/OpenPraxis/pull/139)). Sweep migration for legacy short-marker orphans shipped as `openpraxis admin migrate-comment-orphans` ([#141](https://github.com/k8nstantin/OpenPraxis/pull/141)).
+- **`execution_review` enforcement ([#118](https://github.com/k8nstantin/OpenPraxis/pull/118)).** Task completion blocked unless the agent posted its post-run retrospective.
+
+### Branding
+
+- **OpenPraxis mark ([#161](https://github.com/k8nstantin/OpenPraxis/pull/161)).** Sidebar glyph swapped for a transparent 256×256 PNG served from `/assets/openpraxis-icon.png`. Favicon + apple-touch-icon wired at the same path.


### PR DESCRIPTION
Two reframes of the README landing page:

## 1. Marketing first
Restructured the top of the README so a visitor lands on the value prop, not the changelog.

**Before:** title → tagline → TOC → deeper-reference links → What's new → See it in action → ...
**After:** title → headline → hero screenshot → **Why OpenPraxis** → **Where OpenPraxis fits** → **Features** → TOC → See it in action → ...

### New sections
- **Headline** — \"Ship software with autonomous coding agents — without losing the plot.\"
- **Value prop paragraph** — one paragraph, what OpenPraxis is and why it's different (single binary, local, audited).
- **Hero screenshot** — the overview dashboard above the fold.
- **Why OpenPraxis** — 4 bullets, each framed as a problem the reader already has, with the feature that solves it.
- **Where OpenPraxis fits** — the factory-vs-CNC positioning + explicit comparison table against consumer agent-message managers (e.g. OpenClaw). Points visitors looking for a chat gateway at that tool instead of leaving them to guess. Closes with the one-liner: \"OpenPraxis captures what the agent did and what it cost, every turn, forever.\"
- **Features** — 13 bullets, one per pillar capability.

## 2. Changelog out
Moved \"What's new (April 2026)\" out of the README into \`docs/changelog.md\`. The landing page links to it as a deeper reference alongside \`execution-controls.md\` and \`workflow-engine.md\`. Every PR bullet in the changelog links to its GitHub PR.

## Test plan
- [x] \`make build\` (no Go changes, just confirming build is happy)
- [ ] Render check: hero image resolves, TOC anchors resolve
- [ ] Changelog renders on GitHub at \`docs/changelog.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)