### PR TITLE
fix(ui): skip cross-product depends_on edges in DAG view

### DIFF
--- a/internal/web/ui/views/product-dag.js
+++ b/internal/web/ui/views/product-dag.js
@@ -64,15 +64,28 @@
       meta: JSON.stringify(data.meta || {})
     }});
 
-    // Product → manifest ownership edges, but ONLY for root manifests (those
-    // with no depends_on). For chained manifests, the dep chain already
-    // implies reach from the product, and adding 6 product→manifest edges
-    // forces dagre to route 6 long lines that cross every task in between.
-    // This is the "tangled spaghetti" failure mode from the 2026-04-23
-    // screenshot — it wasn't dagre, it was that we fed it redundant edges.
+    // In-product manifest IDs. Used to filter cross-product depends_on
+    // refs out of the edge set (cytoscape errors hard on an edge whose
+    // source node is missing — crashed the whole render on 2026-04-24
+    // after the Agentic OS umbrella/sub-product split moved M8's deps
+    // out of AOS/Execution into AOS/Kernel).
+    var manifestIds = {};
+    for (var mx = 0; mx < manifests.length; mx++) manifestIds[manifests[mx].id] = true;
+
+    // Product → manifest ownership edges. Emit only when the manifest has
+    // no in-product dep that would otherwise connect it — else dagre draws
+    // redundant long lines (the 2026-04-23 "tangled spaghetti"). A manifest
+    // whose depends_on all point outside this product still gets an
+    // ownership edge so it stays reachable from the root.
     for (var mi = 0; mi < manifests.length; mi++) {
-      if (!manifests[mi].depends_on) {
-        elements.push({ data: { source: data.id, target: manifests[mi].id, edgeType: 'product_link' } });
+      var mown = manifests[mi];
+      var inProductDeps = 0;
+      if (mown.depends_on) {
+        var owndids = mown.depends_on.split(',').map(function(s){return s.trim();}).filter(Boolean);
+        for (var dj = 0; dj < owndids.length; dj++) if (manifestIds[owndids[dj]]) inProductDeps++;
+      }
+      if (inProductDeps === 0) {
+        elements.push({ data: { source: data.id, target: mown.id, edgeType: 'product_link' } });
       }
     }
 
@@ -91,10 +104,13 @@
         taskInfo: completedCount + '/' + taskCount
       }});
 
-      // Manifest → manifest edges (explicit depends_on)
+      // Manifest → manifest edges (explicit depends_on). Cross-product
+      // deps are silently dropped — they belong to the product-dep layer
+      // of THIS product's view, not the manifest layer.
       if (m.depends_on) {
         var depIds = m.depends_on.split(',').map(function(s) { return s.trim(); }).filter(Boolean);
         for (var di = 0; di < depIds.length; di++) {
+          if (!manifestIds[depIds[di]]) continue;
           elements.push({ data: { source: depIds[di], target: m.id, edgeType: 'manifest_dep' } });
         }
       }


### PR DESCRIPTION
## Summary
- Product DAG crashed with "failed to load" on every sub-product after the 2026-04-24 Agentic OS umbrella/sub-product restructure.
- M8 in AOS/Execution had \`depends_on\` pointing at M6/M7b in AOS/Kernel; cytoscape errored on the edge with a missing source node → whole render died.
- Fix: pre-compute in-product manifest IDs, (a) silently drop manifest→manifest dep edges that point outside the product, (b) fall back to a product→manifest ownership edge when all deps are external so the manifest stays reachable from the root.

## Known follow-up (separate PR)
- Umbrella product \`Agentic OS\` still renders empty. \`apiProductHierarchy\` doesn't follow \`product_dep\` edges — would need ~30 lines in \`internal/web/handlers_product.go\` to nest sub-products as children. Out of scope for this fix; file a follow-up once this lands.

## Test plan
- [ ] Merge + restart serve
- [ ] Click AOS / Execution → DAG renders (4 manifests, tasks, no crash)
- [ ] Click AOS / Kernel, AOS / Drivers, AOS / Observability, AOS / Memory, AOS / Plan-Apply, AOS / Security, AOS / Positioning → each renders
- [ ] Click non-AOS products (RC, FA, SD, etc.) → no regression