### PR TITLE
feat(runner-prompt): per-task prompt-context knobs + IncludeInPromptContext flag

### DIFF
--- a/internal/comments/types.go
+++ b/internal/comments/types.go
@@ -63,10 +63,34 @@ func IsValidTargetType(s string) bool {
 
 // CommentTypeInfo carries UI/doc metadata per type. M3 renders the filter
 // dropdown from Registry() so new types added here automatically appear.
+//
+// IncludeInPromptContext controls whether the runner injects comments of
+// this type into the agent's prompt as part of the prior-runs / other-
+// comments context block. Defining this at the type level (not per task)
+// keeps the taxonomy of "what belongs in a prompt" declarative: adding a
+// new comment type is a one-line flag change here, not a runner.go edit.
+// Default: true for types that carry feedback/history an agent needs to
+// avoid repeating work; false for cross-references (link) and text that
+// already lives on the entity (description_revision).
 type CommentTypeInfo struct {
-	Type        CommentType `json:"type"`
-	Label       string      `json:"label"`
-	Description string      `json:"description"`
+	Type                   CommentType `json:"type"`
+	Label                  string      `json:"label"`
+	Description            string      `json:"description"`
+	IncludeInPromptContext bool        `json:"include_in_prompt_context"`
+}
+
+// PromptContextTypes returns the comment types whose Registry entry has
+// IncludeInPromptContext=true. Runner.buildPrompt uses this to filter the
+// set of comments it injects into the agent prompt, so new types added to
+// Registry() participate automatically with a single flag.
+func PromptContextTypes() []CommentType {
+	out := make([]CommentType, 0, len(Registry()))
+	for _, info := range Registry() {
+		if info.IncludeInPromptContext {
+			out = append(out, info.Type)
+		}
+	}
+	return out
 }
 
 // Registry returns metadata for every comment type in the canonical order
@@ -75,49 +99,58 @@ type CommentTypeInfo struct {
 func Registry() []CommentTypeInfo {
 	return []CommentTypeInfo{
 		{
-			Type:        TypeExecutionReview,
-			Label:       "Execution Review",
-			Description: "Post-run retrospective; what shipped, what failed, what the agent learned",
+			Type:                   TypeExecutionReview,
+			Label:                  "Execution Review",
+			Description:            "Post-run retrospective; what shipped, what failed, what the agent learned",
+			IncludeInPromptContext: true,
 		},
 		{
-			Type:        TypeUserNote,
-			Label:       "Note",
-			Description: "Free-form human note on the entity",
+			Type:                   TypeUserNote,
+			Label:                  "Note",
+			Description:            "Free-form human note on the entity",
+			IncludeInPromptContext: true,
 		},
 		{
-			Type:        TypeWatcherFinding,
-			Label:       "Watcher Finding",
-			Description: "Auto-posted gate result — failures, warnings, or passes",
+			Type:                   TypeWatcherFinding,
+			Label:                  "Watcher Finding",
+			Description:            "Auto-posted gate result — failures, warnings, or passes",
+			IncludeInPromptContext: true,
 		},
 		{
-			Type:        TypeAgentNote,
-			Label:       "Agent Note",
-			Description: "Agent-authored observation; distinct from an execution review",
+			Type:                   TypeAgentNote,
+			Label:                  "Agent Note",
+			Description:            "Agent-authored observation; distinct from an execution review",
+			IncludeInPromptContext: true,
 		},
 		{
-			Type:        TypeDecision,
-			Label:       "Decision",
-			Description: "Architectural or scope decision recorded against the entity",
+			Type:                   TypeDecision,
+			Label:                  "Decision",
+			Description:            "Architectural or scope decision recorded against the entity",
+			IncludeInPromptContext: true,
 		},
 		{
-			Type:        TypeLink,
-			Label:       "Link",
-			Description: "Cross-reference to another comment, PR, issue, or external doc",
+			Type:                   TypeLink,
+			Label:                  "Link",
+			Description:            "Cross-reference to another comment, PR, issue, or external doc",
+			IncludeInPromptContext: false, // cross-refs: noise in prompt context
 		},
 		{
-			Type:        TypeReviewRejection,
-			Label:       "Review Rejection",
-			Description: "Reviewer rejected a completed task; kicks it back to scheduled for another pass",
+			Type:                   TypeReviewRejection,
+			Label:                  "Review Rejection",
+			Description:            "Reviewer rejected a completed task; kicks it back to scheduled for another pass",
+			IncludeInPromptContext: true,
 		},
 		{
-			Type:        TypeReviewApproval,
-			Label:       "Review Approval",
-			Description: "Reviewer signed off a completed task; clears the needs-rework flag for manifest closure",
+			Type:                   TypeReviewApproval,
+			Label:                  "Review Approval",
+			Description:            "Reviewer signed off a completed task; clears the needs-rework flag for manifest closure",
+			IncludeInPromptContext: true,
 		},
 		{
-			Type:        TypeDescriptionRevision,
-			Label:       "Description Revision",
-			Description: "Append-only edit of description / content / instructions. Latest revision is the current text.",
+			Type:                   TypeDescriptionRevision,
+			Label:                  "Description Revision",
+			Description:            "Append-only edit of description / content / instructions. Latest revision is the current text.",
+			IncludeInPromptContext: false, // body lives on the entity column; don't re-inject
 		},
 	}
 }

--- a/internal/settings/catalog.go
+++ b/internal/settings/catalog.go
@@ -63,6 +63,13 @@ func Catalog() []KnobDef {
 		}, Default: "", Description: "Model ID passed to the agent as --model. Empty = agent default."},
 		{Key: "retry_on_failure", Type: KnobInt, SliderMin: f(0), SliderMax: f(10), SliderStep: f(1), Default: 0, Description: "Auto-retry count"},
 		{Key: "approval_mode", Type: KnobEnum, EnumValues: []string{"auto", "manual", "on-failure"}, Default: "auto", Description: "Codex approval mode"},
+		// Prompt-context knobs — resolve via the same task → manifest →
+		// product → system inheritance chain as every other knob. Defaults
+		// are heuristic (no empirical measurements) and will be calibrated
+		// from prompt_build_stats once the instrumentation ships; see
+		// idea 019db6ba-ba0 and memory 019db6bb-a4e.
+		{Key: "prompt_max_comment_chars", Type: KnobInt, SliderMin: f(500), SliderMax: f(10000), SliderStep: f(500), Default: 2000, Description: "Max chars per comment when injected into the task-thread context block; longer comments are truncated with a pointer to the full text."},
+		{Key: "prompt_max_context_pct", Type: KnobFloat, SliderMin: f(0.1), SliderMax: f(0.9), SliderStep: f(0.05), Default: 0.4, Description: "Max fraction of the resolved model's context window that the prior-runs + other-comments block may consume; older comments drop first when over budget."},
 		{Key: "allowed_tools", Type: KnobMultiselect, Default: []string{
 			"Bash", "Read", "Write", "Edit", "Glob", "Grep",
 			// MCP tools the runner's prompt template instructs agents to call.

--- a/internal/settings/catalog_test.go
+++ b/internal/settings/catalog_test.go
@@ -5,10 +5,15 @@ import (
 	"testing"
 )
 
-func TestCatalog_HasExactly12Knobs(t *testing.T) {
+func TestCatalog_HasExpectedKnobCount(t *testing.T) {
+	// 12 v1 knobs + 2 prompt-context knobs (prompt_max_comment_chars,
+	// prompt_max_context_pct) added in the runner-hardening manifest
+	// 019db6a6-72f. Both inherit via the existing task → manifest →
+	// product → system resolver.
+	const want = 14
 	got := len(Catalog())
-	if got != 12 {
-		t.Fatalf("Catalog() returned %d knobs, want 12", got)
+	if got != want {
+		t.Fatalf("Catalog() returned %d knobs, want %d", got, want)
 	}
 }
 


### PR DESCRIPTION
Ships the parameterisation layer for the runner prompt-context injection feature (manifest 019db6a6-72f). The runner.go integration that consumes these knobs is a bigger follow-up; this PR is just the plumbing, so operators can set the knobs and the Registry is queryable.

## Changes

**`internal/comments/types.go`** — new `IncludeInPromptContext bool` field on `CommentTypeInfo`:

| Type | Flag | Reason |
|---|:-:|---|
| execution_review, user_note, watcher_finding, agent_note, decision, review_rejection, review_approval | ✅ | Signal the agent needs to avoid repeating work |
| link | ❌ | Cross-refs = noise |
| description_revision | ❌ | Body already on entity column |

Plus helper `PromptContextTypes()` returning the list of flagged-true types.

**`internal/settings/catalog.go`** — two new knobs, same catalog, same resolver (`task → manifest → product → system`):

- `prompt_max_comment_chars` (KnobInt, 500..10000, step 500, default 2000)
- `prompt_max_context_pct` (KnobFloat, 0.1..0.9, step 0.05, default 0.4)

Defaults are heuristic; calibration plan tracked as idea `019db6ba-ba0`, rationale in memory `019db6bb-a4e`.

**`internal/settings/catalog_test.go`** — updated 12-knob guard to 14 with a comment.

## Inheritance (works for free)

```
Set prompt_max_comment_chars=4000 at product scope
  → every task in the product gets longer context per comment.
Override to 6000 at manifest scope    → that manifest's tasks see more.
Override to 8000 at task scope        → only that one task pulls more.
Never touch                           → everyone uses 2000 / 0.40 defaults.
```

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/comments/... ./internal/settings/...`
- [ ] Manual: GET /api/settings/catalog returns the two new knobs; PUT a per-scope value and GET it back resolved at a task-ID scope.

## Not in scope

- `runner.buildPrompt` integration (consumes the knobs + flag) — follow-up.
- `/api/tasks/:id` `branch_commit_count` field + dashboard "No artifacts" chip — follow-up.
- Snapshot tests on the composed prompt — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)