### PR TITLE
feat(ui): Run Stats card on task detail (RS/M1)

### DIFF
--- a/internal/task/repository.go
+++ b/internal/task/repository.go
@@ -703,7 +703,7 @@ func (s *Store) ListRuns(taskID string, limit int) ([]TaskRun, error) {
 	if limit <= 0 {
 		limit = 50
 	}
-	rows, err := s.db.Query(`SELECT id, task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at
+	rows, err := s.db.Query(`SELECT id, task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at, input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version
 		FROM task_runs WHERE task_id = ? ORDER BY run_number DESC LIMIT ?`, taskID, limit)
 	if err != nil {
 		return nil, err
@@ -716,8 +716,9 @@ func (s *Store) ListRuns(taskID string, limit int) ([]TaskRun, error) {
 func (s *Store) GetRun(runID int) (*TaskRun, error) {
 	var r TaskRun
 	var startedStr, completedStr string
-	err := s.db.QueryRow(`SELECT id, task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at FROM task_runs WHERE id = ?`, runID).
-		Scan(&r.ID, &r.TaskID, &r.RunNumber, &r.Output, &r.Status, &r.Actions, &r.Lines, &r.CostUSD, &r.Turns, &startedStr, &completedStr)
+	err := s.db.QueryRow(`SELECT id, task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at, input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version FROM task_runs WHERE id = ?`, runID).
+		Scan(&r.ID, &r.TaskID, &r.RunNumber, &r.Output, &r.Status, &r.Actions, &r.Lines, &r.CostUSD, &r.Turns, &startedStr, &completedStr,
+			&r.InputTokens, &r.OutputTokens, &r.CacheReadTokens, &r.CacheCreateTokens, &r.Model, &r.PricingVersion)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -734,7 +735,7 @@ func (s *Store) ListAllRuns(since time.Time, limit int) ([]TaskRun, error) {
 	if limit <= 0 {
 		limit = 1000
 	}
-	rows, err := s.db.Query(`SELECT id, task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at
+	rows, err := s.db.Query(`SELECT id, task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at, input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version
 		FROM task_runs WHERE started_at >= ? ORDER BY started_at DESC LIMIT ?`,
 		since.UTC().Format(time.RFC3339), limit)
 	if err != nil {

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -40,17 +40,23 @@ type Task struct {
 
 // TaskRun represents a single execution of a task, preserving history.
 type TaskRun struct {
-	ID          int       `json:"id"`
-	TaskID      string    `json:"task_id"`
-	RunNumber   int       `json:"run_number"`
-	Output      string    `json:"output"`
-	Status      string    `json:"status"`
-	Actions     int       `json:"actions"`
-	Lines       int       `json:"lines"`
-	CostUSD     float64   `json:"cost_usd"`
-	Turns       int       `json:"turns"`
-	StartedAt   time.Time `json:"started_at"`
-	CompletedAt time.Time `json:"completed_at"`
+	ID                int       `json:"id"`
+	TaskID            string    `json:"task_id"`
+	RunNumber         int       `json:"run_number"`
+	Output            string    `json:"output"`
+	Status            string    `json:"status"`
+	Actions           int       `json:"actions"`
+	Lines             int       `json:"lines"`
+	CostUSD           float64   `json:"cost_usd"`
+	Turns             int       `json:"turns"`
+	InputTokens       int       `json:"input_tokens"`
+	OutputTokens      int       `json:"output_tokens"`
+	CacheReadTokens   int       `json:"cache_read_tokens"`
+	CacheCreateTokens int       `json:"cache_create_tokens"`
+	Model             string    `json:"model"`
+	PricingVersion    string    `json:"pricing_version"`
+	StartedAt         time.Time `json:"started_at"`
+	CompletedAt       time.Time `json:"completed_at"`
 }
 
 // Store manages task persistence.
@@ -307,7 +313,8 @@ func scanRuns(rows *sql.Rows) ([]TaskRun, error) {
 	for rows.Next() {
 		var r TaskRun
 		var startedStr, completedStr string
-		if err := rows.Scan(&r.ID, &r.TaskID, &r.RunNumber, &r.Output, &r.Status, &r.Actions, &r.Lines, &r.CostUSD, &r.Turns, &startedStr, &completedStr); err != nil {
+		if err := rows.Scan(&r.ID, &r.TaskID, &r.RunNumber, &r.Output, &r.Status, &r.Actions, &r.Lines, &r.CostUSD, &r.Turns, &startedStr, &completedStr,
+			&r.InputTokens, &r.OutputTokens, &r.CacheReadTokens, &r.CacheCreateTokens, &r.Model, &r.PricingVersion); err != nil {
 			return nil, err
 		}
 		r.StartedAt, _ = time.Parse(time.RFC3339, startedStr)

--- a/internal/web/ui/components/run-stats.js
+++ b/internal/web/ui/components/run-stats.js
@@ -1,0 +1,212 @@
+// OpenPraxis — Run Stats card (per-task post-run visualization)
+//
+// Mounted on the task detail page above the description. Surfaces the
+// most recent run + trend across last N runs:
+//   - Token-mix flexbox bar (input / output / cache_read / cache_creation)
+//   - Cache-hit ring via CSS conic-gradient
+//   - Sparklines (cost / turns / actions) via inline SVG <polyline>
+//
+// Tech: zero new vendor libs. SVG + flexbox + CSS conic-gradient.
+// Powered by the new columns added to task_runs in PR #205.
+//
+// Usage:
+//   OL.renderRunStats(containerEl, taskID)
+
+(function (OL) {
+  'use strict';
+
+  var fetchJSON = OL.fetchJSON, esc = OL.esc, timeAgo = OL.timeAgo;
+
+  // ---- helpers ---------------------------------------------------------
+
+  function fmtTokens(n) {
+    if (n >= 1e6) return (n / 1e6).toFixed(1) + 'M';
+    if (n >= 1e3) return (n / 1e3).toFixed(1) + 'k';
+    return String(n);
+  }
+
+  function fmtCost(n) { return '$' + (n || 0).toFixed(2); }
+
+  function fmtDuration(startedISO, completedISO) {
+    if (!startedISO || !completedISO) return '—';
+    var ms = new Date(completedISO) - new Date(startedISO);
+    if (isNaN(ms) || ms <= 0) return '—';
+    var s = Math.round(ms / 1000);
+    if (s < 60) return s + 's';
+    var m = Math.floor(s / 60);
+    var rs = s % 60;
+    return m + 'm ' + rs + 's';
+  }
+
+  // ---- token-mix bar (flexbox divs, matches cost.js precedent) -------
+
+  function renderTokenBar(run) {
+    var input = run.input_tokens || 0;
+    var output = run.output_tokens || 0;
+    var cacheRead = run.cache_read_tokens || 0;
+    var cacheCreate = run.cache_create_tokens || 0;
+    var total = input + output + cacheRead + cacheCreate;
+    if (total === 0) {
+      return '<div class="run-stats-empty">no token data</div>';
+    }
+    var segs = [
+      { label: 'input',        n: input,       cls: 'in' },
+      { label: 'output',       n: output,      cls: 'out' },
+      { label: 'cache-read',   n: cacheRead,   cls: 'cread' },
+      { label: 'cache-create', n: cacheCreate, cls: 'ccreate' },
+    ];
+    var bar = '<div class="run-stats-bar">';
+    segs.forEach(function (s) {
+      if (s.n === 0) return;
+      bar += '<div class="run-stats-bar-seg run-stats-bar-' + s.cls +
+             '" style="flex:' + s.n + '" title="' + s.label + ': ' + s.n.toLocaleString() + '">' +
+             '<span class="run-stats-bar-label">' + s.label + ' ' + fmtTokens(s.n) + '</span>' +
+             '</div>';
+    });
+    bar += '</div>';
+    return bar;
+  }
+
+  // ---- cache-hit ring (CSS conic-gradient) ---------------------------
+
+  function renderCacheRing(run) {
+    var input = run.input_tokens || 0;
+    var output = run.output_tokens || 0;
+    var cacheRead = run.cache_read_tokens || 0;
+    var cacheCreate = run.cache_create_tokens || 0;
+    var total = input + output + cacheRead + cacheCreate;
+    var pct = total > 0 ? Math.round((cacheRead / total) * 100) : 0;
+    return '<div class="run-stats-ring-wrap">' +
+      '<div class="run-stats-ring" style="--pct:' + pct + '" title="' + cacheRead.toLocaleString() + ' / ' + total.toLocaleString() + ' tokens served from cache">' +
+        '<div class="run-stats-ring-hole">' +
+          '<span class="run-stats-ring-pct">' + pct + '%</span>' +
+        '</div>' +
+      '</div>' +
+      '<div class="run-stats-ring-label">cache hit</div>' +
+      '</div>';
+  }
+
+  // ---- sparkline (inline SVG <polyline> + <circle> with hover) -------
+
+  function renderSparkline(label, values, opts) {
+    opts = opts || {};
+    var width = opts.width || 200;
+    var height = opts.height || 28;
+    var padX = 4, padY = 4;
+    var color = opts.color || 'var(--accent)';
+    if (!values || values.length === 0) {
+      return '<div class="run-stats-spark-row"><span class="run-stats-spark-label">' + esc(label) + '</span><span class="run-stats-empty">—</span></div>';
+    }
+    if (values.length === 1) {
+      return '<div class="run-stats-spark-row">' +
+        '<span class="run-stats-spark-label">' + esc(label) + '</span>' +
+        '<span class="run-stats-spark-single" title="run #' + values[0].run + ': ' + esc(values[0].tooltip) + '">' + esc(opts.formatLatest ? opts.formatLatest(values[0].y) : String(values[0].y)) + '</span>' +
+        '</div>';
+    }
+    var ys = values.map(function (v) { return v.y; });
+    var minY = Math.min.apply(null, ys);
+    var maxY = Math.max.apply(null, ys);
+    if (maxY === minY) maxY = minY + 1;
+    var stepX = (width - padX * 2) / (values.length - 1);
+    var pts = values.map(function (v, i) {
+      var x = padX + i * stepX;
+      var y = height - padY - ((v.y - minY) / (maxY - minY)) * (height - padY * 2);
+      return { x: x, y: y, raw: v };
+    });
+    var path = pts.map(function (p) { return p.x.toFixed(1) + ',' + p.y.toFixed(1); }).join(' ');
+    var circles = pts.map(function (p) {
+      return '<circle cx="' + p.x.toFixed(1) + '" cy="' + p.y.toFixed(1) + '" r="2.5" fill="' + color + '" data-run="' + p.raw.run + '"><title>run #' + p.raw.run + ': ' + p.raw.tooltip + '</title></circle>';
+    }).join('');
+    var latest = values[values.length - 1];
+    var latestStr = opts.formatLatest ? opts.formatLatest(latest.y) : String(latest.y);
+    return '<div class="run-stats-spark-row">' +
+      '<span class="run-stats-spark-label">' + esc(label) + '</span>' +
+      '<svg class="run-stats-spark" viewBox="0 0 ' + width + ' ' + height + '" preserveAspectRatio="none" width="' + width + '" height="' + height + '">' +
+        '<polyline points="' + path + '" fill="none" stroke="' + color + '" stroke-width="1.5" />' +
+        circles +
+      '</svg>' +
+      '<span class="run-stats-spark-latest" title="latest run">' + esc(latestStr) + '</span>' +
+      '</div>';
+  }
+
+  // ---- entry point ---------------------------------------------------
+
+  OL.renderRunStats = function (containerEl, taskID) {
+    if (!containerEl || !taskID) return;
+    containerEl.innerHTML = '<div class="run-stats-loading">Loading run stats…</div>';
+
+    fetchJSON('/api/tasks/' + encodeURIComponent(taskID) + '/runs').then(function (runs) {
+      runs = runs || [];
+      if (runs.length === 0) {
+        containerEl.innerHTML = '<div class="run-stats-card run-stats-empty-state">No runs yet. Stats will appear after the first run completes.</div>';
+        return;
+      }
+      // ListRuns returns newest-first per repository.go.
+      var latest = runs[0];
+      // Build sparkline data oldest→newest, capped at last 10.
+      var trend = runs.slice(0, 10).reverse();
+      var costPts = trend.map(function (r) {
+        return { run: r.run_number, y: r.cost_usd || 0,
+          tooltip: fmtCost(r.cost_usd) + ', ' + (r.turns || 0) + ' turns, ' + (r.actions || 0) + ' actions' };
+      });
+      var turnPts = trend.map(function (r) {
+        return { run: r.run_number, y: r.turns || 0,
+          tooltip: (r.turns || 0) + ' turns, ' + fmtCost(r.cost_usd) };
+      });
+      var actionPts = trend.map(function (r) {
+        return { run: r.run_number, y: r.actions || 0,
+          tooltip: (r.actions || 0) + ' actions, ' + (r.turns || 0) + ' turns' };
+      });
+
+      var when = latest.completed_at ? timeAgo(latest.completed_at) : 'in progress';
+      var dur = fmtDuration(latest.started_at, latest.completed_at);
+      var modelLine = latest.model
+        ? esc(latest.model) + ' · pricing ' + esc(latest.pricing_version || '—')
+        : '<span class="run-stats-empty">model not recorded — re-run to populate</span>';
+
+      containerEl.innerHTML =
+        '<div class="run-stats-card">' +
+          '<div class="run-stats-header">' +
+            '<span class="run-stats-title">Run Stats — Run #' + latest.run_number + '</span>' +
+            '<span class="run-stats-when">' + esc(when) + ' · ' + esc(dur) + '</span>' +
+          '</div>' +
+          '<div class="run-stats-tokens-row">' +
+            '<div class="run-stats-tokens-label">Token mix</div>' +
+            renderTokenBar(latest) +
+          '</div>' +
+          '<div class="run-stats-detail-row">' +
+            renderCacheRing(latest) +
+            '<div class="run-stats-sparks">' +
+              renderSparkline('cost', costPts, { color: 'var(--green)', formatLatest: fmtCost }) +
+              renderSparkline('turns', turnPts, { color: 'var(--accent)' }) +
+              renderSparkline('actions', actionPts, { color: 'var(--yellow)' }) +
+            '</div>' +
+          '</div>' +
+          '<div class="run-stats-footer">' +
+            '<span>Turns ' + (latest.turns || 0) + '</span>' +
+            '<span>Actions ' + (latest.actions || 0) + '</span>' +
+            '<span>Lines ' + (latest.lines || 0) + '</span>' +
+            '<span>' + modelLine + '</span>' +
+          '</div>' +
+        '</div>';
+
+      // Wire click on sparkline circles → scroll the run-history section
+      // into view + flash the matching row. Run history sits further down
+      // the task detail panel; a brief highlight helps the eye land.
+      containerEl.querySelectorAll('.run-stats-spark circle').forEach(function (c) {
+        c.style.cursor = 'pointer';
+        c.addEventListener('click', function () {
+          var runNum = c.getAttribute('data-run');
+          var row = document.querySelector('.task-run-item[data-run="' + runNum + '"]');
+          if (row) {
+            row.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            row.classList.add('scroll-highlight');
+            setTimeout(function () { row.classList.remove('scroll-highlight'); }, 2000);
+          }
+        });
+      });
+    }).catch(function (e) {
+      containerEl.innerHTML = '<div class="run-stats-card run-stats-empty-state">Failed to load runs: ' + esc(e.message || String(e)) + '</div>';
+    });
+  };
+})(window.OL);

--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -750,6 +750,7 @@
   <script src="/components/knobs.js"></script>
   <script src="/components/comments.js"></script>
   <script src="/components/revisions.js"></script>
+  <script src="/components/run-stats.js"></script>
   <script src="/views/search.js"></script>
   <script src="/views/overview.js"></script>
   <script src="/views/memories.js"></script>

--- a/internal/web/ui/style.css
+++ b/internal/web/ui/style.css
@@ -1497,3 +1497,72 @@ mark {
 .md-body th, .md-body td { border: 1px solid var(--border); padding: 4px 8px; font-size: 12px; }
 .md-body th { background: var(--bg-secondary); font-weight: 600; }
 .md-body hr { border: none; border-top: 1px solid var(--border); margin: 12px 0; }
+
+/* Run Stats card — per-task post-run visualization (RS/M1).
+   SVG sparklines + flexbox token bar + CSS conic-gradient ring. */
+.run-stats-card {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  padding: 10px 12px;
+  margin-bottom: 12px;
+  font-size: 12px;
+}
+.run-stats-card.run-stats-empty-state {
+  color: var(--text-muted);
+  font-style: italic;
+  padding: 10px 14px;
+}
+.run-stats-loading { color: var(--text-muted); font-size: 12px; padding: 8px 0; }
+.run-stats-empty { color: var(--text-muted); font-style: italic; }
+
+.run-stats-header { display: flex; align-items: baseline; gap: 8px; margin-bottom: 8px; }
+.run-stats-title { font-weight: 600; color: var(--text-primary); }
+.run-stats-when { font-size: 11px; color: var(--text-muted); }
+
+.run-stats-tokens-row { margin-bottom: 8px; }
+.run-stats-tokens-label { font-size: 11px; color: var(--text-muted); margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.04em; }
+
+.run-stats-bar { display: flex; height: 22px; border-radius: 4px; overflow: hidden; background: var(--bg-input); }
+.run-stats-bar-seg {
+  display: flex; align-items: center; justify-content: center;
+  min-width: 0; overflow: hidden; white-space: nowrap;
+  font-family: var(--font-mono); font-size: 10px; color: var(--bg-primary);
+  padding: 0 6px;
+}
+.run-stats-bar-label { overflow: hidden; text-overflow: ellipsis; }
+.run-stats-bar-in       { background: var(--accent); }
+.run-stats-bar-out      { background: var(--yellow); }
+.run-stats-bar-cread    { background: var(--green); }
+.run-stats-bar-ccreate  { background: var(--red); opacity: 0.7; }
+
+.run-stats-detail-row { display: flex; align-items: center; gap: 16px; margin: 10px 0 8px; }
+
+.run-stats-ring-wrap { display: flex; flex-direction: column; align-items: center; gap: 2px; flex-shrink: 0; }
+.run-stats-ring {
+  width: 56px; height: 56px; border-radius: 50%;
+  background: conic-gradient(var(--accent) calc(var(--pct, 0) * 1%), var(--bg-input) 0);
+  display: grid; place-items: center;
+}
+.run-stats-ring-hole {
+  width: 40px; height: 40px; border-radius: 50%;
+  background: var(--bg-secondary);
+  display: grid; place-items: center;
+}
+.run-stats-ring-pct { font-family: var(--font-mono); font-size: 12px; color: var(--accent); font-weight: 600; }
+.run-stats-ring-label { font-size: 10px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em; }
+
+.run-stats-sparks { display: flex; flex-direction: column; gap: 2px; flex: 1; min-width: 0; }
+.run-stats-spark-row { display: flex; align-items: center; gap: 8px; font-size: 11px; }
+.run-stats-spark-label { width: 56px; color: var(--text-muted); font-family: var(--font-mono); flex-shrink: 0; }
+.run-stats-spark { flex: 1; min-width: 0; height: 24px; }
+.run-stats-spark-latest { font-family: var(--font-mono); color: var(--text-primary); width: 70px; text-align: right; flex-shrink: 0; }
+.run-stats-spark-single { font-family: var(--font-mono); color: var(--text-primary); }
+
+.run-stats-footer { display: flex; flex-wrap: wrap; gap: 12px; padding-top: 6px; border-top: 1px solid var(--border); font-size: 11px; color: var(--text-muted); font-family: var(--font-mono); }
+
+@keyframes scroll-highlight-fade {
+  0% { background: rgba(245,158,11,0.4); }
+  100% { background: transparent; }
+}
+.scroll-highlight { animation: scroll-highlight-fade 2s ease-out; }

--- a/internal/web/ui/views/tasks.js
+++ b/internal/web/ui/views/tasks.js
@@ -400,6 +400,7 @@
             ` : ''}
           </div>
 
+          <div id="task-run-stats-mount" style="margin-bottom:12px"></div>
           <div id="task-revisions-mount" style="margin-bottom:12px"></div>
 
           <!-- SCHEDULE SECTION -->
@@ -536,6 +537,11 @@
       const knobMount = document.getElementById('task-knobs-mount');
       if (knobMount && OL.renderKnobSection) {
         OL.renderKnobSection(knobMount, { type: 'task', id: t.id });
+      }
+
+      const runStatsMount = document.getElementById('task-run-stats-mount');
+      if (runStatsMount && OL.renderRunStats) {
+        OL.renderRunStats(runStatsMount, t.id);
       }
 
       const revisionsMount = document.getElementById('task-revisions-mount');


### PR DESCRIPTION
Per-task post-run visualization. Mounted at the top of the task detail page above the description.

Three chart types, **zero new vendor libraries**:
- **SVG `<polyline>` sparklines** for cost / turns / actions over the last 10 runs (hover for exact values, click scrolls to the run row).
- **Flexbox stacked bar** for token mix (input / output / cache_read / cache_creation) — same precedent as `views/cost.js`.
- **CSS `conic-gradient` ring** for cache hit rate.

Plus surfaces the new token columns from #205 through TaskRun + the API.

Puppeteer-verified: card renders on a task with 2 runs, 3 sparklines × 2 points = 6 hover circles, ring shows 0% gracefully for runs without token data.

Tracks product `019dbad4-384`, manifest `019dbad4-f5b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)