### PR TITLE
feat(description-versioning): DV/M3 — HTTP sugar endpoints for history/get/restore

### DIFF
--- a/internal/node/description.go
+++ b/internal/node/description.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/k8nstantin/OpenPraxis/internal/comments"
@@ -102,4 +103,192 @@ func (n *Node) currentDescription(target comments.TargetType, idOrMarker string)
 		return t.Description, t.ID, nil
 	}
 	return "", "", nil
+}
+
+// RevisionEntry is a single description_revision presented to API / MCP
+// callers. Version is 1-based with 1 being the oldest revision — i.e. the
+// backfilled seed row or the first user edit after schema rollout.
+type RevisionEntry struct {
+	ID        string `json:"id"`
+	Version   int    `json:"version"`
+	Author    string `json:"author"`
+	Body      string `json:"body"`
+	CreatedAt int64  `json:"created_at"`
+}
+
+// DescriptionHistory returns the description_revision comments for the given
+// entity, newest first, with a 1-based Version field derived from insertion
+// order (oldest = 1). The targetID argument may be a short marker or the full
+// UUID; the returned rows always carry full comment IDs.
+func (n *Node) DescriptionHistory(
+	ctx context.Context,
+	target comments.TargetType,
+	targetID string,
+	limit int,
+) ([]RevisionEntry, error) {
+	if n == nil || n.Comments == nil {
+		return nil, nil
+	}
+	_, fullID, err := n.currentDescription(target, targetID)
+	if err != nil {
+		return nil, err
+	}
+	if fullID == "" {
+		return nil, fmt.Errorf("%s not found: %s", target, targetID)
+	}
+	ct := comments.TypeDescriptionRevision
+	rows, err := n.Comments.List(ctx, target, fullID, limit, &ct)
+	if err != nil {
+		return nil, err
+	}
+	// List returns newest first. Version numbering is oldest-first, so
+	// the last element gets version 1 and the first element gets len(rows).
+	out := make([]RevisionEntry, 0, len(rows))
+	total := len(rows)
+	for i, c := range rows {
+		out = append(out, RevisionEntry{
+			ID:        c.ID,
+			Version:   total - i,
+			Author:    c.Author,
+			Body:      c.Body,
+			CreatedAt: c.CreatedAt.Unix(),
+		})
+	}
+	return out, nil
+}
+
+// GetDescriptionRevision fetches a single description_revision by id and
+// enforces that it actually belongs to the given (target, targetID) pair
+// so operators can't read a revision from a sibling entity by guessing the
+// comment id.
+func (n *Node) GetDescriptionRevision(
+	ctx context.Context,
+	target comments.TargetType,
+	targetID, commentID string,
+) (*RevisionEntry, error) {
+	if n == nil || n.Comments == nil {
+		return nil, nil
+	}
+	_, fullID, err := n.currentDescription(target, targetID)
+	if err != nil {
+		return nil, err
+	}
+	if fullID == "" {
+		return nil, fmt.Errorf("%s not found: %s", target, targetID)
+	}
+	c, err := n.Comments.Get(ctx, commentID)
+	if err != nil {
+		return nil, err
+	}
+	if c.Type != comments.TypeDescriptionRevision {
+		return nil, fmt.Errorf("comment %s is not a description_revision", commentID)
+	}
+	if c.TargetType != target || c.TargetID != fullID {
+		return nil, fmt.Errorf("revision %s does not belong to %s %s", commentID, target, fullID)
+	}
+	// Version is the count of revisions with created_at <= this one.
+	ct := comments.TypeDescriptionRevision
+	all, err := n.Comments.List(ctx, target, fullID, 0, &ct)
+	if err != nil {
+		return nil, err
+	}
+	version := 0
+	total := len(all)
+	for i, row := range all {
+		if row.ID == c.ID {
+			version = total - i
+			break
+		}
+	}
+	return &RevisionEntry{
+		ID:        c.ID,
+		Version:   version,
+		Author:    c.Author,
+		Body:      c.Body,
+		CreatedAt: c.CreatedAt.Unix(),
+	}, nil
+}
+
+// RestoreDescription re-applies a prior description_revision as the current
+// body. The mechanism is deliberately additive: we record a *new*
+// description_revision whose body equals the historical revision's body, then
+// denormalise that body back onto the entity column via the appropriate
+// store.Update. The original revision row is untouched so the full trail
+// remains intact — an operator can see "restored from X" as the latest row.
+//
+// Returns the newly-created revision ID. When the historical body already
+// matches the current body (i.e. nothing to do) returns ("", nil).
+func (n *Node) RestoreDescription(
+	ctx context.Context,
+	target comments.TargetType,
+	targetID, fromCommentID, author string,
+) (string, error) {
+	if n == nil || n.Comments == nil {
+		return "", nil
+	}
+	rev, err := n.GetDescriptionRevision(ctx, target, targetID, fromCommentID)
+	if err != nil {
+		return "", err
+	}
+	_, fullID, err := n.currentDescription(target, targetID)
+	if err != nil {
+		return "", err
+	}
+	if fullID == "" {
+		return "", fmt.Errorf("%s not found: %s", target, targetID)
+	}
+
+	newCommentID, err := n.RecordDescriptionChange(ctx, target, fullID, rev.Body, author)
+	if err != nil {
+		return "", err
+	}
+	if newCommentID == "" {
+		// Historical body already matches current; no UPDATE needed.
+		return "", nil
+	}
+
+	if err := n.writeEntityDescription(target, fullID, rev.Body); err != nil {
+		return "", err
+	}
+	return newCommentID, nil
+}
+
+// writeEntityDescription updates only the denormalised description/content
+// column for the given entity, preserving all other fields. Used by
+// RestoreDescription so the HTTP/MCP restore path doesn't have to re-send
+// the whole PATCH payload.
+func (n *Node) writeEntityDescription(target comments.TargetType, fullID, body string) error {
+	switch target {
+	case comments.TargetProduct:
+		if n.Products == nil {
+			return fmt.Errorf("products store not wired")
+		}
+		p, err := n.Products.Get(fullID)
+		if err != nil {
+			return err
+		}
+		if p == nil {
+			return fmt.Errorf("product not found: %s", fullID)
+		}
+		return n.Products.Update(p.ID, p.Title, body, p.Status, p.Tags)
+	case comments.TargetManifest:
+		if n.Manifests == nil {
+			return fmt.Errorf("manifests store not wired")
+		}
+		m, err := n.Manifests.Get(fullID)
+		if err != nil {
+			return err
+		}
+		if m == nil {
+			return fmt.Errorf("manifest not found: %s", fullID)
+		}
+		return n.Manifests.Update(m.ID, m.Title, m.Description, body, m.Status, m.ProjectID, m.DependsOn, m.JiraRefs, m.Tags)
+	case comments.TargetTask:
+		if n.Tasks == nil {
+			return fmt.Errorf("tasks store not wired")
+		}
+		_, err := n.Tasks.Update(fullID, nil, &body)
+		return err
+	}
+	return fmt.Errorf("unsupported target type: %s", target)
 }

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -212,6 +212,7 @@ func Handler(n *node.Node, mcpServer *mcp.Server, hub *Hub, peerRegistry *peer.R
 	// /settings prefix without colliding (different verbs / suffixes).
 	registerSettingsExecRoutes(api, n)
 	registerCommentsRoutesFromNode(api, n)
+	registerDescriptionRoutes(api, n)
 
 	api.HandleFunc("/settings/profile", apiProfileGet(n)).Methods("GET")
 	api.HandleFunc("/settings/profile", apiProfileUpdate(n)).Methods("PUT")

--- a/internal/web/handlers_description.go
+++ b/internal/web/handlers_description.go
@@ -1,0 +1,184 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
+	"github.com/k8nstantin/OpenPraxis/internal/node"
+)
+
+// DV/M3 — HTTP sugar endpoints over description_revision comments.
+// Three endpoints per entity type (product / manifest / task); 9 total:
+//
+//   GET  /api/{scope}/{id}/description/history
+//   GET  /api/{scope}/{id}/description/revisions/{comment_id}
+//   POST /api/{scope}/{id}/description/restore/{comment_id}
+//
+// scope ∈ {products, manifests, tasks}. Short-marker and full-UUID
+// target IDs both work — the underlying Node helpers canonicalise.
+
+// revisionView is the JSON shape for a single description_revision entry,
+// with both unix + ISO timestamps so clients don't have to format.
+type revisionView struct {
+	ID           string `json:"id"`
+	Version      int    `json:"version"`
+	Author       string `json:"author"`
+	Body         string `json:"body"`
+	CreatedAt    int64  `json:"created_at"`
+	CreatedAtISO string `json:"created_at_iso"`
+}
+
+func toRevisionView(r node.RevisionEntry) revisionView {
+	return revisionView{
+		ID:           r.ID,
+		Version:      r.Version,
+		Author:       r.Author,
+		Body:         r.Body,
+		CreatedAt:    r.CreatedAt,
+		CreatedAtISO: time.Unix(r.CreatedAt, 0).UTC().Format(time.RFC3339),
+	}
+}
+
+// restoreRequest is the POST body for the restore endpoint. Author is
+// optional — when empty the helper falls back to the peer UUID.
+type restoreRequest struct {
+	Author string `json:"author"`
+}
+
+// restoreResponse returns the newly-created revision + a hint of whether
+// the restore actually wrote a new row. restored=false means the target
+// body already matched the historical body, so we no-op'd.
+type restoreResponse struct {
+	Restored  bool          `json:"restored"`
+	NewID     string        `json:"new_revision_id,omitempty"`
+	From      string        `json:"restored_from"`
+	Revisions []revisionView `json:"history,omitempty"`
+}
+
+// apiDescriptionHistory — GET /api/{scope}/{id}/description/history
+func apiDescriptionHistory(n *node.Node, target comments.TargetType) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := mux.Vars(r)["id"]
+		if id == "" {
+			writeError(w, "id required", http.StatusBadRequest)
+			return
+		}
+		limit := 100
+		if raw := r.URL.Query().Get("limit"); raw != "" {
+			parsed, err := strconv.Atoi(raw)
+			if err != nil {
+				writeError(w, "limit must be an integer", http.StatusBadRequest)
+				return
+			}
+			limit = parsed
+		}
+		rows, err := n.DescriptionHistory(r.Context(), target, id, limit)
+		if err != nil {
+			writeError(w, err.Error(), descriptionErrStatus(err))
+			return
+		}
+		views := make([]revisionView, 0, len(rows))
+		for _, r := range rows {
+			views = append(views, toRevisionView(r))
+		}
+		writeJSON(w, map[string]any{"items": views})
+	}
+}
+
+// apiDescriptionGetRevision — GET /api/{scope}/{id}/description/revisions/{comment_id}
+func apiDescriptionGetRevision(n *node.Node, target comments.TargetType) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		id := vars["id"]
+		commentID := vars["comment_id"]
+		if id == "" || commentID == "" {
+			writeError(w, "id and comment_id required", http.StatusBadRequest)
+			return
+		}
+		rev, err := n.GetDescriptionRevision(r.Context(), target, id, commentID)
+		if err != nil {
+			writeError(w, err.Error(), descriptionErrStatus(err))
+			return
+		}
+		if rev == nil {
+			writeError(w, "revision not found", http.StatusNotFound)
+			return
+		}
+		writeJSON(w, toRevisionView(*rev))
+	}
+}
+
+// apiDescriptionRestore — POST /api/{scope}/{id}/description/restore/{comment_id}
+func apiDescriptionRestore(n *node.Node, target comments.TargetType) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		id := vars["id"]
+		commentID := vars["comment_id"]
+		if id == "" || commentID == "" {
+			writeError(w, "id and comment_id required", http.StatusBadRequest)
+			return
+		}
+		var req restoreRequest
+		if r.ContentLength > 0 {
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				writeError(w, "invalid request body", http.StatusBadRequest)
+				return
+			}
+		}
+		newID, err := n.RestoreDescription(r.Context(), target, id, commentID, req.Author)
+		if err != nil {
+			writeError(w, err.Error(), descriptionErrStatus(err))
+			return
+		}
+		writeJSON(w, restoreResponse{
+			Restored: newID != "",
+			NewID:    newID,
+			From:     commentID,
+		})
+	}
+}
+
+// descriptionErrStatus maps helper errors to HTTP statuses. Helpers in
+// internal/node currently return unwrapped fmt.Errorf strings, so string
+// matching is the pragmatic v1 path; a sentinel-error refactor on those
+// helpers would let this become errors.Is checks instead.
+func descriptionErrStatus(err error) int {
+	if err == nil {
+		return 200
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "not found"),
+		strings.Contains(msg, "does not belong"),
+		strings.Contains(msg, "is not a description_revision"):
+		return http.StatusNotFound
+	}
+	return http.StatusInternalServerError
+}
+
+// descriptionScopeRoutes pairs URL-plural segment with TargetType, mirroring
+// commentScopeRoutes so the loop stays declarative.
+var descriptionScopeRoutes = []struct {
+	segment string
+	target  comments.TargetType
+}{
+	{"products", comments.TargetProduct},
+	{"manifests", comments.TargetManifest},
+	{"tasks", comments.TargetTask},
+}
+
+// registerDescriptionRoutes attaches the 9 DV/M3 endpoints to /api.
+func registerDescriptionRoutes(api *mux.Router, n *node.Node) {
+	for _, s := range descriptionScopeRoutes {
+		base := "/" + s.segment + "/{id}/description"
+		api.HandleFunc(base+"/history", apiDescriptionHistory(n, s.target)).Methods("GET")
+		api.HandleFunc(base+"/revisions/{comment_id}", apiDescriptionGetRevision(n, s.target)).Methods("GET")
+		api.HandleFunc(base+"/restore/{comment_id}", apiDescriptionRestore(n, s.target)).Methods("POST")
+	}
+}

--- a/internal/web/handlers_description_test.go
+++ b/internal/web/handlers_description_test.go
@@ -1,0 +1,372 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/gorilla/mux"
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
+	"github.com/k8nstantin/OpenPraxis/internal/config"
+	"github.com/k8nstantin/OpenPraxis/internal/manifest"
+	"github.com/k8nstantin/OpenPraxis/internal/node"
+	"github.com/k8nstantin/OpenPraxis/internal/product"
+	"github.com/k8nstantin/OpenPraxis/internal/task"
+)
+
+type descriptionTestEnv struct {
+	node   *node.Node
+	server *httptest.Server
+	db     *sql.DB
+}
+
+func newDescriptionTestEnv(t *testing.T) *descriptionTestEnv {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "desc.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := comments.InitSchema(db); err != nil {
+		t.Fatalf("comments schema: %v", err)
+	}
+	pStore, err := product.NewStore(db)
+	if err != nil {
+		t.Fatalf("product: %v", err)
+	}
+	mStore, err := manifest.NewStore(db)
+	if err != nil {
+		t.Fatalf("manifest: %v", err)
+	}
+	tStore, err := task.NewStore(db)
+	if err != nil {
+		t.Fatalf("task: %v", err)
+	}
+
+	n := &node.Node{
+		Config:    &config.Config{Node: config.NodeConfig{UUID: "peer-test"}},
+		Products:  pStore,
+		Manifests: mStore,
+		Tasks:     tStore,
+		Comments:  comments.NewStore(db),
+	}
+
+	r := mux.NewRouter()
+	api := r.PathPrefix("/api").Subrouter()
+	registerDescriptionRoutes(api, n)
+
+	srv := httptest.NewServer(r)
+	t.Cleanup(func() {
+		srv.Close()
+		db.Close()
+	})
+	return &descriptionTestEnv{node: n, server: srv, db: db}
+}
+
+func (e *descriptionTestEnv) do(t *testing.T, method, path string, body any) (*http.Response, []byte) {
+	t.Helper()
+	var buf io.Reader
+	if body != nil {
+		b, _ := json.Marshal(body)
+		buf = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, e.server.URL+path, buf)
+	if err != nil {
+		t.Fatalf("req: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	return resp, out
+}
+
+// seedProductRevisions creates a product with body1 as the initial
+// denormalised body, then applies body2 as a fresh edit (revision + UPDATE)
+// so tests have a non-trivial history to read / restore from. The first
+// revision is backfill-style (seeded directly) because RecordDescriptionChange
+// no-ops when current == new.
+func (e *descriptionTestEnv) seedProductRevisions(t *testing.T, body1, body2 string) (id string) {
+	t.Helper()
+	ctx := nil2ctx()
+	p, err := e.node.Products.Create("P", body1, "open", e.node.PeerID(), nil)
+	if err != nil {
+		t.Fatalf("create product: %v", err)
+	}
+	id = p.ID
+	// Seed v1 directly — mirrors DV/M1 backfill path.
+	if _, err := e.node.Comments.Add(ctx, comments.TargetProduct, id, "alice", comments.TypeDescriptionRevision, body1); err != nil {
+		t.Fatalf("seed rev1: %v", err)
+	}
+	// Record the edit BEFORE the UPDATE (same order as production handler).
+	if _, err := e.node.RecordDescriptionChange(ctx, comments.TargetProduct, id, body2, "bob"); err != nil {
+		t.Fatalf("record 2: %v", err)
+	}
+	if err := e.node.Products.Update(id, p.Title, body2, p.Status, p.Tags); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	return id
+}
+
+// nil2ctx is a tiny helper so seed code stays readable.
+func nil2ctx() context.Context { return context.Background() }
+
+// ---- history ---------------------------------------------------------------
+
+func TestDescriptionHistory_Product(t *testing.T) {
+	env := newDescriptionTestEnv(t)
+	id := env.seedProductRevisions(t, "v1", "v2")
+
+	resp, body := env.do(t, "GET", "/api/products/"+id+"/description/history", nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var out struct {
+		Items []revisionView `json:"items"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode: %v body=%s", err, body)
+	}
+	if len(out.Items) != 2 {
+		t.Fatalf("want 2 items, got %d", len(out.Items))
+	}
+	// Newest first.
+	if out.Items[0].Body != "v2" {
+		t.Fatalf("item[0].body = %q want v2", out.Items[0].Body)
+	}
+	if out.Items[1].Body != "v1" {
+		t.Fatalf("item[1].body = %q want v1", out.Items[1].Body)
+	}
+	// Versions: oldest = 1, newest = 2.
+	if out.Items[0].Version != 2 || out.Items[1].Version != 1 {
+		t.Fatalf("versions = (%d, %d) want (2, 1)", out.Items[0].Version, out.Items[1].Version)
+	}
+}
+
+func TestDescriptionHistory_UnknownEntity_404(t *testing.T) {
+	env := newDescriptionTestEnv(t)
+	resp, _ := env.do(t, "GET", "/api/products/bogus/description/history", nil)
+	if resp.StatusCode != 404 {
+		t.Fatalf("status=%d want 404", resp.StatusCode)
+	}
+}
+
+// ---- get-revision ----------------------------------------------------------
+
+func TestDescriptionGetRevision_OK(t *testing.T) {
+	env := newDescriptionTestEnv(t)
+	id := env.seedProductRevisions(t, "v1", "v2")
+
+	// Find the revision IDs via history.
+	_, body := env.do(t, "GET", "/api/products/"+id+"/description/history", nil)
+	var hist struct {
+		Items []revisionView `json:"items"`
+	}
+	_ = json.Unmarshal(body, &hist)
+	older := hist.Items[1]
+
+	resp, raw := env.do(t, "GET", "/api/products/"+id+"/description/revisions/"+older.ID, nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d raw=%s", resp.StatusCode, raw)
+	}
+	var got revisionView
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Body != "v1" {
+		t.Fatalf("body=%q want v1", got.Body)
+	}
+	if got.Version != 1 {
+		t.Fatalf("version=%d want 1", got.Version)
+	}
+}
+
+func TestDescriptionGetRevision_WrongEntity_404(t *testing.T) {
+	env := newDescriptionTestEnv(t)
+	id := env.seedProductRevisions(t, "v1", "v2")
+
+	// Create a second product with a revision; try to read its revision via
+	// the first product's URL.
+	otherID := env.seedProductRevisions(t, "other-v1", "other-v2")
+	_, body := env.do(t, "GET", "/api/products/"+otherID+"/description/history", nil)
+	var hist struct {
+		Items []revisionView `json:"items"`
+	}
+	_ = json.Unmarshal(body, &hist)
+	foreign := hist.Items[0].ID
+
+	resp, raw := env.do(t, "GET", "/api/products/"+id+"/description/revisions/"+foreign, nil)
+	if resp.StatusCode != 404 {
+		t.Fatalf("status=%d raw=%s want 404", resp.StatusCode, raw)
+	}
+}
+
+// ---- restore ---------------------------------------------------------------
+
+func TestDescriptionRestore_Product(t *testing.T) {
+	env := newDescriptionTestEnv(t)
+	id := env.seedProductRevisions(t, "v1", "v2")
+
+	_, body := env.do(t, "GET", "/api/products/"+id+"/description/history", nil)
+	var hist struct {
+		Items []revisionView `json:"items"`
+	}
+	_ = json.Unmarshal(body, &hist)
+	olderID := hist.Items[1].ID // v1
+
+	resp, raw := env.do(t, "POST", "/api/products/"+id+"/description/restore/"+olderID, restoreRequest{Author: "carol"})
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d raw=%s", resp.StatusCode, raw)
+	}
+	var rr restoreResponse
+	if err := json.Unmarshal(raw, &rr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !rr.Restored {
+		t.Fatalf("restored=false want true (body=%s)", raw)
+	}
+	if rr.NewID == "" {
+		t.Fatalf("new_revision_id empty")
+	}
+
+	// After restore: denormalised column is v1.
+	p, err := env.node.Products.Get(id)
+	if err != nil || p == nil {
+		t.Fatalf("get product: %v", err)
+	}
+	if p.Description != "v1" {
+		t.Fatalf("product.description = %q want v1", p.Description)
+	}
+
+	// History now has 3 rows, newest is the restore (v1).
+	_, body = env.do(t, "GET", "/api/products/"+id+"/description/history", nil)
+	var hist2 struct {
+		Items []revisionView `json:"items"`
+	}
+	_ = json.Unmarshal(body, &hist2)
+	if len(hist2.Items) != 3 {
+		t.Fatalf("len(history)=%d want 3", len(hist2.Items))
+	}
+	if hist2.Items[0].Body != "v1" {
+		t.Fatalf("newest body=%q want v1", hist2.Items[0].Body)
+	}
+	if hist2.Items[0].Author != "carol" {
+		t.Fatalf("newest author=%q want carol", hist2.Items[0].Author)
+	}
+}
+
+func TestDescriptionRestore_NoOpWhenAlreadyCurrent(t *testing.T) {
+	env := newDescriptionTestEnv(t)
+	id := env.seedProductRevisions(t, "v1", "v2")
+
+	_, body := env.do(t, "GET", "/api/products/"+id+"/description/history", nil)
+	var hist struct {
+		Items []revisionView `json:"items"`
+	}
+	_ = json.Unmarshal(body, &hist)
+	newest := hist.Items[0].ID // body matches current
+
+	resp, raw := env.do(t, "POST", "/api/products/"+id+"/description/restore/"+newest, nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d raw=%s", resp.StatusCode, raw)
+	}
+	var rr restoreResponse
+	_ = json.Unmarshal(raw, &rr)
+	if rr.Restored {
+		t.Fatalf("expected restored=false (no-op), got true (raw=%s)", raw)
+	}
+}
+
+// ---- manifest scope --------------------------------------------------------
+
+func TestDescriptionHistory_Manifest(t *testing.T) {
+	env := newDescriptionTestEnv(t)
+	m, err := env.node.Manifests.Create("M1", "summary", "spec-v1", "draft", env.node.PeerID(), env.node.PeerID(), "", "", nil, nil)
+	if err != nil {
+		t.Fatalf("create manifest: %v", err)
+	}
+	ctx := nil2ctx()
+	// Seed v1 directly (current body == new body → RecordDescriptionChange
+	// would no-op).
+	if _, err := env.node.Comments.Add(ctx, comments.TargetManifest, m.ID, "alice", comments.TypeDescriptionRevision, "spec-v1"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Record the edit BEFORE the UPDATE (production handler order).
+	if _, err := env.node.RecordDescriptionChange(ctx, comments.TargetManifest, m.ID, "spec-v2", "bob"); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if err := env.node.Manifests.Update(m.ID, m.Title, m.Description, "spec-v2", m.Status, m.ProjectID, m.DependsOn, m.JiraRefs, m.Tags); err != nil {
+		t.Fatalf("update manifest: %v", err)
+	}
+
+	resp, body := env.do(t, "GET", "/api/manifests/"+m.ID+"/description/history", nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var out struct {
+		Items []revisionView `json:"items"`
+	}
+	_ = json.Unmarshal(body, &out)
+	if len(out.Items) != 2 {
+		t.Fatalf("want 2, got %d", len(out.Items))
+	}
+	if out.Items[0].Body != "spec-v2" {
+		t.Fatalf("body[0]=%q want spec-v2", out.Items[0].Body)
+	}
+}
+
+// ---- task scope ------------------------------------------------------------
+
+func TestDescriptionRestore_Task(t *testing.T) {
+	env := newDescriptionTestEnv(t)
+	tk, err := env.node.Tasks.Create("", "T1", "instr-v1", "", "", env.node.PeerID(), "", "")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	ctx := nil2ctx()
+	if _, err := env.node.Comments.Add(ctx, comments.TargetTask, tk.ID, "alice", comments.TypeDescriptionRevision, "instr-v1"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := env.node.RecordDescriptionChange(ctx, comments.TargetTask, tk.ID, "instr-v2", "bob"); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	v2 := "instr-v2"
+	if _, err := env.node.Tasks.Update(tk.ID, nil, &v2); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	_, body := env.do(t, "GET", "/api/tasks/"+tk.ID+"/description/history", nil)
+	var hist struct {
+		Items []revisionView `json:"items"`
+	}
+	_ = json.Unmarshal(body, &hist)
+	if len(hist.Items) != 2 {
+		t.Fatalf("want 2 revisions, got %d", len(hist.Items))
+	}
+	olderID := hist.Items[1].ID
+
+	resp, raw := env.do(t, "POST", "/api/tasks/"+tk.ID+"/description/restore/"+olderID, restoreRequest{Author: "carol"})
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d raw=%s", resp.StatusCode, raw)
+	}
+	after, err := env.node.Tasks.Get(tk.ID)
+	if err != nil || after == nil {
+		t.Fatalf("get: %v", err)
+	}
+	if after.Description != "instr-v1" {
+		t.Fatalf("task desc after restore = %q want instr-v1", after.Description)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds 9 HTTP endpoints (3 actions × 3 entity scopes) over the existing `description_revision` comment rows: history, get-by-revision, restore.
- Underlying node helpers (`DescriptionHistory`, `GetDescriptionRevision`, `RestoreDescription`) do the real work so MCP (DV/M4) can reuse them.
- `Version` field is 1-based with 1 = oldest revision.
- Restore is strictly additive — it appends a fresh `description_revision` with the historical body and calls `store.Update` to denormalise. Returns `restored=false` when the historical body already matches the current body.
- Cross-entity revision reads are refused with 404 (target membership enforced).

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — all green
- [x] 8 new web-package tests covering history / get / restore across product, manifest, task + no-op + cross-entity 404

## Notes
- Helpers in `internal/node/description.go` currently return `fmt.Errorf` strings rather than sentinel errors; HTTP handler maps via `strings.Contains` as a v1 pragmatism. A sentinel refactor can replace that later.
- Implements DV/M3 in product `019db5af-f63`. DV/M2 shipped in #181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)