### PR TITLE
fix(ui): EasyMDE dark theme + bounded editor sizing

### DIFF
--- a/internal/web/ui/components/editor.js
+++ b/internal/web/ui/components/editor.js
@@ -52,14 +52,21 @@
       };
     }
 
+    // Bound the editor so it never takes over the panel. minHeight gives
+    // a comfortable default, maxHeight caps growth — content beyond that
+    // scrolls inside the editor pane, not the dashboard.
+    // Reasonable defaults — operators can expand via the fullscreen
+    // toolbar button (F11) or drag the editor pane via the splitter.
+    var defaultMin = opts.compact ? '80px' : '180px';
+    var defaultMax = opts.compact ? '220px' : '40vh';
     var instance = new EasyMDE({
       element: textarea,
-      autofocus: opts.autofocus !== false,
+      autofocus: opts.autofocus === true, // off by default — autofocus scrolls the page
       placeholder: opts.placeholder || '',
       spellChecker: opts.spellChecker === true, // off by default — too noisy on code/markers
-      status: opts.status === true ? ['lines', 'words'] : false,
-      minHeight: opts.minHeight || (opts.compact ? '120px' : '40vh'),
-      maxHeight: opts.maxHeight || (opts.compact ? '320px' : ''),
+      status: false,
+      minHeight: opts.minHeight || defaultMin,
+      maxHeight: opts.maxHeight || defaultMax,
       toolbar: opts.toolbar || (opts.compact ? COMPACT_TOOLBAR : FULL_TOOLBAR),
       sideBySideFullscreen: false,
       forceSync: true, // mirror to underlying textarea on every keystroke

--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -6,9 +6,10 @@
   <title>OpenPraxis</title>
   <link rel="icon" type="image/png" href="/assets/openpraxis-icon.png">
   <link rel="apple-touch-icon" href="/assets/openpraxis-icon.png">
+  <!-- EasyMDE first so our dark-theme overrides in style.css win the cascade. -->
+  <link rel="stylesheet" href="/vendor/easymde.min.css">
   <link rel="stylesheet" href="/style.css">
   <link rel="stylesheet" href="/components/comments.css">
-  <link rel="stylesheet" href="/vendor/easymde.min.css">
   <!-- Cytoscape + dagre served locally, not from CDN. If these fail to load
        the product DAG overlay is non-functional; the rest of the dashboard
        is unaffected. Pinned: cytoscape 3.30.4, dagre 0.8.5, cytoscape-dagre 2.5.0.

--- a/internal/web/ui/style.css
+++ b/internal/web/ui/style.css
@@ -1418,66 +1418,84 @@ mark {
 .product-edit-actions .btn-dismiss { padding: 8px 22px; font-size: 13px; }
 .product-edit-form .form-label-compact { font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em; font-weight: 600; }
 
-/* EasyMDE dark-theme overrides — keep the shipped light styles isolated
-   to the editor mount and re-skin to match the dashboard palette. */
-.EasyMDEContainer { color: var(--text-primary); }
+/* EasyMDE dark-theme overrides + visible container boundary.
+   `!important` on the toolbar/codemirror chrome because EasyMDE's bundled
+   easymde.min.css is aggressive (lots of inline styles + high-specificity
+   selectors). We keep the overrides scoped to .EasyMDEContainer so they
+   never bleed into the rest of the dashboard. */
+.EasyMDEContainer {
+  color: var(--text-primary) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: 6px !important;
+  background: var(--bg-input) !important;
+  margin-bottom: 8px !important;
+}
 .EasyMDEContainer .editor-toolbar {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
-  border-bottom: none;
-  border-top-left-radius: 6px;
-  border-top-right-radius: 6px;
-  opacity: 1;
+  background: var(--bg-secondary) !important;
+  border: none !important;
+  border-bottom: 1px solid var(--border) !important;
+  border-top-left-radius: 6px !important;
+  border-top-right-radius: 6px !important;
+  opacity: 1 !important;
+  padding: 6px 8px !important;
 }
 .EasyMDEContainer .editor-toolbar button {
   color: var(--text-secondary) !important;
-  border-color: transparent;
+  border-color: transparent !important;
+  background: transparent !important;
 }
 .EasyMDEContainer .editor-toolbar button:hover,
 .EasyMDEContainer .editor-toolbar button.active {
-  background: var(--bg-input);
-  border-color: var(--border);
+  background: var(--bg-input) !important;
+  border-color: var(--border) !important;
   color: var(--text-primary) !important;
 }
+.EasyMDEContainer .editor-toolbar a,
+.EasyMDEContainer .editor-toolbar i { color: var(--text-secondary) !important; }
 .EasyMDEContainer .editor-toolbar i.separator {
-  border-left: 1px solid var(--border);
-  border-right: none;
+  border-left: 1px solid var(--border) !important;
+  border-right: none !important;
+  color: transparent !important;
 }
 .EasyMDEContainer .CodeMirror {
-  background: var(--bg-input);
-  color: var(--text-primary);
-  border: 1px solid var(--border);
-  border-radius: 0;
-  font-family: var(--font-mono);
-  font-size: 13px;
-  line-height: 1.55;
+  background: var(--bg-input) !important;
+  color: var(--text-primary) !important;
+  border: none !important;
+  border-bottom-left-radius: 6px !important;
+  border-bottom-right-radius: 6px !important;
+  font-family: var(--font-mono) !important;
+  font-size: 13px !important;
+  line-height: 1.55 !important;
 }
-.EasyMDEContainer .CodeMirror-cursor { border-left-color: var(--accent); }
+.EasyMDEContainer .CodeMirror-scroll { background: var(--bg-input) !important; }
+.EasyMDEContainer .CodeMirror-gutters { background: var(--bg-secondary) !important; border-right: 1px solid var(--border) !important; }
+.EasyMDEContainer .CodeMirror-cursor { border-left-color: var(--accent) !important; }
 .EasyMDEContainer .CodeMirror-selected { background: rgba(70, 130, 240, 0.25) !important; }
-.EasyMDEContainer .CodeMirror-line { color: var(--text-primary); }
-.EasyMDEContainer .cm-header { color: var(--accent); font-weight: 700; }
-.EasyMDEContainer .cm-strong { color: var(--text-primary); font-weight: 700; }
-.EasyMDEContainer .cm-em { color: var(--yellow); font-style: italic; }
-.EasyMDEContainer .cm-link { color: var(--accent); }
-.EasyMDEContainer .cm-url { color: var(--text-muted); }
-.EasyMDEContainer .cm-comment, .EasyMDEContainer .cm-quote { color: var(--green); }
-.EasyMDEContainer .cm-formatting { color: var(--text-muted); }
-.EasyMDEContainer .cm-hr { color: var(--text-muted); }
+.EasyMDEContainer .CodeMirror-line { color: var(--text-primary) !important; }
+.EasyMDEContainer .cm-header { color: var(--accent) !important; font-weight: 700; }
+.EasyMDEContainer .cm-strong { color: var(--text-primary) !important; font-weight: 700; }
+.EasyMDEContainer .cm-em { color: var(--yellow) !important; font-style: italic; }
+.EasyMDEContainer .cm-link { color: var(--accent) !important; }
+.EasyMDEContainer .cm-url { color: var(--text-muted) !important; }
+.EasyMDEContainer .cm-comment, .EasyMDEContainer .cm-quote { color: var(--green) !important; }
+.EasyMDEContainer .cm-formatting { color: var(--text-muted) !important; }
+.EasyMDEContainer .cm-hr { color: var(--text-muted) !important; }
 .EasyMDEContainer .editor-preview-side,
 .EasyMDEContainer .editor-preview {
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  border: 1px solid var(--border);
-  font-family: var(--font-base, system-ui, sans-serif);
-  font-size: 14px;
-  line-height: 1.6;
+  background: var(--bg-secondary) !important;
+  color: var(--text-primary) !important;
+  border: none !important;
+  border-left: 1px solid var(--border) !important;
+  font-family: var(--font-base, system-ui, sans-serif) !important;
+  font-size: 14px !important;
+  line-height: 1.6 !important;
 }
 .EasyMDEContainer .editor-preview pre,
 .EasyMDEContainer .editor-preview code {
-  background: var(--bg-input);
-  color: var(--text-primary);
-  font-family: var(--font-mono);
+  background: var(--bg-input) !important;
+  color: var(--text-primary) !important;
+  font-family: var(--font-mono) !important;
 }
-.EasyMDEContainer .editor-statusbar { color: var(--text-muted); }
-.EasyMDEContainer .CodeMirror-fullscreen,
-.EasyMDEContainer .editor-preview-side { background: var(--bg-primary); }
+.EasyMDEContainer .editor-statusbar { color: var(--text-muted) !important; background: var(--bg-secondary) !important; }
+.EasyMDEContainer .CodeMirror-fullscreen { background: var(--bg-primary) !important; z-index: 100; }
+.EasyMDEContainer .editor-preview-side-onleft { border-left: none !important; border-right: 1px solid var(--border) !important; }


### PR DESCRIPTION
Hot-fix on the freshly-merged Unified Editor (PR #191):

- **CSS load order:** easymde.min.css now loads BEFORE style.css so our dark-theme overrides actually win the cascade. Adds `!important` to the override block so the dashboard palette always wins inside `.EasyMDEContainer`.
- **Editor size:** dropped default minHeight from 40vh → 180px and added maxHeight 40vh cap. Compact (comments) mode is 80px–220px. Users hit F11/fullscreen to expand.
- **Visible boundary:** container gets a border + radius so the editor reads as a bounded box, not a free-floating takeover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)