### PR TITLE
docs: end-to-end build-graph feature + full AI-agent tools comparison page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Release](https://img.shields.io/github/v/release/k8nstantin/OpenPraxis?include_prereleases&sort=semver)](https://github.com/k8nstantin/OpenPraxis/releases)
 
-### DAG execution engine + management layer for AI-driven software development.
+### Build products with AI agents — end to end.
 
-**OpenPraxis orchestrates AI-assisted work as a directed acyclic graph.** Products (initiative-level specs) hold Manifests (detailed specs with deliverables), Manifests hold Tasks (scheduled units of work), Tasks hold Runs (individual execution attempts), Runs hold Actions (single tool calls) — with dependencies at every layer and a scheduler that respects them. Each Task dispatches to the best-fit agent (Claude Code, Cursor, Codex) in an isolated git worktree; the platform captures every action, audits the output independently of the agent, and attributes every cost unit back to the spec that drove it.
+**OpenPraxis is a full DAG execution engine for AI-assisted software development.** One initiative becomes a Product. A Product holds chained Manifests (versioned specs with deliverables). Each Manifest holds chained Tasks that dispatch agents (Claude Code, Cursor, Codex) in isolated git worktrees. Every action is captured, every completed Task is audited independently of the agent, every cost unit attributes back to the spec that drove it — on a single graph, visualised, searchable, self-hosted.
 
-**Cost control, quality audit, agent comparison, and forecasting are built on top of that execution graph** — they are outcomes of the engine, not separate tools bolted on.
+**Cost control, independent quality audit, cross-agent comparison, and forecasting are outcomes of the engine** — not separate tools bolted on.
 
 <p align="center">
   <img src="docs/images/overview.png" alt="OpenPraxis dashboard — live spend vs daily budget, running tasks, tasks ranked by cost" width="100%" />
@@ -18,6 +18,7 @@
 
 ### Features
 
+- **End-to-end product build graph.** One Product, many chained Manifests (build-order dependencies), many chained Tasks per Manifest (execution-order + paired reviews). The graph plans, dispatches, audits, and costs every step from initiative spec to merged commit. IDE agents, orchestration SDKs, and observability proxies each cover a slice; OpenPraxis owns the whole chain. [Detailed comparison →](docs/compared-to-ai-agent-tools.md)
 - **Line-item cost attribution.** Every cost unit spent attributed to a task, a spec, a product, a day, and the authorizing policy.
 - **Pre-fire cost forecasting.** Predict what the next run, manifest, or sprint will cost from your actual history, per model, per agent, per spec shape.
 - **Independent quality audit.** Every completed task audited against spec, build, and diff by a separate watcher; paired review tasks post the final verdict.
@@ -28,7 +29,7 @@
 - **Atomic-granularity observability.** Drill from a product's total spend to the exact tool call that caused it in two clicks.
 - **Interactive build DAG.** The whole plan as a clickable, status-colored graph — brief a stakeholder without a deck.
 - **Self-hosted, offline-capable.** Control plane runs on your hardware; we're not in your data path.
-- **→ [How is this different from OpenClaw?](#where-openpraxis-fits)** Short answer: OpenPraxis is a professional AI development platform; OpenClaw is a consumer agent-message manager. See the comparison table below.
+- **→ [How is OpenPraxis different from other AI-agent tools?](docs/compared-to-ai-agent-tools.md)** Full landscape map vs IDE agent runtimes (Cline, Cursor, OpenHands, Goose), orchestration SDKs (CrewAI, LangChain), observability proxies (Helicone, Langfuse, AgentOps), enterprise platforms (watsonx, UiPath), and closest concept match (Paperclip). Plus [OpenClaw comparison ↓](#where-openpraxis-fits) for the consumer-assistant axis.
 
 ### How it fits
 
@@ -175,6 +176,7 @@ Developers write the spec. Leadership sets the budget, caps, and rules. OpenPrax
 - [License](#license)
 
 **Deeper references:**
+- [Compared to other AI-agent tools — full landscape map](docs/compared-to-ai-agent-tools.md) — IDE runtimes, orchestration SDKs, observability proxies, enterprise platforms, and Paperclip
 - [Execution Controls — all 12 knobs in detail](docs/execution-controls.md)
 - [Workflow Engine — DAG, states, activation model, review loop, SCD principle](docs/workflow-engine.md)
 - [Changelog — April 2026 release notes](docs/changelog.md)

--- a/docs/compared-to-ai-agent-tools.md
+++ b/docs/compared-to-ai-agent-tools.md
@@ -1,0 +1,76 @@
+# OpenPraxis compared to other AI-agent tools
+
+*Companion to the [OpenClaw comparison](../README.md#where-openpraxis-fits) in the main README. Covers the broader landscape of AI-agent development tooling as of April 2026.*
+
+Most tools in the AI-agent space solve one slice of the problem. OpenPraxis is positioned as the **full DAG execution engine + management layer** that sits *above* those slices. This document maps the landscape and shows exactly what OpenPraxis does that each category doesn't.
+
+## The landscape (April 2026)
+
+| Category | Examples | What they do | What they don't |
+|---|---|---|---|
+| **Agent runtimes** | [Claude Code](https://www.anthropic.com/claude-code), [Cursor](https://cursor.com), [OpenCode](https://opencode.ai/), [Cline](https://cline.bot), [OpenHands](https://openhands.dev/), [Goose](https://github.com/block/goose) | Execute one agent session against one prompt, inside an IDE or terminal | Orchestrate many sessions; maintain specs; audit results independently; cross-task cost rollup; dispatch to multiple runtimes |
+| **Orchestration frameworks** | [CrewAI](https://crewai.com), [LangChain](https://python.langchain.com), [xpander.ai](https://xpander.ai) | Code-level SDK for composing multi-agent workflows | Operator dashboard; spec hierarchy; audit trail; cost attribution to specs; local-first peer sync |
+| **Observability proxies** | [Helicone](https://helicone.ai), [Langfuse](https://langfuse.com), [Langtrace](https://langtrace.ai), [AgentOps](https://agentops.ai), [Maxim AI](https://getmaxim.ai/) | Route model requests through a proxy; log tokens + cost + traces | Execute the work; own the spec; schedule tasks; audit against deliverables; git integration |
+| **Enterprise governance** | [IBM watsonx](https://www.ibm.com/watsonx), [UiPath AI Agents](https://www.uipath.com) | Governance, SSO, policy, audit — cloud-hosted, heavy | Developer-first workflow; single-binary deploy; no-cloud-dependency; open source |
+| **Closest concept match** | Paperclip (launched March 2026, ~45k GitHub stars in 3 weeks) | Each agent has a role, a budget, a reporting line, and an audit trail | Multi-level spec hierarchy (Product → Manifest → Task); DAG visualization; multi-agent routing per task |
+
+## Feature-by-feature comparison
+
+| Capability | OpenPraxis | IDE runtimes<br/>(Cline / OpenHands / Goose) | Orchestration SDKs<br/>(CrewAI / LangChain) | Observability proxies<br/>(Helicone / Langfuse) | Enterprise<br/>(watsonx / UiPath) | Paperclip |
+|---|:-:|:-:|:-:|:-:|:-:|:-:|
+| Multi-level spec hierarchy (Product → Manifest → Task) | ✅ | — | partial | — | partial | partial |
+| Chained dependencies at every layer | ✅ | — | partial | — | — | — |
+| DAG visualization of the whole build plan | ✅ | — | — | — | — | — |
+| Multi-agent dispatch (Claude Code / Cursor / Codex per task) | ✅ | single runtime | ✅ | N/A | ✅ | partial |
+| Per-action cost attribution back to spec | ✅ | — | — | token-level | partial | ✅ |
+| Pre-fire cost forecasting from history | ✅ | — | — | — | — | — |
+| Cross-agent efficiency comparison on real code | ✅ | — | — | — | — | — |
+| Independent auditor (git + build + manifest-deliverables) | ✅ | — | — | — | — | partial |
+| Review workflow with typed comments | ✅ | — | — | — | partial | partial |
+| Visceral-rule enforcement + amnesia detection | ✅ | — | — | — | partial | — |
+| Cross-session semantic memory | ✅ | — | partial | — | — | partial |
+| Peer-to-peer sync (LAN, CRDT) | ✅ | — | — | — | — | — |
+| Self-hosted single binary | ✅ | varies | code-only | — | ❌ | unclear |
+| Open source | ✅ | mostly | ✅ | mostly | ❌ | ✅ |
+
+## Why the combination matters
+
+Picking one slice — runtime OR orchestration OR observability — is workable for a demo, painful in production. The problems show up at the seams:
+
+- **Runtime alone** (Cline, Goose): you get a working agent, no memory of what it cost, no audit of whether it was correct, no way to rerun "the exact same work but with a different agent."
+- **Orchestration SDK alone** (CrewAI, LangChain): you get code to compose agent workflows, but the specs live in comments, the costs live in billing dashboards, and the audit trail lives in scrollback.
+- **Observability proxy alone** (Helicone, Langfuse): you get tokens and traces, no specs to attribute them to, no way to connect "this run failed" to "this commit shouldn't merge."
+- **Enterprise platform alone** (watsonx, UiPath): you get governance at the cost of developer friction and cloud dependency.
+
+OpenPraxis is the **single operator surface that owns the whole chain**: spec authoring, scheduling, agent dispatch, isolated execution in git worktrees, action capture, independent audit, cost attribution, memory, search, peer sync, and visualization. The DAG is the picture of the whole thing in one place.
+
+## Where OpenPraxis is NOT the right fit
+
+- You want a **conversational chatbot across messaging apps** → use [OpenClaw](https://github.com/openclaw/openclaw) or a similar consumer assistant. OpenPraxis is for developers; it has no messaging integrations.
+- You want **drag-and-drop no-code agent workflows** → use Zapier AI or n8n. OpenPraxis is spec + code driven; non-technical users aren't the audience.
+- You want a **hosted SaaS with vendor managed uptime** → OpenPraxis is self-hosted by design. No hosted control plane exists today.
+- You only care about **one slice** (e.g. just observability, just orchestration) → a best-in-class single-slice tool will be simpler. OpenPraxis's value is in the combination.
+
+## Migration / coexistence notes
+
+- **From Claude Code / Cursor / Codex**: these are agent *runtimes*. OpenPraxis dispatches to them; you keep using them. Nothing to rip out.
+- **From Helicone / Langfuse / AgentOps**: overlaps with OpenPraxis's action-capture + cost-attribution surface. If you were using a proxy purely for cost telemetry, OpenPraxis subsumes it. If you're using it for cross-vendor LLM routing, keep the proxy.
+- **From CrewAI / LangChain**: overlaps with orchestration. Run OpenPraxis if you want a spec-hierarchy + operator dashboard; run CrewAI/LangChain if you want code-level composition without the operator layer.
+- **From watsonx / UiPath**: different scale + buyer. If you need enterprise SSO, change-management, and compliance certifications today, OpenPraxis isn't there yet. If you want local-first and single-binary, OpenPraxis is it.
+
+## See also
+
+- [OpenClaw comparison](../README.md#where-openpraxis-fits) — the consumer-assistant axis
+- [Workflow Engine reference](workflow-engine.md) — full DAG semantics, states, activation model
+- [Execution Controls reference](execution-controls.md) — the 12 knobs that cascade through the hierarchy
+- [Changelog](changelog.md) — April 2026 release notes
+
+Sources for this document (captured 2026-04-22):
+- [16 best AI orchestration platforms for 2026 — Guideflow](https://www.guideflow.com/blog/best-ai-orchestration-platforms)
+- [AI Agent Orchestration Frameworks in 2026 — Catalyst & Code](https://www.catalystandcode.com/blog/ai-agent-orchestration-frameworks)
+- [5 best AI agent observability tools for agent reliability in 2026 — Braintrust](https://www.braintrust.dev/articles/best-ai-agent-observability-tools-2026)
+- [15 AI Agent Observability Tools in 2026 — AIMultiple](https://research.aimultiple.com/agentic-monitoring/)
+- [Top Agent Orchestration Vendors in 2026 — xpander.ai](https://xpander.ai/resources/top-agent-orchestration-vendors-2026)
+- [Top 11 open-source autonomous agents & frameworks — Cline blog](https://cline.bot/blog/top-11-open-source-autonomous-agents-frameworks-in-2025)
+- [Best AI observability tools for autonomous agents 2026 — Arize](https://arize.com/blog/best-ai-observability-tools-for-autonomous-agents-in-2026/)
+- [OpenHands](https://openhands.dev/) · [Goose](https://github.com/block/goose) · [Cline](https://cline.bot) · [OpenCode](https://opencode.ai/)


### PR DESCRIPTION
Two changes landing together.

## 1. New Features bullet — "End-to-end product build graph"
Names OpenPraxis's core differentiator: Product → chained Manifests → chained Tasks + paired reviews, all on one graph. Links to the detailed comparison.

## 2. New doc: `docs/compared-to-ai-agent-tools.md`
Landscape map as of April 2026 covering:
- **Agent runtimes** — Claude Code, Cursor, OpenCode, Cline, OpenHands, Goose
- **Orchestration SDKs** — CrewAI, LangChain, xpander.ai
- **Observability proxies** — Helicone, Langfuse, Langtrace, AgentOps, Maxim AI
- **Enterprise** — IBM watsonx, UiPath
- **Closest concept match** — Paperclip (launched March 2026, ~45k stars in 3 weeks)

14-row feature-by-feature comparison table, "why the combination matters" analysis, explicit "not the right fit" guardrails, migration/coexistence notes for each category. Sources cited.

## Landing page updates
- Lead reframed to "Build products with AI agents — end to end."
- Deeper references list promotes the new comparison doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)