### PR TITLE
feat(description-versioning): DV/M2 — RecordDescriptionChange helper + write-path wiring

### DIFF
--- a/internal/mcp/tools_manifest.go
+++ b/internal/mcp/tools_manifest.go
@@ -7,6 +7,7 @@ import (
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
 	"github.com/k8nstantin/OpenPraxis/internal/manifest"
 )
 
@@ -283,6 +284,14 @@ func (s *Server) handleManifestUpdate(ctx context.Context, req mcplib.CallToolRe
 	if status == "archive" && existing.Status != "archive" {
 		if err := s.node.ValidateArchiveManifest(existing.ID); err != nil {
 			return errResult("%v", err), nil
+		}
+	}
+	// Append a description_revision comment on content changes before the
+	// denormalised UPDATE (DV/M2). Manifest's spec text lives in Content;
+	// the short Description summary is not tracked for history in v1.
+	if argStr(a, "content") != "" {
+		if _, err := s.node.RecordDescriptionChange(ctx, comments.TargetManifest, existing.ID, content, ""); err != nil {
+			return errResult("record revision: %v", err), nil
 		}
 	}
 	if err := s.node.Manifests.Update(existing.ID, title, desc, content, status, projectID, dependsOn, jiraRefs, tags); err != nil {

--- a/internal/mcp/tools_product.go
+++ b/internal/mcp/tools_product.go
@@ -7,6 +7,7 @@ import (
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
 	"github.com/k8nstantin/OpenPraxis/internal/product"
 )
 
@@ -281,6 +282,13 @@ func (s *Server) handleProductUpdate(ctx context.Context, req mcplib.CallToolReq
 	if status == "archive" && existing.Status != "archive" {
 		if err := s.node.ValidateArchiveProduct(existing.ID); err != nil {
 			return errResult("%v", err), nil
+		}
+	}
+	// Append a description_revision comment on description changes before the
+	// denormalised UPDATE (DV/M2). The helper no-ops when desc is unchanged.
+	if argStr(a, "description") != "" {
+		if _, err := s.node.RecordDescriptionChange(ctx, comments.TargetProduct, existing.ID, desc, ""); err != nil {
+			return errResult("record revision: %v", err), nil
 		}
 	}
 	if err := s.node.Products.Update(existing.ID, title, desc, status, tags); err != nil {

--- a/internal/node/description.go
+++ b/internal/node/description.go
@@ -1,0 +1,105 @@
+package node
+
+import (
+	"context"
+	"strings"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
+)
+
+// RecordDescriptionChange compares the proposed new body to the entity's
+// current denormalised description / content / instructions and, if they
+// differ, inserts a description_revision comment on the entity so the full
+// edit history is preserved append-only. Returns the new comment ID, or
+// empty string when the body is unchanged and no revision was recorded.
+//
+// Semantics (DV/M2):
+//   - Entity.description remains the source of truth for fast reads. The
+//     caller is expected to UPDATE it AFTER this call — or abort the whole
+//     edit if this returns an error.
+//   - Revisions are inserted on every real change. Whitespace-only edits
+//     (trailing newline, reformatting) are deliberately not recorded.
+//   - No-op safe: empty new body, missing stores, or matching current body
+//     all return ("", nil) without side effects.
+//   - Not strictly transactional with the entity UPDATE itself — in the
+//     rare case that the entity UPDATE fails after this call succeeds, we
+//     leave a stray revision that represents "someone tried to change it".
+//     Acceptable for v1; a shared-tx helper is a bigger refactor deferred
+//     to a later manifest.
+//
+// Call sites: HTTP apiProductUpdate / apiManifestUpdate / apiTaskUpdate and
+// MCP handleProductUpdate / handleManifestUpdate.
+func (n *Node) RecordDescriptionChange(
+	ctx context.Context,
+	target comments.TargetType,
+	targetID string,
+	newBody string,
+	author string,
+) (string, error) {
+	if n == nil || n.Comments == nil {
+		return "", nil
+	}
+	if strings.TrimSpace(newBody) == "" {
+		return "", nil
+	}
+
+	currentBody, fullID, err := n.currentDescription(target, targetID)
+	if err != nil {
+		return "", err
+	}
+	if fullID == "" {
+		// Entity does not exist yet or lookup store is nil — the caller
+		// will surface that via its own UPDATE path; don't record a
+		// revision against a phantom id.
+		return "", nil
+	}
+	if strings.TrimSpace(currentBody) == strings.TrimSpace(newBody) {
+		return "", nil
+	}
+
+	if author == "" {
+		author = n.PeerID()
+	}
+
+	c, err := n.Comments.Add(ctx, target, fullID, author, comments.TypeDescriptionRevision, newBody)
+	if err != nil {
+		return "", err
+	}
+	return c.ID, nil
+}
+
+// currentDescription reads the entity's current denormalised body + returns
+// the full UUID so callers (and the revision insert) operate on canonical
+// ids instead of short markers. Returns ("", "", nil) for missing rows.
+func (n *Node) currentDescription(target comments.TargetType, idOrMarker string) (body, fullID string, err error) {
+	switch target {
+	case comments.TargetProduct:
+		if n.Products == nil {
+			return "", "", nil
+		}
+		p, err := n.Products.Get(idOrMarker)
+		if err != nil || p == nil {
+			return "", "", err
+		}
+		return p.Description, p.ID, nil
+	case comments.TargetManifest:
+		if n.Manifests == nil {
+			return "", "", nil
+		}
+		m, err := n.Manifests.Get(idOrMarker)
+		if err != nil || m == nil {
+			return "", "", err
+		}
+		return m.Content, m.ID, nil
+	case comments.TargetTask:
+		if n.Tasks == nil {
+			return "", "", nil
+		}
+		t, err := n.Tasks.Get(idOrMarker)
+		if err != nil || t == nil {
+			return "", "", err
+		}
+		return t.Description, t.ID, nil
+	}
+	return "", "", nil
+}

--- a/internal/node/description_test.go
+++ b/internal/node/description_test.go
@@ -1,0 +1,241 @@
+package node
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
+	"github.com/k8nstantin/OpenPraxis/internal/config"
+	"github.com/k8nstantin/OpenPraxis/internal/manifest"
+	"github.com/k8nstantin/OpenPraxis/internal/product"
+	"github.com/k8nstantin/OpenPraxis/internal/task"
+)
+
+func newDescriptionTestNode(t *testing.T) *Node {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if err := comments.InitSchema(db); err != nil {
+		t.Fatalf("comments schema: %v", err)
+	}
+	pStore, err := product.NewStore(db)
+	if err != nil {
+		t.Fatalf("product store: %v", err)
+	}
+	mStore, err := manifest.NewStore(db)
+	if err != nil {
+		t.Fatalf("manifest store: %v", err)
+	}
+	tStore, err := task.NewStore(db)
+	if err != nil {
+		t.Fatalf("task store: %v", err)
+	}
+
+	return &Node{
+		Config: &config.Config{
+			Node: config.NodeConfig{UUID: "peer-test-uuid"},
+		},
+		Products:  pStore,
+		Manifests: mStore,
+		Tasks:     tStore,
+		Comments:  comments.NewStore(db),
+	}
+}
+
+func countRevisions(t *testing.T, n *Node, target comments.TargetType, id string) int {
+	t.Helper()
+	ctx := context.Background()
+	ct := comments.TypeDescriptionRevision
+	rows, err := n.Comments.List(ctx, target, id, 100, &ct)
+	if err != nil {
+		t.Fatalf("list revisions: %v", err)
+	}
+	return len(rows)
+}
+
+func TestRecordDescriptionChange_NoOpWhenUnchanged(t *testing.T) {
+	n := newDescriptionTestNode(t)
+	ctx := context.Background()
+
+	p, err := n.Products.Create("P1", "same body", "open", n.PeerID(), nil)
+	if err != nil {
+		t.Fatalf("create product: %v", err)
+	}
+
+	id, err := n.RecordDescriptionChange(ctx, comments.TargetProduct, p.ID, "same body", "")
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if id != "" {
+		t.Fatalf("expected empty id on no-op, got %q", id)
+	}
+	if got := countRevisions(t, n, comments.TargetProduct, p.ID); got != 0 {
+		t.Fatalf("expected 0 revisions, got %d", got)
+	}
+}
+
+func TestRecordDescriptionChange_RecordsRevisionOnChange(t *testing.T) {
+	n := newDescriptionTestNode(t)
+	ctx := context.Background()
+
+	p, err := n.Products.Create("P1", "original body", "open", n.PeerID(), nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	id, err := n.RecordDescriptionChange(ctx, comments.TargetProduct, p.ID, "new body", "")
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if id == "" {
+		t.Fatalf("expected new comment id, got empty")
+	}
+	if got := countRevisions(t, n, comments.TargetProduct, p.ID); got != 1 {
+		t.Fatalf("expected 1 revision, got %d", got)
+	}
+
+	c, err := n.Comments.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("fetch revision: %v", err)
+	}
+	if c.Body != "new body" {
+		t.Fatalf("body = %q, want 'new body'", c.Body)
+	}
+	if c.Author != n.PeerID() {
+		t.Fatalf("author = %q, want peer id fallback", c.Author)
+	}
+	if c.Type != comments.TypeDescriptionRevision {
+		t.Fatalf("type = %q", c.Type)
+	}
+}
+
+func TestRecordDescriptionChange_WhitespaceOnlyChangeIsNoOp(t *testing.T) {
+	n := newDescriptionTestNode(t)
+	ctx := context.Background()
+
+	p, err := n.Products.Create("P1", "body", "open", n.PeerID(), nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	id, err := n.RecordDescriptionChange(ctx, comments.TargetProduct, p.ID, "  body\n", "")
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if id != "" {
+		t.Fatalf("expected no revision on whitespace-only change, got %q", id)
+	}
+}
+
+func TestRecordDescriptionChange_ManifestUsesContent(t *testing.T) {
+	n := newDescriptionTestNode(t)
+	ctx := context.Background()
+
+	m, err := n.Manifests.Create("M1", "short summary", "original spec", "draft", n.PeerID(), n.PeerID(), "", "", nil, nil)
+	if err != nil {
+		t.Fatalf("create manifest: %v", err)
+	}
+
+	id, err := n.RecordDescriptionChange(ctx, comments.TargetManifest, m.ID, "revised spec", "")
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if id == "" {
+		t.Fatalf("expected revision to be recorded")
+	}
+	if got := countRevisions(t, n, comments.TargetManifest, m.ID); got != 1 {
+		t.Fatalf("got %d revisions", got)
+	}
+
+	// Changing summary (not content) should NOT trigger a revision — the
+	// helper compares against Content for manifests.
+	id, err = n.RecordDescriptionChange(ctx, comments.TargetManifest, m.ID, "original spec", "")
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	// Wait — we just added a revision with 'revised spec' but left the
+	// denormalised Content at 'original spec' because we never called
+	// Update. The helper's current-body read will still see 'original
+	// spec', so passing that as newBody must be a no-op.
+	if id != "" {
+		t.Fatalf("expected no-op when new body matches current content, got %q", id)
+	}
+}
+
+func TestRecordDescriptionChange_TaskUsesDescription(t *testing.T) {
+	n := newDescriptionTestNode(t)
+	ctx := context.Background()
+
+	tk, err := n.Tasks.Create("", "T1", "initial instructions", "", "", n.PeerID(), "", "")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	id, err := n.RecordDescriptionChange(ctx, comments.TargetTask, tk.ID, "updated instructions", "")
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if id == "" {
+		t.Fatalf("expected revision recorded for task change")
+	}
+	if got := countRevisions(t, n, comments.TargetTask, tk.ID); got != 1 {
+		t.Fatalf("got %d revisions", got)
+	}
+}
+
+func TestRecordDescriptionChange_EmptyBodyIsNoOp(t *testing.T) {
+	n := newDescriptionTestNode(t)
+	ctx := context.Background()
+	p, err := n.Products.Create("P1", "body", "open", n.PeerID(), nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	id, err := n.RecordDescriptionChange(ctx, comments.TargetProduct, p.ID, "", "")
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if id != "" {
+		t.Fatalf("expected no revision for empty body, got %q", id)
+	}
+}
+
+func TestRecordDescriptionChange_MissingEntityIsNoOp(t *testing.T) {
+	n := newDescriptionTestNode(t)
+	ctx := context.Background()
+	id, err := n.RecordDescriptionChange(ctx, comments.TargetProduct, "nonexistent-id", "body", "")
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if id != "" {
+		t.Fatalf("expected empty id for missing entity, got %q", id)
+	}
+}
+
+func TestRecordDescriptionChange_AuthorOverride(t *testing.T) {
+	n := newDescriptionTestNode(t)
+	ctx := context.Background()
+	p, err := n.Products.Create("P1", "body", "open", n.PeerID(), nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	id, err := n.RecordDescriptionChange(ctx, comments.TargetProduct, p.ID, "new body", "alice")
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	c, err := n.Comments.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if c.Author != "alice" {
+		t.Fatalf("author = %q, want alice", c.Author)
+	}
+}

--- a/internal/web/handlers_manifest.go
+++ b/internal/web/handlers_manifest.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
 	"github.com/k8nstantin/OpenPraxis/internal/manifest"
 	"github.com/k8nstantin/OpenPraxis/internal/node"
 	"github.com/k8nstantin/OpenPraxis/internal/task"
@@ -191,6 +192,15 @@ func apiManifestUpdate(n *node.Node) http.HandlerFunc {
 		if status == "archive" && existing.Status != "archive" {
 			if err := n.ValidateArchiveManifest(existing.ID); err != nil {
 				http.Error(w, err.Error(), 409)
+				return
+			}
+		}
+		// Record append-only description_revision on content changes, before
+		// the denormalised UPDATE (DV/M2). Manifest's spec text lives in
+		// Content; Description is the short summary line and is not tracked.
+		if req.Content != nil {
+			if _, err := n.RecordDescriptionChange(r.Context(), comments.TargetManifest, existing.ID, content, ""); err != nil {
+				writeError(w, err.Error(), 500)
 				return
 			}
 		}

--- a/internal/web/handlers_product.go
+++ b/internal/web/handlers_product.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
 	"github.com/k8nstantin/OpenPraxis/internal/node"
 	"github.com/k8nstantin/OpenPraxis/internal/product"
 
@@ -150,6 +151,15 @@ func apiProductUpdate(n *node.Node) http.HandlerFunc {
 		if status == "archive" && existing.Status != "archive" {
 			if err := n.ValidateArchiveProduct(existing.ID); err != nil {
 				http.Error(w, err.Error(), 409)
+				return
+			}
+		}
+		// Record an append-only description_revision comment BEFORE the
+		// denormalised UPDATE so edit history is preserved. No-op when
+		// description unchanged (DV/M2).
+		if req.Description != nil {
+			if _, err := n.RecordDescriptionChange(r.Context(), comments.TargetProduct, existing.ID, description, ""); err != nil {
+				http.Error(w, err.Error(), 500)
 				return
 			}
 		}

--- a/internal/web/handlers_task.go
+++ b/internal/web/handlers_task.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
 	"github.com/k8nstantin/OpenPraxis/internal/node"
 	"github.com/k8nstantin/OpenPraxis/internal/task"
 
@@ -223,6 +224,14 @@ func apiTaskUpdate(n *node.Node) http.HandlerFunc {
 				"value", *req.MaxTurns,
 				"successor", "PUT /api/tasks/:id/settings",
 				"retired_in", "M4-T14")
+		}
+		// Record append-only description_revision on instructions changes
+		// before the UPDATE, so edit history is preserved (DV/M2).
+		if req.Description != nil {
+			if _, err := n.RecordDescriptionChange(r.Context(), comments.TargetTask, id, *req.Description, ""); err != nil {
+				writeError(w, err.Error(), 500)
+				return
+			}
 		}
 		t, err := n.Tasks.Update(id, req.Title, req.Description)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Adds `Node.RecordDescriptionChange` — appends an append-only `description_revision` comment when an entity's description actually changes. No-op on whitespace-only edits, empty bodies, and missing entities.
- Wires the helper into all five write paths: HTTP `apiProductUpdate` / `apiManifestUpdate` / `apiTaskUpdate` and MCP `handleProductUpdate` / `handleManifestUpdate`.
- Manifests compare against `Content` (the spec body); products and tasks compare against `Description`. Author defaults to the local peer UUID when the caller passes `""`.

## Notes
- The helper and the denormalised UPDATE are **not** transactional together. If the UPDATE fails after a revision is recorded we leave a stray revision that represents "someone tried to change it". Acceptable for v1 and documented in-code; a shared-tx refactor is deferred.
- Implements DV/M2 in the Description Versioning product `019db5af-f63`. DV/M1 (schema + backfill admin command) shipped in #177.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — all packages pass
- [x] 8 new node-package tests cover: no-op on unchanged, records on change, whitespace-only no-op, manifest uses Content, task uses Description, empty body no-op, missing entity no-op, author override

🤖 Generated with [Claude Code](https://claude.com/claude-code)