### PR TITLE
fix(ui): editor — truly identical everywhere (kill compact variant)

### DIFF
--- a/internal/web/ui/components/editor.js
+++ b/internal/web/ui/components/editor.js
@@ -70,14 +70,13 @@
     // can target it.
     if (!textarea.id) textarea.id = nextId('ol-md-textarea');
 
-    // Mark the textarea so our CSS can theme it consistently across
-    // the dashboard regardless of the call site's own classes.
+    // Mark the textarea so our CSS themes it consistently across the
+    // dashboard regardless of the call site's own classes. NO per-site
+    // variants — same toolbar, same height, same look everywhere.
     textarea.classList.add('ol-md-textarea');
-    if (opts.compact) textarea.classList.add('ol-md-textarea-compact');
 
-    // Build wrapper: toolbar above + textarea below.
     var wrapper = document.createElement('div');
-    wrapper.className = 'ol-md-wrapper' + (opts.compact ? ' ol-md-wrapper-compact' : '');
+    wrapper.className = 'ol-md-wrapper';
     var toolbarHTML = renderToolbar(textarea.id, ACTIONS);
     wrapper.innerHTML = toolbarHTML;
 

--- a/internal/web/ui/style.css
+++ b/internal/web/ui/style.css
@@ -1480,5 +1480,3 @@ mark {
 .ol-md-textarea:focus {
   box-shadow: inset 0 0 0 2px var(--accent);
 }
-.ol-md-textarea-compact { min-height: 90px; }
-.ol-md-wrapper-compact .ol-md-toolbar { padding: 4px 6px; }


### PR DESCRIPTION
Drops the last per-call-site variant. Comments composer and descriptions now have **identical** toolbar AND identical min-height. Same look everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)