### PR TITLE
feat(ui): consolidate all detail-panel buttons into the toolbar + History on top

### DIFF
--- a/internal/web/ui/views/manifests.js
+++ b/internal/web/ui/views/manifests.js
@@ -402,10 +402,7 @@
         } else {
           linkedTasksHtml = `<div style="margin-bottom:16px;padding-top:12px;border-top:1px solid var(--border)">
             <div class="section-title">Executed Tasks</div>
-            <div class="empty-placeholder">
-              No tasks executed yet
-              <button class="btn-search manifest-create-task-btn" style="margin-left:8px;padding:4px 12px;font-size:11px">+ Create Task</button>
-            </div>
+            <div class="empty-placeholder">No tasks executed yet</div>
           </div>`;
         }
       } catch(e) {}
@@ -448,6 +445,7 @@
             ${product ? `<button id="manifest-toolbar-dag" class="btn-search btn-action" onclick="OL.showProductDiagram('${esc(product.id)}','${esc(product.title)}')">&#x25C8; Product DAG</button>` : ''}
             ${statusToggleHtml}
           </div>
+          <div id="manifest-revisions-mount" style="margin-bottom:12px"></div>
           <!-- METADATA BAR -->
           <div class="stats-bar">
             <span>Tasks: <strong style="color:var(--text-primary)">${m.total_tasks || 0}</strong></span>
@@ -464,12 +462,10 @@
           ${linkedIdeasHtml}
           ${linkedTasksHtml}
           <div id="manifest-knobs-mount" style="margin-top:16px"></div>
-          <div id="manifest-revisions-mount" style="margin-top:16px"></div>
           <div id="manifest-comments-mount" style="margin-top:16px"></div>
           ${tags ? `<div style="margin-bottom:12px">${tags}</div>` : ''}
-          <div style="margin-bottom:4px;display:flex;align-items:center;gap:8px">
+          <div style="margin-bottom:4px">
             <span style="font-size:12px;color:var(--text-muted);font-weight:500">Spec / Content</span>
-            <button id="manifest-edit-content-btn" class="btn-search" style="padding:2px 10px;font-size:11px">Edit</button>
           </div>
           <div id="manifest-content-display" class="manifest-content">${esc(m.content)}</div>
           <div id="manifest-content-editor" style="display:none;margin-bottom:12px">
@@ -701,21 +697,25 @@
         });
       }
 
-      // Inline edit: Content (toggle editor)
-      const contentBtn = document.getElementById('manifest-edit-content-btn');
+      // Toolbar Edit → toggle the Spec/Content editor directly.
+      // The inline "Edit" button next to the Spec/Content heading was
+      // removed; the toolbar is the single entry point now.
       const contentDisplay = document.getElementById('manifest-content-display');
       const contentEditor = document.getElementById('manifest-content-editor');
-      if (contentBtn && contentDisplay && contentEditor) {
-        OL.onView(contentBtn, 'click', () => {
-          contentDisplay.style.display = 'none';
-          contentBtn.style.display = 'none';
-          contentEditor.style.display = 'block';
-        });
-        OL.onView(document.getElementById('manifest-content-cancel'), 'click', () => {
-          contentEditor.style.display = 'none';
-          contentDisplay.style.display = '';
-          contentBtn.style.display = '';
-        });
+      const openContentEditor = () => {
+        if (!contentDisplay || !contentEditor) return;
+        contentDisplay.style.display = 'none';
+        contentEditor.style.display = 'block';
+        const ta = document.getElementById('manifest-content-textarea');
+        if (ta) ta.focus();
+      };
+      const closeContentEditor = () => {
+        if (!contentDisplay || !contentEditor) return;
+        contentEditor.style.display = 'none';
+        contentDisplay.style.display = '';
+      };
+      if (contentDisplay && contentEditor) {
+        OL.onView(document.getElementById('manifest-content-cancel'), 'click', closeContentEditor);
         OL.onView(document.getElementById('manifest-content-save'), 'click', async () => {
           const val = document.getElementById('manifest-content-textarea').value;
           await fetch('/api/manifests/' + m.id, {
@@ -727,13 +727,8 @@
           OL.loadManifest(m.id);
         });
       }
-
-      // Toolbar: Edit → trigger the content editor toggle.
       const toolbarEdit = document.getElementById('manifest-toolbar-edit');
-      if (toolbarEdit) OL.onView(toolbarEdit, 'click', () => {
-        const btn = document.getElementById('manifest-edit-content-btn');
-        if (btn) btn.click();
-      });
+      if (toolbarEdit) OL.onView(toolbarEdit, 'click', openContentEditor);
 
       // Toolbar: + New Task → switch to tasks view, open the create form, prefill this manifest.
       const toolbarNewTask = document.getElementById('manifest-toolbar-new-task');
@@ -769,21 +764,6 @@
           OL.loadManifest(m.id);
         } catch (e) { alert('Link failed: ' + e.message); }
       });
-
-      // Create task button (when no tasks exist for this manifest)
-      const createTaskBtn = bodyEl.querySelector('.manifest-create-task-btn');
-      if (createTaskBtn) {
-        OL.onView(createTaskBtn, 'click', () => {
-          OL.switchView('tasks');
-          setTimeout(() => {
-            OL.showTaskCreateForm();
-            setTimeout(() => {
-              const sel = document.getElementById('tc-manifest-id');
-              if (sel) { sel.value = m.id; }
-            }, 100);
-          }, 300);
-        });
-      }
 
     } catch (e) {
       console.error('Load manifest failed:', e);

--- a/internal/web/ui/views/products.js
+++ b/internal/web/ui/views/products.js
@@ -257,7 +257,6 @@
           <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">
             <span style="color:var(--text-muted);font-size:12px;font-weight:500">Depends on</span>
             ${satisfiedPill}
-            <button id="product-add-dep-btn" class="btn-search" style="padding:2px 10px;font-size:11px">+ Add</button>
           </div>
           <div id="product-dep-pills" style="display:flex;flex-wrap:wrap;align-items:center;min-height:24px">
             ${outPills || '<span style="font-size:11px;color:var(--text-muted);font-style:italic">No dependencies</span>'}
@@ -328,18 +327,12 @@
             </div>`;
           }).join('');
           ideasHtml = `<div class="section-divider">
-            <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-              <span style="font-size:13px;color:var(--text-primary);font-weight:600">Linked Ideas <span class="sub-count">(${ideas.length})</span></span>
-              <button class="btn-search btn-xs" onclick="OL.linkIdeaToProduct('${esc(p.id)}')">+ Link Idea</button>
-            </div>
+            <div class="section-title">Linked Ideas <span class="sub-count">(${ideas.length})</span></div>
             <div class="bordered-container">${ideaRows}</div>
           </div>`;
         } else {
           ideasHtml = `<div class="section-divider">
-            <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-              <span style="font-size:13px;color:var(--text-primary);font-weight:600">Linked Ideas</span>
-              <button class="btn-search btn-xs" onclick="OL.linkIdeaToProduct('${esc(p.id)}')">+ Link Idea</button>
-            </div>
+            <div class="section-title">Linked Ideas</div>
             <div class="empty-placeholder">No ideas linked yet</div>
           </div>`;
         }
@@ -376,6 +369,7 @@
             <button class="btn-search btn-action" onclick="OL.createManifest({productId:'${esc(p.id)}'})">+ New Manifest</button>
             <button class="btn-search btn-action" style="background:var(--bg-input)" onclick="OL.linkManifestToProduct('${esc(p.id)}')">+ Link Manifest</button>
             <button class="btn-search btn-action" id="product-toolbar-dep">+ Depends On</button>
+            <button class="btn-search btn-action" onclick="OL.linkIdeaToProduct('${esc(p.id)}')">+ Link Idea</button>
             <button class="btn-search btn-action" onclick="OL.showProductDiagram('${esc(p.id)}','${esc(p.title)}')">&#x25C8; Product DAG</button>
             ${['draft','open','closed','archive'].map(s => {
               const active = p.status === s;
@@ -383,11 +377,11 @@
               return '<button class="product-status-btn btn-action" data-status="' + s + '" style="font-weight:600;text-transform:uppercase;border-radius:4px;cursor:pointer;border:1px solid ' + color + ';background:' + (active ? color : 'transparent') + ';color:' + (active ? 'var(--bg-primary)' : color) + ';opacity:' + (active ? '1' : '0.7') + '" onclick="OL.updateProductStatus(\'' + esc(p.id) + '\',\'' + s + '\')">' + s + '</button>';
             }).join('')}
           </div>
+          <div id="product-revisions-mount" style="margin-bottom:12px"></div>
           ${p.description ? `<div style="font-size:13px;color:var(--text-secondary);line-height:1.6;margin-bottom:12px;white-space:pre-wrap">${esc(p.description)}</div>` : ''}
           ${productDepsHtml}
           ${manifestsHtml}
           <div id="product-knobs-mount" style="margin-top:16px"></div>
-          <div id="product-revisions-mount" style="margin-top:16px"></div>
           <div id="product-comments-mount" style="margin-top:16px"></div>
           ${ideasHtml}
         </div>`;
@@ -437,36 +431,31 @@
         });
       });
 
-      // Toolbar "+ Depends On" — shortcut to the inline picker below.
-      const toolbarDepBtn = document.getElementById('product-toolbar-dep');
-      if (toolbarDepBtn) {
-        toolbarDepBtn.addEventListener('click', () => {
-          const inline = document.getElementById('product-add-dep-btn');
-          if (inline) {
-            inline.click();
-            inline.scrollIntoView({ behavior: 'smooth', block: 'center' });
-          }
-        });
-      }
-
-      // Wire add-dep button + picker. 409 = cycle, 400 = self-loop/bad body,
-      // 404 = missing product. The server error surfaces inline in red.
-      const addDepBtn = document.getElementById('product-add-dep-btn');
+      // Toolbar "+ Depends On" — toggle the picker + scroll the dep
+      // section into view. Replaces the old inline "+ Add" button.
       const depPicker = document.getElementById('product-dep-picker');
       const depSelect = document.getElementById('product-dep-select');
       const depError = document.getElementById('product-dep-error');
+      const depSection = document.getElementById('product-deps-section');
       const showDepError = (msg) => {
         if (!depError) return;
         depError.textContent = msg;
         depError.style.display = msg ? 'block' : 'none';
       };
-      if (addDepBtn && depPicker && depSelect) {
-        addDepBtn.addEventListener('click', () => {
+      const toolbarDepBtn = document.getElementById('product-toolbar-dep');
+      if (toolbarDepBtn && depPicker && depSelect) {
+        toolbarDepBtn.addEventListener('click', () => {
           const visible = depPicker.style.display !== 'none';
           depPicker.style.display = visible ? 'none' : 'block';
           showDepError('');
-          if (!visible) depSelect.focus();
+          if (!visible) {
+            if (depSection) depSection.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            setTimeout(() => depSelect.focus(), 200);
+          }
         });
+      }
+
+      if (depPicker && depSelect) {
         depSelect.addEventListener('change', async () => {
           const selectedId = depSelect.value;
           if (!selectedId) return;

--- a/internal/web/ui/views/tasks.js
+++ b/internal/web/ui/views/tasks.js
@@ -400,6 +400,8 @@
             ` : ''}
           </div>
 
+          <div id="task-revisions-mount" style="margin-bottom:12px"></div>
+
           <!-- SCHEDULE SECTION -->
           <div style="margin-bottom:16px;padding:12px;border:1px solid var(--border);border-radius:8px;background:var(--bg-secondary)">
             ${!isRunningOrPaused ? `
@@ -468,11 +470,10 @@
             </div>
           </div>
 
-          <!-- 4. INSTRUCTIONS (editable) -->
+          <!-- 4. INSTRUCTIONS (editable via toolbar Edit) -->
           <div id="task-instructions-section" style="margin-bottom:12px">
-            <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">
+            <div style="margin-bottom:6px">
               <span class="heading-sm">Instructions</span>
-              <button id="task-instructions-edit-btn" class="btn-search btn-xs" onclick="OL.editInstructions('${esc(t.id)}')">${t.description ? 'Edit' : 'Add Instructions'}</button>
             </div>
             <div id="task-instructions-display">
               ${t.description
@@ -490,9 +491,6 @@
 
           <!-- EXECUTION CONTROLS -->
           <div id="task-knobs-mount" style="margin-top:16px"></div>
-
-          <!-- DESCRIPTION HISTORY -->
-          <div id="task-revisions-mount" style="margin-top:16px"></div>
 
           <!-- COMMENTS -->
           <div id="task-comments-mount" style="margin-top:16px"></div>


### PR DESCRIPTION
## Summary
Operator feedback: scattered controls are \"an easter-egg hunt.\" Fixing both complaints:

1. **History renders directly below the toolbar** on product / manifest / task detail panels (was previously buried below execution-controls + comments).
2. **Every action button lives in the toolbar** — inline duplicates removed:
   - Product: no more inline \`+ Add\` deps / \`+ Link Idea\`; the dep picker dropdown stays inline (it's an input, not a button).
   - Manifest: no more inline Spec/Content \`Edit\` button; no more empty-state \`+ Create Task\`.
   - Task: no more inline Instructions \`Edit\`.
3. \`+ Link Idea\` added to product toolbar.

Operator now scans one row under the title for every action, and sees the edit history before the body content.

## Test plan
- [x] \`node --check\` on modified JS files
- [x] \`go build ./...\` and \`go test ./...\` pass
- [ ] Manual: open a product / manifest / task detail — History card is first under toolbar; all action buttons live in the toolbar row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)