### PR TITLE
feat(templates): RC/M6 per-agent overrides — codex + cursor markdown frames

### DIFF
--- a/internal/templates/defaults.go
+++ b/internal/templates/defaults.go
@@ -103,3 +103,132 @@ func SystemDefaultTitles() map[string]string {
 		SectionClosingProtocol: "Closing protocol + completion line",
 	}
 }
+
+// Markdown-heading frames for agents that don't parse XML well. Claude was
+// trained on <tag>…</tag> blocks and reacts to them as structural cues;
+// Codex / Cursor were tuned harder on markdown and treat unknown XML as
+// text noise. The bodies below render identical PromptData into plain
+// markdown sections (## Heading) so the sections survive the agent's
+// own summarization pass.
+//
+// Each agent has a tiny self-identifier in the preamble so resolver
+// tests (and operators reading a rendered prompt) can tell the two
+// frames apart — the rest of the body is structurally identical.
+
+const markdownVisceralRules = `{{if .VisceralRules}}## Visceral Rules — MANDATORY
+Follow every rule without exception.
+
+{{.VisceralRules}}
+
+{{end}}`
+
+const markdownManifestSpec = `## Manifest: {{.Manifest.Title}}
+
+{{.Manifest.Content}}
+
+`
+
+const markdownTask = `## Task: {{.Task.Title}} ({{.Task.ID}})
+
+{{if .Task.Description}}{{.Task.Description}}
+{{end}}
+`
+
+const markdownInstructions = `## Instructions
+
+Follow the manifest spec exactly. Work autonomously.
+Call visceral_rules and visceral_confirm first.
+
+`
+
+const markdownGitWorkflow = `## Git Workflow — MANDATORY
+
+Every task gets its own branch and PR.
+
+1. Before making ANY code changes, create a new branch:
+   ` + "`" + `git checkout -b openpraxis/{{.BranchPrefix}}` + "`" + `
+2. Make all your changes on this branch.
+3. Commit your work with a descriptive message.
+4. Push the branch: ` + "`" + `git push -u origin openpraxis/{{.BranchPrefix}}` + "`" + `
+5. Create a pull request using: ` + "`" + `gh pr create --title "<title>" --body "<summary>"` + "`" + `
+6. Include the PR URL in your final output.
+
+NEVER work on an existing branch. NEVER push to main.
+
+`
+
+const markdownClosingProtocol = `## Closing Protocol — MANDATORY
+
+Before your final commit+push, call the MCP tool:
+
+    mcp__openpraxis__comment_add
+      target_type = "task"
+      target_id   = "{{.Task.ID}}"
+      type        = "execution_review"
+      author      = "agent"
+      body        = <markdown summary>
+
+The body should include:
+- **What shipped** — files created/edited, key APIs, what's testable
+- **Gates self-check** — which acceptance-criteria bullets you verified locally
+- **What the next task should expect** — APIs, error codes, file layout
+- **Anything surprising** — bugs found, decisions taken, followups to file
+
+This comment is your execution review — the canonical per-task home. The runner records an amnesia flag if this call is missing.
+
+Report completion when done.
+`
+
+const codexPreamble = "You are executing a scheduled task for OpenPraxis (running as the Codex agent).\n\n"
+const cursorPreamble = "You are executing a scheduled task for OpenPraxis (running as the Cursor agent).\n\n"
+
+// AgentDefaults returns the default markdown-heading bodies for an agent.
+// Supported agents: "codex", "cursor". Returns nil for unknown agents so
+// the resolver falls through to the system (XML) defaults.
+func AgentDefaults(agent string) map[string]string {
+	var preamble string
+	switch agent {
+	case "codex":
+		preamble = codexPreamble
+	case "cursor":
+		preamble = cursorPreamble
+	default:
+		return nil
+	}
+	return map[string]string{
+		SectionPreamble:        preamble,
+		SectionVisceralRules:   markdownVisceralRules,
+		SectionManifestSpec:    markdownManifestSpec,
+		SectionTask:            markdownTask,
+		SectionInstructions:    markdownInstructions,
+		SectionGitWorkflow:     markdownGitWorkflow,
+		SectionClosingProtocol: markdownClosingProtocol,
+	}
+}
+
+// codexDefaults returns the markdown-heading section bodies for the
+// Codex agent. Exported indirectly via AgentDefaults("codex").
+func codexDefaults() map[string]string { return AgentDefaults("codex") }
+
+// cursorDefaults returns the markdown-heading section bodies for the
+// Cursor agent. Exported indirectly via AgentDefaults("cursor").
+func cursorDefaults() map[string]string { return AgentDefaults("cursor") }
+
+// SeededAgents is the list of agent names that ship with a built-in
+// markdown-heading override in Seed(). Keep ordered — Seed iterates it
+// to insert rows in a stable order.
+var SeededAgents = []string{"codex", "cursor"}
+
+// AgentDefaultTitles returns the title strings used for seeded agent rows.
+func AgentDefaultTitles(agent string) map[string]string {
+	prefix := agent + " "
+	return map[string]string{
+		SectionPreamble:        prefix + "preamble (markdown)",
+		SectionVisceralRules:   prefix + "visceral rules (markdown)",
+		SectionManifestSpec:    prefix + "manifest spec (markdown)",
+		SectionTask:            prefix + "task block (markdown)",
+		SectionInstructions:    prefix + "instructions (markdown)",
+		SectionGitWorkflow:     prefix + "git workflow (markdown)",
+		SectionClosingProtocol: prefix + "closing protocol (markdown)",
+	}
+}

--- a/internal/templates/seed.go
+++ b/internal/templates/seed.go
@@ -2,17 +2,20 @@ package templates
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 )
 
-// Seed inserts the seven system-scope default rows on first call.
-// Idempotent: detects prior seeding by counting existing system-scope
-// rows and no-ops when any are present. Acceptance #1 in the manifest
-// requires SELECT COUNT(*) FROM prompt_templates == 7 on a fresh DB,
-// so we do NOT insert a separate marker row.
+// Seed inserts the seven system-scope default rows and the per-agent
+// markdown-heading overrides (codex, cursor) on first call.
+//
+// Idempotency is gated per (scope, scope_id) bucket: a bucket is seeded
+// only if it currently holds zero active rows. That lets Seed() be safely
+// re-run after either the system tier or any one agent tier has already
+// been populated, without duplicating rows.
 //
 // peerID is the source_node stamp for audit; changed_by is set to
 // "system-seed" per the manifest.
@@ -21,51 +24,83 @@ func Seed(ctx context.Context, store *Store, peerID string) error {
 		return fmt.Errorf("templates.Seed: nil store")
 	}
 
+	if err := seedBucket(ctx, store, ScopeSystem, "", SystemDefaults(), SystemDefaultTitles(), peerID); err != nil {
+		return err
+	}
+	for _, agent := range SeededAgents {
+		if err := seedBucket(ctx, store, ScopeAgent, agent, AgentDefaults(agent), AgentDefaultTitles(agent), peerID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// seedBucket inserts one row per Section for (scope, scopeID) unless any
+// row already exists in that bucket. Missing bodies/titles fall back to
+// the section name.
+func seedBucket(ctx context.Context, store *Store, scope, scopeID string, bodies, titles map[string]string, peerID string) error {
+	if len(bodies) == 0 {
+		return nil
+	}
+
 	var count int
 	if err := store.DB().QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM prompt_templates WHERE scope = 'system'`,
+		`SELECT COUNT(*) FROM prompt_templates WHERE scope = ? AND scope_id = ?`,
+		scope, scopeID,
 	).Scan(&count); err != nil {
-		return fmt.Errorf("templates.Seed check: %w", err)
+		return fmt.Errorf("templates.Seed check (%s/%s): %w", scope, scopeID, err)
 	}
 	if count > 0 {
 		return nil
 	}
 
-	defaults := SystemDefaults()
-	titles := SystemDefaultTitles()
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 
 	tx, err := store.DB().BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("templates.Seed begin: %w", err)
+		return fmt.Errorf("templates.Seed begin (%s/%s): %w", scope, scopeID, err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	if err := insertBucket(ctx, tx, scope, scopeID, bodies, titles, peerID, now); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("templates.Seed commit (%s/%s): %w", scope, scopeID, err)
+	}
+	return nil
+}
+
+func insertBucket(ctx context.Context, tx *sql.Tx, scope, scopeID string, bodies, titles map[string]string, peerID, now string) error {
 	insert := `INSERT INTO prompt_templates
 		(template_uid, title, scope, scope_id, section, body, status, tags,
 		 source_node, valid_from, valid_to, changed_by, reason, created_at, deleted_at)
-		VALUES (?, ?, 'system', '', ?, ?, 'open', '[]', ?, ?, '', 'system-seed',
-		        'Initial seed from buildPrompt() defaults', ?, '')`
+		VALUES (?, ?, ?, ?, ?, ?, 'open', '[]', ?, ?, '', 'system-seed', ?, ?, '')`
+
+	reason := "Initial seed from buildPrompt() defaults"
+	if scope == ScopeAgent {
+		reason = fmt.Sprintf("Initial seed: %s markdown-heading frame", scopeID)
+	}
 
 	for _, section := range Sections {
-		body := defaults[section]
+		body, ok := bodies[section]
+		if !ok {
+			continue
+		}
 		title := titles[section]
 		if title == "" {
 			title = section
 		}
 		uid, err := uuid.NewV7()
 		if err != nil {
-			return fmt.Errorf("templates.Seed uuid: %w", err)
+			return fmt.Errorf("templates.Seed uuid (%s/%s/%s): %w", scope, scopeID, section, err)
 		}
 		if _, err := tx.ExecContext(ctx, insert,
-			uid.String(), title, section, body, peerID, now, now,
+			uid.String(), title, scope, scopeID, section, body, peerID, now, reason, now,
 		); err != nil {
-			return fmt.Errorf("templates.Seed insert %s: %w", section, err)
+			return fmt.Errorf("templates.Seed insert %s/%s/%s: %w", scope, scopeID, section, err)
 		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("templates.Seed commit: %w", err)
 	}
 	return nil
 }

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -4,10 +4,25 @@ import (
 	"context"
 	"database/sql"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
 )
+
+// fakeAgentLookup answers AgentForTask from a static map — enough to
+// exercise the resolver's agent-scope walk without importing the task
+// package (which would create an import cycle).
+type fakeAgentLookup struct {
+	m map[string]string
+}
+
+func (f *fakeAgentLookup) AgentForTask(_ context.Context, taskID string) (string, error) {
+	if f == nil {
+		return "", nil
+	}
+	return f.m[taskID], nil
+}
 
 func openTestDB(t *testing.T) *sql.DB {
 	t.Helper()
@@ -29,8 +44,11 @@ func openTestDB(t *testing.T) *sql.DB {
 	return db
 }
 
-// TestSeed_InsertsSevenSystemRows verifies acceptance #1: fresh DB →
-// seed writes exactly seven active system rows, one per section.
+// TestSeed_InsertsSevenSystemRows verifies acceptance #1 from RC/M1:
+// fresh DB → seed writes exactly seven active system rows, one per
+// section. With RC/M6 layered on top, the total row count is system(7)
+// + codex(7) + cursor(7) = 21, so this test scopes its count to the
+// system tier.
 func TestSeed_InsertsSevenSystemRows(t *testing.T) {
 	db := openTestDB(t)
 	store := NewStore(db)
@@ -40,12 +58,12 @@ func TestSeed_InsertsSevenSystemRows(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 
-	var total int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM prompt_templates`).Scan(&total); err != nil {
+	var sys int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM prompt_templates WHERE scope='system'`).Scan(&sys); err != nil {
 		t.Fatalf("count: %v", err)
 	}
-	if total != 7 {
-		t.Fatalf("row count = %d, want 7", total)
+	if sys != 7 {
+		t.Fatalf("system row count = %d, want 7", sys)
 	}
 
 	rows, err := store.List(ctx, ScopeSystem, "")
@@ -92,10 +110,94 @@ func TestSeed_Idempotent(t *testing.T) {
 		t.Fatalf("seed 2: %v", err)
 	}
 
-	var total int
+	var total, sys, agent int
 	_ = db.QueryRow(`SELECT COUNT(*) FROM prompt_templates`).Scan(&total)
-	if total != 7 {
-		t.Fatalf("after re-seed count = %d, want 7", total)
+	_ = db.QueryRow(`SELECT COUNT(*) FROM prompt_templates WHERE scope='system'`).Scan(&sys)
+	_ = db.QueryRow(`SELECT COUNT(*) FROM prompt_templates WHERE scope='agent'`).Scan(&agent)
+	if sys != 7 {
+		t.Fatalf("after re-seed system count = %d, want 7", sys)
+	}
+	if agent != 14 {
+		t.Fatalf("after re-seed agent count = %d, want 14", agent)
+	}
+	if total != 21 {
+		t.Fatalf("after re-seed total count = %d, want 21", total)
+	}
+}
+
+// TestSeed_InsertsAgentRows verifies RC/M6 acceptance #1: fresh seed
+// writes 14 active agent-scope rows (7 codex + 7 cursor).
+func TestSeed_InsertsAgentRows(t *testing.T) {
+	db := openTestDB(t)
+	store := NewStore(db)
+	ctx := context.Background()
+
+	if err := Seed(ctx, store, "peer-xyz"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	rows, err := store.List(ctx, ScopeAgent, "")
+	if err != nil {
+		t.Fatalf("list agent: %v", err)
+	}
+	if len(rows) != 14 {
+		t.Fatalf("agent rows = %d, want 14", len(rows))
+	}
+
+	byAgent := map[string]map[string]string{}
+	for _, r := range rows {
+		if byAgent[r.ScopeID] == nil {
+			byAgent[r.ScopeID] = map[string]string{}
+		}
+		byAgent[r.ScopeID][r.Section] = r.Body
+	}
+	for _, agent := range SeededAgents {
+		sections := byAgent[agent]
+		if len(sections) != 7 {
+			t.Fatalf("%s rows = %d, want 7", agent, len(sections))
+		}
+		for _, s := range Sections {
+			if sections[s] == "" {
+				t.Errorf("%s missing section %s", agent, s)
+			}
+		}
+		// Markdown frame — must contain at least one `## ` heading and
+		// must not re-use the Claude XML block opener.
+		joined := ""
+		for _, b := range sections {
+			joined += b
+		}
+		if !strings.Contains(joined, "## ") {
+			t.Errorf("%s bodies missing markdown headings", agent)
+		}
+		if strings.Contains(joined, "<visceral_rules>") || strings.Contains(joined, "<manifest_spec") {
+			t.Errorf("%s bodies should not contain Claude XML tags", agent)
+		}
+	}
+}
+
+// TestSeed_IdempotentPerBucket — after the full seed, a follow-up Seed()
+// doesn't duplicate rows and also doesn't create a second copy of any
+// bucket. A bucket manually emptied mid-flight is NOT re-seeded (the
+// gate is per-bucket presence, not per-section).
+func TestSeed_IdempotentPerBucket(t *testing.T) {
+	db := openTestDB(t)
+	store := NewStore(db)
+	ctx := context.Background()
+
+	if err := Seed(ctx, store, ""); err != nil {
+		t.Fatalf("seed 1: %v", err)
+	}
+	if err := Seed(ctx, store, ""); err != nil {
+		t.Fatalf("seed 2: %v", err)
+	}
+
+	for _, agent := range SeededAgents {
+		var n int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM prompt_templates WHERE scope='agent' AND scope_id=?`, agent).Scan(&n)
+		if n != 7 {
+			t.Fatalf("agent %s rows = %d, want 7", agent, n)
+		}
 	}
 }
 
@@ -179,6 +281,69 @@ func TestResolver_TaskScopeWins(t *testing.T) {
 	}
 	if body2 != defaultPreamble {
 		t.Fatalf("unrelated task should see system default")
+	}
+}
+
+// TestResolver_AgentScope exercises RC/M6 acceptance #4. With seeded
+// agent rows in place, a task whose effective agent is "codex" or
+// "cursor" resolves to that agent's markdown-heading body, while a
+// task on "claude-code" (no agent row) falls through to the system
+// XML body. The same section resolves to three distinct strings.
+func TestResolver_AgentScope(t *testing.T) {
+	db := openTestDB(t)
+	store := NewStore(db)
+	ctx := context.Background()
+	if err := Seed(ctx, store, ""); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	agents := &fakeAgentLookup{m: map[string]string{
+		"task-codex":  "codex",
+		"task-cursor": "cursor",
+		"task-claude": "claude-code",
+	}}
+	r := NewResolver(store, nil, agents)
+
+	gitCodex, err := r.Resolve(ctx, SectionGitWorkflow, "task-codex")
+	if err != nil {
+		t.Fatalf("resolve codex: %v", err)
+	}
+	if !strings.Contains(gitCodex, "## Git Workflow") {
+		t.Errorf("codex git_workflow should contain '## Git Workflow'; got %q", gitCodex)
+	}
+	if strings.Contains(gitCodex, "<git_workflow>") {
+		t.Errorf("codex git_workflow should not contain XML tag")
+	}
+
+	gitCursor, err := r.Resolve(ctx, SectionGitWorkflow, "task-cursor")
+	if err != nil {
+		t.Fatalf("resolve cursor: %v", err)
+	}
+	if !strings.Contains(gitCursor, "## Git Workflow") {
+		t.Errorf("cursor git_workflow should contain '## Git Workflow'; got %q", gitCursor)
+	}
+
+	gitClaude, err := r.Resolve(ctx, SectionGitWorkflow, "task-claude")
+	if err != nil {
+		t.Fatalf("resolve claude: %v", err)
+	}
+	if !strings.Contains(gitClaude, "<git_workflow>") {
+		t.Errorf("claude-code git_workflow should contain XML tag; got %q", gitClaude)
+	}
+
+	// Preamble carries the agent self-identifier, so codex/cursor/claude
+	// must all produce distinct strings for the same section.
+	pCodex, _ := r.Resolve(ctx, SectionPreamble, "task-codex")
+	pCursor, _ := r.Resolve(ctx, SectionPreamble, "task-cursor")
+	pClaude, _ := r.Resolve(ctx, SectionPreamble, "task-claude")
+	if pCodex == pCursor || pCodex == pClaude || pCursor == pClaude {
+		t.Errorf("preambles should be distinct — codex=%q cursor=%q claude=%q", pCodex, pCursor, pClaude)
+	}
+	if !strings.Contains(pCodex, "Codex") {
+		t.Errorf("codex preamble missing Codex identifier: %q", pCodex)
+	}
+	if !strings.Contains(pCursor, "Cursor") {
+		t.Errorf("cursor preamble missing Cursor identifier: %q", pCursor)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Seed 14 agent-scope prompt_templates rows (7 codex + 7 cursor) with markdown-heading bodies that render to the same PromptData as the Claude-targeted XML default set, but swap `<visceral_rules>` / `<manifest_spec>` / etc. for `## Headings`.
- `Seed()` now gates idempotency per `(scope, scope_id)` bucket via a shared helper, so system + codex + cursor each seed independently.
- `AgentDefaults(agent string)` is the canonical entry point for per-agent section bodies; `codexDefaults()` / `cursorDefaults()` wrap it per the manifest.
- Preambles carry an agent self-identifier (`running as the Codex agent` / `running as the Cursor agent`) so rendered prompts are distinguishable across all three tiers.

## Acceptance self-check
- [x] After seed, 14 active agent-scope rows (7 codex + 7 cursor) — `TestSeed_InsertsAgentRows`.
- [x] `Resolve(git_workflow, task-with-agent=codex)` returns markdown `## Git Workflow`, no `<git_workflow>` tag — `TestResolver_AgentScope`.
- [x] `Resolve(git_workflow, task-with-agent=claude-code)` returns the XML body — same test.
- [x] All three preambles distinct — same test.
- [x] Re-running `Seed()` is a no-op per bucket — `TestSeed_Idempotent` + `TestSeed_IdempotentPerBucket`.
- [x] `go test ./internal/templates/...` green (9/9) and full repo `go test ./...` green.

## Test plan
- [x] `go test ./internal/templates/... -v`
- [x] `go test ./...`
- [ ] After merge + fresh `openpraxis serve`, `curl /api/templates?scope=agent | jq length == 14` (needs RC/M2 HTTP list route, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)