### PR TITLE
fix(settings): canonicalise scope_id to full UUID in MCP + HTTP handlers (#207)

### DIFF
--- a/internal/mcp/tools_settings.go
+++ b/internal/mcp/tools_settings.go
@@ -95,7 +95,12 @@ func (s *Server) handleSettingsCatalog(_ context.Context, _ mcplib.CallToolReque
 
 func (s *Server) handleSettingsGet(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	a := args(req)
-	out, err := DoSettingsGet(ctx, s.node.SettingsStore, argStr(a, "scope_type"), argStr(a, "scope_id"))
+	scopeType := argStr(a, "scope_type")
+	scopeID, err := s.node.ResolveScopeID(scopeType, argStr(a, "scope_id"))
+	if err != nil {
+		return errResult("settings_get: %v", err), nil
+	}
+	out, err := DoSettingsGet(ctx, s.node.SettingsStore, scopeType, scopeID)
 	if err != nil {
 		return errResult("settings_get: %v", err), nil
 	}
@@ -104,8 +109,13 @@ func (s *Server) handleSettingsGet(ctx context.Context, req mcplib.CallToolReque
 
 func (s *Server) handleSettingsSet(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	a := args(req)
+	scopeType := argStr(a, "scope_type")
+	scopeID, err := s.node.ResolveScopeID(scopeType, argStr(a, "scope_id"))
+	if err != nil {
+		return errResult("settings_set: %v", err), nil
+	}
 	out, err := DoSettingsSet(ctx, s.node.SettingsStore, s.LoadActiveVisceralRules,
-		argStr(a, "scope_type"), argStr(a, "scope_id"),
+		scopeType, scopeID,
 		argStr(a, "key"), argStr(a, "value"),
 		mcpSetAuthor(ctx))
 	if err != nil {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -494,6 +494,38 @@ func (n *Node) ReindexMemories(ids []string) {
 	}
 }
 
+// ResolveScopeID canonicalises a settings/comment scope_id from a short
+// marker to its full UUID by dispatching on scopeType. Used by every
+// settings + cross-entity write path so short markers don't end up
+// silently orphaned in the database (visceral rule #14, issue #207).
+//
+// Returns ("", nil) for an empty scope_id; returns the input unchanged
+// for unknown scope types (caller validates the type separately).
+func (n *Node) ResolveScopeID(scopeType, scopeID string) (string, error) {
+	if scopeID == "" {
+		return "", nil
+	}
+	switch scopeType {
+	case "product":
+		return n.ResolveProductID(scopeID)
+	case "manifest":
+		return n.ResolveManifestID(scopeID)
+	case "task":
+		if n.Tasks == nil {
+			return scopeID, nil
+		}
+		t, err := n.Tasks.Get(scopeID)
+		if err != nil {
+			return "", fmt.Errorf("resolve task %q: %w", scopeID, err)
+		}
+		if t == nil {
+			return "", fmt.Errorf("task not found: %s", scopeID)
+		}
+		return t.ID, nil
+	}
+	return scopeID, nil
+}
+
 // ResolveProductID resolves a product marker or full ID to the full UUID.
 // Returns empty string if productID is empty, error if not found.
 func (n *Node) ResolveProductID(productID string) (string, error) {

--- a/internal/web/handlers_settings_exec.go
+++ b/internal/web/handlers_settings_exec.go
@@ -155,7 +155,12 @@ func apiSettingsCatalog() http.HandlerFunc {
 func apiScopeSettingsGet(n *node.Node, scopeType string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := mux.Vars(r)["id"]
-		out, err := mcp.DoSettingsGet(r.Context(), n.SettingsStore, scopeType, id)
+		fullID, err := n.ResolveScopeID(scopeType, id)
+		if err != nil {
+			writeError(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		out, err := mcp.DoSettingsGet(r.Context(), n.SettingsStore, scopeType, fullID)
 		if err != nil {
 			writeError(w, err.Error(), settingsHTTPStatus(err))
 			return
@@ -176,6 +181,14 @@ func apiScopeSettingsPut(n *node.Node, scopeType string) http.HandlerFunc {
 	loader := httpVisceralRuleLoader(n)
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := mux.Vars(r)["id"]
+		// Canonicalise the scope_id from short marker → full UUID up front so
+		// the row lands where the resolver can find it (visceral rule #14,
+		// issue #207).
+		fullID, err := n.ResolveScopeID(scopeType, id)
+		if err != nil {
+			writeError(w, err.Error(), http.StatusNotFound)
+			return
+		}
 		// Body is {key: jsonRawValue} — values are kept raw so we can pass the
 		// JSON-encoded form straight into DoSettingsSet (which expects the
 		// same wire shape the MCP tool accepts).
@@ -192,7 +205,7 @@ func apiScopeSettingsPut(n *node.Node, scopeType string) http.HandlerFunc {
 		results := make([]putKeyResult, 0, len(raw))
 		for key, val := range raw {
 			out, err := mcp.DoSettingsSet(r.Context(), n.SettingsStore, loader,
-				scopeType, id, key, string(val), author)
+				scopeType, fullID, key, string(val), author)
 			if err != nil {
 				results = append(results, putKeyResult{
 					Key:   key,
@@ -249,14 +262,19 @@ func apiScopeSettingsDelete(n *node.Node, scopeType string) http.HandlerFunc {
 			writeError(w, err.Error(), settingsHTTPStatus(err))
 			return
 		}
-		if err := n.SettingsStore.Delete(r.Context(), st, id, key); err != nil {
+		fullID, err := n.ResolveScopeID(scopeType, id)
+		if err != nil {
+			writeError(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		if err := n.SettingsStore.Delete(r.Context(), st, fullID, key); err != nil {
 			writeError(w, err.Error(), settingsHTTPStatus(err))
 			return
 		}
 		writeJSON(w, map[string]any{
 			"ok":         true,
 			"scope_type": scopeType,
-			"scope_id":   id,
+			"scope_id":   fullID,
 			"key":        key,
 		})
 	}


### PR DESCRIPTION
Settings written with a short-marker `scope_id` (e.g. `019dba88-973`) were stored as-is. The settings resolver walks via full UUIDs only, so those rows were silently orphaned.

New `node.ResolveScopeID(scopeType, scopeID)` dispatches to the appropriate per-entity resolver. Wired into MCP `handleSettingsSet` / `handleSettingsGet` and HTTP `apiScopeSettingsPut` / `apiScopeSettingsGet` / `apiScopeSettingsDelete`.

Smoke-tested: `PUT /api/products/019dba88-973/settings` now stores the row with the full UUID.

Closes #207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)