### PR TITLE
feat(description-versioning): DV/M4 — MCP tools over description history

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -125,6 +125,7 @@ These behaviors are automatic. Never mention OpenPraxis to the user unless they 
 	s.registerLinkTools()
 	s.registerTaskTools()
 	s.registerSettingsTools()
+	s.registerDescriptionTools()
 
 	s.http = mcpserver.NewStreamableHTTPServer(s.mcp,
 		mcpserver.WithSessionIdleTTL(2*time.Hour),

--- a/internal/mcp/tools_description.go
+++ b/internal/mcp/tools_description.go
@@ -1,0 +1,141 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
+)
+
+// DV/M4 — MCP tools over description_revision history. Thin stdio
+// equivalents of the HTTP endpoints in DV/M3; both surfaces share the
+// same Node helpers (DescriptionHistory / GetDescriptionRevision /
+// RestoreDescription) so behaviour stays in lockstep.
+
+func (s *Server) registerDescriptionTools() {
+	s.mcp.AddTool(
+		mcplib.NewTool("description_history",
+			mcplib.WithDescription("List the description/content/instructions revision history for a product, manifest, or task. Revisions are append-only; the latest revision is always the current body. Returns newest-first."),
+			mcplib.WithString("target_type", mcplib.Required(), mcplib.Description("Entity type: product, manifest, or task")),
+			mcplib.WithString("target_id", mcplib.Required(), mcplib.Description("Entity ID or short marker")),
+			mcplib.WithNumber("limit", mcplib.Description("Max revisions to return. Default 100, cap 1000.")),
+		),
+		s.handleDescriptionHistory,
+	)
+
+	s.mcp.AddTool(
+		mcplib.NewTool("description_get_revision",
+			mcplib.WithDescription("Fetch a single description_revision comment by id. Enforces that the revision belongs to the given target — you cannot read a revision from a sibling entity by guessing its id."),
+			mcplib.WithString("target_type", mcplib.Required(), mcplib.Description("Entity type: product, manifest, or task")),
+			mcplib.WithString("target_id", mcplib.Required(), mcplib.Description("Entity ID or short marker")),
+			mcplib.WithString("revision_id", mcplib.Required(), mcplib.Description("The description_revision comment UUID")),
+		),
+		s.handleDescriptionGetRevision,
+	)
+
+	s.mcp.AddTool(
+		mcplib.NewTool("description_restore",
+			mcplib.WithDescription("Restore a prior description revision. Revisions are append-only; restore creates a new description_revision whose body equals the historical revision's body and denormalises that body back onto the entity. The original revision row is untouched."),
+			mcplib.WithString("target_type", mcplib.Required(), mcplib.Description("Entity type: product, manifest, or task")),
+			mcplib.WithString("target_id", mcplib.Required(), mcplib.Description("Entity ID or short marker")),
+			mcplib.WithString("revision_id", mcplib.Required(), mcplib.Description("The historical description_revision comment UUID to restore")),
+			mcplib.WithString("author", mcplib.Description("Optional author name for the new revision. Defaults to this peer's UUID.")),
+		),
+		s.handleDescriptionRestore,
+	)
+}
+
+// parseTargetType canonicalises the target_type string to a comments
+// TargetType. Returns an error result when the value is unrecognised.
+func parseTargetType(raw string) (comments.TargetType, error) {
+	switch raw {
+	case "product":
+		return comments.TargetProduct, nil
+	case "manifest":
+		return comments.TargetManifest, nil
+	case "task":
+		return comments.TargetTask, nil
+	}
+	return "", fmt.Errorf("target_type must be one of: product, manifest, task (got %q)", raw)
+}
+
+func (s *Server) handleDescriptionHistory(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := req.GetArguments()
+	target, err := parseTargetType(argStr(a, "target_type"))
+	if err != nil {
+		return errResult("%v", err), nil
+	}
+	targetID := argStr(a, "target_id")
+	if targetID == "" {
+		return errResult("target_id is required"), nil
+	}
+	limit := 100
+	if v, ok := a["limit"].(float64); ok && v > 0 {
+		limit = int(v)
+	}
+	rows, err := s.node.DescriptionHistory(ctx, target, targetID, limit)
+	if err != nil {
+		return errResult("%v", err), nil
+	}
+	out, err := json.MarshalIndent(map[string]any{
+		"target_type": string(target),
+		"target_id":   targetID,
+		"items":       rows,
+	}, "", "  ")
+	if err != nil {
+		return errResult("marshal: %v", err), nil
+	}
+	return textResult(string(out)), nil
+}
+
+func (s *Server) handleDescriptionGetRevision(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := req.GetArguments()
+	target, err := parseTargetType(argStr(a, "target_type"))
+	if err != nil {
+		return errResult("%v", err), nil
+	}
+	targetID := argStr(a, "target_id")
+	revisionID := argStr(a, "revision_id")
+	if targetID == "" || revisionID == "" {
+		return errResult("target_id and revision_id are required"), nil
+	}
+	rev, err := s.node.GetDescriptionRevision(ctx, target, targetID, revisionID)
+	if err != nil {
+		return errResult("%v", err), nil
+	}
+	if rev == nil {
+		return errResult("revision not found"), nil
+	}
+	out, err := json.MarshalIndent(rev, "", "  ")
+	if err != nil {
+		return errResult("marshal: %v", err), nil
+	}
+	return textResult(string(out)), nil
+}
+
+func (s *Server) handleDescriptionRestore(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := req.GetArguments()
+	target, err := parseTargetType(argStr(a, "target_type"))
+	if err != nil {
+		return errResult("%v", err), nil
+	}
+	targetID := argStr(a, "target_id")
+	revisionID := argStr(a, "revision_id")
+	if targetID == "" || revisionID == "" {
+		return errResult("target_id and revision_id are required"), nil
+	}
+	author := argStr(a, "author")
+
+	newID, err := s.node.RestoreDescription(ctx, target, targetID, revisionID, author)
+	if err != nil {
+		return errResult("%v", err), nil
+	}
+	if newID == "" {
+		return textResult(fmt.Sprintf("Restore no-op: current body already matches revision %s", revisionID)), nil
+	}
+	return textResult(fmt.Sprintf("Restored %s %s from revision %s. New revision: %s",
+		target, targetID, revisionID, newID)), nil
+}

--- a/internal/mcp/tools_description_test.go
+++ b/internal/mcp/tools_description_test.go
@@ -1,0 +1,217 @@
+package mcp
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
+	"github.com/k8nstantin/OpenPraxis/internal/config"
+	"github.com/k8nstantin/OpenPraxis/internal/manifest"
+	"github.com/k8nstantin/OpenPraxis/internal/node"
+	"github.com/k8nstantin/OpenPraxis/internal/product"
+	"github.com/k8nstantin/OpenPraxis/internal/task"
+)
+
+func newDescriptionTestServer(t *testing.T) *Server {
+	t.Helper()
+	dsn := "file::memory:?cache=shared&_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := comments.InitSchema(db); err != nil {
+		t.Fatalf("comments schema: %v", err)
+	}
+	p, err := product.NewStore(db)
+	if err != nil {
+		t.Fatalf("product: %v", err)
+	}
+	m, err := manifest.NewStore(db)
+	if err != nil {
+		t.Fatalf("manifest: %v", err)
+	}
+	tk, err := task.NewStore(db)
+	if err != nil {
+		t.Fatalf("task: %v", err)
+	}
+	n := &node.Node{
+		Config:    &config.Config{Node: config.NodeConfig{UUID: "peer-test"}},
+		Products:  p,
+		Manifests: m,
+		Tasks:     tk,
+		Comments:  comments.NewStore(db),
+	}
+	return &Server{node: n}
+}
+
+// seedProductHistory creates a product and a two-revision history, returning
+// the full product id + the older revision's comment id.
+func seedProductHistory(t *testing.T, s *Server) (productID, olderRevID, newerRevID string) {
+	t.Helper()
+	ctx := context.Background()
+	p, err := s.node.Products.Create("P", "v1", "open", s.node.PeerID(), nil)
+	if err != nil {
+		t.Fatalf("create product: %v", err)
+	}
+	// v1 seed (current == new, so RecordDescriptionChange would no-op).
+	rev1, err := s.node.Comments.Add(ctx, comments.TargetProduct, p.ID, "alice", comments.TypeDescriptionRevision, "v1")
+	if err != nil {
+		t.Fatalf("seed rev1: %v", err)
+	}
+	rev2ID, err := s.node.RecordDescriptionChange(ctx, comments.TargetProduct, p.ID, "v2", "bob")
+	if err != nil {
+		t.Fatalf("record rev2: %v", err)
+	}
+	if err := s.node.Products.Update(p.ID, p.Title, "v2", p.Status, p.Tags); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	return p.ID, rev1.ID, rev2ID
+}
+
+func TestDescriptionHistory_Tool(t *testing.T) {
+	s := newDescriptionTestServer(t)
+	pid, _, _ := seedProductHistory(t, s)
+
+	res, err := s.handleDescriptionHistory(context.Background(), buildReq(map[string]any{
+		"target_type": "product",
+		"target_id":   pid,
+	}))
+	if err != nil {
+		t.Fatalf("tool: %v", err)
+	}
+	if isErrResult(res) {
+		t.Fatalf("unexpected error result: %s", toolResultText(res))
+	}
+	var payload struct {
+		Items []node.RevisionEntry `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(toolResultText(res)), &payload); err != nil {
+		t.Fatalf("decode: %v raw=%s", err, toolResultText(res))
+	}
+	if len(payload.Items) != 2 {
+		t.Fatalf("want 2 items, got %d", len(payload.Items))
+	}
+	if payload.Items[0].Body != "v2" {
+		t.Fatalf("newest body = %q", payload.Items[0].Body)
+	}
+}
+
+func TestDescriptionHistory_Tool_RejectsBadTargetType(t *testing.T) {
+	s := newDescriptionTestServer(t)
+	res, _ := s.handleDescriptionHistory(context.Background(), buildReq(map[string]any{
+		"target_type": "peer",
+		"target_id":   "x",
+	}))
+	if !isErrResult(res) {
+		t.Fatalf("expected error, got %q", toolResultText(res))
+	}
+}
+
+func TestDescriptionGetRevision_Tool(t *testing.T) {
+	s := newDescriptionTestServer(t)
+	pid, olderID, _ := seedProductHistory(t, s)
+
+	res, err := s.handleDescriptionGetRevision(context.Background(), buildReq(map[string]any{
+		"target_type": "product",
+		"target_id":   pid,
+		"revision_id": olderID,
+	}))
+	if err != nil {
+		t.Fatalf("tool: %v", err)
+	}
+	if isErrResult(res) {
+		t.Fatalf("unexpected error: %s", toolResultText(res))
+	}
+	var rev node.RevisionEntry
+	if err := json.Unmarshal([]byte(toolResultText(res)), &rev); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if rev.Body != "v1" || rev.Version != 1 {
+		t.Fatalf("got body=%q version=%d; want v1 / 1", rev.Body, rev.Version)
+	}
+}
+
+func TestDescriptionGetRevision_Tool_ForeignRevisionRejected(t *testing.T) {
+	s := newDescriptionTestServer(t)
+	pid1, _, _ := seedProductHistory(t, s)
+	_, olderOther, _ := seedProductHistory(t, s)
+
+	res, _ := s.handleDescriptionGetRevision(context.Background(), buildReq(map[string]any{
+		"target_type": "product",
+		"target_id":   pid1,
+		"revision_id": olderOther, // belongs to the other product
+	}))
+	if !isErrResult(res) {
+		t.Fatalf("expected error; got %s", toolResultText(res))
+	}
+}
+
+func TestDescriptionRestore_Tool(t *testing.T) {
+	s := newDescriptionTestServer(t)
+	pid, olderID, _ := seedProductHistory(t, s)
+
+	res, err := s.handleDescriptionRestore(context.Background(), buildReq(map[string]any{
+		"target_type": "product",
+		"target_id":   pid,
+		"revision_id": olderID,
+		"author":      "carol",
+	}))
+	if err != nil {
+		t.Fatalf("tool: %v", err)
+	}
+	if isErrResult(res) {
+		t.Fatalf("unexpected error: %s", toolResultText(res))
+	}
+	msg := toolResultText(res)
+	if !strings.Contains(msg, "Restored product") {
+		t.Fatalf("unexpected message: %q", msg)
+	}
+
+	// Denormalised column rolled back to v1.
+	p, err := s.node.Products.Get(pid)
+	if err != nil || p == nil {
+		t.Fatalf("get: %v", err)
+	}
+	if p.Description != "v1" {
+		t.Fatalf("description after restore = %q want v1", p.Description)
+	}
+
+	// History now has 3 rows.
+	all, err := s.node.DescriptionHistory(context.Background(), comments.TargetProduct, pid, 100)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("history len=%d want 3", len(all))
+	}
+	if all[0].Body != "v1" || all[0].Author != "carol" {
+		t.Fatalf("newest row = (%s, %s) want (v1, carol)", all[0].Body, all[0].Author)
+	}
+}
+
+func TestDescriptionRestore_Tool_NoOpWhenCurrent(t *testing.T) {
+	s := newDescriptionTestServer(t)
+	pid, _, newerID := seedProductHistory(t, s)
+
+	res, err := s.handleDescriptionRestore(context.Background(), buildReq(map[string]any{
+		"target_type": "product",
+		"target_id":   pid,
+		"revision_id": newerID, // body matches current — no-op
+	}))
+	if err != nil {
+		t.Fatalf("tool: %v", err)
+	}
+	if isErrResult(res) {
+		t.Fatalf("unexpected error: %s", toolResultText(res))
+	}
+	if !strings.Contains(toolResultText(res), "no-op") {
+		t.Fatalf("expected no-op message, got: %s", toolResultText(res))
+	}
+}
+


### PR DESCRIPTION
## Summary
Three new MCP tools mirror the HTTP endpoints from DV/M3, sharing the same Node helpers:
- **description_history** — JSON list of revisions, newest first, 1-based Version
- **description_get_revision** — single-revision fetch, enforces target membership
- **description_restore** — append-only restore (new revision + denormalise)

Registered in `server.go` so `tool_list` discovers them.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — all green
- [x] 6 new MCP-package tests

Implements DV/M4 in product `019db5af-f63`. DV/M3 shipped in #182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)