### PR TITLE
feat(ideas): same mechanism as products/manifests/tasks — tree list + full description versioning

### DIFF
--- a/internal/comments/model.go
+++ b/internal/comments/model.go
@@ -12,6 +12,7 @@ const (
 	TargetProduct  TargetType = "product"
 	TargetManifest TargetType = "manifest"
 	TargetTask     TargetType = "task"
+	TargetIdea     TargetType = "idea"
 )
 
 type Comment struct {

--- a/internal/comments/schema.go
+++ b/internal/comments/schema.go
@@ -3,6 +3,7 @@ package comments
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 )
 
 // InitSchema creates the comments table and its indexes on the given DB.
@@ -18,7 +19,7 @@ import (
 func InitSchema(db *sql.DB) error {
 	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS comments (
 		id           TEXT NOT NULL PRIMARY KEY,
-		target_type  TEXT NOT NULL CHECK (target_type IN ('product','manifest','task')),
+		target_type  TEXT NOT NULL CHECK (target_type IN ('product','manifest','task','idea')),
 		target_id    TEXT NOT NULL,
 		author       TEXT NOT NULL,
 		type         TEXT NOT NULL,
@@ -29,6 +30,14 @@ func InitSchema(db *sql.DB) error {
 	)`)
 	if err != nil {
 		return fmt.Errorf("create comments table: %w", err)
+	}
+
+	// Migrate pre-existing DBs whose CHECK constraint still excludes 'idea'.
+	// SQLite can't ALTER a CHECK constraint in place; we detect the old
+	// constraint by probing an idea insert on a throwaway row and, if it
+	// rejects, rebuild the table with the new constraint.
+	if err := migrateTargetTypeCheck(db); err != nil {
+		return fmt.Errorf("migrate target_type check: %w", err)
 	}
 
 	_, err = db.Exec(`CREATE INDEX IF NOT EXISTS idx_comments_target ON comments(target_type, target_id, created_at DESC)`)
@@ -42,4 +51,49 @@ func InitSchema(db *sql.DB) error {
 	}
 
 	return nil
+}
+
+// migrateTargetTypeCheck rebuilds the comments table with the updated CHECK
+// constraint (including 'idea') when a legacy DB still has the old three-value
+// constraint. Idempotent — a no-op on new DBs since CREATE TABLE above ships
+// the new constraint directly.
+func migrateTargetTypeCheck(db *sql.DB) error {
+	var ddl string
+	if err := db.QueryRow(`SELECT sql FROM sqlite_master WHERE type='table' AND name='comments'`).Scan(&ddl); err != nil {
+		return fmt.Errorf("read table ddl: %w", err)
+	}
+	// Already on the new schema?
+	if strings.Contains(ddl, "'idea'") {
+		return nil
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(`CREATE TABLE comments_new (
+		id           TEXT NOT NULL PRIMARY KEY,
+		target_type  TEXT NOT NULL CHECK (target_type IN ('product','manifest','task','idea')),
+		target_id    TEXT NOT NULL,
+		author       TEXT NOT NULL,
+		type         TEXT NOT NULL,
+		body         TEXT NOT NULL,
+		created_at   INTEGER NOT NULL,
+		updated_at   INTEGER,
+		parent_id    TEXT
+	)`); err != nil {
+		return fmt.Errorf("create comments_new: %w", err)
+	}
+	if _, err := tx.Exec(`INSERT INTO comments_new SELECT id, target_type, target_id, author, type, body, created_at, updated_at, parent_id FROM comments`); err != nil {
+		return fmt.Errorf("copy rows: %w", err)
+	}
+	if _, err := tx.Exec(`DROP TABLE comments`); err != nil {
+		return fmt.Errorf("drop old: %w", err)
+	}
+	if _, err := tx.Exec(`ALTER TABLE comments_new RENAME TO comments`); err != nil {
+		return fmt.Errorf("rename: %w", err)
+	}
+	return tx.Commit()
 }

--- a/internal/comments/types.go
+++ b/internal/comments/types.go
@@ -55,7 +55,7 @@ func IsValidCommentType(s string) bool {
 
 func IsValidTargetType(s string) bool {
 	switch TargetType(s) {
-	case TargetProduct, TargetManifest, TargetTask:
+	case TargetProduct, TargetManifest, TargetTask, TargetIdea:
 		return true
 	}
 	return false

--- a/internal/mcp/tools_description.go
+++ b/internal/mcp/tools_description.go
@@ -58,8 +58,10 @@ func parseTargetType(raw string) (comments.TargetType, error) {
 		return comments.TargetManifest, nil
 	case "task":
 		return comments.TargetTask, nil
+	case "idea":
+		return comments.TargetIdea, nil
 	}
-	return "", fmt.Errorf("target_type must be one of: product, manifest, task (got %q)", raw)
+	return "", fmt.Errorf("target_type must be one of: product, manifest, task, idea (got %q)", raw)
 }
 
 func (s *Server) handleDescriptionHistory(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {

--- a/internal/mcp/tools_idea.go
+++ b/internal/mcp/tools_idea.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
 )
 
 func (s *Server) registerIdeaTools() {
@@ -107,6 +109,14 @@ func (s *Server) handleIdeaUpdate(ctx context.Context, req mcplib.CallToolReques
 	tagsStr := argStr(a, "tags")
 	tags := existing.Tags
 	if tagsStr != "" { tags = splitCSV(tagsStr) }
+
+	// DV consistency — append-only description_revision before the
+	// denormalised UPDATE, same pattern as product / manifest / task.
+	if argStr(a, "description") != "" {
+		if _, err := s.node.RecordDescriptionChange(ctx, comments.TargetIdea, existing.ID, desc, ""); err != nil {
+			return errResult("record revision: %v", err), nil
+		}
+	}
 
 	if err := s.node.Ideas.Update(existing.ID, title, desc, status, priority, existing.ProjectID, tags); err != nil {
 		return errResult("update idea: %v", err), nil

--- a/internal/node/description.go
+++ b/internal/node/description.go
@@ -101,6 +101,15 @@ func (n *Node) currentDescription(target comments.TargetType, idOrMarker string)
 			return "", "", err
 		}
 		return t.Description, t.ID, nil
+	case comments.TargetIdea:
+		if n.Ideas == nil {
+			return "", "", nil
+		}
+		i, err := n.Ideas.Get(idOrMarker)
+		if err != nil || i == nil {
+			return "", "", err
+		}
+		return i.Description, i.ID, nil
 	}
 	return "", "", nil
 }
@@ -289,6 +298,18 @@ func (n *Node) writeEntityDescription(target comments.TargetType, fullID, body s
 		}
 		_, err := n.Tasks.Update(fullID, nil, &body)
 		return err
+	case comments.TargetIdea:
+		if n.Ideas == nil {
+			return fmt.Errorf("ideas store not wired")
+		}
+		i, err := n.Ideas.Get(fullID)
+		if err != nil {
+			return err
+		}
+		if i == nil {
+			return fmt.Errorf("idea not found: %s", fullID)
+		}
+		return n.Ideas.Update(i.ID, i.Title, body, i.Status, i.Priority, i.ProjectID, i.Tags)
 	}
 	return fmt.Errorf("unsupported target type: %s", target)
 }

--- a/internal/web/handlers_comments.go
+++ b/internal/web/handlers_comments.go
@@ -265,6 +265,18 @@ func nodeTargetResolver(n *node.Node) TargetResolver {
 				return "", fmt.Errorf("target product not found: %s", raw)
 			}
 			return p.ID, nil
+		case comments.TargetIdea:
+			if n.Ideas == nil {
+				return raw, nil
+			}
+			i, err := n.Ideas.Get(raw)
+			if err != nil {
+				return "", fmt.Errorf("resolve target idea %q: %w", raw, err)
+			}
+			if i == nil {
+				return "", fmt.Errorf("target idea not found: %s", raw)
+			}
+			return i.ID, nil
 		}
 		return raw, nil
 	}
@@ -427,6 +439,7 @@ var commentScopeRoutes = []struct {
 	{"products", comments.TargetProduct},
 	{"manifests", comments.TargetManifest},
 	{"tasks", comments.TargetTask},
+	{"ideas", comments.TargetIdea},
 }
 
 // registerCommentsRoutes attaches the 8 comment endpoints to /api using the

--- a/internal/web/handlers_description.go
+++ b/internal/web/handlers_description.go
@@ -171,6 +171,7 @@ var descriptionScopeRoutes = []struct {
 	{"products", comments.TargetProduct},
 	{"manifests", comments.TargetManifest},
 	{"tasks", comments.TargetTask},
+	{"ideas", comments.TargetIdea},
 }
 
 // registerDescriptionRoutes attaches the 9 DV/M3 endpoints to /api.

--- a/internal/web/handlers_idea.go
+++ b/internal/web/handlers_idea.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
 	"github.com/k8nstantin/OpenPraxis/internal/node"
 
 	"github.com/gorilla/mux"
@@ -136,6 +137,15 @@ func apiIdeaUpdate(n *node.Node) http.HandlerFunc {
 		}
 		tags := existing.Tags
 		if req.Tags != nil { tags = req.Tags }
+		// Record append-only description_revision on description changes
+		// before the denormalised UPDATE (DV consistency with products /
+		// manifests / tasks).
+		if req.Description != nil {
+			if _, err := n.RecordDescriptionChange(r.Context(), comments.TargetIdea, existing.ID, desc, ""); err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+		}
 		if err := n.Ideas.Update(existing.ID, title, desc, status, priority, projectID, tags); err != nil {
 			http.Error(w, err.Error(), 500)
 			return

--- a/internal/web/ui/views/ideas.js
+++ b/internal/web/ui/views/ideas.js
@@ -3,6 +3,7 @@
   var fetchJSON = OL.fetchJSON, esc = OL.esc;
   var _pendingIdeaId = null;
 
+
   function renderIdeaSearchList(el, ideas) {
     if (!ideas || !ideas.length) {
       el.innerHTML = '<div class="empty-state" style="padding:16px">No ideas found</div>';
@@ -63,41 +64,35 @@
         el.innerHTML = '<div class="empty-state" style="padding:16px">No ideas yet</div>';
         return;
       }
-      var html = '';
       var allIdeas = [];
-      for (var pi = 0; pi < peerGroups.length; pi++) {
-        var pg = peerGroups[pi];
-        html += '<div class="tree-node peer-header clickable" data-idea-peer="' + pi + '" role="button" tabindex="0" aria-expanded="true">' +
-          '<span class="tree-arrow">&#x25BC;</span>' +
-          '<span class="status-dot green"></span>' +
-          '<span>' + esc(pg.peer_id) + '</span>' +
-          '<span class="count">' + pg.count + '</span>' +
-        '</div>';
-        html += '<div class="peer-children" data-idea-peer-children="' + pi + '">';
-        for (var ii = 0; ii < pg.ideas.length; ii++) {
-          var i = pg.ideas[ii];
-          allIdeas.push(i);
-          var prioClass = i.priority === 'critical' || i.priority === 'high' ? 'high' : i.priority === 'low' ? 'low' : 'medium';
-          html += '<div class="manifest-item clickable" data-id="' + esc(i.id) + '" role="button" tabindex="0">' +
-            '<div style="display:flex;align-items:center;gap:6px;margin-bottom:4px">' +
-              '<span class="amnesia-score ' + prioClass + ' badge-sm">' + esc(i.priority) + '</span>' +
-              '<span class="session-uuid">' + esc(i.marker) + '</span>' +
-              '<span class="badge">' + esc(i.status) + '</span>' +
-            '</div>' +
-            '<div class="manifest-item-title">' + esc(i.title) + '</div>' +
+      peerGroups.forEach(function(pg) { pg.ideas.forEach(function(i) { allIdeas.push(i); }); });
+
+      OL.renderTree(el, peerGroups, {
+        prefix: 'idea',
+        emptyMessage: 'No ideas yet',
+        levels: [
+          {
+            label: function(pg) { return esc(pg.peer_id); },
+            count: function(pg) { return pg.count; },
+            children: function(pg) { return pg.ideas; },
+          }
+        ],
+        renderLeaf: function(i) {
+          var prioClass = i.priority === 'critical' || i.priority === 'high' ? 'high' :
+            i.priority === 'low' ? 'low' : 'medium';
+          var prioColor = prioClass === 'high' ? 'var(--red)' : prioClass === 'low' ? 'var(--text-muted)' : 'var(--yellow)';
+          return '<div class="tree-node peer-leaf clickable tree-leaf" data-id="' + esc(i.id) + '">' +
+            '<span class="session-uuid">' + esc(i.marker) + '</span>' +
+            '<span class="badge badge-sm" style="color:' + prioColor + '">' + esc(i.priority) + '</span>' +
+            '<span style="font-size:12px;color:var(--text-primary);flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + esc(i.title) + '</span>' +
           '</div>';
-        }
-        html += '</div>';
-      }
-      el.innerHTML = html;
-
-      OL.wireTreeToggles(el, 'data-idea-peer');
-
-      el.querySelectorAll('.manifest-item').forEach(function(item) {
-        OL.onView(item, 'click', function() { OL.loadIdea(item.dataset.id); });
-        OL.onView(item, 'keydown', function(e) {
-          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); OL.loadIdea(item.dataset.id); }
-        });
+        },
+        leafSelector: '.tree-leaf',
+        onLeafClick: function(node) {
+          el.querySelectorAll('.tree-node').forEach(function(n) { n.classList.remove('active'); });
+          node.classList.add('active');
+          OL.loadIdea(node.dataset.id);
+        },
       });
 
       if (_pendingIdeaId) {
@@ -139,7 +134,6 @@
 
       bodyEl.innerHTML =
         '<div class="manifest-detail-view">' +
-          '<!-- BREADCRUMB -->' +
           '<div class="breadcrumb">' +
             '<span class="breadcrumb-link" onclick="OL.switchView(\'ideas\')">' + esc(idea.source_node ? idea.source_node.substring(0,12) : 'node') + '</span>' +
             '<span class="breadcrumb-sep"> &rarr; </span>' +
@@ -152,16 +146,27 @@
             '<span style="font-size:12px;color:var(--text-muted)">by ' + esc(idea.author) + '</span>' +
             '<button class="btn-copy" onclick="OL.copy(\'get idea ' + idea.marker + '\')" title="Copy ref" aria-label="Copy reference">&#x2398;</button>' +
           '</div>' +
-          (idea.description ? '<div style="font-size:14px;color:var(--text-primary);margin:12px 0;line-height:1.5">' + esc(idea.description) + '</div>' : '') +
+          '<div class="toolbar-row">' +
+            '<button class="btn-search btn-action promote-idea-btn">+ Create Manifest from Idea</button>' +
+            '<button class="btn-dismiss btn-action" onclick="OL.archiveIdea(\'' + esc(idea.id) + '\')">Archive</button>' +
+          '</div>' +
+          '<div id="idea-revisions-mount" style="margin-bottom:12px"></div>' +
+          (idea.description ? '<div style="font-size:13px;color:var(--text-secondary);line-height:1.6;margin-bottom:12px;white-space:pre-wrap">' + esc(idea.description) + '</div>' : '') +
           linkedHtml +
+          '<div id="idea-comments-mount" style="margin-top:16px"></div>' +
           '<div style="margin-top:16px;padding-top:12px;border-top:1px solid var(--border);font-size:11px;color:var(--text-muted)">' +
             'Created: ' + new Date(idea.created_at).toLocaleString() + ' | ID: ' + esc(idea.id) +
           '</div>' +
-          '<div style="margin-top:12px;display:flex;gap:8px">' +
-            '<button class="btn-search promote-idea-btn btn-md">Create Manifest from Idea</button>' +
-            '<button class="btn-dismiss" onclick="OL.archiveIdea(\'' + esc(idea.id) + '\')">Archive</button>' +
-          '</div>' +
         '</div>';
+
+      var ideaRevisionsMount = document.getElementById('idea-revisions-mount');
+      if (ideaRevisionsMount && OL.renderRevisionsSection) {
+        OL.renderRevisionsSection(ideaRevisionsMount, { type: 'idea', id: idea.id });
+      }
+      var ideaCommentsMount = document.getElementById('idea-comments-mount');
+      if (ideaCommentsMount && OL.renderCommentsSection) {
+        OL.renderCommentsSection(ideaCommentsMount, { type: 'idea', id: idea.id });
+      }
 
       // Bind manifest links — click to navigate to manifest
       bodyEl.querySelectorAll('.manifest-link').forEach(function(el) {


### PR DESCRIPTION
## Summary
Ideas were the ugly duckling: boxy cards + wall-of-text body + no edit history. Now they use the **same mechanism** as every other entity.

**UI**
- Idea list renders via \`OL.renderTree\` — compact single-line peer→idea rows, same as memories.
- Idea detail mirrors product/manifest/task: breadcrumb, meta bar, top toolbar, History card right under toolbar, description (pre-wrap), linked manifests, comments mount.

**Description versioning extended to ideas**
- \`comments.TargetIdea\` + CHECK constraint updated, idempotent migration for existing DBs.
- Node helpers (\`RecordDescriptionChange\`, \`currentDescription\`, \`writeEntityDescription\`) now dispatch to ideas.
- HTTP \`/api/ideas/:id/{comments,description/history,description/revisions/:cid,description/restore/:cid}\`.
- MCP \`description_history\` / \`description_get_revision\` / \`description_restore\` accept \`target_type='idea'\`.
- \`apiIdeaUpdate\` + MCP \`handleIdeaUpdate\` record a revision before the denormalised UPDATE.

No custom markdown renderer, no idea-specific styling — one mechanism everywhere.

## Test plan
- [x] \`go build ./...\` and \`go test ./...\` — all green
- [x] \`node --check\` on modified JS
- [ ] Manual: open Ideas tab; list renders compact tree; detail shows History above description; edit an idea description → revision appears in History; Restore works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)