### PR TITLE
fix(ui,web): umbrella product hierarchy follows product_dep edges

### DIFF
--- a/internal/web/handlers_product.go
+++ b/internal/web/handlers_product.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -200,6 +201,106 @@ func apiProductManifests(n *node.Node) http.HandlerFunc {
 	}
 }
 
+type hierarchyTaskNode struct {
+	ID        string         `json:"id"`
+	Marker    string         `json:"marker"`
+	Title     string         `json:"title"`
+	Type      string         `json:"type"`
+	Status    string         `json:"status"`
+	DependsOn string         `json:"depends_on"`
+	Meta      map[string]any `json:"meta"`
+}
+
+type hierarchyManifestNode struct {
+	ID              string              `json:"id"`
+	Marker          string              `json:"marker"`
+	Title           string              `json:"title"`
+	Type            string              `json:"type"`
+	Status          string              `json:"status"`
+	DependsOn       string              `json:"depends_on"`
+	DependsOnTitles []string            `json:"depends_on_titles"`
+	Meta            map[string]any      `json:"meta"`
+	Children        []hierarchyTaskNode `json:"children"`
+}
+
+type hierarchyProductNode struct {
+	ID          string                  `json:"id"`
+	Marker      string                  `json:"marker"`
+	Title       string                  `json:"title"`
+	Type        string                  `json:"type"`
+	Status      string                  `json:"status"`
+	Meta        map[string]any          `json:"meta"`
+	Children    []hierarchyManifestNode `json:"children"`
+	SubProducts []hierarchyProductNode  `json:"sub_products,omitempty"`
+}
+
+// buildHierarchyProduct returns a productNode with its manifest children.
+// When depth > 0 it also recurses into product→product dep edges, exposing
+// sub-products as SubProducts so the umbrella product (which owns no manifests
+// directly) still renders its full subsystem tree in the DAG view. Cycles
+// are already rejected at AddDep time; depth cap is defense in depth.
+func buildHierarchyProduct(ctx context.Context, n *node.Node, p *product.Product, depth int, seen map[string]bool) hierarchyProductNode {
+	if seen[p.ID] {
+		return hierarchyProductNode{ID: p.ID, Marker: p.Marker, Title: p.Title, Type: "product", Status: p.Status}
+	}
+	seen[p.ID] = true
+
+	manifests, _ := n.Manifests.ListByProject(p.ID, 200)
+	mNodes := make([]hierarchyManifestNode, 0, len(manifests))
+	totalTasks := 0
+	for _, m := range manifests {
+		tasks, _ := n.Tasks.ListByManifest(m.ID, 200)
+		tNodes := make([]hierarchyTaskNode, 0, len(tasks))
+		for _, t := range tasks {
+			tNodes = append(tNodes, hierarchyTaskNode{
+				ID: t.ID, Marker: t.Marker, Title: t.Title,
+				Type: "task", Status: t.Status, DependsOn: t.DependsOn,
+				Meta: map[string]any{
+					"cost_usd":  t.TotalCost,
+					"turns":     t.TotalTurns,
+					"run_count": t.RunCount,
+				},
+			})
+		}
+		totalTasks += len(tasks)
+		mNodes = append(mNodes, hierarchyManifestNode{
+			ID: m.ID, Marker: m.Marker, Title: m.Title,
+			Type: "manifest", Status: m.Status,
+			DependsOn: m.DependsOn, DependsOnTitles: n.ResolveDependsOnTitles(m.DependsOn),
+			Meta: map[string]any{
+				"total_cost":  m.TotalCost,
+				"total_tasks": len(tasks),
+				"total_turns": m.TotalTurns,
+			},
+			Children: tNodes,
+		})
+	}
+
+	var subNodes []hierarchyProductNode
+	if depth > 0 {
+		deps, _ := n.Products.ListDeps(ctx, p.ID)
+		for _, d := range deps {
+			sub, err := n.Products.Get(d.ID)
+			if err != nil || sub == nil {
+				continue
+			}
+			subNodes = append(subNodes, buildHierarchyProduct(ctx, n, sub, depth-1, seen))
+		}
+	}
+
+	return hierarchyProductNode{
+		ID: p.ID, Marker: p.Marker, Title: p.Title,
+		Type: "product", Status: p.Status,
+		Meta: map[string]any{
+			"total_cost":      p.TotalCost,
+			"total_manifests": len(manifests),
+			"total_tasks":     totalTasks,
+		},
+		Children:    mNodes,
+		SubProducts: subNodes,
+	}
+}
+
 func apiProductHierarchy(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := mux.Vars(r)["id"]
@@ -208,82 +309,7 @@ func apiProductHierarchy(n *node.Node) http.HandlerFunc {
 			http.Error(w, "product not found", 404)
 			return
 		}
-
-		type taskNode struct {
-			ID        string         `json:"id"`
-			Marker    string         `json:"marker"`
-			Title     string         `json:"title"`
-			Type      string         `json:"type"`
-			Status    string         `json:"status"`
-			DependsOn string         `json:"depends_on"`
-			Meta      map[string]any `json:"meta"`
-		}
-		type manifestNode struct {
-			ID              string         `json:"id"`
-			Marker          string         `json:"marker"`
-			Title           string         `json:"title"`
-			Type            string         `json:"type"`
-			Status          string         `json:"status"`
-			DependsOn       string         `json:"depends_on"`
-			DependsOnTitles []string       `json:"depends_on_titles"`
-			Meta            map[string]any `json:"meta"`
-			Children        []taskNode     `json:"children"`
-		}
-		type productNode struct {
-			ID       string         `json:"id"`
-			Marker   string         `json:"marker"`
-			Title    string         `json:"title"`
-			Type     string         `json:"type"`
-			Status   string         `json:"status"`
-			Meta     map[string]any `json:"meta"`
-			Children []manifestNode `json:"children"`
-		}
-
-		manifests, _ := n.Manifests.ListByProject(p.ID, 200)
-		var mNodes []manifestNode
-		totalTasks := 0
-		totalCost := 0.0
-
-		for _, m := range manifests {
-			tasks, _ := n.Tasks.ListByManifest(m.ID, 200)
-			var tNodes []taskNode
-			for _, t := range tasks {
-				tNodes = append(tNodes, taskNode{
-					ID: t.ID, Marker: t.Marker, Title: t.Title,
-					Type: "task", Status: t.Status, DependsOn: t.DependsOn,
-					Meta: map[string]any{
-						"cost_usd":  t.TotalCost,
-						"turns":     t.TotalTurns,
-						"run_count": t.RunCount,
-					},
-				})
-			}
-			totalTasks += len(tasks)
-			totalCost += m.TotalCost
-
-			mNodes = append(mNodes, manifestNode{
-				ID: m.ID, Marker: m.Marker, Title: m.Title,
-				Type: "manifest", Status: m.Status,
-				DependsOn: m.DependsOn, DependsOnTitles: n.ResolveDependsOnTitles(m.DependsOn),
-				Meta: map[string]any{
-					"total_cost":  m.TotalCost,
-					"total_tasks": len(tasks),
-					"total_turns": m.TotalTurns,
-				},
-				Children: tNodes,
-			})
-		}
-
-		result := productNode{
-			ID: p.ID, Marker: p.Marker, Title: p.Title,
-			Type: "product", Status: p.Status,
-			Meta: map[string]any{
-				"total_cost":      p.TotalCost,
-				"total_manifests": len(manifests),
-				"total_tasks":     totalTasks,
-			},
-			Children: mNodes,
-		}
+		result := buildHierarchyProduct(r.Context(), n, p, 2, map[string]bool{})
 		writeJSON(w, result)
 	}
 }

--- a/internal/web/ui/views/product-dag.js
+++ b/internal/web/ui/views/product-dag.js
@@ -51,96 +51,109 @@
   OL.buildDagElements = function(data) {
     var elements = [];
     if (!data) return elements;
-    var manifests = data.children || [];
 
     function shortLabel(title) {
       return title.replace(/^QA\s+/, '').replace(/^OpenPraxis\s+/, '').replace(/\s*—\s*.+$/, '');
     }
 
-    // Product node
-    elements.push({ data: {
-      id: data.id, label: data.title, title: data.title, type: 'product',
-      status: data.status, marker: data.marker,
-      meta: JSON.stringify(data.meta || {})
-    }});
+    var seenProducts = {};
 
-    // In-product manifest IDs. Used to filter cross-product depends_on
-    // refs out of the edge set (cytoscape errors hard on an edge whose
-    // source node is missing — crashed the whole render on 2026-04-24
-    // after the Agentic OS umbrella/sub-product split moved M8's deps
-    // out of AOS/Execution into AOS/Kernel).
-    var manifestIds = {};
-    for (var mx = 0; mx < manifests.length; mx++) manifestIds[manifests[mx].id] = true;
-
-    // Product → manifest ownership edges. Emit only when the manifest has
-    // no in-product dep that would otherwise connect it — else dagre draws
-    // redundant long lines (the 2026-04-23 "tangled spaghetti"). A manifest
-    // whose depends_on all point outside this product still gets an
-    // ownership edge so it stays reachable from the root.
-    for (var mi = 0; mi < manifests.length; mi++) {
-      var mown = manifests[mi];
-      var inProductDeps = 0;
-      if (mown.depends_on) {
-        var owndids = mown.depends_on.split(',').map(function(s){return s.trim();}).filter(Boolean);
-        for (var dj = 0; dj < owndids.length; dj++) if (manifestIds[owndids[dj]]) inProductDeps++;
-      }
-      if (inProductDeps === 0) {
-        elements.push({ data: { source: data.id, target: mown.id, edgeType: 'product_link' } });
-      }
-    }
-
-    for (var col = 0; col < manifests.length; col++) {
-      var m = manifests[col];
-      var tasks = m.children || [];
-      var taskCount = tasks.length;
-      var completedCount = tasks.filter(function(t) { return t.status === 'completed'; }).length;
+    // addProduct emits the product node, its manifest children (with tasks),
+    // and recursively any sub_products returned by the hierarchy endpoint.
+    // Sub-products let the umbrella product (e.g. "Agentic OS") render its
+    // 8 subsystem children as a single DAG, even though the umbrella owns
+    // no manifests directly. Cycles are rejected at AddDep time; seen-set
+    // is defense in depth.
+    function addProduct(p) {
+      if (!p || seenProducts[p.id]) return;
+      seenProducts[p.id] = true;
 
       elements.push({ data: {
-        id: m.id,
-        label: shortLabel(m.title),
-        title: m.title, type: 'manifest', status: m.status,
-        marker: m.marker, depends_on: m.depends_on || '',
-        meta: JSON.stringify(m.meta || {}),
-        taskInfo: completedCount + '/' + taskCount
+        id: p.id, label: p.title, title: p.title, type: 'product',
+        status: p.status, marker: p.marker,
+        meta: JSON.stringify(p.meta || {})
       }});
 
-      // Manifest → manifest edges (explicit depends_on). Cross-product
-      // deps are silently dropped — they belong to the product-dep layer
-      // of THIS product's view, not the manifest layer.
-      if (m.depends_on) {
-        var depIds = m.depends_on.split(',').map(function(s) { return s.trim(); }).filter(Boolean);
-        for (var di = 0; di < depIds.length; di++) {
-          if (!manifestIds[depIds[di]]) continue;
-          elements.push({ data: { source: depIds[di], target: m.id, edgeType: 'manifest_dep' } });
+      var manifests = p.children || [];
+      var manifestIds = {};
+      for (var mx = 0; mx < manifests.length; mx++) manifestIds[manifests[mx].id] = true;
+
+      // Product → manifest ownership edges. Emit only when the manifest has
+      // no in-product dep that would otherwise connect it (avoids the
+      // 2026-04-23 "tangled spaghetti"). Cross-product deps count as
+      // external, so a manifest whose deps all point outside still gets an
+      // ownership edge.
+      for (var mi = 0; mi < manifests.length; mi++) {
+        var mown = manifests[mi];
+        var inProductDeps = 0;
+        if (mown.depends_on) {
+          var owndids = mown.depends_on.split(',').map(function(s){return s.trim();}).filter(Boolean);
+          for (var dj = 0; dj < owndids.length; dj++) if (manifestIds[owndids[dj]]) inProductDeps++;
+        }
+        if (inProductDeps === 0) {
+          elements.push({ data: { source: p.id, target: mown.id, edgeType: 'product_link' } });
         }
       }
 
-      // Task nodes + edges. Each task gets an edge from its actual
-      // depends_on parent when that parent is inside the same manifest;
-      // otherwise an ownership edge from the manifest itself. Dagre
-      // handles the layout from the edge set.
-      var taskIds = {};
-      tasks.forEach(function(t) { taskIds[t.id] = true; });
+      for (var col = 0; col < manifests.length; col++) {
+        var m = manifests[col];
+        var tasks = m.children || [];
+        var taskCount = tasks.length;
+        var completedCount = tasks.filter(function(t) { return t.status === 'completed'; }).length;
 
-      for (var ti = 0; ti < tasks.length; ti++) {
-        var t = tasks[ti];
-        // Labels render inside the 120×44 node and wrap to ~2 lines at
-        // font-size 9px → ~36 chars before ellipsis kicks in.
-        var shortTitle = t.title.length > 36 ? t.title.substring(0, 35) + '…' : t.title;
         elements.push({ data: {
-          id: t.id, label: shortTitle,
-          title: t.title, type: 'task', status: t.status,
-          marker: t.marker, depends_on: t.depends_on || '',
-          meta: JSON.stringify(t.meta || {})
+          id: m.id,
+          label: shortLabel(m.title),
+          title: m.title, type: 'manifest', status: m.status,
+          marker: m.marker, depends_on: m.depends_on || '',
+          meta: JSON.stringify(m.meta || {}),
+          taskInfo: completedCount + '/' + taskCount
         }});
 
-        if (t.depends_on && taskIds[t.depends_on]) {
-          elements.push({ data: { source: t.depends_on, target: t.id, edgeType: 'task_dep' } });
-        } else {
-          elements.push({ data: { source: m.id, target: t.id, edgeType: 'ownership' } });
+        // Manifest → manifest edges (explicit depends_on). Cross-product
+        // deps dropped — they belong to the product-dep layer, not the
+        // manifest layer of THIS product's view.
+        if (m.depends_on) {
+          var depIds = m.depends_on.split(',').map(function(s) { return s.trim(); }).filter(Boolean);
+          for (var di = 0; di < depIds.length; di++) {
+            if (!manifestIds[depIds[di]]) continue;
+            elements.push({ data: { source: depIds[di], target: m.id, edgeType: 'manifest_dep' } });
+          }
+        }
+
+        var taskIds = {};
+        tasks.forEach(function(t) { taskIds[t.id] = true; });
+
+        for (var ti = 0; ti < tasks.length; ti++) {
+          var t = tasks[ti];
+          var shortTitle = t.title.length > 36 ? t.title.substring(0, 35) + '…' : t.title;
+          elements.push({ data: {
+            id: t.id, label: shortTitle,
+            title: t.title, type: 'task', status: t.status,
+            marker: t.marker, depends_on: t.depends_on || '',
+            meta: JSON.stringify(t.meta || {})
+          }});
+
+          if (t.depends_on && taskIds[t.depends_on]) {
+            elements.push({ data: { source: t.depends_on, target: t.id, edgeType: 'task_dep' } });
+          } else {
+            elements.push({ data: { source: m.id, target: t.id, edgeType: 'ownership' } });
+          }
         }
       }
+
+      // Sub-products: product→product dep edges the hierarchy endpoint
+      // exposes on the umbrella. Recurse so the full subsystem tree ranks
+      // below this product in dagre's layout.
+      var subs = p.sub_products || [];
+      for (var si = 0; si < subs.length; si++) {
+        var sub = subs[si];
+        elements.push({ data: { source: p.id, target: sub.id, edgeType: 'product_link' } });
+        addProduct(sub);
+      }
     }
+
+    addProduct(data);
     return elements;
   };
 


### PR DESCRIPTION
## Summary
- Umbrella products (zero owned manifests) rendered blank in the DAG view because \`apiProductHierarchy\` only followed \`project_id\`, not \`product_dep\` edges.
- Backend: extend the hierarchy response with \`sub_products[]\` built from \`Products.ListDeps\`, depth-capped at 2.
- Frontend: \`buildDagElements\` refactored into a recursive \`addProduct\` that emits product→sub-product ownership edges + recurses into each sub-product's manifests/tasks, with a seen-set guard.

## Test plan
- [ ] Merge + restart serve
- [ ] Click Agentic OS → renders umbrella + 8 sub-product children + their manifests/tasks in one DAG
- [ ] Click any sub-product → renders that sub-product's own DAG (still works, no regression)
- [ ] Click non-AOS products → no regression