### PR TITLE
docs(readme): Review Tasks chained off their parent Task (depends_on), not Manifest siblings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,8 @@ flowchart TB
 
     M1 -->|holds| T1a["Task<br/><i>atomic</i>"]:::task
     M1 --- T1b["Task<br/><i>atomic</i>"]:::task
-    M1 --- T1c["Task<br/><i>atomic</i>"]:::task
     T1a -. depends_on .-> R1a[Review<br/>Task]:::review
     T1b -. depends_on .-> R1b[Review<br/>Task]:::review
-    T1c -. depends_on .-> R1c[Review<br/>Task]:::review
 
     M2 --- T2a["Task<br/><i>atomic</i>"]:::task
     M2 --- T2b["Task<br/><i>atomic</i>"]:::task
@@ -35,7 +33,9 @@ flowchart TB
     T2b -. depends_on .-> R2b[Review<br/>Task]:::review
 
     M3 --- T3a["Task<br/><i>atomic</i>"]:::task
+    M3 --- T3b["Task<br/><i>atomic</i>"]:::task
     T3a -. depends_on .-> R3a[Review<br/>Task]:::review
+    T3b -. depends_on .-> R3b[Review<br/>Task]:::review
 
     classDef idea fill:#1a1a2e,stroke:#3b82f6,stroke-width:2px,color:#e4e4e7
     classDef product fill:#4c1d95,stroke:#8b5cf6,stroke-width:3px,color:#fff

--- a/README.md
+++ b/README.md
@@ -25,14 +25,17 @@ flowchart TB
     M1 -->|holds| T1a["Task<br/><i>atomic</i>"]:::task
     M1 --- T1b["Task<br/><i>atomic</i>"]:::task
     M1 --- T1c["Task<br/><i>atomic</i>"]:::task
-    M1 --- R1[Review<br/>Task]:::review
+    T1a -. depends_on .-> R1a[Review<br/>Task]:::review
+    T1b -. depends_on .-> R1b[Review<br/>Task]:::review
+    T1c -. depends_on .-> R1c[Review<br/>Task]:::review
 
     M2 --- T2a["Task<br/><i>atomic</i>"]:::task
     M2 --- T2b["Task<br/><i>atomic</i>"]:::task
-    M2 --- R2[Review<br/>Task]:::review
+    T2a -. depends_on .-> R2a[Review<br/>Task]:::review
+    T2b -. depends_on .-> R2b[Review<br/>Task]:::review
 
     M3 --- T3a["Task<br/><i>atomic</i>"]:::task
-    M3 --- R3[Review<br/>Task]:::review
+    T3a -. depends_on .-> R3a[Review<br/>Task]:::review
 
     classDef idea fill:#1a1a2e,stroke:#3b82f6,stroke-width:2px,color:#e4e4e7
     classDef product fill:#4c1d95,stroke:#8b5cf6,stroke-width:3px,color:#fff
@@ -41,7 +44,7 @@ flowchart TB
     classDef review fill:#0a0a0f,stroke:#f59e0b,color:#f59e0b
 ```
 
-**Progression:** *Idea* → *Product* → *Manifest* → *Task (atomic)*. Idea at the top — the captured concept. Product beneath it as the spec root. Manifests chain off the Product (dotted arrows are `depends_on` build-order). Tasks hang off each Manifest as grapes — the Task is the **atomic unit of work** that dispatches one agent in one worktree. Every Manifest can pair Tasks with a Review Task that auto-activates to post the verdict.
+**Progression:** *Idea* → *Product* → *Manifest* → *Task (atomic)* → *Review Task*. Idea at the top — the captured concept. Product beneath it as the spec root. Manifests chain off the Product (dotted arrows are `depends_on` build-order). Tasks hang off each Manifest as grapes — the Task is the **atomic unit of work** that dispatches one agent in one worktree. Each Task pairs with its own Review Task, chained via `depends_on`: when the parent Task completes, the Review Task auto-activates, inspects the real-world side effects, and posts `review_approval` or `review_rejection` on the parent. The watcher's gate findings surface as comments; the Review Task owns the verdict.
 
 **Cost control, independent quality audit, cross-agent comparison, and forecasting are outcomes of the engine** — not separate tools bolted on.
 


### PR DESCRIPTION
Review-task pattern was shown wrong in the diagram — each Review Task is paired with its parent Task via `depends_on`, not as a sibling under the Manifest.

## Diagram update
Each main Task now has a dotted `depends_on` arrow to its own Review Task:
- Manifest A: 3 Tasks → 3 paired Review Tasks
- Manifest B: 2 Tasks → 2 paired Review Tasks
- Manifest C: 1 Task → 1 paired Review Task

## Caption update
Progression extended:
```
Idea → Product → Manifest → Task (atomic) → Review Task
```

Prose explains: "Each Task pairs with its own Review Task, chained via `depends_on`: when the parent Task completes, the Review Task auto-activates, inspects the real-world side effects, and posts `review_approval` or `review_rejection` on the parent. The watcher's gate findings surface as comments; the Review Task owns the verdict."

🤖 Generated with [Claude Code](https://claude.com/claude-code)