### PR TITLE
feat(ideas): inline Edit toolbar + DV backfill extends to ideas

### DIFF
--- a/internal/comments/backfill.go
+++ b/internal/comments/backfill.go
@@ -19,11 +19,13 @@ type BackfillReport struct {
 	ManifestsSkipped  int
 	TasksSeeded       int
 	TasksSkipped      int
+	IdeasSeeded       int
+	IdeasSkipped      int
 }
 
 // Total returns the total number of rows that would be (or were) inserted.
 func (r BackfillReport) Total() int {
-	return r.ProductsSeeded + r.ManifestsSeeded + r.TasksSeeded
+	return r.ProductsSeeded + r.ManifestsSeeded + r.TasksSeeded + r.IdeasSeeded
 }
 
 // BackfillDescriptionRevisions seeds one description_revision comment per
@@ -101,6 +103,25 @@ func BackfillDescriptionRevisions(ctx context.Context, db *sql.DB, apply bool) (
 		}
 	}
 
+	// Ideas (added when idea was promoted to a full DV target type —
+	// missing from the original DV/M1 backfill because ideas weren't
+	// in scope at that time).
+	ideaRows, err := queryBackfillIdeas(ctx, db)
+	if err != nil {
+		return rep, fmt.Errorf("query ideas: %w", err)
+	}
+	for _, r := range ideaRows {
+		ok, err := seedRevision(ctx, db, apply, "idea", r.id, r.author, r.body, r.updatedStr)
+		if err != nil {
+			return rep, err
+		}
+		if ok {
+			rep.IdeasSeeded++
+		} else {
+			rep.IdeasSkipped++
+		}
+	}
+
 	return rep, nil
 }
 
@@ -143,6 +164,19 @@ func queryBackfillTasks(ctx context.Context, db *sql.DB) ([]backfillRow, error) 
 	rows, err := db.QueryContext(ctx, `
 		SELECT id, COALESCE(source_node, ''), COALESCE(description, ''), COALESCE(updated_at, '')
 		FROM tasks
+		WHERE COALESCE(deleted_at, '') = ''
+		  AND COALESCE(description, '') <> ''`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanBackfillRows(rows)
+}
+
+func queryBackfillIdeas(ctx context.Context, db *sql.DB) ([]backfillRow, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT id, COALESCE(source_node, ''), COALESCE(description, ''), COALESCE(updated_at, '')
+		FROM ideas
 		WHERE COALESCE(deleted_at, '') = ''
 		  AND COALESCE(description, '') <> ''`)
 	if err != nil {

--- a/internal/comments/backfill_test.go
+++ b/internal/comments/backfill_test.go
@@ -56,6 +56,13 @@ func createEntityTables(t *testing.T, db *sql.DB) {
 			updated_at TEXT NOT NULL DEFAULT '',
 			deleted_at TEXT NOT NULL DEFAULT ''
 		)`,
+		`CREATE TABLE ideas (
+			id TEXT PRIMARY KEY, title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			source_node TEXT NOT NULL DEFAULT '',
+			updated_at TEXT NOT NULL DEFAULT '',
+			deleted_at TEXT NOT NULL DEFAULT ''
+		)`,
 	}
 	for _, s := range schemas {
 		if _, err := db.Exec(s); err != nil {

--- a/internal/web/ui/views/ideas.js
+++ b/internal/web/ui/views/ideas.js
@@ -147,11 +147,21 @@
             '<button class="btn-copy" onclick="OL.copy(\'get idea ' + idea.marker + '\')" title="Copy ref" aria-label="Copy reference">&#x2398;</button>' +
           '</div>' +
           '<div class="toolbar-row">' +
+            '<button id="idea-toolbar-edit" class="btn-search btn-action">&#9998; Edit</button>' +
             '<button class="btn-search btn-action promote-idea-btn">+ Create Manifest from Idea</button>' +
             '<button class="btn-dismiss btn-action" onclick="OL.archiveIdea(\'' + esc(idea.id) + '\')">Archive</button>' +
           '</div>' +
           '<div id="idea-revisions-mount" style="margin-bottom:12px"></div>' +
-          (idea.description ? '<div style="font-size:13px;color:var(--text-secondary);line-height:1.6;margin-bottom:12px;white-space:pre-wrap">' + esc(idea.description) + '</div>' : '') +
+          '<div id="idea-desc-display" style="font-size:13px;color:var(--text-secondary);line-height:1.6;margin-bottom:12px;white-space:pre-wrap">' +
+            (idea.description ? esc(idea.description) : '<span style="color:var(--text-muted);font-style:italic">No description — click Edit to add</span>') +
+          '</div>' +
+          '<div id="idea-desc-editor" style="display:none;margin-bottom:12px">' +
+            '<textarea id="idea-desc-textarea" class="conv-search" style="width:100%;min-height:240px;font-family:var(--font-mono);font-size:13px;padding:10px;resize:vertical;line-height:1.5">' + esc(idea.description || '') + '</textarea>' +
+            '<div style="margin-top:6px;display:flex;gap:8px">' +
+              '<button id="idea-desc-save" class="btn-search" style="padding:4px 16px;font-size:12px">Save</button>' +
+              '<button id="idea-desc-cancel" class="btn-dismiss" style="padding:4px 12px;font-size:12px">Cancel</button>' +
+            '</div>' +
+          '</div>' +
           linkedHtml +
           '<div id="idea-comments-mount" style="margin-top:16px"></div>' +
           '<div style="margin-top:16px;padding-top:12px;border-top:1px solid var(--border);font-size:11px;color:var(--text-muted)">' +
@@ -166,6 +176,36 @@
       var ideaCommentsMount = document.getElementById('idea-comments-mount');
       if (ideaCommentsMount && OL.renderCommentsSection) {
         OL.renderCommentsSection(ideaCommentsMount, { type: 'idea', id: idea.id });
+      }
+
+      // Toolbar Edit → toggle inline textarea; Save PUTs /api/ideas/:id
+      // which records a description_revision before the denormalised UPDATE.
+      var editBtn = document.getElementById('idea-toolbar-edit');
+      var descDisplay = document.getElementById('idea-desc-display');
+      var descEditor = document.getElementById('idea-desc-editor');
+      var descTextarea = document.getElementById('idea-desc-textarea');
+      if (editBtn && descDisplay && descEditor) {
+        OL.onView(editBtn, 'click', function() {
+          descDisplay.style.display = 'none';
+          descEditor.style.display = 'block';
+          if (descTextarea) descTextarea.focus();
+        });
+        OL.onView(document.getElementById('idea-desc-cancel'), 'click', function() {
+          descEditor.style.display = 'none';
+          descDisplay.style.display = '';
+          if (descTextarea) descTextarea.value = idea.description || '';
+        });
+        OL.onView(document.getElementById('idea-desc-save'), 'click', async function() {
+          var val = descTextarea ? descTextarea.value : '';
+          var resp = await fetch('/api/ideas/' + idea.id, {
+            method: 'PUT',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({ description: val })
+          });
+          if (!resp.ok) { alert('Save failed: HTTP ' + resp.status); return; }
+          OL.loadIdeas();
+          OL.loadIdea(idea.id);
+        });
       }
 
       // Bind manifest links — click to navigate to manifest


### PR DESCRIPTION
## Summary
- **Inline Edit** on idea detail. Toolbar Edit button toggles a textarea editor; Save PUTs \`/api/ideas/:id\` which records a description_revision before the denormalised UPDATE. Versioning is automatic — same wiring as the other three entities.
- **Backfill extended to ideas**. \`BackfillDescriptionRevisions\` now seeds a v1 revision for every existing idea with a non-empty description. Report gains IdeasSeeded / IdeasSkipped counts. Idempotent re-runs.

Together with #187, ideas are a full citizen in description versioning — editable, versioned, restorable, and backfillable identically to products / manifests / tasks.

## Test plan
- [x] \`go build ./...\` and \`go test ./...\` — all green
- [x] \`node --check\` on modified JS
- [x] Backfill test covers ideas table

🤖 Generated with [Claude Code](https://claude.com/claude-code)