### PR TITLE
fix: actually wire all 5 Run Stats sparklines on shared time axis

### DIFF
--- a/internal/task/host_metrics.go
+++ b/internal/task/host_metrics.go
@@ -17,10 +17,21 @@ import (
 // per-run Run Stats card can overlay host load on the same timeline as
 // the model's own turn/cost/actions lines.
 type HostMetricsSample struct {
-	TS     time.Time `json:"ts"`
-	CPUPct float64   `json:"cpu_pct"`
-	RSSMB  float64   `json:"rss_mb"`
+	TS      time.Time `json:"ts"`
+	CPUPct  float64   `json:"cpu_pct"`
+	RSSMB   float64   `json:"rss_mb"`
+	// Live task counters captured at the same tick as host CPU/RSS.
+	// Feeds the Run Stats card's 5-aligned-sparkline layout — same X-axis
+	// as CPU/RSS. Populated by a runner-supplied TaskStatFn closure.
+	CostUSD float64 `json:"cost_usd"`
+	Turns   int     `json:"turns"`
+	Actions int     `json:"actions"`
 }
+
+// TaskStatFn pulls the attached task's live counters at sample time. The
+// runner supplies it at Attach (closes over the RunningTask pointer so
+// it sees live updates).
+type TaskStatFn func() (costUSD float64, turns int, actions int)
 
 // HostMetrics is the summary rolled up from a task's samples on Detach.
 // Persisted as denormalised columns on task_runs so dashboards can sort
@@ -38,9 +49,16 @@ type HostMetrics struct {
 //
 // Cheap by design: one `ps -o %cpu=,rss= -p <pid>` fork every Interval
 // (default 5s). Zero when no tasks are attached — fanout is a no-op.
+// attachedTask bundles the per-task sample buffer with the callback the
+// sampler invokes at each tick to read live cost/turns/actions.
+type attachedTask struct {
+	samples []HostMetricsSample
+	statFn  TaskStatFn
+}
+
 type HostSampler struct {
 	mu       sync.Mutex
-	attached map[string]*[]HostMetricsSample
+	attached map[string]*attachedTask
 
 	interval time.Duration
 	pid      int
@@ -55,7 +73,7 @@ func NewHostSampler(interval time.Duration) *HostSampler {
 		interval = 5 * time.Second
 	}
 	return &HostSampler{
-		attached: make(map[string]*[]HostMetricsSample),
+		attached: make(map[string]*attachedTask),
 		interval: interval,
 		pid:      os.Getpid(),
 		stopCh:   make(chan struct{}),
@@ -111,20 +129,31 @@ func (s *HostSampler) loop(ctx context.Context) {
 	}
 }
 
-func (s *HostSampler) fanout(sample HostMetricsSample) {
+// fanout snaps host CPU/RSS into each attached task's sample buffer,
+// enriching per-task fields from the Attach-time callback. Host values
+// are identical across all attached tasks in one tick.
+func (s *HostSampler) fanout(hostOnly HostMetricsSample) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for _, slot := range s.attached {
-		*slot = append(*slot, sample)
+	for _, at := range s.attached {
+		sample := hostOnly
+		if at.statFn != nil {
+			sample.CostUSD, sample.Turns, sample.Actions = at.statFn()
+		}
+		at.samples = append(at.samples, sample)
 	}
 }
 
-// Attach registers a task to receive samples. Starting-empty — reattach
-// clears any prior state.
-func (s *HostSampler) Attach(taskID string) {
+// Attach registers a task to receive samples + supplies a callback the
+// sampler invokes at each tick to read live cost/turns/actions.
+// statFn may be nil; per-task counters default to zero in that case.
+// Starting-empty — reattach clears prior state.
+func (s *HostSampler) Attach(taskID string, statFn TaskStatFn) {
 	s.mu.Lock()
-	buf := make([]HostMetricsSample, 0, 64)
-	s.attached[taskID] = &buf
+	s.attached[taskID] = &attachedTask{
+		samples: make([]HostMetricsSample, 0, 64),
+		statFn:  statFn,
+	}
 	s.mu.Unlock()
 }
 
@@ -133,13 +162,13 @@ func (s *HostSampler) Attach(taskID string) {
 // unknown task ID — returns empty.
 func (s *HostSampler) Detach(taskID string) ([]HostMetricsSample, HostMetrics) {
 	s.mu.Lock()
-	slot := s.attached[taskID]
+	at := s.attached[taskID]
 	delete(s.attached, taskID)
 	s.mu.Unlock()
-	if slot == nil {
+	if at == nil {
 		return nil, HostMetrics{}
 	}
-	return *slot, rollupSamples(*slot)
+	return at.samples, rollupSamples(at.samples)
 }
 
 func rollupSamples(samples []HostMetricsSample) HostMetrics {

--- a/internal/task/repository.go
+++ b/internal/task/repository.go
@@ -730,13 +730,16 @@ func (s *Store) RecordHostMetrics(runID int64, samples []HostMetricsSample, metr
 		return fmt.Errorf("begin host-samples tx: %w", err)
 	}
 	defer tx.Rollback()
-	stmt, err := tx.Prepare(`INSERT INTO task_run_host_samples (run_id, ts, cpu_pct, rss_mb) VALUES (?, ?, ?, ?)`)
+	stmt, err := tx.Prepare(`INSERT INTO task_run_host_samples
+		(run_id, ts, cpu_pct, rss_mb, cost_usd, turns, actions)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare host-samples insert: %w", err)
 	}
 	defer stmt.Close()
 	for _, smp := range samples {
-		if _, err := stmt.Exec(runID, smp.TS.UTC().Format(time.RFC3339Nano), smp.CPUPct, smp.RSSMB); err != nil {
+		if _, err := stmt.Exec(runID, smp.TS.UTC().Format(time.RFC3339Nano),
+			smp.CPUPct, smp.RSSMB, smp.CostUSD, smp.Turns, smp.Actions); err != nil {
 			return fmt.Errorf("insert host sample: %w", err)
 		}
 	}
@@ -745,8 +748,16 @@ func (s *Store) RecordHostMetrics(runID int64, samples []HostMetricsSample, metr
 
 // ListHostSamples returns the time-series host samples for a run.
 // Ordered by ts ASC so the frontend can render left-to-right directly.
+// Reads all 5 metrics captured at each sample: host CPU/RSS + live task
+// counters (cost/turns/actions) — they share the same time axis so the
+// Run Stats card can overlay all 5 sparklines aligned.
 func (s *Store) ListHostSamples(runID int64) ([]HostMetricsSample, error) {
-	rows, err := s.db.Query(`SELECT ts, cpu_pct, rss_mb FROM task_run_host_samples WHERE run_id = ? ORDER BY ts ASC`, runID)
+	rows, err := s.db.Query(
+		`SELECT ts, cpu_pct, rss_mb, cost_usd, turns, actions
+		 FROM task_run_host_samples
+		 WHERE run_id = ? ORDER BY ts ASC`,
+		runID,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -755,7 +766,7 @@ func (s *Store) ListHostSamples(runID int64) ([]HostMetricsSample, error) {
 	for rows.Next() {
 		var tsStr string
 		var smp HostMetricsSample
-		if err := rows.Scan(&tsStr, &smp.CPUPct, &smp.RSSMB); err != nil {
+		if err := rows.Scan(&tsStr, &smp.CPUPct, &smp.RSSMB, &smp.CostUSD, &smp.Turns, &smp.Actions); err != nil {
 			return nil, err
 		}
 		if t, err := time.Parse(time.RFC3339Nano, tsStr); err == nil {

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -874,7 +874,13 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 	// Detach + RecordHostMetrics. Nil sampler → no-op (tests + pre-wire
 	// code paths).
 	if r.hostSampler != nil {
-		r.hostSampler.Attach(t.ID)
+		// The callback closes over rt so samples capture live cost / turns
+		// (unique message ids) / actions alongside host CPU/RSS on the
+		// same 5s cadence — powers the Run Stats 5-aligned sparklines.
+		rtRef := rt
+		r.hostSampler.Attach(t.ID, func() (float64, int, int) {
+			return rtRef.CumulativeCostUSD, len(rtRef.usageByMessage), rtRef.Actions
+		})
 	}
 
 	// Read output in background

--- a/internal/web/ui/components/run-stats.js
+++ b/internal/web/ui/components/run-stats.js
@@ -98,9 +98,23 @@
       return '<div class="run-stats-spark-row"><span class="run-stats-spark-label">' + esc(label) + '</span><span class="run-stats-empty">—</span></div>';
     }
     if (values.length === 1) {
+      // One data point — draw a flat horizontal line at mid-height with a
+      // terminal dot, so the row looks like a sparkline even with just one
+      // value. Keeps visual parity with multi-point rows; previously this
+      // case rendered as plain text and looked like a broken layout next
+      // to populated rows on the same card.
+      var v0 = values[0];
+      var single = opts.formatLatest ? opts.formatLatest(v0.y) : String(v0.y);
+      var midY = height / 2;
+      var x1 = padX;
+      var x2 = width - padX;
       return '<div class="run-stats-spark-row">' +
         '<span class="run-stats-spark-label">' + esc(label) + '</span>' +
-        '<span class="run-stats-spark-single" title="run #' + values[0].run + ': ' + esc(values[0].tooltip) + '">' + esc(opts.formatLatest ? opts.formatLatest(values[0].y) : String(values[0].y)) + '</span>' +
+        '<svg class="run-stats-spark" viewBox="0 0 ' + width + ' ' + height + '" preserveAspectRatio="none" width="' + width + '" height="' + height + '">' +
+          '<line x1="' + x1.toFixed(1) + '" y1="' + midY.toFixed(1) + '" x2="' + x2.toFixed(1) + '" y2="' + midY.toFixed(1) + '" stroke="' + color + '" stroke-width="1.5" />' +
+          '<circle cx="' + x2.toFixed(1) + '" cy="' + midY.toFixed(1) + '" r="2.5" fill="' + color + '" data-run="' + v0.run + '"><title>run #' + v0.run + ': ' + v0.tooltip + '</title></circle>' +
+        '</svg>' +
+        '<span class="run-stats-spark-latest" title="latest run">' + esc(single) + '</span>' +
         '</div>';
     }
     var ys = values.map(function (v) { return v.y; });
@@ -168,20 +182,60 @@
       var runs = ctx.runs;
       var latest = ctx.latest;
       var hostSamples = ctx.hostSamples;
-      // Build sparkline data oldest→newest, capped at last 10.
+      // All 5 sparklines share the same X-axis (time-into-run) when the
+      // current run has within-run samples. Each 5-second host-sampler
+      // tick snapshots host CPU/RSS AND live task counters (cost/turns/
+      // actions) simultaneously, so lines are aligned and correlate:
+      // turn bump → cost jump; CPU spike → actions burst.
+      //
+      // Legacy-run fallback: runs captured before the sampler shipped
+      // (or before the 5-unified cost/turns/actions fields landed) have
+      // either empty samples OR samples with zero cost/turns/actions.
+      // For those rows, fall back to per-run trend (cross-run aggregate)
+      // so the chart isn't a flat-zero liar.
       var trend = runs.slice(0, 10).reverse();
-      var costPts = trend.map(function (r) {
-        return { run: r.run_number, y: r.cost_usd || 0,
-          tooltip: fmtCost(r.cost_usd) + ', ' + (r.turns || 0) + ' turns, ' + (r.actions || 0) + ' actions' };
-      });
-      var turnPts = trend.map(function (r) {
-        return { run: r.run_number, y: r.turns || 0,
-          tooltip: (r.turns || 0) + ' turns, ' + fmtCost(r.cost_usd) };
-      });
-      var actionPts = trend.map(function (r) {
-        return { run: r.run_number, y: r.actions || 0,
-          tooltip: (r.actions || 0) + ' actions, ' + (r.turns || 0) + ' turns' };
-      });
+      var s20 = subsample(hostSamples, 20);
+      var tLabel = function (s) { return (s && s.ts) ? s.ts.slice(11, 19) : ''; };
+      var hasSampleVal = function (field) {
+        for (var i = 0; i < hostSamples.length; i++) {
+          if ((hostSamples[i][field] || 0) > 0) return true;
+        }
+        return false;
+      };
+      var costPts, turnPts, actionPts;
+      if (hasSampleVal('cost_usd')) {
+        costPts = s20.map(function (s, i) {
+          return { run: i, y: s.cost_usd || 0,
+            tooltip: fmtCost(s.cost_usd) + ' at ' + tLabel(s) };
+        });
+      } else {
+        costPts = trend.map(function (r) {
+          return { run: r.run_number, y: r.cost_usd || 0,
+            tooltip: fmtCost(r.cost_usd) + ', ' + (r.turns || 0) + ' turns, ' + (r.actions || 0) + ' actions' };
+        });
+      }
+      if (hasSampleVal('turns')) {
+        turnPts = s20.map(function (s, i) {
+          return { run: i, y: s.turns || 0,
+            tooltip: (s.turns || 0) + ' turns at ' + tLabel(s) };
+        });
+      } else {
+        turnPts = trend.map(function (r) {
+          return { run: r.run_number, y: r.turns || 0,
+            tooltip: (r.turns || 0) + ' turns, ' + fmtCost(r.cost_usd) };
+        });
+      }
+      if (hasSampleVal('actions')) {
+        actionPts = s20.map(function (s, i) {
+          return { run: i, y: s.actions || 0,
+            tooltip: (s.actions || 0) + ' actions at ' + tLabel(s) };
+        });
+      } else {
+        actionPts = trend.map(function (r) {
+          return { run: r.run_number, y: r.actions || 0,
+            tooltip: (r.actions || 0) + ' actions, ' + (r.turns || 0) + ' turns' };
+        });
+      }
       // Host CPU/RSS points are a within-run time series (one per ~5s
       // sample). Different X-axis conceptually but rendered by the same
       // sparkline helper so the visual vocabulary is consistent.


### PR DESCRIPTION
## Summary

End-to-end version of the unified-5-samples feature. Prior PRs shipped it partially — schema + runner + front-end were each missing pieces so the cost/turns/actions were silently written as zeros and dropped by the reader.

## What changed

- `HostMetricsSample` struct gets `CostUSD`/`Turns`/`Actions` fields (prev: missing → Scan dropped them)
- `TaskStatFn` callback type + `HostSampler.Attach(taskID, statFn)` signature
- Runner closes over `RunningTask` → sampler reads live `CumulativeCostUSD` / `len(usageByMessage)` / `Actions` at each tick
- `RecordHostMetrics` INSERT writes all 6 columns (was 4)
- `ListHostSamples` SELECT + Scan reads all 6 columns (was 4)
- Frontend renders all 5 sparklines from one `subsample(samples, 20)` with per-metric fallback to cross-run trend on legacy runs
- `renderSparkline` single-value case draws a flat horizontal line + terminal dot SVG (was plain text)

## Test plan

- [x] `go build ./...` green
- [x] API round-trip: `/api/task_runs/257/host_samples` last row now reads `cost=2.07 turns=22 actions=30` (was zeros)
- [ ] Reload dashboard → 5 aligned wavy sparklines on T6 detail panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)