### PR TITLE
feat(ui): markdown render consistency — goldmark across all entity bodies (MRC/M1)

### DIFF
--- a/internal/web/handlers_comments.go
+++ b/internal/web/handlers_comments.go
@@ -31,6 +31,30 @@ var markdownRenderer = goldmark.New(
 	),
 )
 
+// EnrichWithHTML augments an entity payload with rendered HTML fields so
+// the dashboard can show formatted markdown in product / manifest / task /
+// idea bodies — same goldmark pipeline comments already use. The caller
+// passes an entity struct + a map of {output_key: raw_markdown}; the
+// returned map carries every JSON field of the entity plus an extra
+// `<output_key>_html` key per pair.
+//
+// Example: EnrichWithHTML(product, map[string]string{"description": p.Description})
+// adds `description_html` to the response payload.
+func EnrichWithHTML(entity any, mdFields map[string]string) map[string]any {
+	data, err := json.Marshal(entity)
+	if err != nil {
+		return nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil
+	}
+	for outKey, raw := range mdFields {
+		out[outKey+"_html"] = renderMarkdown(raw)
+	}
+	return out
+}
+
 // renderMarkdown converts a raw comment body to safe HTML. Returns the raw
 // body wrapped in a <p> on goldmark error so the UI always has something to
 // display.

--- a/internal/web/handlers_idea.go
+++ b/internal/web/handlers_idea.go
@@ -95,7 +95,7 @@ func apiIdeaGet(n *node.Node) http.HandlerFunc {
 			http.Error(w, "not found", 404)
 			return
 		}
-		writeJSON(w, i)
+		writeJSON(w, EnrichWithHTML(i, map[string]string{"description": i.Description}))
 	}
 }
 

--- a/internal/web/handlers_manifest.go
+++ b/internal/web/handlers_manifest.go
@@ -118,7 +118,13 @@ func apiManifestGet(n *node.Node) http.HandlerFunc {
 			writeError(w, "not found", 404)
 			return
 		}
-		writeJSON(w, enrichManifest(n, m))
+		// Single GET enriches with rendered HTML for the body fields so
+		// the dashboard renders formatted markdown. List endpoints stay
+		// lean (no HTML render per row).
+		writeJSON(w, EnrichWithHTML(enrichManifest(n, m), map[string]string{
+			"content":     m.Content,
+			"description": m.Description,
+		}))
 	}
 }
 

--- a/internal/web/handlers_product.go
+++ b/internal/web/handlers_product.go
@@ -109,7 +109,7 @@ func apiProductGet(n *node.Node) http.HandlerFunc {
 			http.Error(w, "not found", 404)
 			return
 		}
-		writeJSON(w, p)
+		writeJSON(w, EnrichWithHTML(p, map[string]string{"description": p.Description}))
 	}
 }
 

--- a/internal/web/handlers_task.go
+++ b/internal/web/handlers_task.go
@@ -198,7 +198,7 @@ func apiTaskGet(n *node.Node) http.HandlerFunc {
 			writeError(w, "not found", 404)
 			return
 		}
-		writeJSON(w, t)
+		writeJSON(w, EnrichWithHTML(t, map[string]string{"description": t.Description}))
 	}
 }
 

--- a/internal/web/ui/style.css
+++ b/internal/web/ui/style.css
@@ -1480,3 +1480,28 @@ mark {
 .ol-md-textarea:focus {
   box-shadow: inset 0 0 0 2px var(--accent);
 }
+
+/* Rendered markdown body — used wherever an entity description / content
+   is shown after goldmark renders it server-side. Same look across
+   product / manifest / task / idea so operators see consistent typography. */
+.md-body { font-size: 13px; line-height: 1.6; color: var(--text-primary); word-break: break-word; }
+.md-body h1, .md-body h2, .md-body h3, .md-body h4 { color: var(--text-primary); margin: 14px 0 6px; line-height: 1.3; font-weight: 600; }
+.md-body h1 { font-size: 18px; }
+.md-body h2 { font-size: 16px; color: var(--accent); }
+.md-body h3 { font-size: 14px; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em; }
+.md-body h4 { font-size: 13px; color: var(--text-muted); }
+.md-body p { margin: 0 0 8px; }
+.md-body p:last-child { margin-bottom: 0; }
+.md-body strong { color: var(--text-primary); font-weight: 700; }
+.md-body em { color: var(--yellow); font-style: italic; }
+.md-body a { color: var(--accent); text-decoration: underline; }
+.md-body code { background: var(--bg-primary); padding: 1px 6px; border-radius: 3px; font-family: var(--font-mono); font-size: 12px; color: var(--text-primary); }
+.md-body pre { background: var(--bg-primary); padding: 10px 12px; border-radius: 4px; overflow-x: auto; margin: 8px 0; border: 1px solid var(--border); }
+.md-body pre code { background: transparent; padding: 0; font-size: 12px; }
+.md-body blockquote { border-left: 3px solid var(--border); padding: 4px 12px; margin: 8px 0; color: var(--text-secondary); background: var(--bg-secondary); }
+.md-body ul, .md-body ol { margin: 6px 0 8px 22px; padding: 0; }
+.md-body li { margin: 2px 0; }
+.md-body table { border-collapse: collapse; margin: 8px 0; }
+.md-body th, .md-body td { border: 1px solid var(--border); padding: 4px 8px; font-size: 12px; }
+.md-body th { background: var(--bg-secondary); font-weight: 600; }
+.md-body hr { border: none; border-top: 1px solid var(--border); margin: 12px 0; }

--- a/internal/web/ui/views/ideas.js
+++ b/internal/web/ui/views/ideas.js
@@ -152,8 +152,8 @@
             '<button class="btn-dismiss btn-action" onclick="OL.archiveIdea(\'' + esc(idea.id) + '\')">Archive</button>' +
           '</div>' +
           '<div id="idea-revisions-mount" style="margin-bottom:12px"></div>' +
-          '<div id="idea-desc-display" style="font-size:13px;color:var(--text-secondary);line-height:1.6;margin-bottom:12px;white-space:pre-wrap">' +
-            (idea.description ? esc(idea.description) : '<span style="color:var(--text-muted);font-style:italic">No description — click Edit to add</span>') +
+          '<div id="idea-desc-display" class="md-body" style="margin-bottom:12px">' +
+            (idea.description ? (idea.description_html || esc(idea.description)) : '<span style="color:var(--text-muted);font-style:italic">No description — click Edit to add</span>') +
           '</div>' +
           '<div id="idea-desc-editor" style="display:none;margin-bottom:12px">' +
             '<textarea id="idea-desc-textarea" class="conv-search" style="width:100%;min-height:240px;font-family:var(--font-mono);font-size:13px;padding:10px;resize:vertical;line-height:1.5">' + esc(idea.description || '') + '</textarea>' +

--- a/internal/web/ui/views/manifests.js
+++ b/internal/web/ui/views/manifests.js
@@ -457,11 +457,11 @@
             <span>Created: ${new Date(m.created_at).toLocaleString()}</span>
             <span>Updated: ${new Date(m.updated_at).toLocaleString()}</span>
           </div>
-          <div id="manifest-edit-desc" class="manifest-editable" style="font-size:13px;color:var(--text-secondary);margin-bottom:12px;padding:4px;border-radius:4px;cursor:pointer" title="Click to edit description">${esc(m.description) || '<span style="color:var(--text-muted);font-style:italic">No description — click to add</span>'}</div>
+          <div id="manifest-edit-desc" class="manifest-editable md-body" style="margin-bottom:12px;padding:4px;border-radius:4px;cursor:pointer" title="Click to edit description">${m.description_html || esc(m.description) || '<span style="color:var(--text-muted);font-style:italic">No description — click to add</span>'}</div>
           <div style="margin-bottom:4px">
             <span style="font-size:12px;color:var(--text-muted);font-weight:500">Spec / Content</span>
           </div>
-          <div id="manifest-content-display" class="manifest-content">${esc(m.content)}</div>
+          <div id="manifest-content-display" class="manifest-content md-body">${m.content_html || esc(m.content)}</div>
           <div id="manifest-content-editor" style="display:none;margin-bottom:12px">
             <textarea id="manifest-content-textarea" class="conv-search" style="width:100%;min-height:300px;font-family:monospace;font-size:13px;padding:12px;resize:vertical;line-height:1.5">${esc(m.content)}</textarea>
             <div style="margin-top:6px;display:flex;gap:8px">

--- a/internal/web/ui/views/products.js
+++ b/internal/web/ui/views/products.js
@@ -378,7 +378,7 @@
             }).join('')}
           </div>
           <div id="product-revisions-mount" style="margin-bottom:12px"></div>
-          ${p.description ? `<div style="font-size:13px;color:var(--text-secondary);line-height:1.6;margin-bottom:12px;white-space:pre-wrap">${esc(p.description)}</div>` : ''}
+          ${p.description ? `<div class="md-body" style="margin-bottom:12px">${p.description_html || esc(p.description)}</div>` : ''}
           ${productDepsHtml}
           ${manifestsHtml}
           <div id="product-knobs-mount" style="margin-top:16px"></div>

--- a/internal/web/ui/views/tasks.js
+++ b/internal/web/ui/views/tasks.js
@@ -477,7 +477,7 @@
             </div>
             <div id="task-instructions-display">
               ${t.description
-                ? `<div style="font-size:13px;color:var(--text-secondary);padding:10px 12px;border:1px solid var(--border);border-radius:6px;background:var(--bg-secondary);white-space:pre-wrap;word-break:break-word;font-family:var(--font-mono);line-height:1.5;max-height:400px;overflow-y:auto">${esc(t.description)}</div>`
+                ? `<div class="md-body" style="padding:10px 12px;border:1px solid var(--border);border-radius:6px;background:var(--bg-secondary);max-height:400px;overflow-y:auto">${t.description_html || esc(t.description)}</div>`
                 : `<div style="font-size:12px;color:var(--text-muted);font-style:italic">No instructions</div>`}
             </div>
             <div id="task-instructions-editor" style="display:none">


### PR DESCRIPTION
Operators saw raw markdown for product / manifest / task / idea bodies (literal `**bold**`). Comments were already rendered via goldmark — now everything matches.

- Server: new `EnrichWithHTML` helper, four GET endpoints add `<field>_html` keys.
- Frontend: views inject `<entity>.<field>_html` via innerHTML (with esc fallback). New `.md-body` CSS class for consistent typography.

Same goldmark pipeline comments use, zero new deps. Implements MRC/M1 in product `019dba67-940`.

Puppeteer-verified: `<strong>`, `<code>`, `<p>` all render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)