### PR TITLE
feat(task): add task_set_manifest — swap a task's primary manifest_id

### DIFF
--- a/internal/mcp/tools_task.go
+++ b/internal/mcp/tools_task.go
@@ -98,6 +98,15 @@ func (s *Server) registerTaskTools() {
 	)
 
 	s.mcp.AddTool(
+		mcplib.NewTool("task_set_manifest",
+			mcplib.WithDescription("Swap a task's PRIMARY manifest_id (the column on tasks.manifest_id, NOT the many-to-many task_manifests link table that task_link_manifest writes). Used to re-home a task when manifests are split / merged / restructured."),
+			mcplib.WithString("task_id", mcplib.Required(), mcplib.Description("Task ID or marker")),
+			mcplib.WithString("manifest_id", mcplib.Required(), mcplib.Description("New primary manifest ID or marker")),
+		),
+		s.handleTaskSetManifest,
+	)
+
+	s.mcp.AddTool(
 		mcplib.NewTool("task_pause",
 			mcplib.WithDescription("Pause a running task. Sends SIGSTOP to the agent process, freezing it in place. The task can be resumed later."),
 			mcplib.WithString("id", mcplib.Required(), mcplib.Description("Task ID or marker")),
@@ -400,6 +409,29 @@ func (s *Server) handleTaskLinkManifest(ctx context.Context, req mcplib.CallTool
 	}
 
 	return textResult(fmt.Sprintf("Linked: task [%s] %s → manifest [%s] %s",
+		t.Marker, t.Title, m.Marker, m.Title)), nil
+}
+
+func (s *Server) handleTaskSetManifest(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := args(req)
+	taskID := argStr(a, "task_id")
+	manifestID := argStr(a, "manifest_id")
+
+	t, err := s.node.Tasks.Get(taskID)
+	if err != nil || t == nil {
+		return errResult("task not found: %s", taskID), nil
+	}
+
+	m, err := s.node.Manifests.Get(manifestID)
+	if err != nil || m == nil {
+		return errResult("manifest not found: %s", manifestID), nil
+	}
+
+	if _, err := s.node.Tasks.SetManifest(t.ID, m.ID); err != nil {
+		return errResult("set manifest failed: %v", err), nil
+	}
+
+	return textResult(fmt.Sprintf("Task [%s] %s primary manifest set → [%s] %s",
 		t.Marker, t.Title, m.Marker, m.Title)), nil
 }
 

--- a/internal/task/repository.go
+++ b/internal/task/repository.go
@@ -243,6 +243,23 @@ func (s *Store) Update(id string, title, description *string) (*Task, error) {
 	return s.Get(id)
 }
 
+// SetManifest swaps a task's primary manifest_id. Used to re-home a task
+// when an operator splits / restructures manifests after the task was
+// originally created (e.g. ELS atomic split moved 12 tasks under 6 new
+// implementation manifests). The id may be a marker or full UUID. Returns
+// the task as it stands after the update.
+func (s *Store) SetManifest(taskID, manifestID string) (*Task, error) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.Exec(
+		"UPDATE tasks SET manifest_id = ?, updated_at = ? WHERE (id = ? OR id LIKE ?) AND deleted_at = ''",
+		manifestID, now, taskID, taskID+"%",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("set manifest: %w", err)
+	}
+	return s.Get(taskID)
+}
+
 // UpdateStatus changes a task's status, validating the transition against
 // the canonical state machine in status.go. Returns the same validation
 // error surface ValidateTransition produces when the move is illegal — the

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -186,6 +186,7 @@ func Handler(n *node.Node, mcpServer *mcp.Server, hub *Hub, peerRegistry *peer.R
 	api.HandleFunc("/tasks/{id}/output", apiTaskOutput(n)).Methods("GET")
 	api.HandleFunc("/tasks/{id}/link-manifest", apiTaskLinkManifest(n)).Methods("POST")
 	api.HandleFunc("/tasks/{id}/unlink-manifest", apiTaskUnlinkManifest(n)).Methods("POST")
+	api.HandleFunc("/tasks/{id}/set-manifest", apiTaskSetManifest(n)).Methods("PUT")
 	api.HandleFunc("/tasks/{id}/manifests", apiTaskManifests(n)).Methods("GET")
 	api.HandleFunc("/tasks/{id}/dependency", apiTaskSetDependency(n)).Methods("PUT")
 	api.HandleFunc("/visceral/by-peer", apiVisceralByPeer(n)).Methods("GET")

--- a/internal/web/handlers_task.go
+++ b/internal/web/handlers_task.go
@@ -336,6 +336,44 @@ func apiTaskRunGet(n *node.Node) http.HandlerFunc {
 	}
 }
 
+// apiTaskSetManifest swaps a task's primary manifest_id (the column on
+// tasks.manifest_id, NOT the many-to-many task_manifests join table that
+// LinkManifest writes). Used by the dashboard / MCP to re-home tasks
+// when manifests are split or merged.
+func apiTaskSetManifest(n *node.Node) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		taskID := mux.Vars(r)["id"]
+		var req struct {
+			ManifestID string `json:"manifest_id"`
+		}
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		if req.ManifestID == "" {
+			writeError(w, "manifest_id is required", 400)
+			return
+		}
+		t, err := n.Tasks.Get(taskID)
+		if err != nil || t == nil {
+			writeError(w, "task not found", 404)
+			return
+		}
+		// Resolve marker → full UUID so the column always carries the
+		// canonical id.
+		fullID, errMsg := resolveManifestID(n, req.ManifestID)
+		if errMsg != "" {
+			writeError(w, errMsg, 404)
+			return
+		}
+		updated, err := n.Tasks.SetManifest(t.ID, fullID)
+		if err != nil {
+			writeError(w, err.Error(), 500)
+			return
+		}
+		writeJSON(w, updated)
+	}
+}
+
 func apiTaskLinkManifest(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		taskID := mux.Vars(r)["id"]


### PR DESCRIPTION
Adds a small admin capability to re-home a task when manifests are split / merged / restructured. Distinct from `task_link_manifest` (many-to-many join table); this swaps the canonical `tasks.manifest_id` column.

- `Tasks.SetManifest(taskID, manifestID)` in the store
- `PUT /api/tasks/:id/set-manifest` with body `{manifest_id}`
- `task_set_manifest` MCP tool

Used immediately by the ELS atomic split (12 tasks moving from M1 to their new I1..I6 implementation manifests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)