### PR TITLE
feat(description-versioning): DV/M5 — dashboard History section with diff + restore

### DIFF
--- a/internal/web/ui/components/revisions.js
+++ b/internal/web/ui/components/revisions.js
@@ -1,0 +1,179 @@
+// OpenPraxis — Description Revisions component (DV/M5)
+//
+// Fetches /api/{type}s/:id/description/history and renders a collapsible
+// History section with per-row "View diff" and "Restore" buttons. Shared
+// across product / manifest / task detail views.
+//
+// Integration:
+//   OL.renderRevisionsSection(containerEl, { type: 'product'|'manifest'|'task', id: '<id>' })
+
+(function (OL) {
+  'use strict';
+
+  var fetchJSON = OL.fetchJSON, esc = OL.esc, timeAgo = OL.timeAgo;
+
+  // ---- LCS line diff --------------------------------------------------------
+  // Tiny line-level diff, ~O(n·m). Adequate for description bodies (tens to
+  // hundreds of lines); not for large files. Returns an array of
+  // { tag: 'eq'|'add'|'del', line: '...' } rows matching unified-diff order.
+  function diffLines(oldText, newText) {
+    var a = (oldText || '').split('\n');
+    var b = (newText || '').split('\n');
+    var n = a.length, m = b.length;
+    var dp = new Array(n + 1);
+    for (var i = 0; i <= n; i++) {
+      dp[i] = new Int32Array(m + 1);
+    }
+    for (i = n - 1; i >= 0; i--) {
+      for (var j = m - 1; j >= 0; j--) {
+        dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+      }
+    }
+    var out = [];
+    i = 0; j = 0;
+    while (i < n && j < m) {
+      if (a[i] === b[j]) {
+        out.push({ tag: 'eq', line: a[i] });
+        i++; j++;
+      } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+        out.push({ tag: 'del', line: a[i] });
+        i++;
+      } else {
+        out.push({ tag: 'add', line: b[j] });
+        j++;
+      }
+    }
+    while (i < n) { out.push({ tag: 'del', line: a[i++] }); }
+    while (j < m) { out.push({ tag: 'add', line: b[j++] }); }
+    return out;
+  }
+
+  function renderDiff(oldBody, newBody) {
+    var rows = diffLines(oldBody, newBody);
+    if (!rows.length) return '<div class="diff-empty">(no changes)</div>';
+    var html = rows.map(function (r) {
+      var cls = r.tag === 'add' ? 'diff-add' : r.tag === 'del' ? 'diff-del' : 'diff-eq';
+      var prefix = r.tag === 'add' ? '+ ' : r.tag === 'del' ? '- ' : '  ';
+      return '<div class="diff-line ' + cls + '">' + esc(prefix + r.line) + '</div>';
+    }).join('');
+    return '<pre class="diff-pre">' + html + '</pre>';
+  }
+
+  // ---- modal ---------------------------------------------------------------
+
+  function openModal(title, bodyHtml) {
+    var existing = document.getElementById('ol-revision-modal');
+    if (existing) existing.remove();
+    var modal = document.createElement('div');
+    modal.id = 'ol-revision-modal';
+    modal.className = 'revision-modal-backdrop';
+    modal.innerHTML =
+      '<div class="revision-modal">' +
+        '<div class="revision-modal-header">' +
+          '<span class="revision-modal-title">' + esc(title) + '</span>' +
+          '<button type="button" class="revision-modal-close" aria-label="Close">&times;</button>' +
+        '</div>' +
+        '<div class="revision-modal-body">' + bodyHtml + '</div>' +
+      '</div>';
+    document.body.appendChild(modal);
+    var close = function () { modal.remove(); document.removeEventListener('keydown', onKey); };
+    var onKey = function (e) { if (e.key === 'Escape') close(); };
+    modal.querySelector('.revision-modal-close').onclick = close;
+    modal.addEventListener('click', function (e) { if (e.target === modal) close(); });
+    document.addEventListener('keydown', onKey);
+  }
+
+  // ---- entry point ---------------------------------------------------------
+
+  OL.renderRevisionsSection = function (containerEl, scope) {
+    if (!containerEl || !scope || !scope.type || !scope.id) return;
+
+    var base = '/api/' + scope.type + 's/' + encodeURIComponent(scope.id) + '/description';
+    containerEl.innerHTML = '<div class="revisions-loading">Loading history…</div>';
+
+    function load() {
+      return fetchJSON(base + '/history?limit=100').then(function (resp) {
+        return (resp && resp.items) || [];
+      });
+    }
+
+    function paint(items) {
+      if (!items.length) {
+        containerEl.innerHTML =
+          '<div class="revisions-section">' +
+            '<div class="revisions-header">History</div>' +
+            '<div class="revisions-empty">No revisions yet. Edits to this entity\'s description will show up here.</div>' +
+          '</div>';
+        return;
+      }
+      var rows = items.map(function (r, idx) {
+        var isNewest = idx === 0;
+        var preview = (r.body || '').split('\n')[0] || '(empty)';
+        if (preview.length > 140) preview = preview.slice(0, 140) + '…';
+        var currentBadge = isNewest ? '<span class="revision-current-badge">current</span>' : '';
+        var actions =
+          '<button type="button" class="revision-btn revision-diff-btn" data-idx="' + idx + '">View diff</button>' +
+          (isNewest ? '' : '<button type="button" class="revision-btn revision-restore-btn" data-idx="' + idx + '">Restore</button>');
+        return (
+          '<div class="revision-row" data-idx="' + idx + '">' +
+            '<div class="revision-row-meta">' +
+              '<span class="revision-version">v' + r.version + '</span>' +
+              '<span class="revision-author">' + esc(r.author) + '</span>' +
+              '<span class="revision-time">' + esc(timeAgo(new Date(r.created_at * 1000).toISOString())) + '</span>' +
+              currentBadge +
+            '</div>' +
+            '<div class="revision-preview">' + esc(preview) + '</div>' +
+            '<div class="revision-actions">' + actions + '</div>' +
+          '</div>'
+        );
+      }).join('');
+      containerEl.innerHTML =
+        '<div class="revisions-section">' +
+          '<div class="revisions-header">History <span class="revisions-count">(' + items.length + ')</span></div>' +
+          '<div class="revisions-list">' + rows + '</div>' +
+        '</div>';
+      bind(items);
+    }
+
+    function bind(items) {
+      containerEl.querySelectorAll('.revision-diff-btn').forEach(function (btn) {
+        btn.onclick = function () {
+          var i = Number(btn.getAttribute('data-idx'));
+          var cur = items[i];
+          // Diff vs the next-older revision. For the oldest row, diff
+          // against empty — shows every line as an addition.
+          var prev = items[i + 1];
+          var oldBody = prev ? prev.body : '';
+          var newBody = cur ? cur.body : '';
+          var title = 'v' + cur.version + (prev ? ' vs v' + prev.version : ' (initial)');
+          openModal(title, renderDiff(oldBody, newBody));
+        };
+      });
+      containerEl.querySelectorAll('.revision-restore-btn').forEach(function (btn) {
+        btn.onclick = function () {
+          var i = Number(btn.getAttribute('data-idx'));
+          var r = items[i];
+          if (!confirm('Restore v' + r.version + '?\n\nThis creates a new revision matching the historical body. The current body will be replaced.')) return;
+          var author = (OL.currentUser && OL.currentUser()) || 'operator';
+          fetch(base + '/restore/' + encodeURIComponent(r.id), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ author: author }),
+          }).then(function (resp) {
+            return resp.json().then(function (data) { return { ok: resp.ok, data: data }; });
+          }).then(function (res) {
+            if (!res.ok) throw new Error((res.data && res.data.error) || 'restore failed');
+            // Reload history inline. Parent view reloads on its own cadence
+            // — the denormalised description column is what callers see
+            // and the next view switch will pull the new body.
+            return load().then(paint);
+          }).catch(function (e) { alert(e.message || e); });
+        };
+      });
+    }
+
+    load().then(paint).catch(function (e) {
+      containerEl.innerHTML = '<div class="revisions-error">Failed to load history: ' + esc(e.message || String(e)) + '</div>';
+    });
+  };
+})(window.OL);

--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -747,6 +747,7 @@
   <script src="/lifecycle.js"></script>
   <script src="/components/knobs.js"></script>
   <script src="/components/comments.js"></script>
+  <script src="/components/revisions.js"></script>
   <script src="/views/search.js"></script>
   <script src="/views/overview.js"></script>
   <script src="/views/memories.js"></script>

--- a/internal/web/ui/style.css
+++ b/internal/web/ui/style.css
@@ -1374,3 +1374,36 @@ mark {
 .comment-body th, .comment-body td { border: 1px solid var(--border); padding: 4px 8px; }
 .comment-body a { color: var(--accent); }
 .comment-body ul, .comment-body ol { margin: 4px 0 6px 20px; padding: 0; }
+
+/* DV/M5 — Description revisions */
+.revisions-section { border: 1px solid var(--border); border-radius: 6px; padding: 10px; background: var(--bg-secondary); }
+.revisions-header { font-size: 12px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px; display: flex; align-items: center; gap: 8px; text-transform: uppercase; letter-spacing: 0.04em; }
+.revisions-count { color: var(--text-muted); font-weight: 400; }
+.revisions-empty, .revisions-loading, .revisions-error { font-size: 12px; color: var(--text-muted); padding: 8px 0; }
+.revisions-error { color: var(--red); }
+.revisions-list { display: flex; flex-direction: column; gap: 6px; }
+.revision-row { display: grid; grid-template-columns: auto 1fr auto; gap: 10px; align-items: center; padding: 8px 10px; background: var(--bg-primary); border: 1px solid var(--border); border-radius: 4px; font-size: 12px; }
+.revision-row-meta { display: flex; gap: 8px; align-items: center; flex-shrink: 0; }
+.revision-version { font-family: var(--font-mono); font-weight: 600; color: var(--accent); }
+.revision-author { color: var(--text-primary); }
+.revision-time { color: var(--text-muted); font-size: 11px; }
+.revision-current-badge { padding: 1px 6px; background: var(--green); color: var(--bg-primary); border-radius: 3px; font-size: 10px; text-transform: uppercase; font-weight: 600; }
+.revision-preview { color: var(--text-secondary); font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.revision-actions { display: flex; gap: 4px; flex-shrink: 0; }
+.revision-btn { background: var(--bg-input); border: 1px solid var(--border); color: var(--text-primary); font-size: 11px; padding: 3px 8px; border-radius: 3px; cursor: pointer; }
+.revision-btn:hover { background: var(--border); }
+.revision-restore-btn { color: var(--yellow); }
+
+.revision-modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.6); display: flex; align-items: center; justify-content: center; z-index: 1000; }
+.revision-modal { background: var(--bg-secondary); border: 1px solid var(--border); border-radius: 8px; width: min(900px, 90vw); max-height: 85vh; display: flex; flex-direction: column; }
+.revision-modal-header { display: flex; align-items: center; gap: 12px; padding: 10px 14px; border-bottom: 1px solid var(--border); }
+.revision-modal-title { font-weight: 600; flex: 1; }
+.revision-modal-close { background: transparent; border: none; color: var(--text-muted); font-size: 22px; cursor: pointer; line-height: 1; }
+.revision-modal-body { padding: 12px 14px; overflow: auto; }
+
+.diff-pre { margin: 0; background: var(--bg-primary); padding: 8px; border-radius: 4px; font-family: var(--font-mono); font-size: 12px; line-height: 1.45; }
+.diff-line { white-space: pre-wrap; }
+.diff-line.diff-add { background: rgba(0,217,126,0.10); color: var(--green); }
+.diff-line.diff-del { background: rgba(231,76,60,0.10); color: var(--red); }
+.diff-line.diff-eq { color: var(--text-muted); }
+.diff-empty { color: var(--text-muted); font-size: 12px; }

--- a/internal/web/ui/views/manifests.js
+++ b/internal/web/ui/views/manifests.js
@@ -464,6 +464,7 @@
           ${linkedIdeasHtml}
           ${linkedTasksHtml}
           <div id="manifest-knobs-mount" style="margin-top:16px"></div>
+          <div id="manifest-revisions-mount" style="margin-top:16px"></div>
           <div id="manifest-comments-mount" style="margin-top:16px"></div>
           ${tags ? `<div style="margin-bottom:12px">${tags}</div>` : ''}
           <div style="margin-bottom:4px;display:flex;align-items:center;gap:8px">
@@ -488,6 +489,11 @@
       const knobMount = document.getElementById('manifest-knobs-mount');
       if (knobMount && OL.renderKnobSection) {
         OL.renderKnobSection(knobMount, { type: 'manifest', id: m.id });
+      }
+
+      const revisionsMount = document.getElementById('manifest-revisions-mount');
+      if (revisionsMount && OL.renderRevisionsSection) {
+        OL.renderRevisionsSection(revisionsMount, { type: 'manifest', id: m.id });
       }
 
       const commentsMount = document.getElementById('manifest-comments-mount');

--- a/internal/web/ui/views/products.js
+++ b/internal/web/ui/views/products.js
@@ -386,6 +386,7 @@
           ${productDepsHtml}
           ${manifestsHtml}
           <div id="product-knobs-mount" style="margin-top:16px"></div>
+          <div id="product-revisions-mount" style="margin-top:16px"></div>
           <div id="product-comments-mount" style="margin-top:16px"></div>
           ${ideasHtml}
         </div>`;
@@ -393,6 +394,11 @@
       const knobMount = document.getElementById('product-knobs-mount');
       if (knobMount && OL.renderKnobSection) {
         OL.renderKnobSection(knobMount, { type: 'product', id: p.id });
+      }
+
+      const revisionsMount = document.getElementById('product-revisions-mount');
+      if (revisionsMount && OL.renderRevisionsSection) {
+        OL.renderRevisionsSection(revisionsMount, { type: 'product', id: p.id });
       }
 
       const commentsMount = document.getElementById('product-comments-mount');

--- a/internal/web/ui/views/tasks.js
+++ b/internal/web/ui/views/tasks.js
@@ -490,6 +490,9 @@
           <!-- EXECUTION CONTROLS -->
           <div id="task-knobs-mount" style="margin-top:16px"></div>
 
+          <!-- DESCRIPTION HISTORY -->
+          <div id="task-revisions-mount" style="margin-top:16px"></div>
+
           <!-- COMMENTS -->
           <div id="task-comments-mount" style="margin-top:16px"></div>
 
@@ -534,6 +537,11 @@
       const knobMount = document.getElementById('task-knobs-mount');
       if (knobMount && OL.renderKnobSection) {
         OL.renderKnobSection(knobMount, { type: 'task', id: t.id });
+      }
+
+      const revisionsMount = document.getElementById('task-revisions-mount');
+      if (revisionsMount && OL.renderRevisionsSection) {
+        OL.renderRevisionsSection(revisionsMount, { type: 'task', id: t.id });
       }
 
       const commentsMount = document.getElementById('task-comments-mount');


### PR DESCRIPTION
## Summary
Adds a shared \`OL.renderRevisionsSection\` component that mounts under each entity detail panel (product / manifest / task). Each row shows version / author / timestamp / first-line preview with:
- **View diff** → modal with unified line-diff vs the immediately-previous revision
- **Restore** → POSTs to \`/description/restore/:comment_id\` with confirm dialog; inline history refreshes on success

Diff is a small client-side LCS line differ (~O(n·m)) — no new vendor libraries, fits the zero-build ES5 pattern used by the rest of the dashboard.

Completes the Description Versioning product \`019db5af-f63\`. DV/M1 (#177), M2 (#181), M3 (#182), M4 (#183), M5 (this PR).

## Test plan
- [x] \`go build ./...\` and \`go test ./...\` — all green
- [x] \`node --check\` on the new JS file
- [ ] Manual: open a product / manifest / task with edit history; verify rows render, diff modal shows expected ± lines, Restore creates a new row at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)