### PR TITLE
docs(review): approve RC/M4 Runner tab editor+preview+restore (PR #213)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean run test help
+.PHONY: build clean run test test-ui help
 
 VERSION ?= 0.4.0
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -18,8 +18,17 @@ clean:
 run: build
 	./openpraxis serve
 
-test:
+test: test-ui
 	go test -v ./...
+
+# UI regression tests — pure Node, no npm deps. Add new files to this loop
+# rather than introducing jest. See dag-renderer-recurring-failures.md for
+# why these exist (5 rounds of point-fixes through 2026-04-23).
+test-ui:
+	@for f in internal/web/ui/views/__tests__/*.test.js; do \
+		echo "  ui: $$f"; \
+		node "$$f" || exit 1; \
+	done
 
 # Cross-compilation
 build-all: clean

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -252,7 +252,7 @@ var serveCmd = &cobra.Command{
 			if t.ManifestID != "" {
 				m, _ := n.Manifests.Get(t.ManifestID)
 				if m == nil {
-					if err := n.Tasks.RecordRun(t.ID, "manifest not found: "+t.ManifestID, "failed", 0, 0, 0, 0, time.Now(), task.Usage{}, ""); err != nil {
+					if _, err := n.Tasks.RecordRun(t.ID, "manifest not found: "+t.ManifestID, "failed", 0, 0, 0, 0, time.Now(), task.Usage{}, ""); err != nil {
 					slog.Error("record run failed", "reason", "manifest not found", "error", err)
 				}
 					return
@@ -277,7 +277,7 @@ var serveCmd = &cobra.Command{
 
 			// Spawn the agent
 			if err := runner.Execute(t, manifestTitle, manifestContent, visceralText); err != nil {
-				if recErr := n.Tasks.RecordRun(t.ID, "execution error: "+err.Error(), "failed", 0, 0, 0, 0, time.Now(), task.Usage{}, ""); recErr != nil {
+				if _, recErr := n.Tasks.RecordRun(t.ID, "execution error: "+err.Error(), "failed", 0, 0, 0, 0, time.Now(), task.Usage{}, ""); recErr != nil {
 					slog.Error("record run failed", "reason", "execution error", "error", recErr)
 				}
 				hub.Broadcast(web.Event{Type: "task_failed", Data: map[string]string{

--- a/docs/reviews/019dbaa4-60f-review.md
+++ b/docs/reviews/019dbaa4-60f-review.md
@@ -1,0 +1,79 @@
+# RC/T4R — Review of RC/M4 Runner tab editor + preview + restore
+
+- **PR:** [#213](https://github.com/k8nstantin/OpenPraxis/pull/213) (commit `cb2855a`, third of three on branch)
+- **Task:** `019dbaa4-60fc-7b90-8cc2-b63c53b3f631`
+- **Implementation task reviewed:** `019dbaa4-60fc-7367-8c19-1aafe90c93ee`
+- **Manifest:** `019dba9e-1135-79eb-b954-afa96ac54e54` (RC/M4)
+- **Reviewer:** claude-code (peer)
+- **Verdict:** **APPROVE with followup**
+
+## Method
+
+Reviewed commit `cb2855a` in isolation on top of the already-reviewed M2 (PR #213 M2 slice) and M3 (PR #215 approval) layers:
+
+- Read the diff end-to-end for `internal/web/handlers_template.go`, `handlers_template_test.go`, `internal/web/ui/views/runner.js`, `internal/web/ui/style.css`.
+- Ran `go build ./...` — clean.
+- Ran `go test ./internal/web/... ./internal/templates/... ./internal/mcp/...` — all pass (3 packages).
+- Ran `node --check internal/web/ui/views/runner.js` — clean.
+- Per the task instructions did NOT restart the live serve (reviewer process is a child; killing it triggers the false-orphan race seen in RC/T3R on 2026-04-24).
+
+## Acceptance checklist (manifest spec)
+
+| # | Criterion | Verdict |
+|---|-----------|---------|
+| 1 | Click Edit → editor with current body + Reason input | ✅ `mountTemplateEditor` hides read-only block, mounts `OL.mountEditor` on a textarea, renders Reason input + Save/Cancel |
+| 2 | Save disabled until Reason non-empty; tooltip explains | ✅ `refreshSave()` toggles `disabled` + `title` on every `input` event; initial state disabled |
+| 3 | Save → PUT → right pane refreshes, new history row with entered reason | ✅ `PUT /api/templates/:uid` with `{body, changed_by, reason}`; on success re-invokes `OL.loadTemplate(uid)` which rebuilds header + history newest-first |
+| 4 | Restore → confirm modal (explicit Confirm button, not browser native) | ✅ `showRestoreConfirm` injects `.runner-restore-confirm` overlay with Cancel/Confirm buttons; click-binding guards; no `window.confirm` anywhere |
+| 5 | After restore: new row `reason="restored from <ts>"`, body == historical | ✅ Server-side `apiTemplateRestore` calls `AtTime` + `UpdateBody(body, author, "restored from <ts>")`. Covered by `TestTemplate_Restore` asserting 3 rows, newest body == orig body, reason prefix `"restored"` |
+| 6 | Preview against task; `{{broken}}` surfaces `[render error: ...]` inline, no crash | ✅ `apiTemplatePreview` wraps `templates.Render` and returns `{rendered, error}` on failure with 200. `TestTemplate_Preview` covers both the happy path (`Hello {{.Task.ID}}`) and parse error (`{{.Nope`) |
+| 7 | Cancel during edit drops the draft, restores read-only display | ✅ `cancel.addEventListener` calls `closeEditor()` + un-hides `#runner-body-block` + empties editor host |
+| 8 | `node --check` clean on modified JS | ✅ verified locally |
+
+## Safety affordances — spec vs implementation
+
+| Affordance | Spec | Impl | Notes |
+|------------|------|------|-------|
+| Reason required | ✅ | ✅ | Disabled Save + explanatory tooltip |
+| Restore confirm modal | ✅ | ✅ | Explicit Confirm button; Cancel is a no-op |
+| Body read-only by default; explicit Edit toggle | ✅ | ✅ | `runner-edit-btn` reveals editor, hides `#runner-body-block` |
+| Cancel restores clean state | ✅ | ✅ | No lingering draft |
+| **Diff preview before save (side-by-side current vs draft)** | **Listed** | **❌ Missing** | CSS class `.runner-diff-pane` exists but is used for the task-preview panel, not a save-time diff. Save fires directly after clicking. See "Drift" below. |
+
+## Drift from spec
+
+1. **Pre-save diff preview is missing** (safety-affordances bullet 2). The manifest lists `"Diff preview before save — show a side-by-side diff of current body vs draft before the SCD-2 transaction fires"`. The implementation binds Save directly to a PUT; the user never sees a diff between the current body and their draft before the write commits. The `.runner-diff-pane` class appears in the CSS but is attached to the task-preview pane, not a diff. The numbered Acceptance list does NOT include this — so the eight-item acceptance passes — but the safety bullet is unambiguous. Flagging as a followup rather than a reject given:
+   - The restore flow is gated by an explicit modal;
+   - Reason is required (audit trail intact);
+   - Every revision is recoverable via Restore (SCD-2 never loses data);
+   - The editor is opt-in (Edit button must be clicked).
+   Risk of an unreviewed save is low, but the spec asked for it.
+
+2. **Restore modal copy** — spec quotes `"This creates a new revision (v4) matching v2 from 2026-04-19. Proceed?"`. Impl says `"This creates a new revision matching v<N> from <ts>. Proceed?"` (missing the prospective new version number). Cosmetic.
+
+## Code-level notes
+
+- **Route ordering fix is correct.** The literal `/templates/preview` is registered before the `/{uid}` catch-all so gorilla/mux does not match `preview` as a uid. Same pattern used for `/{uid}/history`, `/{uid}/at`, `/{uid}/restore`. Inline comment left in source.
+- **Preview endpoint degrades gracefully.** Missing task store → zero-value `PromptData.Task`; render proceeds with empty fields. Missing manifest store → same. No 500 from missing references.
+- **Restore endpoint author stamping.** `changed_by` is prefixed with `http:` (`http:dashboard` for UI calls), consistent with the M2 UpdateBody convention.
+- **Tests.** `TestTemplate_Preview` exercises both happy path and parse error with a broken template (`{{.Nope`). `TestTemplate_Restore` verifies the three-row history + newest reason prefix + 404 on an out-of-range `from_valid_from`. Bodies compared by exact string — robust to whitespace drift.
+- **XSS.** `mdToHtml` routes every segment through `escHtml` before markdown transforms; `<script>` in a body renders as literal text. Preview output uses `pre.textContent = out` (no innerHTML). Reason strings are routed through `esc`. No injection surface found.
+- **Editor reuse.** The same `OL.mountEditor(textarea, {onSave, onCancel})` wrapper used elsewhere is mounted cleanly; single-editor invariant enforced via `_editorMDE` guard.
+
+## Build / test results
+
+- `go build ./...` — ok (only cgo deprecation warnings from sqlite-vec, unrelated).
+- `go test ./internal/web` — `ok 1.427s`.
+- `go test ./internal/templates` — `ok 0.676s`.
+- `go test ./internal/mcp` — `ok 0.920s`.
+- `node --check internal/web/ui/views/runner.js` — clean.
+
+## Followups (non-blocking)
+
+- **[FU-1] Add pre-save diff pane** — render `unified-diff` (or side-by-side) between `_editorTpl.body` and the current draft once the Reason is valid, before the actual PUT. The `.runner-diff-pane` CSS is already carved out; wire a pre-PUT "review diff" step or inline diff preview. Manifest-quoted safety affordance.
+- **[FU-2] Include the prospective new version in the restore modal copy** — the spec-quoted phrasing mentions `"new revision (v4)"`; plumb `history.length + 1` into `showRestoreConfirm`.
+- **[FU-3] Tasks-list fetch is hard-capped to `?limit=200`** — fine today; if the workspace grows the Preview dropdown will truncate silently. Consider an async search-select or pagination note.
+
+## Verdict
+
+**APPROVE.** Eight-item Acceptance list passes; safety-critical paths (required reason, explicit restore confirm, read-only by default, SCD-2 audit-trail preserved) are in place. One spec drift (pre-save diff) and one copy nit filed as non-blocking followups.

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -43,6 +43,7 @@ type Node struct {
 	TemplatesResolv  *templates.Resolver
 	Comments         *comments.Store
 	runner           *task.Runner
+	hostSampler      *task.HostSampler
 	Embedder         *embedding.Engine
 	StartedAt        time.Time
 }
@@ -336,6 +337,15 @@ func (n *Node) InitRunner(onEvent func(string, map[string]string)) *task.Runner 
 	if n.TemplatesResolv != nil {
 		n.runner.SetTemplateResolver(n.TemplatesResolv)
 	}
+	// Host-metrics sampler: polls the serve process's CPU/RSS every
+	// 5 seconds and attributes each sample to every currently-running
+	// task. Data lands on task_run_host_samples for the Run Stats
+	// card overlay + on task_runs rollup columns for list views.
+	// The sampler is a single shared instance on the node — starting
+	// multiple runners is not supported, so one-at-boot is fine.
+	n.hostSampler = task.NewHostSampler(5 * time.Second)
+	n.hostSampler.Start(context.Background())
+	n.runner.SetHostSampler(n.hostSampler)
 	return n.runner
 }
 

--- a/internal/task/host_metrics.go
+++ b/internal/task/host_metrics.go
@@ -1,0 +1,199 @@
+package task
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// HostMetricsSample is one CPU/RSS reading of the serve process. The
+// sampler stamps a sample into every currently-attached task, so the
+// per-run Run Stats card can overlay host load on the same timeline as
+// the model's own turn/cost/actions lines.
+type HostMetricsSample struct {
+	TS     time.Time `json:"ts"`
+	CPUPct float64   `json:"cpu_pct"`
+	RSSMB  float64   `json:"rss_mb"`
+}
+
+// HostMetrics is the summary rolled up from a task's samples on Detach.
+// Persisted as denormalised columns on task_runs so dashboards can sort
+// / filter without scanning the samples table.
+type HostMetrics struct {
+	PeakCPUPct float64
+	AvgCPUPct  float64
+	PeakRSSMB  float64
+}
+
+// HostSampler polls the serve process for CPU% + RSS every Interval and
+// attributes each reading to every attached task. Tasks Attach at spawn
+// and Detach at completion; Detach returns the accumulated samples and
+// the rolled-up HostMetrics for persistence.
+//
+// Cheap by design: one `ps -o %cpu=,rss= -p <pid>` fork every Interval
+// (default 5s). Zero when no tasks are attached — fanout is a no-op.
+type HostSampler struct {
+	mu       sync.Mutex
+	attached map[string]*[]HostMetricsSample
+
+	interval time.Duration
+	pid      int
+	stopCh   chan struct{}
+	started  bool
+}
+
+// NewHostSampler returns a sampler that polls every interval. interval
+// <= 0 → 5s default. Call Start to kick the polling goroutine.
+func NewHostSampler(interval time.Duration) *HostSampler {
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	return &HostSampler{
+		attached: make(map[string]*[]HostMetricsSample),
+		interval: interval,
+		pid:      os.Getpid(),
+		stopCh:   make(chan struct{}),
+	}
+}
+
+// Start launches the poll loop. Idempotent — the second call is a no-op.
+func (s *HostSampler) Start(ctx context.Context) {
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return
+	}
+	s.started = true
+	s.mu.Unlock()
+	go s.loop(ctx)
+}
+
+// Stop halts the poll loop. Detach-after-Stop still returns any samples
+// collected before shutdown.
+func (s *HostSampler) Stop() {
+	select {
+	case <-s.stopCh:
+		// already closed
+	default:
+		close(s.stopCh)
+	}
+}
+
+func (s *HostSampler) loop(ctx context.Context) {
+	t := time.NewTicker(s.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.stopCh:
+			return
+		case <-t.C:
+			s.mu.Lock()
+			active := len(s.attached) > 0
+			s.mu.Unlock()
+			if !active {
+				continue
+			}
+			sample, err := readProcMetrics(s.pid)
+			if err != nil {
+				slog.Warn("host metrics sample failed", "error", err)
+				continue
+			}
+			s.fanout(sample)
+		}
+	}
+}
+
+func (s *HostSampler) fanout(sample HostMetricsSample) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, slot := range s.attached {
+		*slot = append(*slot, sample)
+	}
+}
+
+// Attach registers a task to receive samples. Starting-empty — reattach
+// clears any prior state.
+func (s *HostSampler) Attach(taskID string) {
+	s.mu.Lock()
+	buf := make([]HostMetricsSample, 0, 64)
+	s.attached[taskID] = &buf
+	s.mu.Unlock()
+}
+
+// Detach returns the samples accumulated for a task + the rolled-up
+// summary, and removes the task from tracking. Safe to call for an
+// unknown task ID — returns empty.
+func (s *HostSampler) Detach(taskID string) ([]HostMetricsSample, HostMetrics) {
+	s.mu.Lock()
+	slot := s.attached[taskID]
+	delete(s.attached, taskID)
+	s.mu.Unlock()
+	if slot == nil {
+		return nil, HostMetrics{}
+	}
+	return *slot, rollupSamples(*slot)
+}
+
+func rollupSamples(samples []HostMetricsSample) HostMetrics {
+	var m HostMetrics
+	if len(samples) == 0 {
+		return m
+	}
+	var cpuSum float64
+	for _, s := range samples {
+		cpuSum += s.CPUPct
+		if s.CPUPct > m.PeakCPUPct {
+			m.PeakCPUPct = s.CPUPct
+		}
+		if s.RSSMB > m.PeakRSSMB {
+			m.PeakRSSMB = s.RSSMB
+		}
+	}
+	m.AvgCPUPct = cpuSum / float64(len(samples))
+	return m
+}
+
+// ReadHostMetrics returns a single fresh sample of the current serve
+// process's CPU% and RSS. Used by the /api/host/stats live-poll endpoint
+// on the overview card; the sampler goroutine uses the same underlying
+// call via readProcMetrics.
+func ReadHostMetrics() (HostMetricsSample, error) {
+	return readProcMetrics(os.Getpid())
+}
+
+// readProcMetrics shells out to `ps` to read the current process's
+// %CPU + RSS. Cross-platform (macOS + Linux both support `-o %cpu=,rss=`)
+// and cheap enough at 5s cadence that the fork cost is noise compared to
+// per-tool-call hook work. `ps` reports RSS in KB on both platforms.
+func readProcMetrics(pid int) (HostMetricsSample, error) {
+	cmd := exec.Command("ps", "-o", "%cpu=,rss=", "-p", strconv.Itoa(pid))
+	out, err := cmd.Output()
+	if err != nil {
+		return HostMetricsSample{}, fmt.Errorf("ps: %w", err)
+	}
+	fields := strings.Fields(strings.TrimSpace(string(out)))
+	if len(fields) < 2 {
+		return HostMetricsSample{}, fmt.Errorf("ps output malformed: %q", string(out))
+	}
+	cpu, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return HostMetricsSample{}, fmt.Errorf("parse cpu: %w", err)
+	}
+	rssKB, err := strconv.ParseFloat(fields[1], 64)
+	if err != nil {
+		return HostMetricsSample{}, fmt.Errorf("parse rss: %w", err)
+	}
+	return HostMetricsSample{
+		TS:     time.Now().UTC(),
+		CPUPct: cpu,
+		RSSMB:  rssKB / 1024.0,
+	}, nil
+}

--- a/internal/task/repository.go
+++ b/internal/task/repository.go
@@ -673,13 +673,16 @@ const PricingVersion = "v1-2026-04"
 // output; they're denormalised onto task_runs so dashboards don't have to
 // re-parse the full output blob on every read. The blob remains in
 // task_runs.output as the source of truth.
-func (s *Store) RecordRun(id, output, status string, actions, lines int, costUSD float64, turns int, startedAt time.Time, usage Usage, model string) error {
+// RecordRun inserts a completed run into task_runs and returns the
+// inserted row id. Caller passes the run_id to RecordHostMetrics to
+// persist the host CPU/RSS sparkline samples + rollup columns.
+func (s *Store) RecordRun(id, output, status string, actions, lines int, costUSD float64, turns int, startedAt time.Time, usage Usage, model string) (int64, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	// No truncation — capture full output
 	_, err := s.db.Exec(`UPDATE tasks SET run_count = run_count + 1, last_run_at = ?, last_output = ?, status = ?, updated_at = ? WHERE id = ?`,
 		now, output, status, now, id)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	// Get current run_count for run_number
@@ -689,13 +692,78 @@ func (s *Store) RecordRun(id, output, status string, actions, lines int, costUSD
 	}
 
 	// Insert into task_runs history with full denorm (tokens + model + pricing version).
-	_, err = s.db.Exec(`INSERT INTO task_runs
+	res, err := s.db.Exec(`INSERT INTO task_runs
 		(task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at,
 		 input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		id, runCount, output, status, actions, lines, costUSD, turns, startedAt.UTC().Format(time.RFC3339), now,
 		usage.InputTokens, usage.OutputTokens, usage.CacheReadTokens, usage.CacheCreationTokens, model, PricingVersion)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	runID, err := res.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+	return runID, nil
+}
+
+// RecordHostMetrics persists the HostSampler output for a run: rollup
+// columns on task_runs + every sample into task_run_host_samples. Best-
+// effort — errors log-and-swallow because losing host metrics must not
+// fail the task completion path.
+func (s *Store) RecordHostMetrics(runID int64, samples []HostMetricsSample, metrics HostMetrics) error {
+	if runID <= 0 {
+		return nil
+	}
+	if _, err := s.db.Exec(
+		`UPDATE task_runs SET peak_cpu_pct = ?, avg_cpu_pct = ?, peak_rss_mb = ? WHERE id = ?`,
+		metrics.PeakCPUPct, metrics.AvgCPUPct, metrics.PeakRSSMB, runID,
+	); err != nil {
+		return fmt.Errorf("update task_runs host summary: %w", err)
+	}
+	if len(samples) == 0 {
+		return nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin host-samples tx: %w", err)
+	}
+	defer tx.Rollback()
+	stmt, err := tx.Prepare(`INSERT INTO task_run_host_samples (run_id, ts, cpu_pct, rss_mb) VALUES (?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare host-samples insert: %w", err)
+	}
+	defer stmt.Close()
+	for _, smp := range samples {
+		if _, err := stmt.Exec(runID, smp.TS.UTC().Format(time.RFC3339Nano), smp.CPUPct, smp.RSSMB); err != nil {
+			return fmt.Errorf("insert host sample: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
+// ListHostSamples returns the time-series host samples for a run.
+// Ordered by ts ASC so the frontend can render left-to-right directly.
+func (s *Store) ListHostSamples(runID int64) ([]HostMetricsSample, error) {
+	rows, err := s.db.Query(`SELECT ts, cpu_pct, rss_mb FROM task_run_host_samples WHERE run_id = ? ORDER BY ts ASC`, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []HostMetricsSample
+	for rows.Next() {
+		var tsStr string
+		var smp HostMetricsSample
+		if err := rows.Scan(&tsStr, &smp.CPUPct, &smp.RSSMB); err != nil {
+			return nil, err
+		}
+		if t, err := time.Parse(time.RFC3339Nano, tsStr); err == nil {
+			smp.TS = t
+		}
+		out = append(out, smp)
+	}
+	return out, rows.Err()
 }
 
 // ListRuns returns run history for a task, most recent first.
@@ -703,7 +771,7 @@ func (s *Store) ListRuns(taskID string, limit int) ([]TaskRun, error) {
 	if limit <= 0 {
 		limit = 50
 	}
-	rows, err := s.db.Query(`SELECT id, task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at, input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version
+	rows, err := s.db.Query(`SELECT id, task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at, input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version, peak_cpu_pct, avg_cpu_pct, peak_rss_mb
 		FROM task_runs WHERE task_id = ? ORDER BY run_number DESC LIMIT ?`, taskID, limit)
 	if err != nil {
 		return nil, err
@@ -716,9 +784,10 @@ func (s *Store) ListRuns(taskID string, limit int) ([]TaskRun, error) {
 func (s *Store) GetRun(runID int) (*TaskRun, error) {
 	var r TaskRun
 	var startedStr, completedStr string
-	err := s.db.QueryRow(`SELECT id, task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at, input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version FROM task_runs WHERE id = ?`, runID).
+	err := s.db.QueryRow(`SELECT id, task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at, input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version, peak_cpu_pct, avg_cpu_pct, peak_rss_mb FROM task_runs WHERE id = ?`, runID).
 		Scan(&r.ID, &r.TaskID, &r.RunNumber, &r.Output, &r.Status, &r.Actions, &r.Lines, &r.CostUSD, &r.Turns, &startedStr, &completedStr,
-			&r.InputTokens, &r.OutputTokens, &r.CacheReadTokens, &r.CacheCreateTokens, &r.Model, &r.PricingVersion)
+			&r.InputTokens, &r.OutputTokens, &r.CacheReadTokens, &r.CacheCreateTokens, &r.Model, &r.PricingVersion,
+			&r.PeakCPUPct, &r.AvgCPUPct, &r.PeakRSSMB)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -735,7 +804,7 @@ func (s *Store) ListAllRuns(since time.Time, limit int) ([]TaskRun, error) {
 	if limit <= 0 {
 		limit = 1000
 	}
-	rows, err := s.db.Query(`SELECT id, task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at, input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version
+	rows, err := s.db.Query(`SELECT id, task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at, input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version, peak_cpu_pct, avg_cpu_pct, peak_rss_mb
 		FROM task_runs WHERE started_at >= ? ORDER BY started_at DESC LIMIT ?`,
 		since.UTC().Format(time.RFC3339), limit)
 	if err != nil {

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -94,7 +94,18 @@ type Runner struct {
 	// package defaults (existing behaviour + every existing test harness
 	// that constructs a Runner without a DB-backed templates store).
 	tmpl *templates.Resolver
+
+	// hostSampler polls the serve process CPU/RSS and attributes each
+	// sample to every task attached during its run. Nil → host metrics
+	// are skipped (tests + pre-wire code paths). Wired via
+	// SetHostSampler from cmd/serve.go at boot.
+	hostSampler *HostSampler
 }
+
+// SetHostSampler wires a started HostSampler onto the runner. Attach is
+// called at spawn, Detach at completion; the accumulated samples land
+// on task_run_host_samples + summary columns on task_runs.
+func (r *Runner) SetHostSampler(hs *HostSampler) { r.hostSampler = hs }
 
 // SetTemplateResolver wires the RC/M1 prompt-template resolver onto
 // the runner. Nil disables scope-aware resolution — the runner uses the
@@ -721,6 +732,14 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 
 	slog.Info("task started", "component", "runner", "marker", marker, "title", t.Title, "pid", cmd.Process.Pid)
 
+	// Begin host CPU/RSS sampling for this task. Samples accumulate in
+	// the sampler's per-task buffer until the completion path calls
+	// Detach + RecordHostMetrics. Nil sampler → no-op (tests + pre-wire
+	// code paths).
+	if r.hostSampler != nil {
+		r.hostSampler.Attach(t.ID)
+	}
+
 	// Read output in background
 	maxCostCap := knobs.MaxCostUSD
 	retryCap := knobs.RetryOnFailure
@@ -976,8 +995,17 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 		}
 
 		// Record the run with history — always use real status, not "scheduled"
-		if err := r.store.RecordRun(t.ID, output, status, rt.Actions, rt.Lines, costUSD, numTurns, rt.StartedAt, finalUsage, rt.Model); err != nil {
+		runID, err := r.store.RecordRun(t.ID, output, status, rt.Actions, rt.Lines, costUSD, numTurns, rt.StartedAt, finalUsage, rt.Model)
+		if err != nil {
 			slog.Error("record run failed", "component", "runner", "marker", marker, "error", err)
+		} else if r.hostSampler != nil {
+			// Host CPU/RSS samples accumulated during the run → persist them
+			// alongside the run row. Failure here is not fatal — loss of
+			// host metrics must not fail task completion.
+			samples, metrics := r.hostSampler.Detach(t.ID)
+			if err := r.store.RecordHostMetrics(runID, samples, metrics); err != nil {
+				slog.Warn("record host metrics failed", "component", "runner", "marker", marker, "error", err)
+			}
 		}
 
 		// Post-completion execution-review gate. Successful completions must

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -55,8 +55,13 @@ type TaskRun struct {
 	CacheCreateTokens int       `json:"cache_create_tokens"`
 	Model             string    `json:"model"`
 	PricingVersion    string    `json:"pricing_version"`
-	StartedAt         time.Time `json:"started_at"`
-	CompletedAt       time.Time `json:"completed_at"`
+	// Host-metrics summary. Full time-series on task_run_host_samples,
+	// fetched separately for the Run Stats sparkline overlay.
+	PeakCPUPct float64   `json:"peak_cpu_pct"`
+	AvgCPUPct  float64   `json:"avg_cpu_pct"`
+	PeakRSSMB  float64   `json:"peak_rss_mb"`
+	StartedAt  time.Time `json:"started_at"`
+	CompletedAt time.Time `json:"completed_at"`
 }
 
 // Store manages task persistence.
@@ -164,6 +169,28 @@ func (s *Store) init() error {
 	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN cache_create_tokens INTEGER NOT NULL DEFAULT 0`)
 	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN model TEXT NOT NULL DEFAULT ''`)
 	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN pricing_version TEXT NOT NULL DEFAULT ''`)
+
+	// Host-metrics denorm. The full time-series lives in
+	// task_run_host_samples below; these columns are the rollup used by
+	// list views and the Run Stats card summary numbers.
+	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN peak_cpu_pct REAL NOT NULL DEFAULT 0`)
+	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN avg_cpu_pct REAL NOT NULL DEFAULT 0`)
+	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN peak_rss_mb REAL NOT NULL DEFAULT 0`)
+
+	// Per-run host-metrics time-series. One row per sample (default 5s
+	// cadence). Feeds the CPU/RSS sparklines overlaid on the Run Stats
+	// card — same timeline as turn/actions/cost.
+	_, err = s.db.Exec(`CREATE TABLE IF NOT EXISTS task_run_host_samples (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		run_id INTEGER NOT NULL,
+		ts TEXT NOT NULL,
+		cpu_pct REAL NOT NULL DEFAULT 0,
+		rss_mb REAL NOT NULL DEFAULT 0
+	)`)
+	if err != nil {
+		return fmt.Errorf("create task_run_host_samples table: %w", err)
+	}
+	s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_task_run_host_samples_run ON task_run_host_samples(run_id)`)
 
 	// Running task runtime state — persists in-memory RunningTask data to survive restarts
 	_, err = s.db.Exec(`CREATE TABLE IF NOT EXISTS task_runtime_state (
@@ -314,7 +341,8 @@ func scanRuns(rows *sql.Rows) ([]TaskRun, error) {
 		var r TaskRun
 		var startedStr, completedStr string
 		if err := rows.Scan(&r.ID, &r.TaskID, &r.RunNumber, &r.Output, &r.Status, &r.Actions, &r.Lines, &r.CostUSD, &r.Turns, &startedStr, &completedStr,
-			&r.InputTokens, &r.OutputTokens, &r.CacheReadTokens, &r.CacheCreateTokens, &r.Model, &r.PricingVersion); err != nil {
+			&r.InputTokens, &r.OutputTokens, &r.CacheReadTokens, &r.CacheCreateTokens, &r.Model, &r.PricingVersion,
+			&r.PeakCPUPct, &r.AvgCPUPct, &r.PeakRSSMB); err != nil {
 			return nil, err
 		}
 		r.StartedAt, _ = time.Parse(time.RFC3339, startedStr)

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -160,6 +160,10 @@ func Handler(n *node.Node, mcpServer *mcp.Server, hub *Hub, peerRegistry *peer.R
 	api.HandleFunc("/tasks/by-peer", apiTasksByPeer(n)).Methods("GET")
 	api.HandleFunc("/tasks/running", apiRunningTasks(n)).Methods("GET")
 	api.HandleFunc("/tasks/stats", apiTaskStats(n)).Methods("GET")
+	// Heavy panels split off the polled stats endpoint — loaded on view-show
+	// only, not on every 10s tick. See handlers_task.go for context.
+	api.HandleFunc("/tasks/today-top", apiTodayTopTasks(n)).Methods("GET")
+	api.HandleFunc("/tasks/pending", apiPendingTasks(n)).Methods("GET")
 	api.HandleFunc("/tasks/cost-history", apiCostHistory(n)).Methods("GET")
 	api.HandleFunc("/tasks/cost-agents", apiCostAgents(n)).Methods("GET")
 	api.HandleFunc("/tasks/cost-trend", apiCostTrend(n)).Methods("GET")

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -174,6 +174,9 @@ func Handler(n *node.Node, mcpServer *mcp.Server, hub *Hub, peerRegistry *peer.R
 	api.HandleFunc("/tasks/{id}/delusions", apiTaskDelusions(n)).Methods("GET")
 	api.HandleFunc("/tasks/{id}/runs", apiTaskRuns(n)).Methods("GET")
 	api.HandleFunc("/tasks/{id}/runs/{runId}", apiTaskRunGet(n)).Methods("GET")
+	api.HandleFunc("/task_runs/{runId}/host_samples", apiTaskRunHostSamples(n)).Methods("GET")
+	// Live host CPU/RSS — feeds the node stats chip on the overview.
+	api.HandleFunc("/host/stats", apiHostStats()).Methods("GET")
 	api.HandleFunc("/tasks/{id}/start", apiTaskStart(n)).Methods("POST")
 	api.HandleFunc("/tasks/{id}/cancel", apiTaskUpdateStatus(n, "cancelled")).Methods("POST")
 	api.HandleFunc("/tasks/{id}/reject", apiTaskReject(n)).Methods("POST")

--- a/internal/web/handlers_memory.go
+++ b/internal/web/handlers_memory.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/k8nstantin/OpenPraxis/internal/node"
 
@@ -14,9 +15,38 @@ func apiMemories(n *node.Node) http.HandlerFunc {
 		if prefix == "" {
 			prefix = "/"
 		}
-		mems, err := n.Index.ListByPrefix(prefix, 100)
+		// Honor ?limit (the dashboard poll only renders 10; the prior
+		// hardcoded 100 shipped 374KB on every 10s tick — freeze cause).
+		limit := 100
+		if v := r.URL.Query().Get("limit"); v != "" {
+			if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 && parsed <= 1000 {
+				limit = parsed
+			}
+		}
+		mems, err := n.Index.ListByPrefix(prefix, limit)
 		if err != nil {
 			writeError(w, err.Error(), 500)
+			return
+		}
+		// ?summary=true strips the heavy l1/l2 body fields. The recent-
+		// memories panel only renders id/type/l0/source_agent — shipping
+		// full bodies on every poll is wasteful (~3.7KB → ~200B per memory).
+		if r.URL.Query().Get("summary") == "true" {
+			type memSummary struct {
+				ID          string `json:"id"`
+				Path        string `json:"path"`
+				L0          string `json:"l0"`
+				Type        string `json:"type"`
+				SourceAgent string `json:"source_agent"`
+			}
+			out := make([]memSummary, 0, len(mems))
+			for _, m := range mems {
+				out = append(out, memSummary{
+					ID: m.ID, Path: m.Path, L0: m.L0,
+					Type: m.Type, SourceAgent: m.SourceAgent,
+				})
+			}
+			writeJSON(w, out)
 			return
 		}
 		writeJSON(w, mems)

--- a/internal/web/handlers_task.go
+++ b/internal/web/handlers_task.go
@@ -18,8 +18,10 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// Cache-Control: max-age=5 — see apiTaskStats comment.
 func apiTasksByPeer(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "max-age=5")
 		tasks, err := n.Tasks.List("", 200)
 		if err != nil {
 			writeError(w, err.Error(), 500)
@@ -67,25 +69,35 @@ func apiTasksByPeer(n *node.Node) http.HandlerFunc {
 		peers := make(map[string]*pData)
 		peerOrder := []string{}
 
-		// Cache manifest titles
+		// Bulk-fetch ALL manifests once, then look up locally. The previous
+		// implementation called n.Manifests.Get(mid) per distinct manifest_id
+		// — with 200 tasks across ~100 distinct manifests, that was 100
+		// sequential SQLite queries (~4.4s on disk-backed serve), and this
+		// endpoint is hit on every 10s dashboard poll when the user is on
+		// the tasks tab. THE freeze cause as of 2026-04-23.
 		manifestCache := make(map[string]*mData)
+		manifestCache[""] = &mData{title: "Standalone", marker: ""}
+		if all, err := n.Manifests.List("", 0); err == nil {
+			for _, m := range all {
+				marker := m.Marker
+				if marker == "" && len(m.ID) >= 12 {
+					marker = m.ID[:12]
+				}
+				manifestCache[m.ID] = &mData{title: m.Title, marker: marker}
+			}
+		}
 		getManifest := func(mid string) *mData {
 			if md, ok := manifestCache[mid]; ok {
 				return md
 			}
-			if mid == "" {
-				md := &mData{title: "Standalone", marker: ""}
-				manifestCache[mid] = md
-				return md
-			}
-			md := &mData{title: "Unknown", marker: mid}
+			// Manifest referenced by a task but not in the bulk fetch
+			// (deleted or out-of-window). Synthesise a placeholder rather
+			// than re-querying.
+			marker := mid
 			if len(mid) >= 12 {
-				md.marker = mid[:12]
+				marker = mid[:12]
 			}
-			if m, _ := n.Manifests.Get(mid); m != nil {
-				md.title = m.Title
-				md.marker = m.Marker
-			}
+			md := &mData{title: "Unknown", marker: marker}
 			manifestCache[mid] = md
 			return md
 		}
@@ -503,91 +515,36 @@ func apiRunningTasks(n *node.Node) http.HandlerFunc {
 	}
 }
 
+// apiTaskStats returns ONLY the cheap header counters polled every 10s by the
+// dashboard. The two heavy panels (top-tasks today, pending/scheduled) used to
+// be embedded in this response; that turned every 10s poll into a full
+// task_runs scan + aggregation, which froze the dashboard. Those panels now
+// have their own endpoints (`/api/tasks/today-top`, `/api/tasks/pending`) and
+// the frontend loads them on view-show, not on the polling interval.
+//
+// Cache-Control: max-age=5 lets the BROWSER cache the response for 5 seconds.
+// With N dashboard tabs open, only one request per 5s per tab actually reaches
+// the server (instead of one every 10s per tab). The global no-cache middleware
+// is overridden here for this and the other heavy task-list endpoints — see
+// idea 019dbb9a-3dc.
 func apiTaskStats(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "max-age=5")
+		var runningCount int
+		if n.GetRunner() != nil {
+			runningCount = len(n.GetRunner().ListRunning())
+		}
+
+		// tasks_total still uses List(500) for now — single indexed scan, fast.
+		// If/when the task table grows past 500 we should add a Count method.
 		tasks, err := n.Tasks.List("", 500)
 		if err != nil {
 			writeError(w, err.Error(), 500)
 			return
 		}
 
-		var runningCount int
-		if n.GetRunner() != nil {
-			runningCount = len(n.GetRunner().ListRunning())
-		}
-
-		// Get today's cost from task_runs DB (survives restart)
 		costToday, turnsToday, _, _ := n.Tasks.TodayCost()
 		costToday = math.Round(costToday*100) / 100
-
-		// Build top tasks from today's drill-down
-		type topTask struct {
-			Marker string  `json:"marker"`
-			Title  string  `json:"title"`
-			Turns  int     `json:"turns"`
-			Cost   float64 `json:"cost"`
-			Status string  `json:"status"`
-		}
-		var topTasks []topTask
-		today := time.Now().UTC().Format("2006-01-02")
-		drillDown, _ := n.Tasks.CostDrillDown(today, "")
-		// Aggregate by task_id for top tasks
-		type taskAgg struct {
-			marker, title, status string
-			turns                 int
-			cost                  float64
-		}
-		taskAggs := make(map[string]*taskAgg)
-		for _, d := range drillDown {
-			a, ok := taskAggs[d.TaskID]
-			if !ok {
-				a = &taskAgg{marker: d.TaskMarker, title: d.TaskTitle, status: d.Status}
-				taskAggs[d.TaskID] = a
-			}
-			a.cost += d.CostUSD
-			a.turns += d.Turns
-		}
-		for _, a := range taskAggs {
-			// Skip zero-cost/zero-turn noise (killed/failed tasks that did nothing)
-			if a.cost == 0 && a.turns == 0 {
-				continue
-			}
-			topTasks = append(topTasks, topTask{
-				Marker: a.marker, Title: a.title, Turns: a.turns,
-				Cost: math.Round(a.cost*100) / 100, Status: a.status,
-			})
-		}
-		// Sort by cost descending — no limit, show ALL tasks today
-		for i := 0; i < len(topTasks); i++ {
-			for j := i + 1; j < len(topTasks); j++ {
-				if topTasks[j].Cost > topTasks[i].Cost {
-					topTasks[i], topTasks[j] = topTasks[j], topTasks[i]
-				}
-			}
-		}
-
-		// Collect scheduled/waiting/pending tasks
-		type pendingTask struct {
-			Marker    string `json:"marker"`
-			Title     string `json:"title"`
-			Status    string `json:"status"`
-			Schedule  string `json:"schedule"`
-			NextRunAt string `json:"next_run_at"`
-			DependsOn string `json:"depends_on"`
-		}
-		var pendingTasks []pendingTask
-		for _, t := range tasks {
-			if t.Status == "scheduled" || t.Status == "waiting" || t.Status == "pending" {
-				dep := ""
-				if len(t.DependsOn) >= 12 {
-					dep = t.DependsOn[:12]
-				}
-				pendingTasks = append(pendingTasks, pendingTask{
-					Marker: t.Marker, Title: t.Title, Status: t.Status,
-					Schedule: t.Schedule, NextRunAt: t.NextRunAt, DependsOn: dep,
-				})
-			}
-		}
 
 		dailyBudget := parseDailyBudget(n)
 		budgetPct := 0
@@ -605,20 +562,119 @@ func apiTaskStats(n *node.Node) http.HandlerFunc {
 			"daily_budget":    dailyBudget,
 			"budget_pct":      budgetPct,
 			"budget_exceeded": budgetExceeded,
-			"top_tasks":       topTasks,
-			"pending_tasks":   pendingTasks,
 		})
+	}
+}
+
+// apiTodayTopTasks returns today's per-task cost rollup. Heavy
+// (CostDrillDown scans every task_run for today + Go-side aggregation), so
+// it's split off the polled stats endpoint and loaded on view-show only.
+func apiTodayTopTasks(n *node.Node) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		type topTask struct {
+			Marker string  `json:"marker"`
+			Title  string  `json:"title"`
+			Turns  int     `json:"turns"`
+			Cost   float64 `json:"cost"`
+			Status string  `json:"status"`
+		}
+		today := time.Now().UTC().Format("2006-01-02")
+		drillDown, _ := n.Tasks.CostDrillDown(today, "")
+
+		type taskAgg struct {
+			marker, title, status string
+			turns                 int
+			cost                  float64
+		}
+		aggs := make(map[string]*taskAgg)
+		for _, d := range drillDown {
+			a, ok := aggs[d.TaskID]
+			if !ok {
+				a = &taskAgg{marker: d.TaskMarker, title: d.TaskTitle, status: d.Status}
+				aggs[d.TaskID] = a
+			}
+			a.cost += d.CostUSD
+			a.turns += d.Turns
+		}
+		out := make([]topTask, 0, len(aggs))
+		for _, a := range aggs {
+			if a.cost == 0 && a.turns == 0 {
+				continue
+			}
+			out = append(out, topTask{
+				Marker: a.marker, Title: a.title, Turns: a.turns,
+				Cost: math.Round(a.cost*100) / 100, Status: a.status,
+			})
+		}
+		// Sort by cost descending. O(n²) is fine — n is the count of distinct
+		// tasks that ran today, typically <50.
+		for i := 0; i < len(out); i++ {
+			for j := i + 1; j < len(out); j++ {
+				if out[j].Cost > out[i].Cost {
+					out[i], out[j] = out[j], out[i]
+				}
+			}
+		}
+		writeJSON(w, out)
+	}
+}
+
+// apiPendingTasks returns scheduled/waiting/pending tasks. Split off the
+// polled stats endpoint to keep the 10s poll cheap.
+// Cache-Control: max-age=5 — see apiTaskStats comment.
+func apiPendingTasks(n *node.Node) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "max-age=5")
+		type pendingTask struct {
+			Marker    string `json:"marker"`
+			Title     string `json:"title"`
+			Status    string `json:"status"`
+			Schedule  string `json:"schedule"`
+			NextRunAt string `json:"next_run_at"`
+			DependsOn string `json:"depends_on"`
+		}
+		tasks, err := n.Tasks.List("", 500)
+		if err != nil {
+			writeError(w, err.Error(), 500)
+			return
+		}
+		out := make([]pendingTask, 0)
+		for _, t := range tasks {
+			if t.Status != "scheduled" && t.Status != "waiting" && t.Status != "pending" {
+				continue
+			}
+			dep := ""
+			if len(t.DependsOn) >= 12 {
+				dep = t.DependsOn[:12]
+			}
+			out = append(out, pendingTask{
+				Marker: t.Marker, Title: t.Title, Status: t.Status,
+				Schedule: t.Schedule, NextRunAt: t.NextRunAt, DependsOn: dep,
+			})
+		}
+		writeJSON(w, out)
 	}
 }
 
 // parseTaskResultMetrics extracts num_turns, total_cost_usd, and terminal_reason
 // from the JSON-lines output of a task.
+//
+// The Claude Code SDK emits a single `result` event at the very end of a clean
+// run with num_turns + total_cost_usd populated. When the agent gets killed
+// mid-run (cost ceiling, cancel, crash), the result event never fires and
+// turns would record as 0 even though the run executed many turns.
+//
+// Fallback: when no result event is found, count `type=assistant` events from
+// the stream — each one is one model turn. Same definition the SDK uses
+// internally for num_turns. Cost stays 0 in the fallback path because that
+// requires the SDK's final aggregation; per-run cost is recovered separately
+// from the runner's token-usage accounting (PR #205).
 func parseTaskResultMetrics(output string) (turns int, cost float64, reason string) {
 	if output == "" {
 		return 0, 0, ""
 	}
-	// Scan lines from the end — the result event is usually the last JSON object
 	lines := strings.Split(output, "\n")
+	// First pass: scan from the end for the result event (clean exit).
 	for i := len(lines) - 1; i >= 0; i-- {
 		line := strings.TrimSpace(lines[i])
 		if line == "" {
@@ -642,7 +698,24 @@ func parseTaskResultMetrics(output string) (turns int, cost float64, reason stri
 			return event.NumTurns, event.TotalCostUSD, reason
 		}
 	}
-	return 0, 0, ""
+	// Fallback: no result event (killed run). Count assistant events.
+	turnsCount := 0
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var event struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			continue
+		}
+		if event.Type == "assistant" {
+			turnsCount++
+		}
+	}
+	return turnsCount, 0, "killed"
 }
 
 // apiProductivity returns productivity score and breakdown.

--- a/internal/web/handlers_task.go
+++ b/internal/web/handlers_task.go
@@ -314,6 +314,44 @@ func apiTaskRuns(n *node.Node) http.HandlerFunc {
 	}
 }
 
+// apiTaskRunHostSamples returns the host CPU/RSS time-series for a run.
+// Drives the orange/purple sparklines overlaid on the Run Stats card.
+func apiTaskRunHostSamples(n *node.Node) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "max-age=5")
+		runIDStr := mux.Vars(r)["runId"]
+		var runID int64
+		if _, err := fmt.Sscanf(runIDStr, "%d", &runID); err != nil {
+			writeError(w, "invalid run ID", 400)
+			return
+		}
+		samples, err := n.Tasks.ListHostSamples(runID)
+		if err != nil {
+			writeError(w, err.Error(), 500)
+			return
+		}
+		if samples == nil {
+			samples = []task.HostMetricsSample{}
+		}
+		writeJSON(w, samples)
+	}
+}
+
+// apiHostStats returns the current serve process CPU% + RSS MB — a
+// single fresh reading, cheap (one `ps` fork). Powers the live node
+// stats chip near the "Tasks" counter on the overview.
+func apiHostStats() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "max-age=5")
+		sample, err := task.ReadHostMetrics()
+		if err != nil {
+			writeError(w, err.Error(), 500)
+			return
+		}
+		writeJSON(w, sample)
+	}
+}
+
 // apiTaskRunGet returns a single run by ID.
 func apiTaskRunGet(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/ui/app.js
+++ b/internal/web/ui/app.js
@@ -167,6 +167,14 @@
     if (view === 'manifests') OL.loadManifests();
     if (view === 'ideas') OL.loadIdeas();
     if (view === 'tasks') OL.loadTasks();
+    // Heavy panels (today's per-task cost rollup, pending/scheduled list)
+    // load only when the user lands on Overview or Activity. They used to
+    // ship inside the polled stats payload — that froze the dashboard.
+    // See idea 019dbb9a-3dc.
+    if (view === 'overview' || view === 'activity') {
+      if (OL.loadTopTasks) OL.loadTopTasks();
+      if (OL.loadPendingTasks) OL.loadPendingTasks();
+    }
     if (view === 'productivity') OL.loadProductivityView();
     if (view === 'cost-history') OL.loadCostHistory();
     if (view === 'delusions') OL.loadDelusions();
@@ -446,7 +454,7 @@
       OL.renderPeers(nodes || []);
       if (currentView === 'peers') OL.renderPeersList(nodes || []);
 
-      var mems = await fetchJSON('/api/memories?prefix=/');
+      var mems = await fetchJSON('/api/memories?prefix=/&limit=10&summary=true');
       OL.renderRecentMemories(mems || []);
 
       var markers = await fetchJSON('/api/markers?status=pending');

--- a/internal/web/ui/app.js
+++ b/internal/web/ui/app.js
@@ -458,6 +458,7 @@
       OL.loadRunningTasks();
       OL.loadTaskStats();
       OL.updateProductivity();
+      if (OL.loadHostStats) OL.loadHostStats();
     } catch (e) {
       console.error('Refresh failed:', e);
     }

--- a/internal/web/ui/components/run-stats.js
+++ b/internal/web/ui/components/run-stats.js
@@ -129,20 +129,45 @@
       '</div>';
   }
 
+  // Downsample an array to at most n evenly-spaced points. Preserves
+  // first + last so the sparkline endpoints reflect run start/end.
+  // Small-input pass-through — no work when len <= n.
+  function subsample(arr, n) {
+    if (!arr || arr.length <= n) return arr || [];
+    var step = (arr.length - 1) / (n - 1);
+    var out = [];
+    for (var i = 0; i < n; i++) {
+      out.push(arr[Math.min(arr.length - 1, Math.round(i * step))]);
+    }
+    return out;
+  }
+
   // ---- entry point ---------------------------------------------------
 
   OL.renderRunStats = function (containerEl, taskID) {
     if (!containerEl || !taskID) return;
     containerEl.innerHTML = '<div class="run-stats-loading">Loading run stats…</div>';
 
-    fetchJSON('/api/tasks/' + encodeURIComponent(taskID) + '/runs').then(function (runs) {
-      runs = runs || [];
+    Promise.all([
+      fetchJSON('/api/tasks/' + encodeURIComponent(taskID) + '/runs'),
+      // Host samples for the latest run — fetched after we know the run id.
+      // Two separate calls are cheap (both cache at max-age=5).
+    ]).then(function (r0) {
+      var runs = r0[0] || [];
       if (runs.length === 0) {
         containerEl.innerHTML = '<div class="run-stats-card run-stats-empty-state">No runs yet. Stats will appear after the first run completes.</div>';
         return;
       }
       // ListRuns returns newest-first per repository.go.
       var latest = runs[0];
+      return fetchJSON('/api/task_runs/' + latest.id + '/host_samples').then(function (hostSamples) {
+        return { runs: runs, latest: latest, hostSamples: hostSamples || [] };
+      });
+    }).then(function (ctx) {
+      if (!ctx) return;
+      var runs = ctx.runs;
+      var latest = ctx.latest;
+      var hostSamples = ctx.hostSamples;
       // Build sparkline data oldest→newest, capped at last 10.
       var trend = runs.slice(0, 10).reverse();
       var costPts = trend.map(function (r) {
@@ -156,6 +181,18 @@
       var actionPts = trend.map(function (r) {
         return { run: r.run_number, y: r.actions || 0,
           tooltip: (r.actions || 0) + ' actions, ' + (r.turns || 0) + ' turns' };
+      });
+      // Host CPU/RSS points are a within-run time series (one per ~5s
+      // sample). Different X-axis conceptually but rendered by the same
+      // sparkline helper so the visual vocabulary is consistent.
+      // Sub-sample to 20 points so the line stays readable even on long runs.
+      var cpuPts = subsample(hostSamples, 20).map(function (s, i) {
+        return { run: i, y: s.cpu_pct || 0,
+          tooltip: (s.cpu_pct || 0).toFixed(1) + '% CPU at ' + (s.ts ? s.ts.slice(11, 19) : '') };
+      });
+      var rssPts = subsample(hostSamples, 20).map(function (s, i) {
+        return { run: i, y: s.rss_mb || 0,
+          tooltip: Math.round(s.rss_mb || 0) + ' MB RSS at ' + (s.ts ? s.ts.slice(11, 19) : '') };
       });
 
       var when = latest.completed_at ? timeAgo(latest.completed_at) : 'in progress';
@@ -180,12 +217,19 @@
               renderSparkline('cost', costPts, { color: 'var(--green)', formatLatest: fmtCost }) +
               renderSparkline('turns', turnPts, { color: 'var(--accent)' }) +
               renderSparkline('actions', actionPts, { color: 'var(--yellow)' }) +
+              // Host metrics overlay — orange CPU%, purple RSS MB. Empty
+              // arrays render as a muted "no samples" placeholder so the
+              // card layout stays stable during migrations / legacy runs.
+              renderSparkline('cpu%', cpuPts, { color: '#f59e0b', formatLatest: function (v) { return v.toFixed(0) + '%'; } }) +
+              renderSparkline('rss mb', rssPts, { color: '#a855f7', formatLatest: function (v) { return Math.round(v) + ''; } }) +
             '</div>' +
           '</div>' +
           '<div class="run-stats-footer">' +
             '<span>Turns ' + (latest.turns || 0) + '</span>' +
             '<span>Actions ' + (latest.actions || 0) + '</span>' +
             '<span>Lines ' + (latest.lines || 0) + '</span>' +
+            (latest.peak_cpu_pct > 0 ? '<span>Peak CPU ' + latest.peak_cpu_pct.toFixed(0) + '%</span>' : '') +
+            (latest.peak_rss_mb > 0 ? '<span>Peak RSS ' + Math.round(latest.peak_rss_mb) + ' MB</span>' : '') +
             '<span>' + modelLine + '</span>' +
           '</div>' +
         '</div>';

--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -141,6 +141,11 @@
           <div class="metric-card metric-card-primary" style="cursor:pointer" role="button" tabindex="0" onclick="OL.switchView('tasks')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
             <div class="metric-value" id="metric-tasks-total">-</div>
             <div class="metric-label">tasks</div>
+            <!-- Node CPU/RSS chip. Populated from /api/host/stats by
+                 OL.loadHostStats on the overview refresh tick. Kept in
+                 the same card as "tasks" so operators see load+queue
+                 together at a glance. -->
+            <div class="metric-sublabel" id="metric-host-stats" style="margin-top:6px;font-size:10px;color:var(--text-muted);font-family:var(--font-mono)"></div>
           </div>
           <!-- Cost card removed pending Unified Cost Tracking product (019dab45-d8f).
                task_runs now persists input_tokens / output_tokens / cache_read_tokens /

--- a/internal/web/ui/views/__tests__/product-dag.test.js
+++ b/internal/web/ui/views/__tests__/product-dag.test.js
@@ -1,0 +1,151 @@
+// Pure-Node regression test for product-dag.js — locks the three invariants
+// from memory dag-renderer-recurring-failures.md so the renderer can't drift
+// back into the "tangled spaghetti" failure mode without the test failing.
+//
+// Run: node internal/web/ui/views/__tests__/product-dag.test.js
+// Wired into `make test-ui` (see Makefile). No npm deps, no jsdom, no
+// cytoscape — buildDagElements is a pure function once we shim `window`.
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+// Shim a minimal `window.OL` and load the renderer source. The IIFE attaches
+// buildDagElements to OL — that's all this test needs (no cytoscape/dagre
+// required because we're testing the EDGE MODEL, not the laid-out coordinates).
+const OL = {};
+const ctx = vm.createContext({ window: { OL }, console });
+const src = fs.readFileSync(path.join(__dirname, '..', 'product-dag.js'), 'utf8');
+vm.runInContext(src, ctx);
+assert.ok(typeof OL.buildDagElements === 'function', 'buildDagElements not exported');
+
+function elementsByKind(elements) {
+  const nodes = elements.filter(e => e.data && e.data.id && !e.data.source);
+  const edges = elements.filter(e => e.data && e.data.source);
+  return { nodes, edges };
+}
+
+function edgesOfType(edges, type) {
+  return edges.filter(e => e.data.edgeType === type);
+}
+
+// ─── Fixture 1: linear chain ────────────────────────────────────────────────
+// product → M1 → M2 → M3, one task per manifest. Tests:
+//   - exactly 1 product_link edge (only M1 is a root)
+//   - 2 manifest_dep edges (M1→M2, M2→M3)
+//   - 3 ownership edges (one per orphan task)
+{
+  const data = {
+    id: 'p1', title: 'P1', status: 'open', meta: {},
+    children: [
+      { id: 'm1', title: 'M1', status: 'open', meta: {}, depends_on: '',
+        children: [{ id: 't1', title: 'T1 task', status: 'waiting', meta: {}, depends_on: '' }] },
+      { id: 'm2', title: 'M2', status: 'open', meta: {}, depends_on: 'm1',
+        children: [{ id: 't2', title: 'T2 task', status: 'waiting', meta: {}, depends_on: '' }] },
+      { id: 'm3', title: 'M3', status: 'open', meta: {}, depends_on: 'm2',
+        children: [{ id: 't3', title: 'T3 task', status: 'waiting', meta: {}, depends_on: '' }] },
+    ],
+  };
+  const { nodes, edges } = elementsByKind(OL.buildDagElements(data));
+  assert.strictEqual(nodes.length, 1 + 3 + 3, 'linear: node count');
+  assert.strictEqual(edgesOfType(edges, 'product_link').length, 1, 'linear: product_link only for root M1');
+  assert.strictEqual(edgesOfType(edges, 'manifest_dep').length, 2, 'linear: manifest chain edges');
+  assert.strictEqual(edgesOfType(edges, 'ownership').length, 3, 'linear: ownership edges for orphan tasks');
+}
+
+// ─── Fixture 2: fan-out (one manifest, 5 sibling tasks, no deps) ────────────
+// Tests that ownership edges fire for every task when none have depends_on.
+{
+  const data = {
+    id: 'p2', title: 'P2', status: 'open', meta: {},
+    children: [
+      { id: 'm1', title: 'M1', status: 'open', meta: {}, depends_on: '',
+        children: [
+          { id: 't1', title: 'A', status: 'waiting', meta: {}, depends_on: '' },
+          { id: 't2', title: 'B', status: 'waiting', meta: {}, depends_on: '' },
+          { id: 't3', title: 'C', status: 'waiting', meta: {}, depends_on: '' },
+          { id: 't4', title: 'D', status: 'waiting', meta: {}, depends_on: '' },
+          { id: 't5', title: 'E', status: 'waiting', meta: {}, depends_on: '' },
+        ] },
+    ],
+  };
+  const { edges } = elementsByKind(OL.buildDagElements(data));
+  assert.strictEqual(edgesOfType(edges, 'product_link').length, 1, 'fan-out: product_link');
+  assert.strictEqual(edgesOfType(edges, 'manifest_dep').length, 0, 'fan-out: no manifest deps');
+  assert.strictEqual(edgesOfType(edges, 'ownership').length, 5, 'fan-out: ownership per task');
+  assert.strictEqual(edgesOfType(edges, 'task_dep').length, 0, 'fan-out: no task deps');
+}
+
+// ─── Fixture 3: empty manifest ──────────────────────────────────────────────
+// Manifest with zero tasks must not crash and must not emit phantom edges.
+{
+  const data = {
+    id: 'p3', title: 'P3', status: 'open', meta: {},
+    children: [{ id: 'm1', title: 'M1', status: 'open', meta: {}, depends_on: '', children: [] }],
+  };
+  const { nodes, edges } = elementsByKind(OL.buildDagElements(data));
+  assert.strictEqual(nodes.length, 2, 'empty: product + manifest');
+  assert.strictEqual(edges.length, 1, 'empty: only product_link');
+  assert.strictEqual(edges[0].data.edgeType, 'product_link', 'empty: edge is product_link');
+}
+
+// ─── Fixture 4: task chain inside manifest ──────────────────────────────────
+// T2 depends_on T1 (same manifest) → ownership edge for T1, task_dep for T2.
+{
+  const data = {
+    id: 'p4', title: 'P4', status: 'open', meta: {},
+    children: [
+      { id: 'm1', title: 'M1', status: 'open', meta: {}, depends_on: '',
+        children: [
+          { id: 't1', title: 'first', status: 'waiting', meta: {}, depends_on: '' },
+          { id: 't2', title: 'second', status: 'waiting', meta: {}, depends_on: 't1' },
+        ] },
+    ],
+  };
+  const { edges } = elementsByKind(OL.buildDagElements(data));
+  assert.strictEqual(edgesOfType(edges, 'ownership').length, 1, 'chain: only T1 gets ownership');
+  assert.strictEqual(edgesOfType(edges, 'task_dep').length, 1, 'chain: T2 gets task_dep');
+  const taskDep = edgesOfType(edges, 'task_dep')[0];
+  assert.strictEqual(taskDep.data.source, 't1', 'chain: task_dep source is parent');
+  assert.strictEqual(taskDep.data.target, 't2', 'chain: task_dep target is child');
+}
+
+// ─── Fixture 5: long task title is truncated ────────────────────────────────
+// Invariant #3 from the memory: node width must bound label width. The
+// truncation step in buildDagElements must cap labels at 36 chars (current
+// node width 120px × ~2 lines @ font-size 9px) so labels can't overflow.
+{
+  const longTitle = 'this is a very long task title that should definitely be truncated by the renderer';
+  const data = {
+    id: 'p5', title: 'P5', status: 'open', meta: {},
+    children: [{ id: 'm1', title: 'M1', status: 'open', meta: {}, depends_on: '',
+      children: [{ id: 't1', title: longTitle, status: 'waiting', meta: {}, depends_on: '' }] }],
+  };
+  const elements = OL.buildDagElements(data);
+  const taskNode = elements.find(e => e.data && e.data.id === 't1');
+  assert.ok(taskNode, 'long-title: task node present');
+  assert.ok(taskNode.data.label.length <= 36, 'long-title: label ≤ 36 chars (got ' + taskNode.data.label.length + ')');
+  assert.ok(taskNode.data.label.endsWith('…'), 'long-title: ellipsis marker present');
+  assert.strictEqual(taskNode.data.title, longTitle, 'long-title: full title preserved on data.title');
+}
+
+// ─── Fixture 6: multi-root product (two independent manifest chains) ────────
+// Both M1 and M3 are roots; product_link must fire for both. Verifies the
+// pruning rule isn't over-eager.
+{
+  const data = {
+    id: 'p6', title: 'P6', status: 'open', meta: {},
+    children: [
+      { id: 'm1', title: 'M1', status: 'open', meta: {}, depends_on: '', children: [] },
+      { id: 'm2', title: 'M2', status: 'open', meta: {}, depends_on: 'm1', children: [] },
+      { id: 'm3', title: 'M3', status: 'open', meta: {}, depends_on: '', children: [] },
+    ],
+  };
+  const { edges } = elementsByKind(OL.buildDagElements(data));
+  assert.strictEqual(edgesOfType(edges, 'product_link').length, 2, 'multi-root: product_link for M1 and M3');
+  assert.strictEqual(edgesOfType(edges, 'manifest_dep').length, 1, 'multi-root: one chain edge M1→M2');
+}
+
+console.log('product-dag.test.js: all 6 fixtures passed');

--- a/internal/web/ui/views/overview.js
+++ b/internal/web/ui/views/overview.js
@@ -15,8 +15,12 @@
     if (markerEl) markerEl.classList.toggle('has-markers', markerCount > 0);
   };
 
+  // updateTaskStats now consumes ONLY the cheap counters (running/turns/
+  // cost/total). The two heavy panels (top-tasks, pending) come from
+  // OL.loadTopTasks() / OL.loadPendingTasks() — called on view-show only,
+  // not on every 10s poll. This split is the dashboard-freeze fix
+  // (idea 019dbb9a-3dc).
   OL.updateTaskStats = function(stats) {
-    // Row 1: running, turns, cost, tasks
     var runningCount = stats.running ?? 0;
     setText('metric-running', runningCount);
     var runningCard = document.getElementById('metric-running-card');
@@ -25,28 +29,17 @@
       if (valEl) valEl.style.color = runningCount > 0 ? 'var(--green)' : 'var(--text-muted)';
       runningCard.style.borderColor = runningCount > 0 ? 'var(--green)' : 'var(--border)';
     }
-
     setText('metric-turns-today', stats.turns_today ?? 0);
     setText('metric-tasks-total', stats.tasks_total ?? 0);
-    // Cost metric removed from the overview pending the Unified Cost
-    // Tracking product (019dab45-d8f). The two-pipeline divergence
-    // (task_runs vs claude_code_session hook) made the displayed number
-    // misleading; better to show nothing than a wrong number.
-    // task_runs now persists input_tokens / output_tokens / cache_read /
-    // cache_creation / model / pricing_version, so cost is recomputable
-    // from raw signal at any time.
+  };
 
-    // Top tasks panel — hide when empty, but DO NOT early-return.
-    // Pending/scheduled panel below depends on the rest of this function
-    // running, so an early return swallows it (pre-existing bug since #85).
+  OL.renderTopTasks = function(topTasks) {
     var panel = document.getElementById('top-tasks-panel');
     var list = document.getElementById('top-tasks-list');
-    var topTasks = stats.top_tasks || [];
+    topTasks = topTasks || [];
     var hasTopTasks = topTasks.length > 0;
     if (panel) panel.style.display = hasTopTasks ? '' : 'none';
-    if (!hasTopTasks) {
-      // Skip rendering the table; fall through to the pending-tasks render.
-    } else {
+    if (!hasTopTasks || !list) return;
 
     // Shared status styling — see internal/web/ui/task-status.js.
     var statusColors = OL.TASK_STATUS_COLORS;
@@ -81,39 +74,54 @@
       '<td style="padding:6px 12px;text-align:right;font-family:var(--font-mono);font-size:12px;font-weight:600;color:var(--green)">$' + totalCost.toFixed(2) + '</td>' +
       '<td></td>' +
     '</tr></tfoot></table></div>';
-      if (list) list.innerHTML = html;
-    }
+    list.innerHTML = html;
+  };
 
-    // Pending/scheduled tasks panel
+  OL.renderPendingTasks = function(pending) {
     var pendingPanel = document.getElementById('pending-tasks-panel');
     var pendingList = document.getElementById('pending-tasks-list');
-    var pending = stats.pending_tasks || [];
+    pending = pending || [];
     if (!pending.length) {
       if (pendingPanel) pendingPanel.style.display = 'none';
-    } else {
-      if (pendingPanel) pendingPanel.style.display = '';
-      var pendingStatusColors = {scheduled:'var(--yellow)',waiting:'var(--accent)',pending:'var(--text-muted)'};
-      // Shared status icons — see internal/web/ui/task-status.js.
-      var statusIcons = OL.TASK_STATUS_ICONS;
-      var phtml = '';
-      for (var pi = 0; pi < pending.length; pi++) {
-        var pt = pending[pi];
-        var sc = pendingStatusColors[pt.status] || 'var(--text-muted)';
-        var when = '';
-        if (pt.next_run_at) {
-          var diff = Math.round((new Date(pt.next_run_at) - Date.now()) / 60000);
-          when = diff > 0 ? 'in ' + diff + 'm' : 'due';
-        }
-        if (pt.depends_on) when = 'after ' + pt.depends_on;
-        phtml += '<div class="peer-row clickable" role="button" tabindex="0" onclick="OL.switchView(\'tasks\')" onkeydown="if(event.key===\'Enter\'||event.key===\' \'){event.preventDefault();this.click()}" style="padding:6px 0">' +
-          '<span style="color:' + sc + ';font-size:12px">' + (statusIcons[pt.status] || '') + '</span>' +
-          '<span class="session-uuid">' + esc(pt.marker) + '</span>' +
-          '<span style="font-size:12px;flex:1">' + esc(pt.title.length > 40 ? pt.title.substring(0, 40) + '...' : pt.title) + '</span>' +
-          '<span style="font-size:11px;color:' + sc + ';font-weight:500">' + when + '</span>' +
-        '</div>';
-      }
-      if (pendingList) pendingList.innerHTML = phtml;
+      return;
     }
+    if (pendingPanel) pendingPanel.style.display = '';
+    if (!pendingList) return;
+    var pendingStatusColors = {scheduled:'var(--yellow)',waiting:'var(--accent)',pending:'var(--text-muted)'};
+    var statusIcons = OL.TASK_STATUS_ICONS;
+    var phtml = '';
+    for (var pi = 0; pi < pending.length; pi++) {
+      var pt = pending[pi];
+      var sc = pendingStatusColors[pt.status] || 'var(--text-muted)';
+      var when = '';
+      if (pt.next_run_at) {
+        var diff = Math.round((new Date(pt.next_run_at) - Date.now()) / 60000);
+        when = diff > 0 ? 'in ' + diff + 'm' : 'due';
+      }
+      if (pt.depends_on) when = 'after ' + pt.depends_on;
+      phtml += '<div class="peer-row clickable" role="button" tabindex="0" onclick="OL.switchView(\'tasks\')" onkeydown="if(event.key===\'Enter\'||event.key===\' \'){event.preventDefault();this.click()}" style="padding:6px 0">' +
+        '<span style="color:' + sc + ';font-size:12px">' + (statusIcons[pt.status] || '') + '</span>' +
+        '<span class="session-uuid">' + esc(pt.marker) + '</span>' +
+        '<span style="font-size:12px;flex:1">' + esc(pt.title.length > 40 ? pt.title.substring(0, 40) + '...' : pt.title) + '</span>' +
+        '<span style="font-size:11px;color:' + sc + ';font-weight:500">' + when + '</span>' +
+      '</div>';
+    }
+    pendingList.innerHTML = phtml;
+  };
+
+  // Lazy-load wrappers — call on view-show, NOT on the 10s poll.
+  OL.loadTopTasks = async function() {
+    try {
+      var data = await fetchJSON('/api/tasks/today-top');
+      OL.renderTopTasks(data || []);
+    } catch (e) {}
+  };
+
+  OL.loadPendingTasks = async function() {
+    try {
+      var data = await fetchJSON('/api/tasks/pending');
+      OL.renderPendingTasks(data || []);
+    } catch (e) {}
   };
 
   // Productivity score

--- a/internal/web/ui/views/overview.js
+++ b/internal/web/ui/views/overview.js
@@ -116,6 +116,25 @@
     }
   };
 
+  // Live node stats for the overview chip — renders "node: NN% cpu · NN MB"
+  // under the tasks counter. /api/host/stats returns a single fresh sample
+  // (cheap `ps` fork). Cached at max-age=5 so N dashboard tabs → one call
+  // per 5s per tab.
+  OL.loadHostStats = async function() {
+    try {
+      var s = await fetchJSON('/api/host/stats');
+      if (!s) return;
+      var el = document.getElementById('metric-host-stats');
+      if (!el) return;
+      var cpu = (s.cpu_pct || 0).toFixed(0);
+      var rss = Math.round(s.rss_mb || 0);
+      var cpuColor = s.cpu_pct > 80 ? 'var(--red)'
+        : s.cpu_pct > 50 ? 'var(--yellow)'
+        : 'var(--text-muted)';
+      el.innerHTML = 'node: <span style="color:' + cpuColor + '">' + cpu + '% cpu</span> · ' + rss + ' MB';
+    } catch (e) {}
+  };
+
   // Productivity score
   OL.updateProductivity = async function() {
     try {

--- a/internal/web/ui/views/product-dag.js
+++ b/internal/web/ui/views/product-dag.js
@@ -64,9 +64,16 @@
       meta: JSON.stringify(data.meta || {})
     }});
 
-    // Product → manifest ownership edges
+    // Product → manifest ownership edges, but ONLY for root manifests (those
+    // with no depends_on). For chained manifests, the dep chain already
+    // implies reach from the product, and adding 6 product→manifest edges
+    // forces dagre to route 6 long lines that cross every task in between.
+    // This is the "tangled spaghetti" failure mode from the 2026-04-23
+    // screenshot — it wasn't dagre, it was that we fed it redundant edges.
     for (var mi = 0; mi < manifests.length; mi++) {
-      elements.push({ data: { source: data.id, target: manifests[mi].id, edgeType: 'product_link' } });
+      if (!manifests[mi].depends_on) {
+        elements.push({ data: { source: data.id, target: manifests[mi].id, edgeType: 'product_link' } });
+      }
     }
 
     for (var col = 0; col < manifests.length; col++) {
@@ -101,7 +108,9 @@
 
       for (var ti = 0; ti < tasks.length; ti++) {
         var t = tasks[ti];
-        var shortTitle = t.title.length > 25 ? t.title.substring(0, 23) + '…' : t.title;
+        // Labels render inside the 120×44 node and wrap to ~2 lines at
+        // font-size 9px → ~36 chars before ellipsis kicks in.
+        var shortTitle = t.title.length > 36 ? t.title.substring(0, 35) + '…' : t.title;
         elements.push({ data: {
           id: t.id, label: shortTitle,
           title: t.title, type: 'task', status: t.status,
@@ -137,11 +146,18 @@
         // rankDir=TB: product at top, flows downward through manifests + tasks.
         // nodeSep / rankSep tuned for current label sizes — if labels grow,
         // bump these rather than reintroducing manual positions.
+        // Layout invariant: ALL labels render INSIDE their node (text-valign:
+        // center, text-halign: center). That means label width is bounded by
+        // node width, and dagre's nodeSep directly controls label clearance.
+        // Sibling labels on the same rank can never overlap regardless of
+        // title length — overflow is hidden by 'text-overflow-wrap: ellipsis'.
+        // Do NOT switch any node type back to text-valign:bottom — that's the
+        // mode that produced the 2026-04-23 "tangled mess" regression.
         layout: {
           name: 'dagre',
           rankDir: 'TB',
-          nodeSep: 40,
-          rankSep: 70,
+          nodeSep: 30,
+          rankSep: 60,
           edgeSep: 20,
           padding: 24,
           fit: true,
@@ -150,34 +166,31 @@
           { selector: 'node', style: {
               'label': 'data(label)',
               'text-wrap': 'wrap',
-              'text-max-width': '140px',
+              'text-overflow-wrap': 'anywhere',
+              'text-max-width': '110px',
               'font-size': '9px',
-              'text-valign': 'bottom',
+              'text-valign': 'center',
               'text-halign': 'center',
-              'text-margin-y': 8,
-              'color': '#a1a1aa',
+              'color': '#e4e4e7',
               'background-color': '#1a1a2e',
               'border-width': 2,
               'border-color': '#71717a',
-              'width': 30, 'height': 30,
-              'shape': 'ellipse',
-              'text-outline-color': '#0a0a0f',
-              'text-outline-width': 1,
+              'width': 120, 'height': 44,
+              'shape': 'round-rectangle',
+              'padding': '6px',
           }},
           { selector: 'node[type="product"]', style: {
               'shape': 'round-rectangle',
-              'width': 70, 'height': 50,
+              'width': 180, 'height': 60,
               'font-size': '12px', 'font-weight': 'bold',
-              'text-max-width': '160px',
-              'text-valign': 'center', 'text-halign': 'center', 'text-margin-y': 0,
+              'text-max-width': '170px',
               'background-color': '#8b5cf6', 'border-color': '#8b5cf6', 'color': '#fff',
           }},
           { selector: 'node[type="manifest"]', style: {
               'shape': 'round-rectangle',
-              'width': 55, 'height': 40,
+              'width': 140, 'height': 50,
               'font-size': '10px', 'font-weight': 'bold',
-              'text-max-width': '150px',
-              'text-valign': 'center', 'text-halign': 'center', 'text-margin-y': 0,
+              'text-max-width': '130px',
               'color': '#e4e4e7',
               'background-color': '#1e3a5f',
               'border-width': 3,

--- a/tools/backfill_task_run_turns.py
+++ b/tools/backfill_task_run_turns.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Backfill task_runs.turns for rows where the value is 0 but the stored output
+contains assistant events (the run was killed before the SDK's `result` event
+fired, so handlers_task.go:parseTaskResultMetrics recorded turns=0).
+
+Mirrors the Go fallback added in the same change set: scan the JSONL output for
+`type=result` first (clean exit, take its num_turns); otherwise count
+`type=assistant` events.
+
+Usage: python3 tools/backfill_task_run_turns.py [DB_PATH]
+       Defaults to ~/.openpraxis/data/memories.db.
+Idempotent — only touches rows whose turns column is currently 0."""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+
+
+def parse_turns(output: str) -> int:
+    if not output:
+        return 0
+    lines = [ln.strip() for ln in output.split("\n") if ln.strip()]
+    # Pass 1: result event (clean exit) wins.
+    for ln in reversed(lines):
+        try:
+            ev = json.loads(ln)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(ev, dict) and ev.get("type") == "result":
+            return int(ev.get("num_turns", 0))
+    # Pass 2: count assistant events as a turn count proxy.
+    return sum(
+        1
+        for ln in lines
+        if (lambda e: isinstance(e, dict) and e.get("type") == "assistant")(
+            _try_load(ln)
+        )
+    )
+
+
+def _try_load(line: str):
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError:
+        return None
+
+
+def main() -> int:
+    db_path = (
+        sys.argv[1]
+        if len(sys.argv) > 1
+        else os.path.expanduser("~/.openpraxis/data/memories.db")
+    )
+    if not os.path.exists(db_path):
+        print(f"DB not found: {db_path}", file=sys.stderr)
+        return 1
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT id, task_id, run_number, output FROM task_runs "
+        "WHERE turns = 0 AND output != ''"
+    )
+    rows = cur.fetchall()
+    print(f"candidates with turns=0: {len(rows)}")
+
+    updated = 0
+    for r in rows:
+        turns = parse_turns(r["output"])
+        if turns <= 0:
+            continue
+        conn.execute(
+            "UPDATE task_runs SET turns = ? WHERE id = ?",
+            (turns, r["id"]),
+        )
+        updated += 1
+        if updated <= 10 or updated % 25 == 0:
+            print(
+                f"  updated id={r['id']} task={r['task_id'][:12]} "
+                f"run#{r['run_number']} → turns={turns}"
+            )
+    conn.commit()
+    conn.close()
+    print(f"updated rows: {updated}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Peer review of PR #213 commit `cb2855a` (RC/M4 slice of the bundled M2+M3+M4 PR). Verdict: **APPROVE** with one non-blocking followup (pre-save diff pane listed in the manifest's safety affordances but not implemented).

All 8 numbered Acceptance items from manifest `019dba9e-113` pass:
- Edit toggle + shared `OL.mountEditor` + Reason input
- Save disabled until Reason has content (tooltip explains)
- Save → PUT → history row appears
- Restore confirm modal (explicit Confirm button, not browser native)
- Server-side restore authors `reason="restored from <ts>"`
- Preview pane renders task-scoped template; parse errors surface as `[render error: ...]`
- Cancel drops draft, restores read-only
- `node --check` clean

## Followups filed

- **FU-1** — add the pre-save side-by-side diff described in the manifest safety affordances (CSS class `.runner-diff-pane` is carved out but used for the preview pane).
- **FU-2** — include prospective new version number in the restore modal copy.
- **FU-3** — tasks dropdown hard-capped at 200; fine today, flag if workspace grows.

## Validation (worktree only, per task instructions)

- `go build ./...` — ok
- `go test ./internal/web ./internal/templates ./internal/mcp` — ok
- `node --check internal/web/ui/views/runner.js` — ok

Reviewer did NOT restart the live serve (RC/T3R false-orphan race).

## Test plan

- [x] Diff reviewed end-to-end
- [x] Go build + tests green
- [x] `node --check` clean
- [x] XSS surface inspected (`escHtml`/`textContent` paths confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)