### PR TITLE
chore(release): v0.4.0 — bump Makefile version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build clean run test help
 
-VERSION ?= 0.3.0
+VERSION ?= 0.4.0
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS = -ldflags "-X github.com/k8nstantin/OpenPraxis/cmd.Version=$(VERSION) \


### PR DESCRIPTION
Bumps `VERSION ?= 0.3.0` → `0.4.0`. Once merged, tag `v0.4.0` will trigger the release workflow to build binaries for darwin/arm64 + linux/amd64 and draft a GitHub Release.

See commit message for the changelog.