### PR TITLE
feat: host CPU/RSS overlay on Run Stats card + node chip on overview

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -252,7 +252,7 @@ var serveCmd = &cobra.Command{
 			if t.ManifestID != "" {
 				m, _ := n.Manifests.Get(t.ManifestID)
 				if m == nil {
-					if err := n.Tasks.RecordRun(t.ID, "manifest not found: "+t.ManifestID, "failed", 0, 0, 0, 0, time.Now(), task.Usage{}, ""); err != nil {
+					if _, err := n.Tasks.RecordRun(t.ID, "manifest not found: "+t.ManifestID, "failed", 0, 0, 0, 0, time.Now(), task.Usage{}, ""); err != nil {
 					slog.Error("record run failed", "reason", "manifest not found", "error", err)
 				}
 					return
@@ -277,7 +277,7 @@ var serveCmd = &cobra.Command{
 
 			// Spawn the agent
 			if err := runner.Execute(t, manifestTitle, manifestContent, visceralText); err != nil {
-				if recErr := n.Tasks.RecordRun(t.ID, "execution error: "+err.Error(), "failed", 0, 0, 0, 0, time.Now(), task.Usage{}, ""); recErr != nil {
+				if _, recErr := n.Tasks.RecordRun(t.ID, "execution error: "+err.Error(), "failed", 0, 0, 0, 0, time.Now(), task.Usage{}, ""); recErr != nil {
 					slog.Error("record run failed", "reason", "execution error", "error", recErr)
 				}
 				hub.Broadcast(web.Event{Type: "task_failed", Data: map[string]string{

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -43,6 +43,7 @@ type Node struct {
 	TemplatesResolv  *templates.Resolver
 	Comments         *comments.Store
 	runner           *task.Runner
+	hostSampler      *task.HostSampler
 	Embedder         *embedding.Engine
 	StartedAt        time.Time
 }
@@ -336,6 +337,15 @@ func (n *Node) InitRunner(onEvent func(string, map[string]string)) *task.Runner 
 	if n.TemplatesResolv != nil {
 		n.runner.SetTemplateResolver(n.TemplatesResolv)
 	}
+	// Host-metrics sampler: polls the serve process's CPU/RSS every
+	// 5 seconds and attributes each sample to every currently-running
+	// task. Data lands on task_run_host_samples for the Run Stats
+	// card overlay + on task_runs rollup columns for list views.
+	// The sampler is a single shared instance on the node — starting
+	// multiple runners is not supported, so one-at-boot is fine.
+	n.hostSampler = task.NewHostSampler(5 * time.Second)
+	n.hostSampler.Start(context.Background())
+	n.runner.SetHostSampler(n.hostSampler)
 	return n.runner
 }
 

--- a/internal/task/host_metrics.go
+++ b/internal/task/host_metrics.go
@@ -1,0 +1,199 @@
+package task
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// HostMetricsSample is one CPU/RSS reading of the serve process. The
+// sampler stamps a sample into every currently-attached task, so the
+// per-run Run Stats card can overlay host load on the same timeline as
+// the model's own turn/cost/actions lines.
+type HostMetricsSample struct {
+	TS     time.Time `json:"ts"`
+	CPUPct float64   `json:"cpu_pct"`
+	RSSMB  float64   `json:"rss_mb"`
+}
+
+// HostMetrics is the summary rolled up from a task's samples on Detach.
+// Persisted as denormalised columns on task_runs so dashboards can sort
+// / filter without scanning the samples table.
+type HostMetrics struct {
+	PeakCPUPct float64
+	AvgCPUPct  float64
+	PeakRSSMB  float64
+}
+
+// HostSampler polls the serve process for CPU% + RSS every Interval and
+// attributes each reading to every attached task. Tasks Attach at spawn
+// and Detach at completion; Detach returns the accumulated samples and
+// the rolled-up HostMetrics for persistence.
+//
+// Cheap by design: one `ps -o %cpu=,rss= -p <pid>` fork every Interval
+// (default 5s). Zero when no tasks are attached — fanout is a no-op.
+type HostSampler struct {
+	mu       sync.Mutex
+	attached map[string]*[]HostMetricsSample
+
+	interval time.Duration
+	pid      int
+	stopCh   chan struct{}
+	started  bool
+}
+
+// NewHostSampler returns a sampler that polls every interval. interval
+// <= 0 → 5s default. Call Start to kick the polling goroutine.
+func NewHostSampler(interval time.Duration) *HostSampler {
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	return &HostSampler{
+		attached: make(map[string]*[]HostMetricsSample),
+		interval: interval,
+		pid:      os.Getpid(),
+		stopCh:   make(chan struct{}),
+	}
+}
+
+// Start launches the poll loop. Idempotent — the second call is a no-op.
+func (s *HostSampler) Start(ctx context.Context) {
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return
+	}
+	s.started = true
+	s.mu.Unlock()
+	go s.loop(ctx)
+}
+
+// Stop halts the poll loop. Detach-after-Stop still returns any samples
+// collected before shutdown.
+func (s *HostSampler) Stop() {
+	select {
+	case <-s.stopCh:
+		// already closed
+	default:
+		close(s.stopCh)
+	}
+}
+
+func (s *HostSampler) loop(ctx context.Context) {
+	t := time.NewTicker(s.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.stopCh:
+			return
+		case <-t.C:
+			s.mu.Lock()
+			active := len(s.attached) > 0
+			s.mu.Unlock()
+			if !active {
+				continue
+			}
+			sample, err := readProcMetrics(s.pid)
+			if err != nil {
+				slog.Warn("host metrics sample failed", "error", err)
+				continue
+			}
+			s.fanout(sample)
+		}
+	}
+}
+
+func (s *HostSampler) fanout(sample HostMetricsSample) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, slot := range s.attached {
+		*slot = append(*slot, sample)
+	}
+}
+
+// Attach registers a task to receive samples. Starting-empty — reattach
+// clears any prior state.
+func (s *HostSampler) Attach(taskID string) {
+	s.mu.Lock()
+	buf := make([]HostMetricsSample, 0, 64)
+	s.attached[taskID] = &buf
+	s.mu.Unlock()
+}
+
+// Detach returns the samples accumulated for a task + the rolled-up
+// summary, and removes the task from tracking. Safe to call for an
+// unknown task ID — returns empty.
+func (s *HostSampler) Detach(taskID string) ([]HostMetricsSample, HostMetrics) {
+	s.mu.Lock()
+	slot := s.attached[taskID]
+	delete(s.attached, taskID)
+	s.mu.Unlock()
+	if slot == nil {
+		return nil, HostMetrics{}
+	}
+	return *slot, rollupSamples(*slot)
+}
+
+func rollupSamples(samples []HostMetricsSample) HostMetrics {
+	var m HostMetrics
+	if len(samples) == 0 {
+		return m
+	}
+	var cpuSum float64
+	for _, s := range samples {
+		cpuSum += s.CPUPct
+		if s.CPUPct > m.PeakCPUPct {
+			m.PeakCPUPct = s.CPUPct
+		}
+		if s.RSSMB > m.PeakRSSMB {
+			m.PeakRSSMB = s.RSSMB
+		}
+	}
+	m.AvgCPUPct = cpuSum / float64(len(samples))
+	return m
+}
+
+// ReadHostMetrics returns a single fresh sample of the current serve
+// process's CPU% and RSS. Used by the /api/host/stats live-poll endpoint
+// on the overview card; the sampler goroutine uses the same underlying
+// call via readProcMetrics.
+func ReadHostMetrics() (HostMetricsSample, error) {
+	return readProcMetrics(os.Getpid())
+}
+
+// readProcMetrics shells out to `ps` to read the current process's
+// %CPU + RSS. Cross-platform (macOS + Linux both support `-o %cpu=,rss=`)
+// and cheap enough at 5s cadence that the fork cost is noise compared to
+// per-tool-call hook work. `ps` reports RSS in KB on both platforms.
+func readProcMetrics(pid int) (HostMetricsSample, error) {
+	cmd := exec.Command("ps", "-o", "%cpu=,rss=", "-p", strconv.Itoa(pid))
+	out, err := cmd.Output()
+	if err != nil {
+		return HostMetricsSample{}, fmt.Errorf("ps: %w", err)
+	}
+	fields := strings.Fields(strings.TrimSpace(string(out)))
+	if len(fields) < 2 {
+		return HostMetricsSample{}, fmt.Errorf("ps output malformed: %q", string(out))
+	}
+	cpu, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return HostMetricsSample{}, fmt.Errorf("parse cpu: %w", err)
+	}
+	rssKB, err := strconv.ParseFloat(fields[1], 64)
+	if err != nil {
+		return HostMetricsSample{}, fmt.Errorf("parse rss: %w", err)
+	}
+	return HostMetricsSample{
+		TS:     time.Now().UTC(),
+		CPUPct: cpu,
+		RSSMB:  rssKB / 1024.0,
+	}, nil
+}

--- a/internal/task/repository.go
+++ b/internal/task/repository.go
@@ -673,13 +673,16 @@ const PricingVersion = "v1-2026-04"
 // output; they're denormalised onto task_runs so dashboards don't have to
 // re-parse the full output blob on every read. The blob remains in
 // task_runs.output as the source of truth.
-func (s *Store) RecordRun(id, output, status string, actions, lines int, costUSD float64, turns int, startedAt time.Time, usage Usage, model string) error {
+// RecordRun inserts a completed run into task_runs and returns the
+// inserted row id. Caller passes the run_id to RecordHostMetrics to
+// persist the host CPU/RSS sparkline samples + rollup columns.
+func (s *Store) RecordRun(id, output, status string, actions, lines int, costUSD float64, turns int, startedAt time.Time, usage Usage, model string) (int64, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	// No truncation — capture full output
 	_, err := s.db.Exec(`UPDATE tasks SET run_count = run_count + 1, last_run_at = ?, last_output = ?, status = ?, updated_at = ? WHERE id = ?`,
 		now, output, status, now, id)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	// Get current run_count for run_number
@@ -689,13 +692,78 @@ func (s *Store) RecordRun(id, output, status string, actions, lines int, costUSD
 	}
 
 	// Insert into task_runs history with full denorm (tokens + model + pricing version).
-	_, err = s.db.Exec(`INSERT INTO task_runs
+	res, err := s.db.Exec(`INSERT INTO task_runs
 		(task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at,
 		 input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		id, runCount, output, status, actions, lines, costUSD, turns, startedAt.UTC().Format(time.RFC3339), now,
 		usage.InputTokens, usage.OutputTokens, usage.CacheReadTokens, usage.CacheCreationTokens, model, PricingVersion)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	runID, err := res.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+	return runID, nil
+}
+
+// RecordHostMetrics persists the HostSampler output for a run: rollup
+// columns on task_runs + every sample into task_run_host_samples. Best-
+// effort — errors log-and-swallow because losing host metrics must not
+// fail the task completion path.
+func (s *Store) RecordHostMetrics(runID int64, samples []HostMetricsSample, metrics HostMetrics) error {
+	if runID <= 0 {
+		return nil
+	}
+	if _, err := s.db.Exec(
+		`UPDATE task_runs SET peak_cpu_pct = ?, avg_cpu_pct = ?, peak_rss_mb = ? WHERE id = ?`,
+		metrics.PeakCPUPct, metrics.AvgCPUPct, metrics.PeakRSSMB, runID,
+	); err != nil {
+		return fmt.Errorf("update task_runs host summary: %w", err)
+	}
+	if len(samples) == 0 {
+		return nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin host-samples tx: %w", err)
+	}
+	defer tx.Rollback()
+	stmt, err := tx.Prepare(`INSERT INTO task_run_host_samples (run_id, ts, cpu_pct, rss_mb) VALUES (?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare host-samples insert: %w", err)
+	}
+	defer stmt.Close()
+	for _, smp := range samples {
+		if _, err := stmt.Exec(runID, smp.TS.UTC().Format(time.RFC3339Nano), smp.CPUPct, smp.RSSMB); err != nil {
+			return fmt.Errorf("insert host sample: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
+// ListHostSamples returns the time-series host samples for a run.
+// Ordered by ts ASC so the frontend can render left-to-right directly.
+func (s *Store) ListHostSamples(runID int64) ([]HostMetricsSample, error) {
+	rows, err := s.db.Query(`SELECT ts, cpu_pct, rss_mb FROM task_run_host_samples WHERE run_id = ? ORDER BY ts ASC`, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []HostMetricsSample
+	for rows.Next() {
+		var tsStr string
+		var smp HostMetricsSample
+		if err := rows.Scan(&tsStr, &smp.CPUPct, &smp.RSSMB); err != nil {
+			return nil, err
+		}
+		if t, err := time.Parse(time.RFC3339Nano, tsStr); err == nil {
+			smp.TS = t
+		}
+		out = append(out, smp)
+	}
+	return out, rows.Err()
 }
 
 // ListRuns returns run history for a task, most recent first.
@@ -703,7 +771,7 @@ func (s *Store) ListRuns(taskID string, limit int) ([]TaskRun, error) {
 	if limit <= 0 {
 		limit = 50
 	}
-	rows, err := s.db.Query(`SELECT id, task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at, input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version
+	rows, err := s.db.Query(`SELECT id, task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at, input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version, peak_cpu_pct, avg_cpu_pct, peak_rss_mb
 		FROM task_runs WHERE task_id = ? ORDER BY run_number DESC LIMIT ?`, taskID, limit)
 	if err != nil {
 		return nil, err
@@ -716,9 +784,10 @@ func (s *Store) ListRuns(taskID string, limit int) ([]TaskRun, error) {
 func (s *Store) GetRun(runID int) (*TaskRun, error) {
 	var r TaskRun
 	var startedStr, completedStr string
-	err := s.db.QueryRow(`SELECT id, task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at, input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version FROM task_runs WHERE id = ?`, runID).
+	err := s.db.QueryRow(`SELECT id, task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at, input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version, peak_cpu_pct, avg_cpu_pct, peak_rss_mb FROM task_runs WHERE id = ?`, runID).
 		Scan(&r.ID, &r.TaskID, &r.RunNumber, &r.Output, &r.Status, &r.Actions, &r.Lines, &r.CostUSD, &r.Turns, &startedStr, &completedStr,
-			&r.InputTokens, &r.OutputTokens, &r.CacheReadTokens, &r.CacheCreateTokens, &r.Model, &r.PricingVersion)
+			&r.InputTokens, &r.OutputTokens, &r.CacheReadTokens, &r.CacheCreateTokens, &r.Model, &r.PricingVersion,
+			&r.PeakCPUPct, &r.AvgCPUPct, &r.PeakRSSMB)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -735,7 +804,7 @@ func (s *Store) ListAllRuns(since time.Time, limit int) ([]TaskRun, error) {
 	if limit <= 0 {
 		limit = 1000
 	}
-	rows, err := s.db.Query(`SELECT id, task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at, input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version
+	rows, err := s.db.Query(`SELECT id, task_id, run_number, output, status, actions, lines, cost_usd, turns, started_at, completed_at, input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, pricing_version, peak_cpu_pct, avg_cpu_pct, peak_rss_mb
 		FROM task_runs WHERE started_at >= ? ORDER BY started_at DESC LIMIT ?`,
 		since.UTC().Format(time.RFC3339), limit)
 	if err != nil {

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -94,7 +94,18 @@ type Runner struct {
 	// package defaults (existing behaviour + every existing test harness
 	// that constructs a Runner without a DB-backed templates store).
 	tmpl *templates.Resolver
+
+	// hostSampler polls the serve process CPU/RSS and attributes each
+	// sample to every task attached during its run. Nil → host metrics
+	// are skipped (tests + pre-wire code paths). Wired via
+	// SetHostSampler from cmd/serve.go at boot.
+	hostSampler *HostSampler
 }
+
+// SetHostSampler wires a started HostSampler onto the runner. Attach is
+// called at spawn, Detach at completion; the accumulated samples land
+// on task_run_host_samples + summary columns on task_runs.
+func (r *Runner) SetHostSampler(hs *HostSampler) { r.hostSampler = hs }
 
 // SetTemplateResolver wires the RC/M1 prompt-template resolver onto
 // the runner. Nil disables scope-aware resolution — the runner uses the
@@ -721,6 +732,14 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 
 	slog.Info("task started", "component", "runner", "marker", marker, "title", t.Title, "pid", cmd.Process.Pid)
 
+	// Begin host CPU/RSS sampling for this task. Samples accumulate in
+	// the sampler's per-task buffer until the completion path calls
+	// Detach + RecordHostMetrics. Nil sampler → no-op (tests + pre-wire
+	// code paths).
+	if r.hostSampler != nil {
+		r.hostSampler.Attach(t.ID)
+	}
+
 	// Read output in background
 	maxCostCap := knobs.MaxCostUSD
 	retryCap := knobs.RetryOnFailure
@@ -976,8 +995,17 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 		}
 
 		// Record the run with history — always use real status, not "scheduled"
-		if err := r.store.RecordRun(t.ID, output, status, rt.Actions, rt.Lines, costUSD, numTurns, rt.StartedAt, finalUsage, rt.Model); err != nil {
+		runID, err := r.store.RecordRun(t.ID, output, status, rt.Actions, rt.Lines, costUSD, numTurns, rt.StartedAt, finalUsage, rt.Model)
+		if err != nil {
 			slog.Error("record run failed", "component", "runner", "marker", marker, "error", err)
+		} else if r.hostSampler != nil {
+			// Host CPU/RSS samples accumulated during the run → persist them
+			// alongside the run row. Failure here is not fatal — loss of
+			// host metrics must not fail task completion.
+			samples, metrics := r.hostSampler.Detach(t.ID)
+			if err := r.store.RecordHostMetrics(runID, samples, metrics); err != nil {
+				slog.Warn("record host metrics failed", "component", "runner", "marker", marker, "error", err)
+			}
 		}
 
 		// Post-completion execution-review gate. Successful completions must

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -55,8 +55,13 @@ type TaskRun struct {
 	CacheCreateTokens int       `json:"cache_create_tokens"`
 	Model             string    `json:"model"`
 	PricingVersion    string    `json:"pricing_version"`
-	StartedAt         time.Time `json:"started_at"`
-	CompletedAt       time.Time `json:"completed_at"`
+	// Host-metrics summary. Full time-series on task_run_host_samples,
+	// fetched separately for the Run Stats sparkline overlay.
+	PeakCPUPct float64   `json:"peak_cpu_pct"`
+	AvgCPUPct  float64   `json:"avg_cpu_pct"`
+	PeakRSSMB  float64   `json:"peak_rss_mb"`
+	StartedAt  time.Time `json:"started_at"`
+	CompletedAt time.Time `json:"completed_at"`
 }
 
 // Store manages task persistence.
@@ -164,6 +169,28 @@ func (s *Store) init() error {
 	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN cache_create_tokens INTEGER NOT NULL DEFAULT 0`)
 	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN model TEXT NOT NULL DEFAULT ''`)
 	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN pricing_version TEXT NOT NULL DEFAULT ''`)
+
+	// Host-metrics denorm. The full time-series lives in
+	// task_run_host_samples below; these columns are the rollup used by
+	// list views and the Run Stats card summary numbers.
+	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN peak_cpu_pct REAL NOT NULL DEFAULT 0`)
+	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN avg_cpu_pct REAL NOT NULL DEFAULT 0`)
+	s.db.Exec(`ALTER TABLE task_runs ADD COLUMN peak_rss_mb REAL NOT NULL DEFAULT 0`)
+
+	// Per-run host-metrics time-series. One row per sample (default 5s
+	// cadence). Feeds the CPU/RSS sparklines overlaid on the Run Stats
+	// card — same timeline as turn/actions/cost.
+	_, err = s.db.Exec(`CREATE TABLE IF NOT EXISTS task_run_host_samples (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		run_id INTEGER NOT NULL,
+		ts TEXT NOT NULL,
+		cpu_pct REAL NOT NULL DEFAULT 0,
+		rss_mb REAL NOT NULL DEFAULT 0
+	)`)
+	if err != nil {
+		return fmt.Errorf("create task_run_host_samples table: %w", err)
+	}
+	s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_task_run_host_samples_run ON task_run_host_samples(run_id)`)
 
 	// Running task runtime state — persists in-memory RunningTask data to survive restarts
 	_, err = s.db.Exec(`CREATE TABLE IF NOT EXISTS task_runtime_state (
@@ -314,7 +341,8 @@ func scanRuns(rows *sql.Rows) ([]TaskRun, error) {
 		var r TaskRun
 		var startedStr, completedStr string
 		if err := rows.Scan(&r.ID, &r.TaskID, &r.RunNumber, &r.Output, &r.Status, &r.Actions, &r.Lines, &r.CostUSD, &r.Turns, &startedStr, &completedStr,
-			&r.InputTokens, &r.OutputTokens, &r.CacheReadTokens, &r.CacheCreateTokens, &r.Model, &r.PricingVersion); err != nil {
+			&r.InputTokens, &r.OutputTokens, &r.CacheReadTokens, &r.CacheCreateTokens, &r.Model, &r.PricingVersion,
+			&r.PeakCPUPct, &r.AvgCPUPct, &r.PeakRSSMB); err != nil {
 			return nil, err
 		}
 		r.StartedAt, _ = time.Parse(time.RFC3339, startedStr)

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -174,6 +174,9 @@ func Handler(n *node.Node, mcpServer *mcp.Server, hub *Hub, peerRegistry *peer.R
 	api.HandleFunc("/tasks/{id}/delusions", apiTaskDelusions(n)).Methods("GET")
 	api.HandleFunc("/tasks/{id}/runs", apiTaskRuns(n)).Methods("GET")
 	api.HandleFunc("/tasks/{id}/runs/{runId}", apiTaskRunGet(n)).Methods("GET")
+	api.HandleFunc("/task_runs/{runId}/host_samples", apiTaskRunHostSamples(n)).Methods("GET")
+	// Live host CPU/RSS — feeds the node stats chip on the overview.
+	api.HandleFunc("/host/stats", apiHostStats()).Methods("GET")
 	api.HandleFunc("/tasks/{id}/start", apiTaskStart(n)).Methods("POST")
 	api.HandleFunc("/tasks/{id}/cancel", apiTaskUpdateStatus(n, "cancelled")).Methods("POST")
 	api.HandleFunc("/tasks/{id}/reject", apiTaskReject(n)).Methods("POST")

--- a/internal/web/handlers_task.go
+++ b/internal/web/handlers_task.go
@@ -314,6 +314,44 @@ func apiTaskRuns(n *node.Node) http.HandlerFunc {
 	}
 }
 
+// apiTaskRunHostSamples returns the host CPU/RSS time-series for a run.
+// Drives the orange/purple sparklines overlaid on the Run Stats card.
+func apiTaskRunHostSamples(n *node.Node) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "max-age=5")
+		runIDStr := mux.Vars(r)["runId"]
+		var runID int64
+		if _, err := fmt.Sscanf(runIDStr, "%d", &runID); err != nil {
+			writeError(w, "invalid run ID", 400)
+			return
+		}
+		samples, err := n.Tasks.ListHostSamples(runID)
+		if err != nil {
+			writeError(w, err.Error(), 500)
+			return
+		}
+		if samples == nil {
+			samples = []task.HostMetricsSample{}
+		}
+		writeJSON(w, samples)
+	}
+}
+
+// apiHostStats returns the current serve process CPU% + RSS MB — a
+// single fresh reading, cheap (one `ps` fork). Powers the live node
+// stats chip near the "Tasks" counter on the overview.
+func apiHostStats() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "max-age=5")
+		sample, err := task.ReadHostMetrics()
+		if err != nil {
+			writeError(w, err.Error(), 500)
+			return
+		}
+		writeJSON(w, sample)
+	}
+}
+
 // apiTaskRunGet returns a single run by ID.
 func apiTaskRunGet(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/ui/app.js
+++ b/internal/web/ui/app.js
@@ -458,6 +458,7 @@
       OL.loadRunningTasks();
       OL.loadTaskStats();
       OL.updateProductivity();
+      if (OL.loadHostStats) OL.loadHostStats();
     } catch (e) {
       console.error('Refresh failed:', e);
     }

--- a/internal/web/ui/components/run-stats.js
+++ b/internal/web/ui/components/run-stats.js
@@ -129,20 +129,45 @@
       '</div>';
   }
 
+  // Downsample an array to at most n evenly-spaced points. Preserves
+  // first + last so the sparkline endpoints reflect run start/end.
+  // Small-input pass-through — no work when len <= n.
+  function subsample(arr, n) {
+    if (!arr || arr.length <= n) return arr || [];
+    var step = (arr.length - 1) / (n - 1);
+    var out = [];
+    for (var i = 0; i < n; i++) {
+      out.push(arr[Math.min(arr.length - 1, Math.round(i * step))]);
+    }
+    return out;
+  }
+
   // ---- entry point ---------------------------------------------------
 
   OL.renderRunStats = function (containerEl, taskID) {
     if (!containerEl || !taskID) return;
     containerEl.innerHTML = '<div class="run-stats-loading">Loading run stats…</div>';
 
-    fetchJSON('/api/tasks/' + encodeURIComponent(taskID) + '/runs').then(function (runs) {
-      runs = runs || [];
+    Promise.all([
+      fetchJSON('/api/tasks/' + encodeURIComponent(taskID) + '/runs'),
+      // Host samples for the latest run — fetched after we know the run id.
+      // Two separate calls are cheap (both cache at max-age=5).
+    ]).then(function (r0) {
+      var runs = r0[0] || [];
       if (runs.length === 0) {
         containerEl.innerHTML = '<div class="run-stats-card run-stats-empty-state">No runs yet. Stats will appear after the first run completes.</div>';
         return;
       }
       // ListRuns returns newest-first per repository.go.
       var latest = runs[0];
+      return fetchJSON('/api/task_runs/' + latest.id + '/host_samples').then(function (hostSamples) {
+        return { runs: runs, latest: latest, hostSamples: hostSamples || [] };
+      });
+    }).then(function (ctx) {
+      if (!ctx) return;
+      var runs = ctx.runs;
+      var latest = ctx.latest;
+      var hostSamples = ctx.hostSamples;
       // Build sparkline data oldest→newest, capped at last 10.
       var trend = runs.slice(0, 10).reverse();
       var costPts = trend.map(function (r) {
@@ -156,6 +181,18 @@
       var actionPts = trend.map(function (r) {
         return { run: r.run_number, y: r.actions || 0,
           tooltip: (r.actions || 0) + ' actions, ' + (r.turns || 0) + ' turns' };
+      });
+      // Host CPU/RSS points are a within-run time series (one per ~5s
+      // sample). Different X-axis conceptually but rendered by the same
+      // sparkline helper so the visual vocabulary is consistent.
+      // Sub-sample to 20 points so the line stays readable even on long runs.
+      var cpuPts = subsample(hostSamples, 20).map(function (s, i) {
+        return { run: i, y: s.cpu_pct || 0,
+          tooltip: (s.cpu_pct || 0).toFixed(1) + '% CPU at ' + (s.ts ? s.ts.slice(11, 19) : '') };
+      });
+      var rssPts = subsample(hostSamples, 20).map(function (s, i) {
+        return { run: i, y: s.rss_mb || 0,
+          tooltip: Math.round(s.rss_mb || 0) + ' MB RSS at ' + (s.ts ? s.ts.slice(11, 19) : '') };
       });
 
       var when = latest.completed_at ? timeAgo(latest.completed_at) : 'in progress';
@@ -180,12 +217,19 @@
               renderSparkline('cost', costPts, { color: 'var(--green)', formatLatest: fmtCost }) +
               renderSparkline('turns', turnPts, { color: 'var(--accent)' }) +
               renderSparkline('actions', actionPts, { color: 'var(--yellow)' }) +
+              // Host metrics overlay — orange CPU%, purple RSS MB. Empty
+              // arrays render as a muted "no samples" placeholder so the
+              // card layout stays stable during migrations / legacy runs.
+              renderSparkline('cpu%', cpuPts, { color: '#f59e0b', formatLatest: function (v) { return v.toFixed(0) + '%'; } }) +
+              renderSparkline('rss mb', rssPts, { color: '#a855f7', formatLatest: function (v) { return Math.round(v) + ''; } }) +
             '</div>' +
           '</div>' +
           '<div class="run-stats-footer">' +
             '<span>Turns ' + (latest.turns || 0) + '</span>' +
             '<span>Actions ' + (latest.actions || 0) + '</span>' +
             '<span>Lines ' + (latest.lines || 0) + '</span>' +
+            (latest.peak_cpu_pct > 0 ? '<span>Peak CPU ' + latest.peak_cpu_pct.toFixed(0) + '%</span>' : '') +
+            (latest.peak_rss_mb > 0 ? '<span>Peak RSS ' + Math.round(latest.peak_rss_mb) + ' MB</span>' : '') +
             '<span>' + modelLine + '</span>' +
           '</div>' +
         '</div>';

--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -141,6 +141,11 @@
           <div class="metric-card metric-card-primary" style="cursor:pointer" role="button" tabindex="0" onclick="OL.switchView('tasks')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
             <div class="metric-value" id="metric-tasks-total">-</div>
             <div class="metric-label">tasks</div>
+            <!-- Node CPU/RSS chip. Populated from /api/host/stats by
+                 OL.loadHostStats on the overview refresh tick. Kept in
+                 the same card as "tasks" so operators see load+queue
+                 together at a glance. -->
+            <div class="metric-sublabel" id="metric-host-stats" style="margin-top:6px;font-size:10px;color:var(--text-muted);font-family:var(--font-mono)"></div>
           </div>
           <!-- Cost card removed pending Unified Cost Tracking product (019dab45-d8f).
                task_runs now persists input_tokens / output_tokens / cache_read_tokens /

--- a/internal/web/ui/views/overview.js
+++ b/internal/web/ui/views/overview.js
@@ -116,6 +116,25 @@
     }
   };
 
+  // Live node stats for the overview chip — renders "node: NN% cpu · NN MB"
+  // under the tasks counter. /api/host/stats returns a single fresh sample
+  // (cheap `ps` fork). Cached at max-age=5 so N dashboard tabs → one call
+  // per 5s per tab.
+  OL.loadHostStats = async function() {
+    try {
+      var s = await fetchJSON('/api/host/stats');
+      if (!s) return;
+      var el = document.getElementById('metric-host-stats');
+      if (!el) return;
+      var cpu = (s.cpu_pct || 0).toFixed(0);
+      var rss = Math.round(s.rss_mb || 0);
+      var cpuColor = s.cpu_pct > 80 ? 'var(--red)'
+        : s.cpu_pct > 50 ? 'var(--yellow)'
+        : 'var(--text-muted)';
+      el.innerHTML = 'node: <span style="color:' + cpuColor + '">' + cpu + '% cpu</span> · ' + rss + ' MB';
+    } catch (e) {}
+  };
+
   // Productivity score
   OL.updateProductivity = async function() {
     try {


### PR DESCRIPTION
## Summary

Captures host CPU% + RSS MB during every task run and overlays them on the Run Stats card's existing sparklines (same timeline as cost/turns/actions). Adds a live node-stats chip on the overview next to the "tasks" counter. Enables P2P capacity planning from recorded task data.

## Backend

- `HostSampler` polls the serve process every 5s via `ps`. Zero cost when idle; attributes each sample to every attached task.
- Schema: 3 rollup columns on `task_runs` + new `task_run_host_samples` time-series table.
- `RecordRun` returns the run id; new `RecordHostMetrics(runID, samples, metrics)` writes the summary + bulk-inserts samples in one tx.
- `Runner.hostSampler` wired from `node.InitRunner`; Attach at spawn, Detach+persist at completion. Nil sampler is supported (tests unchanged).
- Two new endpoints: `/api/task_runs/:runId/host_samples` (time-series) and `/api/host/stats` (fresh live sample).

## Frontend

- Run Stats card gains CPU% (orange) + RSS MB (purple) sparklines. Footer shows Peak CPU + Peak RSS.
- Overview card gains `node: NN% cpu · NN MB` chip under the tasks counter. CPU colored red/yellow/muted by load.

## Deploy

**This PR is built on a branch and does NOT affect the running serve until the next restart.** Matches the user's request: "defer deploy, next tasks will pick it up."

## Test plan

- [x] `make build` — green
- [x] `node --check` on all touched JS files — green
- [ ] Run a task after deploy, verify sparklines populate
- [ ] Overview chip shows live CPU%/RSS
- [ ] Peak CPU/RSS values land on task_runs rollup columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)