### PR TITLE
fix(web): hierarchy depth 2→1 — umbrella renders as a clean tree

### DIFF
--- a/internal/web/handlers_product.go
+++ b/internal/web/handlers_product.go
@@ -309,7 +309,14 @@ func apiProductHierarchy(n *node.Node) http.HandlerFunc {
 			http.Error(w, "product not found", 404)
 			return
 		}
-		result := buildHierarchyProduct(r.Context(), n, p, 2, map[string]bool{})
+		// Depth 1: umbrella shows its direct sub-products; each sub-product
+		// returns only its manifests, NOT its own subsystem deps. Depth 2
+		// caused the 2026-04-24 "tangled mess" where Execution appeared as
+		// a child of both Agentic OS (rollup) AND Observability (subsystem
+		// dep), with both edges drawn on top of each other in the same
+		// product layer. Subsystem deps only render when that product is
+		// the root of the view, not when it's a nested child.
+		result := buildHierarchyProduct(r.Context(), n, p, 1, map[string]bool{})
 		writeJSON(w, result)
 	}
 }


### PR DESCRIPTION
## Summary
Umbrella DAG (Agentic OS) was tangled because the hierarchy endpoint walked the product→product dep graph TWO levels deep, so subsystem deps (Execution→Kernel, Observability→Execution, etc.) appeared as edges at the same product layer as the umbrella→sub rollup edges. Same visual weight, different semantics, dagre crossed them.

Depth 1: umbrella → 8 direct sub-products → manifests → tasks. Subsystem deps still visible when you click into the sub-product directly.

## Test plan
- [ ] Merge + restart
- [ ] Click Agentic OS → tree-shaped, no edges between sub-products
- [ ] Click AOS / Execution → still shows M8/M9/M12/M13 with their dep chain (no regression)