### PR TITLE
feat(task): persist token + model + pricing_version on task_runs; defer cost UI

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -252,7 +252,7 @@ var serveCmd = &cobra.Command{
 			if t.ManifestID != "" {
 				m, _ := n.Manifests.Get(t.ManifestID)
 				if m == nil {
-					if err := n.Tasks.RecordRun(t.ID, "manifest not found: "+t.ManifestID, "failed", 0, 0, 0, 0, time.Now()); err != nil {
+					if err := n.Tasks.RecordRun(t.ID, "manifest not found: "+t.ManifestID, "failed", 0, 0, 0, 0, time.Now(), task.Usage{}, ""); err != nil {
 					slog.Error("record run failed", "reason", "manifest not found", "error", err)
 				}
 					return
@@ -277,7 +277,7 @@ var serveCmd = &cobra.Command{
 
 			// Spawn the agent
 			if err := runner.Execute(t, manifestTitle, manifestContent, visceralText); err != nil {
-				if recErr := n.Tasks.RecordRun(t.ID, "execution error: "+err.Error(), "failed", 0, 0, 0, 0, time.Now()); recErr != nil {
+				if recErr := n.Tasks.RecordRun(t.ID, "execution error: "+err.Error(), "failed", 0, 0, 0, 0, time.Now(), task.Usage{}, ""); recErr != nil {
 					slog.Error("record run failed", "reason", "execution error", "error", recErr)
 				}
 				hub.Broadcast(web.Event{Type: "task_failed", Data: map[string]string{

--- a/internal/task/repository.go
+++ b/internal/task/repository.go
@@ -661,8 +661,19 @@ func (s *Store) ClearActionRequest(id string) error {
 	return err
 }
 
+// PricingVersion stamps the pricing table identity used to compute cost_usd
+// for a task_runs row. Increment whenever internal/task/pricing.go's rate
+// table changes so the future Unified Cost Tracking product (019dab45-d8f)
+// can re-cost historical rows under the right table — or flag drift when
+// today's rates differ from when the row was originally written.
+const PricingVersion = "v1-2026-04"
+
 // RecordRun updates run stats after a task executes and saves to run history.
-func (s *Store) RecordRun(id, output, status string, actions, lines int, costUSD float64, turns int, startedAt time.Time) error {
+// usage carries the per-token counts parsed from the agent's stream-json
+// output; they're denormalised onto task_runs so dashboards don't have to
+// re-parse the full output blob on every read. The blob remains in
+// task_runs.output as the source of truth.
+func (s *Store) RecordRun(id, output, status string, actions, lines int, costUSD float64, turns int, startedAt time.Time, usage Usage, model string) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 	// No truncation — capture full output
 	_, err := s.db.Exec(`UPDATE tasks SET run_count = run_count + 1, last_run_at = ?, last_output = ?, status = ?, updated_at = ? WHERE id = ?`,
@@ -677,9 +688,13 @@ func (s *Store) RecordRun(id, output, status string, actions, lines int, costUSD
 		slog.Warn("query run_count failed", "task_id", id, "error", err)
 	}
 
-	// Insert into task_runs history
-	_, err = s.db.Exec(`INSERT INTO task_runs (task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		id, runCount, output, status, actions, lines, costUSD, turns, startedAt.UTC().Format(time.RFC3339), now)
+	// Insert into task_runs history with full denorm (tokens + model + pricing version).
+	_, err = s.db.Exec(`INSERT INTO task_runs
+		(task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at,
+		 input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, runCount, output, status, actions, lines, costUSD, turns, startedAt.UTC().Format(time.RFC3339), now,
+		usage.InputTokens, usage.OutputTokens, usage.CacheReadTokens, usage.CacheCreationTokens, model, PricingVersion)
 	return err
 }
 

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -936,19 +936,23 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 			costUSD = rt.CumulativeCostUSD
 		}
 
-		// Calibrate model pricing from the authoritative final cost so the
-		// next run's live estimate is closer to reality. We use the result
-		// event's usage if present; otherwise fall back to the summed
-		// per-message usage we tracked during the run.
-		if costUSD > 0 {
-			var finalUsage Usage
-			if ru, ok := parseFinalResultUsage(output); ok {
-				finalUsage = ru
-			} else {
-				for _, mu := range rt.usageByMessage {
-					finalUsage = finalUsage.Add(mu)
-				}
+		// Compute final per-token usage from stream-json (preferred) or
+		// the summed per-message usage we tracked during the run. Used
+		// both for pricing calibration AND for the denormalised columns
+		// on task_runs (so dashboards / future cost recompute don't
+		// re-parse the output blob).
+		var finalUsage Usage
+		if ru, ok := parseFinalResultUsage(output); ok {
+			finalUsage = ru
+		} else {
+			for _, mu := range rt.usageByMessage {
+				finalUsage = finalUsage.Add(mu)
 			}
+		}
+
+		// Calibrate model pricing from the authoritative final cost so the
+		// next run's live estimate is closer to reality.
+		if costUSD > 0 {
 			if err := r.store.CalibrateModelPricing(rt.Model, costUSD, finalUsage); err != nil {
 				slog.Warn("calibrate model pricing failed", "component", "runner",
 					"marker", marker, "model", rt.Model, "error", err)
@@ -956,7 +960,7 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 		}
 
 		// Record the run with history — always use real status, not "scheduled"
-		if err := r.store.RecordRun(t.ID, output, status, rt.Actions, rt.Lines, costUSD, numTurns, rt.StartedAt); err != nil {
+		if err := r.store.RecordRun(t.ID, output, status, rt.Actions, rt.Lines, costUSD, numTurns, rt.StartedAt, finalUsage, rt.Model); err != nil {
 			slog.Error("record run failed", "component", "runner", "marker", marker, "error", err)
 		}
 

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -147,6 +147,17 @@ func (s *Store) init() error {
 	// Migrate: add cost_usd and turns columns to task_runs
 	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN cost_usd REAL NOT NULL DEFAULT 0`)
 	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN turns INTEGER NOT NULL DEFAULT 0`)
+	// Token + model + pricing-version denorm. Source of truth stays the
+	// raw stream-json in task_runs.output; these columns let dashboards
+	// avoid re-parsing on every read and let the future Unified Cost
+	// Tracking product (019dab45-d8f) recompute cost retroactively under
+	// a different pricing table.
+	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN input_tokens INTEGER NOT NULL DEFAULT 0`)
+	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN output_tokens INTEGER NOT NULL DEFAULT 0`)
+	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN cache_read_tokens INTEGER NOT NULL DEFAULT 0`)
+	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN cache_create_tokens INTEGER NOT NULL DEFAULT 0`)
+	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN model TEXT NOT NULL DEFAULT ''`)
+	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN pricing_version TEXT NOT NULL DEFAULT ''`)
 
 	// Running task runtime state — persists in-memory RunningTask data to survive restarts
 	_, err = s.db.Exec(`CREATE TABLE IF NOT EXISTS task_runtime_state (

--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -129,7 +129,7 @@
           <div class="panel-body" id="running-tasks-list"></div>
         </div>
 
-        <div class="metrics-grid" style="grid-template-columns:repeat(4,1fr)">
+        <div class="metrics-grid" style="grid-template-columns:repeat(3,1fr)">
           <div class="metric-card metric-card-primary" id="metric-running-card" style="cursor:pointer" role="button" tabindex="0" onclick="OL.switchView('tasks')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
             <div class="metric-value" id="metric-running" style="color:var(--green)">0</div>
             <div class="metric-label">running</div>
@@ -138,14 +138,14 @@
             <div class="metric-value" id="metric-turns-today">-</div>
             <div class="metric-label">turns today</div>
           </div>
-          <div class="metric-card metric-card-primary" id="metric-cost-card" style="cursor:pointer" role="button" tabindex="0" onclick="OL.switchView('cost-history')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
-            <div class="metric-value" id="metric-cost-today">-</div>
-            <div class="metric-label" id="metric-cost-label">cost today</div>
-          </div>
           <div class="metric-card metric-card-primary" style="cursor:pointer" role="button" tabindex="0" onclick="OL.switchView('tasks')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
             <div class="metric-value" id="metric-tasks-total">-</div>
             <div class="metric-label">tasks</div>
           </div>
+          <!-- Cost card removed pending Unified Cost Tracking product (019dab45-d8f).
+               task_runs now persists input_tokens / output_tokens / cache_read_tokens /
+               cache_creation_tokens / model / pricing_version, so cost is recomputable
+               from raw signal at any time. -->
         </div>
 
         <div class="metrics-grid metrics-grid-secondary" style="grid-template-columns:repeat(4,1fr)">

--- a/internal/web/ui/views/overview.js
+++ b/internal/web/ui/views/overview.js
@@ -27,46 +27,14 @@
     }
 
     setText('metric-turns-today', stats.turns_today ?? 0);
-    var cost = stats.cost_today ?? 0;
-    var budget = stats.daily_budget ?? 0;
-    var budgetPct = stats.budget_pct ?? 0;
-
-    // Show "$X / $Y" format when budget is set, otherwise just "$X"
-    var costValEl = document.getElementById('metric-cost-today');
-    if (budget > 0) {
-      setText('metric-cost-today', '$' + cost.toFixed(2) + ' / $' + budget.toFixed(0));
-      if (costValEl) costValEl.style.fontSize = '22px';
-    } else {
-      setText('metric-cost-today', '$' + cost.toFixed(2));
-      if (costValEl) costValEl.style.fontSize = '';
-    }
-
-    // Color logic: green < 80%, yellow 80-100%, red > 100% (with pulse)
-    var costEl = document.getElementById('metric-cost-today');
-    var costCard = document.getElementById('metric-cost-card');
-    if (costEl) {
-      if (budget > 0) {
-        if (budgetPct >= 100) {
-          costEl.style.color = 'var(--red)';
-          costEl.style.animation = 'pulse 1s infinite';
-          if (costCard) costCard.style.borderColor = 'var(--red)';
-        } else if (budgetPct >= 80) {
-          costEl.style.color = 'var(--yellow)';
-          costEl.style.animation = '';
-          if (costCard) costCard.style.borderColor = 'var(--yellow)';
-        } else {
-          costEl.style.color = 'var(--green)';
-          costEl.style.animation = '';
-          if (costCard) costCard.style.borderColor = '';
-        }
-      } else {
-        // No budget set — always green
-        costEl.style.color = 'var(--green)';
-        costEl.style.animation = '';
-        if (costCard) costCard.style.borderColor = '';
-      }
-    }
     setText('metric-tasks-total', stats.tasks_total ?? 0);
+    // Cost metric removed from the overview pending the Unified Cost
+    // Tracking product (019dab45-d8f). The two-pipeline divergence
+    // (task_runs vs claude_code_session hook) made the displayed number
+    // misleading; better to show nothing than a wrong number.
+    // task_runs now persists input_tokens / output_tokens / cache_read /
+    // cache_creation / model / pricing_version, so cost is recomputable
+    // from raw signal at any time.
 
     // Top tasks panel — hide when empty, but DO NOT early-return.
     // Pending/scheduled panel below depends on the rest of this function


### PR DESCRIPTION
Two coupled changes so cost is recomputable retroactively from raw signal, and the misleading cost meter is removed pending the proper Unified Cost Tracking product (`019dab45-d8f`).

**task_runs gets 6 new columns**: input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version. Source of truth stays the stream-json blob in `task_runs.output`; the new columns are denormalisation so dashboards don't re-parse and so future cost recompute can stamp which pricing table was used.

**Overview UI**: cost card removed (three-column grid now). The displayed "$X / $Y" was sourced from one of two cost pipelines and showed less than half of real spend; better to show nothing than a wrong number. `/cost-history` view stays for legacy partial visibility. Will return properly when `019dab45-d8f` ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)