### PR TITLE
feat(ui): render each knob's description inline under the row

### DIFF
--- a/internal/web/ui/components/knobs.js
+++ b/internal/web/ui/components/knobs.js
@@ -121,6 +121,15 @@
     const warnings = renderWarnings(knob, currentValue);
     const saveStatus = '<span class="knob-save-status" data-knob-key="' + esc(knob.key) + '"></span>';
 
+    // Description renders inline under the meta row so every knob carries
+    // its own help text without the operator needing to hover for the
+    // tooltip. Source: knob.description from the catalog. Kept as the
+    // tooltip on the label too, for screen-readers and mouse hover on
+    // compact layouts.
+    const description = knob.description
+      ? '<div class="knob-description">' + esc(knob.description) + '</div>'
+      : '';
+
     return (
       '<div class="knob-row" data-knob-key="' + esc(knob.key) + '" data-knob-type="' + esc(knob.type) + '">' +
         '<div class="knob-row-main">' +
@@ -130,6 +139,7 @@
           resetBtn +
         '</div>' +
         '<div class="knob-row-meta">' + provenance + warnings + '</div>' +
+        description +
       '</div>'
     );
   }

--- a/internal/web/ui/style.css
+++ b/internal/web/ui/style.css
@@ -1310,6 +1310,10 @@ mark {
 .knob-save-status.err { color: var(--red); }
 .knob-save-status.pending { color: var(--text-muted); }
 .knob-unsupported { color: var(--text-muted); font-size: 11px; font-style: italic; }
+/* Inline description under each knob row — sourced from the catalog's
+   Description field. Muted, aligned with the meta row, so it explains
+   the control without competing with the current value. */
+.knob-description { padding-left: 170px; color: var(--text-muted); font-size: 11px; line-height: 1.4; margin-top: 2px; }
 
 /* Responsive */
 @media (max-width: 768px) {
@@ -1320,6 +1324,7 @@ mark {
   .search-results { left: 0; }
   .knob-row-meta { padding-left: 0; }
   .knob-label { min-width: 0; }
+  .knob-description { padding-left: 0; }
 }
 
 /* === Entity Comments (M3-T6) — rendered by OL.renderCommentsSection === */


### PR DESCRIPTION
Execution Controls panels previously hid the description behind a tooltip. Now each knob renders its description directly under the meta row in muted small type.

Source: the existing `knob.description` field already on every catalog entry. No new content; just surfaces data that was already there.

Responsive: description `padding-left` collapses to 0 at ≤768px to match the meta row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)