### PR TITLE
feat(ui): + Depends On toolbar button on product + task detail

### DIFF
--- a/internal/web/ui/views/products.js
+++ b/internal/web/ui/views/products.js
@@ -375,6 +375,7 @@
             <button class="btn-search btn-action" onclick="OL.editProduct('${esc(p.id)}')">&#9998; Edit</button>
             <button class="btn-search btn-action" onclick="OL.createManifest({productId:'${esc(p.id)}'})">+ New Manifest</button>
             <button class="btn-search btn-action" style="background:var(--bg-input)" onclick="OL.linkManifestToProduct('${esc(p.id)}')">+ Link Manifest</button>
+            <button class="btn-search btn-action" id="product-toolbar-dep">+ Depends On</button>
             <button class="btn-search btn-action" onclick="OL.showProductDiagram('${esc(p.id)}','${esc(p.title)}')">&#x25C8; Product DAG</button>
             ${['draft','open','closed','archive'].map(s => {
               const active = p.status === s;
@@ -435,6 +436,18 @@
           }
         });
       });
+
+      // Toolbar "+ Depends On" — shortcut to the inline picker below.
+      const toolbarDepBtn = document.getElementById('product-toolbar-dep');
+      if (toolbarDepBtn) {
+        toolbarDepBtn.addEventListener('click', () => {
+          const inline = document.getElementById('product-add-dep-btn');
+          if (inline) {
+            inline.click();
+            inline.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          }
+        });
+      }
 
       // Wire add-dep button + picker. 409 = cycle, 400 = self-loop/bad body,
       // 404 = missing product. The server error surfaces inline in red.

--- a/internal/web/ui/views/tasks.js
+++ b/internal/web/ui/views/tasks.js
@@ -390,6 +390,7 @@
               : (t.status === 'scheduled'
                   ? `<button class="btn-dismiss btn-action" onclick="OL.taskAction('${esc(t.id)}','cancel')">&#10005; Cancel</button>`
                   : `<button class="btn-dismiss btn-action" onclick="OL.taskArchive('${esc(t.id)}')">&#10005; Cancel</button>`)}
+            <button class="btn-search btn-action" id="task-toolbar-dep">+ Depends On</button>
             ${taskProduct
               ? `<button class="btn-search btn-action" onclick="OL.showProductDiagram('${esc(taskProduct.id)}','${esc(taskProduct.title)}')">&#x25C8; Product DAG</button>`
               : `<button class="btn-search btn-action" disabled style="opacity:0.5" title="Task has no linked product">&#x25C8; Product DAG</button>`}
@@ -547,6 +548,17 @@
       const commentsMount = document.getElementById('task-comments-mount');
       if (commentsMount && OL.renderCommentsSection) {
         OL.renderCommentsSection(commentsMount, { type: 'task', id: t.id });
+      }
+
+      // Toolbar "+ Depends On" — scroll to the dep section + focus input.
+      const toolbarDepBtn = document.getElementById('task-toolbar-dep');
+      if (toolbarDepBtn) {
+        toolbarDepBtn.addEventListener('click', () => {
+          const section = document.getElementById('task-dependency-section');
+          const input = document.getElementById('task-dep-search');
+          if (section) section.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          if (input) setTimeout(() => input.focus(), 250);
+        });
       }
 
       // Manifest cross-link — fetch title + wire click


### PR DESCRIPTION
## Summary
Adds a **+ Depends On** button to the top toolbar on product and task detail panels. Clicking it jumps to and focuses the inline dependency picker / search that already lives lower in the panel. Manifest detail already had + Dep in its toolbar, so no change there.

Existing inline pickers are kept intact — toolbar button is a shortcut, not a replacement. Partial scope of manifest \`019db5bb-59b\` (UI polish — consolidate action buttons).

## Test plan
- [x] \`go build ./...\` and \`go test ./...\` pass
- [x] \`node --check\` on modified JS files
- [ ] Manual: on a product detail, click + Depends On → inline picker opens + scrolls into view. On a task detail, click + Depends On → dep section scrolls in, search input focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)