### PR TITLE
feat(templates): RC/M1 backend read substrate — prompt_templates + resolver + seed

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -19,6 +19,7 @@ import (
 	"github.com/k8nstantin/OpenPraxis/internal/product"
 	"github.com/k8nstantin/OpenPraxis/internal/settings"
 	"github.com/k8nstantin/OpenPraxis/internal/task"
+	"github.com/k8nstantin/OpenPraxis/internal/templates"
 	"github.com/k8nstantin/OpenPraxis/internal/watcher"
 )
 
@@ -38,6 +39,8 @@ type Node struct {
 	Watcher          *watcher.Store
 	SettingsStore    *settings.Store
 	SettingsResolver *settings.Resolver
+	Templates        *templates.Store
+	TemplatesResolv  *templates.Resolver
 	Comments         *comments.Store
 	runner           *task.Runner
 	Embedder         *embedding.Engine
@@ -228,6 +231,15 @@ func New(cfg *config.Config) (*Node, error) {
 	manifestSettingsAdapter := &manifest.SettingsAdapter{Store: manifestStore}
 	settingsResolver := settings.NewResolver(settingsStore, taskSettingsAdapter, manifestSettingsAdapter)
 
+	// RC/M1: prompt_templates substrate. Schema + system seed run every
+	// boot; both are idempotent. Resolver walks task → manifest → product
+	// → agent → system using a task-scope lookup into the task store.
+	if err := templates.InitSchema(index.DB()); err != nil {
+		return nil, fmt.Errorf("init templates schema: %w", err)
+	}
+	templatesStore := templates.NewStore(index.DB())
+	templatesResolver := templates.NewResolver(templatesStore, &taskTemplatesScopeAdapter{tasks: taskStore, manifests: manifestStore}, nil)
+
 	// M4-T14: one-time migration of legacy tasks.max_turns column values into
 	// settings rows at task scope, followed by dropping the column. Both are
 	// idempotent — the migration is gated by a marker row; the drop is a
@@ -257,6 +269,8 @@ func New(cfg *config.Config) (*Node, error) {
 		Watcher:          watcherStore,
 		SettingsStore:    settingsStore,
 		SettingsResolver: settingsResolver,
+		Templates:        templatesStore,
+		TemplatesResolv:  templatesResolver,
 		Comments:         commentsStore,
 		Embedder:         embedder,
 		StartedAt:        time.Now(),
@@ -265,7 +279,40 @@ func New(cfg *config.Config) (*Node, error) {
 	// One-time migration: normalize source_node from hostname to UUID
 	n.migrateSourceNodeToUUID()
 
+	// RC/M1: seed the prompt_templates system rows on first boot.
+	// Idempotent — no-op if any system-scope row already exists.
+	if err := templates.Seed(context.Background(), templatesStore, n.PeerID()); err != nil {
+		return nil, fmt.Errorf("seed prompt templates: %w", err)
+	}
+
 	return n, nil
+}
+
+// taskTemplatesScopeAdapter translates a task id into its manifest and
+// product ids for the templates resolver. Kept here (not in the
+// templates package) so templates stays free of a task/manifest import.
+type taskTemplatesScopeAdapter struct {
+	tasks     *task.Store
+	manifests *manifest.Store
+}
+
+func (a *taskTemplatesScopeAdapter) ManifestAndProductForTask(ctx context.Context, taskID string) (string, string, error) {
+	if a.tasks == nil {
+		return "", "", nil
+	}
+	t, err := a.tasks.Get(taskID)
+	if err != nil || t == nil {
+		return "", "", nil
+	}
+	manifestID := t.ManifestID
+	var productID string
+	if manifestID != "" && a.manifests != nil {
+		m, err := a.manifests.Get(manifestID)
+		if err == nil && m != nil {
+			productID = m.ProjectID
+		}
+	}
+	return manifestID, productID, nil
 }
 
 // InitRunner creates and sets the task Runner using the Node's own stores.
@@ -281,6 +328,13 @@ func (n *Node) InitRunner(onEvent func(string, map[string]string)) *task.Runner 
 	// if Comments is nil — the runner treats nil as "feature off".
 	if n.Comments != nil {
 		n.runner.SetExecutionReviewChecker(&executionReviewCheckerAdapter{s: n.Comments})
+	}
+	// RC/M1: hand the prompt_templates resolver to the runner so
+	// buildPrompt walks scope tiers instead of using the in-code
+	// defaults. Nil is safe — the runner falls back to the package
+	// defaults for any section the resolver doesn't answer.
+	if n.TemplatesResolv != nil {
+		n.runner.SetTemplateResolver(n.TemplatesResolv)
 	}
 	return n.runner
 }

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/k8nstantin/OpenPraxis/internal/action"
 	"github.com/k8nstantin/OpenPraxis/internal/settings"
+	"github.com/k8nstantin/OpenPraxis/internal/templates"
 )
 
 // RunningTask tracks an actively executing task.
@@ -87,7 +88,18 @@ type Runner struct {
 	// flags from the post-completion path. Empty is fine — amnesia.task_id
 	// is what the task detail pulls on.
 	sourceNode string
+
+	// tmpl resolves per-section prompt bodies by walking
+	// task → manifest → product → agent → system. Nil falls back to the
+	// package defaults (existing behaviour + every existing test harness
+	// that constructs a Runner without a DB-backed templates store).
+	tmpl *templates.Resolver
 }
+
+// SetTemplateResolver wires the RC/M1 prompt-template resolver onto
+// the runner. Nil disables scope-aware resolution — the runner uses the
+// package defaults, preserving pre-RC/M1 byte-for-byte output.
+func (r *Runner) SetTemplateResolver(t *templates.Resolver) { r.tmpl = t }
 
 // ExecutionReviewChecker answers whether a task has at least one
 // execution_review comment authored by the agent. Wired via
@@ -553,7 +565,11 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 	}
 
 	// Build the prompt
-	prompt := buildPrompt(t, manifestTitle, manifestContent, visceralRules)
+	prompt, err := buildPrompt(t, manifestTitle, manifestContent, visceralRules, r.tmpl)
+	if err != nil {
+		return fmt.Errorf("build prompt: %w", err)
+	}
+
 
 	// Allowed tools: catalog-resolved list wins over the baseline. Empty
 	// resolution (no catalog default set) falls back to defaultAllowedTools
@@ -1257,70 +1273,68 @@ func (r *Runner) GetOutput(taskID string) ([]string, bool) {
 	return rt.Output, true
 }
 
-// buildPrompt assembles the runner's task prompt. Each section is wrapped
-// in an XML tag (Anthropic's recommended pattern for delimiting prompt
-// sections to Claude — measurably improves instruction-following on long
-// contexts). The body of each section is markdown.
-func buildPrompt(t *Task, manifestTitle, manifestContent, visceralRules string) string {
+// buildPrompt assembles the runner's task prompt from the seven prompt
+// sections (RC/M1 read substrate). Each section body is resolved via
+// tmpl (task → manifest → product → agent → system) and rendered as a
+// text/template against a shared PromptData payload.
+//
+// When tmpl is nil, or a section resolves to "", the package defaults
+// in internal/templates are used so every historical test harness + the
+// snapshot test produce byte-identical output to the pre-RC/M1
+// hardcoded writer.
+func buildPrompt(t *Task, manifestTitle, manifestContent, visceralRules string, tmpl *templates.Resolver) (string, error) {
+	data := templates.PromptData{
+		Task: templates.TaskView{
+			ID:          t.ID,
+			Title:       t.Title,
+			Description: t.Description,
+			Agent:       t.Agent,
+		},
+		Manifest: templates.ManifestView{
+			ID:      t.ManifestID,
+			Title:   manifestTitle,
+			Content: manifestContent,
+		},
+		VisceralRules: visceralRules,
+		BranchPrefix:  branchPrefix(t.ID),
+		Now:           time.Now(),
+	}
+
+	defaults := templates.SystemDefaults()
+	ctx := context.Background()
+
 	var b strings.Builder
-	b.WriteString("You are executing a scheduled task for OpenPraxis.\n\n")
-
-	if visceralRules != "" {
-		b.WriteString("<visceral_rules>\n")
-		b.WriteString("MANDATORY — follow every rule without exception.\n\n")
-		b.WriteString(visceralRules)
-		b.WriteString("\n</visceral_rules>\n\n")
+	for _, section := range templates.Sections {
+		body := ""
+		if tmpl != nil {
+			resolved, err := tmpl.Resolve(ctx, section, t.ID)
+			if err != nil {
+				return "", fmt.Errorf("resolve %s: %w", section, err)
+			}
+			body = resolved
+		}
+		if body == "" {
+			body = defaults[section]
+		}
+		if body == "" {
+			continue
+		}
+		rendered, err := templates.Render(body, data)
+		if err != nil {
+			return "", fmt.Errorf("render %s: %w", section, err)
+		}
+		b.WriteString(rendered)
 	}
+	return b.String(), nil
+}
 
-	b.WriteString(fmt.Sprintf("<manifest_spec title=%q>\n", manifestTitle))
-	b.WriteString(manifestContent)
-	b.WriteString("\n</manifest_spec>\n\n")
-
-	b.WriteString(fmt.Sprintf("<task title=%q id=%q>\n", t.Title, t.ID))
-	if t.Description != "" {
-		b.WriteString(t.Description)
-		b.WriteString("\n")
+// branchPrefix mirrors the pre-RC/M1 marker rule: the first 12 chars of
+// the task id when the id is long enough, otherwise the id verbatim.
+// Kept as a helper so the template default and the runner both derive
+// the prefix the same way.
+func branchPrefix(taskID string) string {
+	if len(taskID) >= 12 {
+		return taskID[:12]
 	}
-	b.WriteString("</task>\n\n")
-
-	b.WriteString("<instructions>\n")
-	b.WriteString("Follow the manifest spec exactly. Work autonomously.\n")
-	b.WriteString("Call visceral_rules and visceral_confirm first.\n")
-	b.WriteString("</instructions>\n\n")
-
-	// Git isolation: each task gets its own branch and PR.
-	marker := t.ID
-	if len(marker) >= 12 {
-		marker = marker[:12]
-	}
-	b.WriteString("<git_workflow>\n")
-	b.WriteString("MANDATORY — every task gets its own branch and PR.\n\n")
-	b.WriteString("1. Before making ANY code changes, create a new branch:\n")
-	b.WriteString(fmt.Sprintf("   git checkout -b openpraxis/%s\n", marker))
-	b.WriteString("2. Make all your changes on this branch.\n")
-	b.WriteString("3. Commit your work with a descriptive message.\n")
-	b.WriteString(fmt.Sprintf("4. Push the branch: git push -u origin openpraxis/%s\n", marker))
-	b.WriteString("5. Create a pull request using: gh pr create --title \"<title>\" --body \"<summary>\"\n")
-	b.WriteString("6. Include the PR URL in your final output.\n\n")
-	b.WriteString("NEVER work on an existing branch. NEVER push to main.\n")
-	b.WriteString("</git_workflow>\n\n")
-
-	b.WriteString("<closing_protocol>\n")
-	b.WriteString("MANDATORY — before your final commit+push, call the MCP tool:\n\n")
-	b.WriteString("    mcp__openpraxis__comment_add\n")
-	b.WriteString(fmt.Sprintf("      target_type = \"task\"\n      target_id   = \"%s\"\n", t.ID))
-	b.WriteString("      type        = \"execution_review\"\n")
-	b.WriteString("      author      = \"agent\"\n")
-	b.WriteString("      body        = <markdown summary>\n\n")
-	b.WriteString("The body should include:\n")
-	b.WriteString("- **What shipped** — files created/edited, key APIs, what's testable\n")
-	b.WriteString("- **Gates self-check** — which acceptance-criteria bullets you verified locally (git gate: commits exist; build gate: go build passes; manifest gate: deliverables addressed)\n")
-	b.WriteString("- **What the next task should expect** — APIs, error codes, file layout\n")
-	b.WriteString("- **Anything surprising** — bugs found, decisions taken, followups to file\n\n")
-	b.WriteString("This comment is your execution review — the canonical per-task home. The runner records an amnesia flag if this call is missing.\n")
-	b.WriteString("</closing_protocol>\n\n")
-
-	b.WriteString("Report completion when done.\n")
-
-	return b.String()
+	return taskID
 }

--- a/internal/task/runner_exec_review_test.go
+++ b/internal/task/runner_exec_review_test.go
@@ -61,7 +61,10 @@ func openAmnesiaDB(t *testing.T) *action.Store {
 // finishing, and must interpolate the full task ID into target_id.
 func TestRunner_PromptTemplate_IncludesClosingSection(t *testing.T) {
 	task := &Task{ID: "019da142-479c-70d2-865b-d6e593883e3f", Title: "demo"}
-	got := buildPrompt(task, "Manifest X", "manifest body", "rules body")
+	got, err := buildPrompt(task, "Manifest X", "manifest body", "rules body", nil)
+	if err != nil {
+		t.Fatalf("buildPrompt: %v", err)
+	}
 
 	mustContain(t, got, "<closing_protocol>")
 	mustContain(t, got, "mcp__openpraxis__comment_add")

--- a/internal/task/runner_prompt_snapshot_test.go
+++ b/internal/task/runner_prompt_snapshot_test.go
@@ -1,0 +1,175 @@
+package task
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// legacyBuildPrompt is a verbatim copy of the pre-RC/M1 hardcoded
+// buildPrompt. Kept here as an oracle so the refactored buildPrompt
+// can be asserted byte-identical without depending on the committed
+// snapshot file being in sync.
+func legacyBuildPrompt(t *Task, manifestTitle, manifestContent, visceralRules string) string {
+	var b strings.Builder
+	b.WriteString("You are executing a scheduled task for OpenPraxis.\n\n")
+
+	if visceralRules != "" {
+		b.WriteString("<visceral_rules>\n")
+		b.WriteString("MANDATORY — follow every rule without exception.\n\n")
+		b.WriteString(visceralRules)
+		b.WriteString("\n</visceral_rules>\n\n")
+	}
+
+	b.WriteString(fmt.Sprintf("<manifest_spec title=%q>\n", manifestTitle))
+	b.WriteString(manifestContent)
+	b.WriteString("\n</manifest_spec>\n\n")
+
+	b.WriteString(fmt.Sprintf("<task title=%q id=%q>\n", t.Title, t.ID))
+	if t.Description != "" {
+		b.WriteString(t.Description)
+		b.WriteString("\n")
+	}
+	b.WriteString("</task>\n\n")
+
+	b.WriteString("<instructions>\n")
+	b.WriteString("Follow the manifest spec exactly. Work autonomously.\n")
+	b.WriteString("Call visceral_rules and visceral_confirm first.\n")
+	b.WriteString("</instructions>\n\n")
+
+	marker := t.ID
+	if len(marker) >= 12 {
+		marker = marker[:12]
+	}
+	b.WriteString("<git_workflow>\n")
+	b.WriteString("MANDATORY — every task gets its own branch and PR.\n\n")
+	b.WriteString("1. Before making ANY code changes, create a new branch:\n")
+	b.WriteString(fmt.Sprintf("   git checkout -b openpraxis/%s\n", marker))
+	b.WriteString("2. Make all your changes on this branch.\n")
+	b.WriteString("3. Commit your work with a descriptive message.\n")
+	b.WriteString(fmt.Sprintf("4. Push the branch: git push -u origin openpraxis/%s\n", marker))
+	b.WriteString("5. Create a pull request using: gh pr create --title \"<title>\" --body \"<summary>\"\n")
+	b.WriteString("6. Include the PR URL in your final output.\n\n")
+	b.WriteString("NEVER work on an existing branch. NEVER push to main.\n")
+	b.WriteString("</git_workflow>\n\n")
+
+	b.WriteString("<closing_protocol>\n")
+	b.WriteString("MANDATORY — before your final commit+push, call the MCP tool:\n\n")
+	b.WriteString("    mcp__openpraxis__comment_add\n")
+	b.WriteString(fmt.Sprintf("      target_type = \"task\"\n      target_id   = \"%s\"\n", t.ID))
+	b.WriteString("      type        = \"execution_review\"\n")
+	b.WriteString("      author      = \"agent\"\n")
+	b.WriteString("      body        = <markdown summary>\n\n")
+	b.WriteString("The body should include:\n")
+	b.WriteString("- **What shipped** — files created/edited, key APIs, what's testable\n")
+	b.WriteString("- **Gates self-check** — which acceptance-criteria bullets you verified locally (git gate: commits exist; build gate: go build passes; manifest gate: deliverables addressed)\n")
+	b.WriteString("- **What the next task should expect** — APIs, error codes, file layout\n")
+	b.WriteString("- **Anything surprising** — bugs found, decisions taken, followups to file\n\n")
+	b.WriteString("This comment is your execution review — the canonical per-task home. The runner records an amnesia flag if this call is missing.\n")
+	b.WriteString("</closing_protocol>\n\n")
+
+	b.WriteString("Report completion when done.\n")
+	return b.String()
+}
+
+// TestRunner_BuildPrompt_ByteIdentical ensures the RC/M1 resolver +
+// renderer path reproduces the pre-refactor hardcoded buildPrompt byte
+// for byte. Also round-trips against testdata/runner_prompt_snapshot.txt
+// so an accidental template edit is caught by CI even if someone also
+// breaks legacyBuildPrompt in the same change.
+//
+// Set UPDATE_SNAPSHOT=1 to rewrite the snapshot file (used exactly once,
+// at check-in time).
+func TestRunner_BuildPrompt_ByteIdentical(t *testing.T) {
+	sample := &Task{
+		ID:          "019dba9f-9c5b-76ba-8221-e7e11093887f",
+		Title:       "Sample Task",
+		Description: "Do the thing.\nSecond line.",
+		ManifestID:  "019dba89-45d1-76ba-8221-000000000000",
+	}
+	manifestTitle := "Sample Manifest"
+	manifestContent := "This is the manifest body.\n\n## Section\n\nMore text."
+	visceralRules := "1. first rule\n2. second rule"
+
+	legacy := legacyBuildPrompt(sample, manifestTitle, manifestContent, visceralRules)
+
+	got, err := buildPrompt(sample, manifestTitle, manifestContent, visceralRules, nil)
+	if err != nil {
+		t.Fatalf("buildPrompt: %v", err)
+	}
+	if got != legacy {
+		diffPreview(t, "buildPrompt vs legacy", got, legacy)
+		t.Fatalf("buildPrompt output diverged from legacy (len got=%d, legacy=%d)", len(got), len(legacy))
+	}
+
+	snapshotPath := filepath.Join("testdata", "runner_prompt_snapshot.txt")
+	if os.Getenv("UPDATE_SNAPSHOT") == "1" {
+		if err := os.MkdirAll(filepath.Dir(snapshotPath), 0o755); err != nil {
+			t.Fatalf("mkdir testdata: %v", err)
+		}
+		if err := os.WriteFile(snapshotPath, []byte(got), 0o644); err != nil {
+			t.Fatalf("write snapshot: %v", err)
+		}
+		t.Logf("wrote snapshot %s (%d bytes)", snapshotPath, len(got))
+		return
+	}
+
+	want, err := os.ReadFile(snapshotPath)
+	if err != nil {
+		t.Fatalf("read snapshot (run with UPDATE_SNAPSHOT=1 to create): %v", err)
+	}
+	if string(want) != got {
+		diffPreview(t, "buildPrompt vs snapshot file", got, string(want))
+		t.Fatalf("buildPrompt output diverged from testdata snapshot")
+	}
+}
+
+// TestRunner_BuildPrompt_VisceralRulesEmpty covers the skip-when-empty
+// branch: the visceral_rules section must disappear entirely, not
+// render as an empty wrapper.
+func TestRunner_BuildPrompt_VisceralRulesEmpty(t *testing.T) {
+	sample := &Task{ID: "abc", Title: "x"}
+	got, err := buildPrompt(sample, "M", "m body", "", nil)
+	if err != nil {
+		t.Fatalf("buildPrompt: %v", err)
+	}
+	if strings.Contains(got, "<visceral_rules>") {
+		t.Fatalf("visceral_rules section should be absent when VisceralRules is empty; got:\n%s", got)
+	}
+	legacy := legacyBuildPrompt(sample, "M", "m body", "")
+	if got != legacy {
+		diffPreview(t, "empty-visceral vs legacy", got, legacy)
+		t.Fatalf("buildPrompt diverged on empty visceral rules")
+	}
+}
+
+// diffPreview prints the first 400 chars of each side + the first
+// position at which the two strings diverge so `go test` surfaces the
+// actual mismatch instead of forcing the reader to diff two blobs by hand.
+func diffPreview(t *testing.T, label, got, want string) {
+	t.Helper()
+	t.Logf("%s — diff", label)
+	minLen := len(got)
+	if len(want) < minLen {
+		minLen = len(want)
+	}
+	for i := 0; i < minLen; i++ {
+		if got[i] != want[i] {
+			start := i - 20
+			if start < 0 {
+				start = 0
+			}
+			end := i + 40
+			if end > minLen {
+				end = minLen
+			}
+			t.Logf("first diff at byte %d:\n  got : %q\n  want: %q", i, got[start:end], want[start:end])
+			return
+		}
+	}
+	if len(got) != len(want) {
+		t.Logf("content matches up to %d bytes; lengths differ got=%d want=%d", minLen, len(got), len(want))
+	}
+}

--- a/internal/task/testdata/runner_prompt_snapshot.txt
+++ b/internal/task/testdata/runner_prompt_snapshot.txt
@@ -1,0 +1,61 @@
+You are executing a scheduled task for OpenPraxis.
+
+<visceral_rules>
+MANDATORY — follow every rule without exception.
+
+1. first rule
+2. second rule
+</visceral_rules>
+
+<manifest_spec title="Sample Manifest">
+This is the manifest body.
+
+## Section
+
+More text.
+</manifest_spec>
+
+<task title="Sample Task" id="019dba9f-9c5b-76ba-8221-e7e11093887f">
+Do the thing.
+Second line.
+</task>
+
+<instructions>
+Follow the manifest spec exactly. Work autonomously.
+Call visceral_rules and visceral_confirm first.
+</instructions>
+
+<git_workflow>
+MANDATORY — every task gets its own branch and PR.
+
+1. Before making ANY code changes, create a new branch:
+   git checkout -b openpraxis/019dba9f-9c5
+2. Make all your changes on this branch.
+3. Commit your work with a descriptive message.
+4. Push the branch: git push -u origin openpraxis/019dba9f-9c5
+5. Create a pull request using: gh pr create --title "<title>" --body "<summary>"
+6. Include the PR URL in your final output.
+
+NEVER work on an existing branch. NEVER push to main.
+</git_workflow>
+
+<closing_protocol>
+MANDATORY — before your final commit+push, call the MCP tool:
+
+    mcp__openpraxis__comment_add
+      target_type = "task"
+      target_id   = "019dba9f-9c5b-76ba-8221-e7e11093887f"
+      type        = "execution_review"
+      author      = "agent"
+      body        = <markdown summary>
+
+The body should include:
+- **What shipped** — files created/edited, key APIs, what's testable
+- **Gates self-check** — which acceptance-criteria bullets you verified locally (git gate: commits exist; build gate: go build passes; manifest gate: deliverables addressed)
+- **What the next task should expect** — APIs, error codes, file layout
+- **Anything surprising** — bugs found, decisions taken, followups to file
+
+This comment is your execution review — the canonical per-task home. The runner records an amnesia flag if this call is missing.
+</closing_protocol>
+
+Report completion when done.

--- a/internal/templates/defaults.go
+++ b/internal/templates/defaults.go
@@ -1,0 +1,105 @@
+package templates
+
+// Default section bodies. These are the canonical seed values for the
+// system-scope rows — reproducing the pre-RC/M1 hardcoded buildPrompt()
+// output byte-for-byte when rendered with the equivalent PromptData.
+//
+// Ordering / separator notes: each body carries its own trailing
+// whitespace, so the runner just concatenates the seven rendered
+// sections with no extra joiner. The closing_protocol body folds in
+// the "Report completion when done." tail since that line used to be
+// appended after the final section wrapper.
+
+const defaultPreamble = "You are executing a scheduled task for OpenPraxis.\n\n"
+
+const defaultVisceralRules = `{{if .VisceralRules}}<visceral_rules>
+MANDATORY — follow every rule without exception.
+
+{{.VisceralRules}}
+</visceral_rules>
+
+{{end}}`
+
+const defaultManifestSpec = `<manifest_spec title={{printf "%q" .Manifest.Title}}>
+{{.Manifest.Content}}
+</manifest_spec>
+
+`
+
+const defaultTask = `<task title={{printf "%q" .Task.Title}} id={{printf "%q" .Task.ID}}>
+{{if .Task.Description}}{{.Task.Description}}
+{{end}}</task>
+
+`
+
+const defaultInstructions = `<instructions>
+Follow the manifest spec exactly. Work autonomously.
+Call visceral_rules and visceral_confirm first.
+</instructions>
+
+`
+
+const defaultGitWorkflow = `<git_workflow>
+MANDATORY — every task gets its own branch and PR.
+
+1. Before making ANY code changes, create a new branch:
+   git checkout -b openpraxis/{{.BranchPrefix}}
+2. Make all your changes on this branch.
+3. Commit your work with a descriptive message.
+4. Push the branch: git push -u origin openpraxis/{{.BranchPrefix}}
+5. Create a pull request using: gh pr create --title "<title>" --body "<summary>"
+6. Include the PR URL in your final output.
+
+NEVER work on an existing branch. NEVER push to main.
+</git_workflow>
+
+`
+
+const defaultClosingProtocol = `<closing_protocol>
+MANDATORY — before your final commit+push, call the MCP tool:
+
+    mcp__openpraxis__comment_add
+      target_type = "task"
+      target_id   = "{{.Task.ID}}"
+      type        = "execution_review"
+      author      = "agent"
+      body        = <markdown summary>
+
+The body should include:
+- **What shipped** — files created/edited, key APIs, what's testable
+- **Gates self-check** — which acceptance-criteria bullets you verified locally (git gate: commits exist; build gate: go build passes; manifest gate: deliverables addressed)
+- **What the next task should expect** — APIs, error codes, file layout
+- **Anything surprising** — bugs found, decisions taken, followups to file
+
+This comment is your execution review — the canonical per-task home. The runner records an amnesia flag if this call is missing.
+</closing_protocol>
+
+Report completion when done.
+`
+
+// SystemDefaults returns the canonical default body for each section.
+// Exported so tests and the seed can use the exact same strings.
+func SystemDefaults() map[string]string {
+	return map[string]string{
+		SectionPreamble:        defaultPreamble,
+		SectionVisceralRules:   defaultVisceralRules,
+		SectionManifestSpec:    defaultManifestSpec,
+		SectionTask:            defaultTask,
+		SectionInstructions:    defaultInstructions,
+		SectionGitWorkflow:     defaultGitWorkflow,
+		SectionClosingProtocol: defaultClosingProtocol,
+	}
+}
+
+// SystemDefaultTitles returns human-readable titles for each default.
+func SystemDefaultTitles() map[string]string {
+	return map[string]string{
+		SectionPreamble:        "System preamble",
+		SectionVisceralRules:   "Visceral rules block",
+		SectionManifestSpec:    "Manifest spec block",
+		SectionTask:            "Task block",
+		SectionInstructions:    "Instructions block",
+		SectionGitWorkflow:     "Git workflow block",
+		SectionClosingProtocol: "Closing protocol + completion line",
+	}
+}

--- a/internal/templates/model.go
+++ b/internal/templates/model.go
@@ -1,0 +1,54 @@
+package templates
+
+// Scope values for prompt_templates.scope.
+const (
+	ScopeSystem   = "system"
+	ScopeProduct  = "product"
+	ScopeManifest = "manifest"
+	ScopeTask     = "task"
+	ScopeAgent    = "agent"
+)
+
+// Sections are the ordered prompt segments assembled by the runner.
+var Sections = []string{
+	SectionPreamble,
+	SectionVisceralRules,
+	SectionManifestSpec,
+	SectionTask,
+	SectionInstructions,
+	SectionGitWorkflow,
+	SectionClosingProtocol,
+}
+
+const (
+	SectionPreamble        = "preamble"
+	SectionVisceralRules   = "visceral_rules"
+	SectionManifestSpec    = "manifest_spec"
+	SectionTask            = "task"
+	SectionInstructions    = "instructions"
+	SectionGitWorkflow     = "git_workflow"
+	SectionClosingProtocol = "closing_protocol"
+)
+
+// Template mirrors a single row of prompt_templates. SCD-Type-2 audit
+// columns (valid_from / valid_to / changed_by / reason) travel with every
+// row so point-in-time reads and history queries can be served from one
+// table.
+type Template struct {
+	ID          int64  `json:"id"`
+	TemplateUID string `json:"template_uid"`
+	Title       string `json:"title"`
+	Scope       string `json:"scope"`
+	ScopeID     string `json:"scope_id"`
+	Section     string `json:"section"`
+	Body        string `json:"body"`
+	Status      string `json:"status"`
+	Tags        string `json:"tags"`
+	SourceNode  string `json:"source_node"`
+	ValidFrom   string `json:"valid_from"`
+	ValidTo     string `json:"valid_to"`
+	ChangedBy   string `json:"changed_by"`
+	Reason      string `json:"reason"`
+	CreatedAt   string `json:"created_at"`
+	DeletedAt   string `json:"deleted_at"`
+}

--- a/internal/templates/render.go
+++ b/internal/templates/render.go
@@ -1,0 +1,62 @@
+package templates
+
+import (
+	"fmt"
+	"strings"
+	"text/template"
+	"time"
+)
+
+// TaskView is the minimal task payload a prompt template can reference.
+// A view type (rather than *task.Task) keeps the templates package free of
+// any dependency on internal/task, so the import arrow only points one way.
+type TaskView struct {
+	ID          string
+	Title       string
+	Description string
+	Agent       string
+}
+
+// ManifestView is the minimal manifest payload surfaced to templates.
+type ManifestView struct {
+	ID      string
+	Title   string
+	Content string
+}
+
+// ProductView is the minimal product payload surfaced to templates.
+type ProductView struct {
+	ID    string
+	Title string
+}
+
+// PromptData is the full shape a template body may address. Fields that
+// aren't used by the current default bodies are still populated so
+// future operator-authored templates (RC/M2..M6) can reference them
+// without another refactor.
+type PromptData struct {
+	Task          TaskView
+	Manifest      ManifestView
+	Product       ProductView
+	Settings      map[string]any
+	PriorRuns     []string
+	OtherComments []string
+	VisceralRules string
+	BranchPrefix  string
+	Now           time.Time
+}
+
+// Render parses `body` as a text/template and executes it against data.
+// Parse errors are returned verbatim; execution errors wrap the section
+// name when one is supplied.
+func Render(body string, data PromptData) (string, error) {
+	t, err := template.New("prompt").Parse(body)
+	if err != nil {
+		return "", fmt.Errorf("parse template: %w", err)
+	}
+	var b strings.Builder
+	if err := t.Execute(&b, data); err != nil {
+		return "", fmt.Errorf("execute template: %w", err)
+	}
+	return b.String(), nil
+}

--- a/internal/templates/resolver.go
+++ b/internal/templates/resolver.go
@@ -1,0 +1,104 @@
+package templates
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+)
+
+// AgentLookup answers what agent name is effectively assigned to the given
+// task — the resolver uses it to walk into the agent-scope tier between
+// product and system. Nil means "skip agent tier".
+type AgentLookup interface {
+	AgentForTask(ctx context.Context, taskID string) (string, error)
+}
+
+// ScopeLookup fills in manifest and product scope ids for a task. Nil
+// means the caller will pass those explicitly (e.g. tests).
+type ScopeLookup interface {
+	ManifestAndProductForTask(ctx context.Context, taskID string) (manifestID, productID string, err error)
+}
+
+// Resolver walks task → manifest → product → agent → system, returning
+// the first currently-active body it finds for `section`. Returns "" if
+// no active row exists at any scope (caller falls back to the package
+// defaults).
+type Resolver struct {
+	store  *Store
+	scope  ScopeLookup
+	agents AgentLookup
+}
+
+func NewResolver(store *Store, scope ScopeLookup, agents AgentLookup) *Resolver {
+	return &Resolver{store: store, scope: scope, agents: agents}
+}
+
+// Resolve returns the active template body for `section` at `taskID`.
+// Missing-row at a tier falls through to the next tier. Only DB errors
+// other than sql.ErrNoRows surface.
+func (r *Resolver) Resolve(ctx context.Context, section, taskID string) (string, error) {
+	if taskID != "" {
+		if body, ok, err := r.lookup(ctx, ScopeTask, taskID, section); err != nil {
+			return "", err
+		} else if ok {
+			return body, nil
+		}
+	}
+
+	var manifestID, productID string
+	if taskID != "" && r.scope != nil {
+		var err error
+		manifestID, productID, err = r.scope.ManifestAndProductForTask(ctx, taskID)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if manifestID != "" {
+		if body, ok, err := r.lookup(ctx, ScopeManifest, manifestID, section); err != nil {
+			return "", err
+		} else if ok {
+			return body, nil
+		}
+	}
+
+	if productID != "" {
+		if body, ok, err := r.lookup(ctx, ScopeProduct, productID, section); err != nil {
+			return "", err
+		} else if ok {
+			return body, nil
+		}
+	}
+
+	if taskID != "" && r.agents != nil {
+		if agentName, err := r.agents.AgentForTask(ctx, taskID); err != nil {
+			return "", err
+		} else if agentName != "" {
+			if body, ok, err := r.lookup(ctx, ScopeAgent, agentName, section); err != nil {
+				return "", err
+			} else if ok {
+				return body, nil
+			}
+		}
+	}
+
+	if body, ok, err := r.lookup(ctx, ScopeSystem, "", section); err != nil {
+		return "", err
+	} else if ok {
+		return body, nil
+	}
+
+	return "", nil
+}
+
+// lookup returns (body, found, error). sql.ErrNoRows is folded into found=false.
+func (r *Resolver) lookup(ctx context.Context, scope, scopeID, section string) (string, bool, error) {
+	t, err := r.store.Get(ctx, scope, scopeID, section)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return t.Body, true, nil
+}

--- a/internal/templates/schema.go
+++ b/internal/templates/schema.go
@@ -1,0 +1,50 @@
+package templates
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// InitSchema creates the prompt_templates table plus its two indexes.
+// SCD-Type-2 layout: template_uid is the stable logical id; each mutation
+// inserts a new row with valid_from=now() and closes the previous row by
+// stamping its valid_to. The active set is the subset where valid_to=''.
+//
+// Caller is responsible for opening the DB with WAL + busy_timeout=5000
+// (visceral rule #10).
+func InitSchema(db *sql.DB) error {
+	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS prompt_templates (
+		id           INTEGER PRIMARY KEY AUTOINCREMENT,
+		template_uid TEXT NOT NULL,
+		title        TEXT NOT NULL,
+		scope        TEXT NOT NULL,
+		scope_id     TEXT NOT NULL DEFAULT '',
+		section      TEXT NOT NULL,
+		body         TEXT NOT NULL DEFAULT '',
+		status       TEXT NOT NULL DEFAULT 'open',
+		tags         TEXT NOT NULL DEFAULT '[]',
+		source_node  TEXT NOT NULL DEFAULT '',
+		valid_from   TEXT NOT NULL,
+		valid_to     TEXT NOT NULL DEFAULT '',
+		changed_by   TEXT NOT NULL DEFAULT '',
+		reason       TEXT NOT NULL DEFAULT '',
+		created_at   TEXT NOT NULL,
+		deleted_at   TEXT NOT NULL DEFAULT ''
+	)`)
+	if err != nil {
+		return fmt.Errorf("create prompt_templates table: %w", err)
+	}
+
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_prompt_templates_current
+		ON prompt_templates(scope, scope_id, section)
+		WHERE valid_to = ''`); err != nil {
+		return fmt.Errorf("create current index: %w", err)
+	}
+
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_prompt_templates_history
+		ON prompt_templates(template_uid, valid_from DESC)`); err != nil {
+		return fmt.Errorf("create history index: %w", err)
+	}
+
+	return nil
+}

--- a/internal/templates/seed.go
+++ b/internal/templates/seed.go
@@ -1,0 +1,71 @@
+package templates
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Seed inserts the seven system-scope default rows on first call.
+// Idempotent: detects prior seeding by counting existing system-scope
+// rows and no-ops when any are present. Acceptance #1 in the manifest
+// requires SELECT COUNT(*) FROM prompt_templates == 7 on a fresh DB,
+// so we do NOT insert a separate marker row.
+//
+// peerID is the source_node stamp for audit; changed_by is set to
+// "system-seed" per the manifest.
+func Seed(ctx context.Context, store *Store, peerID string) error {
+	if store == nil || store.DB() == nil {
+		return fmt.Errorf("templates.Seed: nil store")
+	}
+
+	var count int
+	if err := store.DB().QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM prompt_templates WHERE scope = 'system'`,
+	).Scan(&count); err != nil {
+		return fmt.Errorf("templates.Seed check: %w", err)
+	}
+	if count > 0 {
+		return nil
+	}
+
+	defaults := SystemDefaults()
+	titles := SystemDefaultTitles()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	tx, err := store.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("templates.Seed begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	insert := `INSERT INTO prompt_templates
+		(template_uid, title, scope, scope_id, section, body, status, tags,
+		 source_node, valid_from, valid_to, changed_by, reason, created_at, deleted_at)
+		VALUES (?, ?, 'system', '', ?, ?, 'open', '[]', ?, ?, '', 'system-seed',
+		        'Initial seed from buildPrompt() defaults', ?, '')`
+
+	for _, section := range Sections {
+		body := defaults[section]
+		title := titles[section]
+		if title == "" {
+			title = section
+		}
+		uid, err := uuid.NewV7()
+		if err != nil {
+			return fmt.Errorf("templates.Seed uuid: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, insert,
+			uid.String(), title, section, body, peerID, now, now,
+		); err != nil {
+			return fmt.Errorf("templates.Seed insert %s: %w", section, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("templates.Seed commit: %w", err)
+	}
+	return nil
+}

--- a/internal/templates/store.go
+++ b/internal/templates/store.go
@@ -1,0 +1,94 @@
+package templates
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// Store is a read-only accessor for prompt_templates. The RC/M1 substrate
+// ships no write API; RC/M2 layers in transactional SCD-2 mutations over
+// this same table.
+type Store struct {
+	db *sql.DB
+}
+
+func NewStore(db *sql.DB) *Store { return &Store{db: db} }
+
+// DB returns the underlying connection. Seed() needs direct access to
+// issue the transactional bootstrap insert.
+func (s *Store) DB() *sql.DB { return s.db }
+
+// activeFilter is the WHERE clause that pins a read to the currently-active
+// row: open (status not closed/archived), not deleted, and the open end of
+// its SCD-2 interval.
+const activeFilter = `valid_to = '' AND deleted_at = '' AND status NOT IN ('closed','archive')`
+
+const selectCols = `id, template_uid, title, scope, scope_id, section, body, status, tags,
+	source_node, valid_from, valid_to, changed_by, reason, created_at, deleted_at`
+
+func scanRow(sc interface{ Scan(...interface{}) error }) (*Template, error) {
+	t := &Template{}
+	err := sc.Scan(&t.ID, &t.TemplateUID, &t.Title, &t.Scope, &t.ScopeID, &t.Section,
+		&t.Body, &t.Status, &t.Tags, &t.SourceNode, &t.ValidFrom, &t.ValidTo,
+		&t.ChangedBy, &t.Reason, &t.CreatedAt, &t.DeletedAt)
+	if err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+// Get returns the active row for (scope, scopeID, section) or sql.ErrNoRows.
+func (s *Store) Get(ctx context.Context, scope, scopeID, section string) (*Template, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+selectCols+` FROM prompt_templates
+		 WHERE scope = ? AND scope_id = ? AND section = ? AND `+activeFilter+`
+		 ORDER BY id DESC LIMIT 1`,
+		scope, scopeID, section)
+	t, err := scanRow(row)
+	if err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+// GetByUID returns the currently-active row for the given template_uid.
+func (s *Store) GetByUID(ctx context.Context, uid string) (*Template, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+selectCols+` FROM prompt_templates
+		 WHERE template_uid = ? AND `+activeFilter+`
+		 ORDER BY id DESC LIMIT 1`,
+		uid)
+	return scanRow(row)
+}
+
+// List returns all active rows, optionally filtered by scope and/or section.
+// Empty filter value disables that filter.
+func (s *Store) List(ctx context.Context, scope, section string) ([]*Template, error) {
+	q := `SELECT ` + selectCols + ` FROM prompt_templates WHERE ` + activeFilter
+	args := []interface{}{}
+	if scope != "" {
+		q += ` AND scope = ?`
+		args = append(args, scope)
+	}
+	if section != "" {
+		q += ` AND section = ?`
+		args = append(args, section)
+	}
+	q += ` ORDER BY scope, scope_id, section, id DESC`
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list prompt_templates: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*Template
+	for rows.Next() {
+		t, err := scanRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -1,0 +1,196 @@
+package templates
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "templates.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		t.Fatalf("wal: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
+		t.Fatalf("busy: %v", err)
+	}
+	if err := InitSchema(db); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	return db
+}
+
+// TestSeed_InsertsSevenSystemRows verifies acceptance #1: fresh DB →
+// seed writes exactly seven active system rows, one per section.
+func TestSeed_InsertsSevenSystemRows(t *testing.T) {
+	db := openTestDB(t)
+	store := NewStore(db)
+	ctx := context.Background()
+
+	if err := Seed(ctx, store, "peer-xyz"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var total int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM prompt_templates`).Scan(&total); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if total != 7 {
+		t.Fatalf("row count = %d, want 7", total)
+	}
+
+	rows, err := store.List(ctx, ScopeSystem, "")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 7 {
+		t.Fatalf("system rows = %d, want 7", len(rows))
+	}
+
+	seen := map[string]bool{}
+	for _, r := range rows {
+		seen[r.Section] = true
+		if r.Scope != ScopeSystem || r.ScopeID != "" {
+			t.Errorf("unexpected scope (%s,%s) for %s", r.Scope, r.ScopeID, r.Section)
+		}
+		if r.ValidTo != "" || r.DeletedAt != "" {
+			t.Errorf("seed row %s should be active (valid_to=%q deleted_at=%q)", r.Section, r.ValidTo, r.DeletedAt)
+		}
+		if r.ChangedBy != "system-seed" {
+			t.Errorf("changed_by = %q, want system-seed", r.ChangedBy)
+		}
+		if r.Body == "" {
+			t.Errorf("section %q body is empty", r.Section)
+		}
+	}
+	for _, s := range Sections {
+		if !seen[s] {
+			t.Errorf("missing section %q", s)
+		}
+	}
+}
+
+// TestSeed_Idempotent — a second Seed call after the first is a no-op.
+func TestSeed_Idempotent(t *testing.T) {
+	db := openTestDB(t)
+	store := NewStore(db)
+	ctx := context.Background()
+
+	if err := Seed(ctx, store, "peer-a"); err != nil {
+		t.Fatalf("seed 1: %v", err)
+	}
+	if err := Seed(ctx, store, "peer-a"); err != nil {
+		t.Fatalf("seed 2: %v", err)
+	}
+
+	var total int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM prompt_templates`).Scan(&total)
+	if total != 7 {
+		t.Fatalf("after re-seed count = %d, want 7", total)
+	}
+}
+
+// TestStore_GetAndGetByUID exercises the two read paths on a seeded DB.
+func TestStore_GetAndGetByUID(t *testing.T) {
+	db := openTestDB(t)
+	store := NewStore(db)
+	ctx := context.Background()
+
+	if err := Seed(ctx, store, "peer-a"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	got, err := store.Get(ctx, ScopeSystem, "", SectionPreamble)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Body != defaultPreamble {
+		t.Fatalf("preamble body mismatch")
+	}
+	byUID, err := store.GetByUID(ctx, got.TemplateUID)
+	if err != nil {
+		t.Fatalf("GetByUID: %v", err)
+	}
+	if byUID.ID != got.ID {
+		t.Fatalf("GetByUID returned row %d, want %d", byUID.ID, got.ID)
+	}
+}
+
+// TestResolver_FallsThroughToSystem — with no task/manifest/product rows
+// overlaid, a resolve at every section should return the system body.
+func TestResolver_FallsThroughToSystem(t *testing.T) {
+	db := openTestDB(t)
+	store := NewStore(db)
+	ctx := context.Background()
+	if err := Seed(ctx, store, ""); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	r := NewResolver(store, nil, nil)
+	for _, sec := range Sections {
+		body, err := r.Resolve(ctx, sec, "")
+		if err != nil {
+			t.Fatalf("resolve %s: %v", sec, err)
+		}
+		if body == "" {
+			t.Fatalf("resolve %s returned empty", sec)
+		}
+	}
+}
+
+// TestResolver_TaskScopeWins — inserting a task-scope row for one
+// section masks the system default for that task only.
+func TestResolver_TaskScopeWins(t *testing.T) {
+	db := openTestDB(t)
+	store := NewStore(db)
+	ctx := context.Background()
+	if err := Seed(ctx, store, ""); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO prompt_templates
+		(template_uid, title, scope, scope_id, section, body, status, tags,
+		 source_node, valid_from, valid_to, changed_by, reason, created_at, deleted_at)
+		VALUES ('task-uid', 'override', 'task', 'task-1', ?, 'OVERRIDDEN', 'open', '[]',
+		        '', '2026-01-01T00:00:00Z', '', 'test', 'override', '2026-01-01T00:00:00Z', '')`,
+		SectionPreamble)
+	if err != nil {
+		t.Fatalf("insert override: %v", err)
+	}
+	r := NewResolver(store, nil, nil)
+	body, err := r.Resolve(ctx, SectionPreamble, "task-1")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if body != "OVERRIDDEN" {
+		t.Fatalf("task override not returned; got %q", body)
+	}
+	// Another task should still get the system default.
+	body2, err := r.Resolve(ctx, SectionPreamble, "task-2")
+	if err != nil {
+		t.Fatalf("resolve other: %v", err)
+	}
+	if body2 != defaultPreamble {
+		t.Fatalf("unrelated task should see system default")
+	}
+}
+
+// TestRender_Printf ensures the %q verb round-trips identical to
+// fmt.Sprintf — the rendered prompt relies on it for <task title=%q>.
+func TestRender_Printf(t *testing.T) {
+	out, err := Render(`title={{printf "%q" .Task.Title}}`, PromptData{Task: TaskView{Title: `he said "hi"`}})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	want := `title="he said \"hi\""`
+	if out != want {
+		t.Fatalf("printf render = %q, want %q", out, want)
+	}
+}

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -214,6 +214,7 @@ func Handler(n *node.Node, mcpServer *mcp.Server, hub *Hub, peerRegistry *peer.R
 	registerSettingsExecRoutes(api, n)
 	registerCommentsRoutesFromNode(api, n)
 	registerDescriptionRoutes(api, n)
+	registerTemplateRoutes(api, n)
 
 	api.HandleFunc("/settings/profile", apiProfileGet(n)).Methods("GET")
 	api.HandleFunc("/settings/profile", apiProfileUpdate(n)).Methods("PUT")

--- a/internal/web/handlers_template.go
+++ b/internal/web/handlers_template.go
@@ -1,0 +1,59 @@
+package web
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/k8nstantin/OpenPraxis/internal/node"
+	"github.com/k8nstantin/OpenPraxis/internal/templates"
+)
+
+// registerTemplateRoutes wires the RC/M1 read-only prompt template
+// endpoints. PUT/history/restore land in RC/M2.
+func registerTemplateRoutes(api *mux.Router, n *node.Node) {
+	api.HandleFunc("/templates", apiTemplatesList(n)).Methods("GET")
+	api.HandleFunc("/templates/{uid}", apiTemplateGet(n)).Methods("GET")
+}
+
+func apiTemplatesList(n *node.Node) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if n.Templates == nil {
+			writeError(w, "templates store not initialized", http.StatusServiceUnavailable)
+			return
+		}
+		scope := r.URL.Query().Get("scope")
+		section := r.URL.Query().Get("section")
+		rows, err := n.Templates.List(r.Context(), scope, section)
+		if err != nil {
+			writeError(w, "list templates: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if rows == nil {
+			rows = []*templates.Template{}
+		}
+		writeJSON(w, rows)
+	}
+}
+
+func apiTemplateGet(n *node.Node) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if n.Templates == nil {
+			writeError(w, "templates store not initialized", http.StatusServiceUnavailable)
+			return
+		}
+		uid := mux.Vars(r)["uid"]
+		t, err := n.Templates.GetByUID(r.Context(), uid)
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, "template not found", http.StatusNotFound)
+			return
+		}
+		if err != nil {
+			writeError(w, "get template: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, t)
+	}
+}


### PR DESCRIPTION
## Summary
- Ships the read-only substrate for the Runner Controls product per manifest RC/M1 (019dba89-45d): new `internal/templates/` package, `prompt_templates` SCD-2 table, resolver walking task → manifest → product → agent → system, byte-identical rewrite of `runner.buildPrompt` using `text/template`, idempotent seed of 7 system-scope rows, and two read-only HTTP endpoints.
- Runtime output is byte-identical to the pre-refactor hardcoded writer — asserted in `runner_prompt_snapshot_test.go` both against a verbatim legacy oracle and a checked-in `testdata/runner_prompt_snapshot.txt`.
- Out of scope: PUT/history/restore, MCP tools, Runner tab UI (land in RC/M2..M6).

## Test plan
- [x] `go build ./...` green.
- [x] `make build` green (codesigned `openpraxis` binary).
- [x] `go test ./internal/templates/... ./internal/task/... ./internal/node/... ./internal/web/...` all green.
- [x] `go test ./...` all green across the repo.
- [x] Live integration against `/tmp/rc-m1-test`:
  - `sqlite3 .../memories.db 'SELECT COUNT(*) FROM prompt_templates'` → **7** on first boot, still **7** after restart (idempotent seed).
  - `curl /api/templates?scope=system` → 7 rows covering all seven sections.
  - `curl /api/templates/{uid}` → active row with non-empty markdown body.
- [x] `runner_exec_review_test` passes unchanged.
- [x] Snapshot + empty-visceral edge case covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)