### PR TITLE
fix(ui,web): nest umbrella sub-products in the products menu

### DIFF
--- a/internal/web/handlers_product.go
+++ b/internal/web/handlers_product.go
@@ -14,6 +14,22 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// pItemMenu is the products-by-peer menu row. SubProducts is filled when
+// this product is detected as an umbrella (no manifests + has out-deps).
+type pItemMenu struct {
+	ID             string      `json:"id"`
+	Marker         string      `json:"marker"`
+	Title          string      `json:"title"`
+	Status         string      `json:"status"`
+	TotalManifests int         `json:"total_manifests"`
+	TotalTasks     int         `json:"total_tasks"`
+	TotalTurns     int         `json:"total_turns"`
+	TotalCost      float64     `json:"total_cost"`
+	CreatedAt      string      `json:"created_at"`
+	UpdatedAt      string      `json:"updated_at"`
+	SubProducts    []pItemMenu `json:"sub_products,omitempty"`
+}
+
 func apiProductsByPeer(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		products, err := n.Products.List("", 200)
@@ -21,26 +37,57 @@ func apiProductsByPeer(n *node.Node) http.HandlerFunc {
 			http.Error(w, err.Error(), 500)
 			return
 		}
-		type pItem struct {
-			ID             string  `json:"id"`
-			Marker         string  `json:"marker"`
-			Title          string  `json:"title"`
-			Status         string  `json:"status"`
-			TotalManifests int     `json:"total_manifests"`
-			TotalTasks     int     `json:"total_tasks"`
-			TotalTurns     int     `json:"total_turns"`
-			TotalCost      float64 `json:"total_cost"`
-			CreatedAt      string  `json:"created_at"`
-			UpdatedAt      string  `json:"updated_at"`
-		}
 		type peerGroup struct {
-			PeerID   string  `json:"peer_id"`
-			Count    int     `json:"count"`
-			Products []pItem `json:"products"`
+			PeerID   string      `json:"peer_id"`
+			Count    int         `json:"count"`
+			Products []pItemMenu `json:"products"`
 		}
-		peers := make(map[string][]pItem)
+
+		// An "umbrella" is a product with zero manifests of its own that has
+		// outgoing product_dep edges. Its dep targets render nested under it
+		// in the menu and are filtered from the top-level list. Self-
+		// documenting: anyone makes an umbrella by creating an empty product
+		// + wiring sub-products via product_dep_add. First umbrella claiming
+		// a sub wins (deterministic by product list order).
+		ctx := r.Context()
+		parentOf := map[string]string{}
+		umbrellaSubs := map[string][]string{}
+		for _, p := range products {
+			if p.TotalManifests > 0 {
+				continue
+			}
+			deps, _ := n.Products.ListDeps(ctx, p.ID)
+			if len(deps) == 0 {
+				continue
+			}
+			for _, d := range deps {
+				if _, claimed := parentOf[d.ID]; !claimed {
+					parentOf[d.ID] = p.ID
+				}
+				umbrellaSubs[p.ID] = append(umbrellaSubs[p.ID], d.ID)
+			}
+		}
+
+		itemFor := func(p *product.Product) pItemMenu {
+			return pItemMenu{
+				ID: p.ID, Marker: p.Marker, Title: p.Title, Status: p.Status,
+				TotalManifests: p.TotalManifests, TotalTasks: p.TotalTasks,
+				TotalTurns: p.TotalTurns, TotalCost: p.TotalCost,
+				CreatedAt: p.CreatedAt.Format(time.RFC3339),
+				UpdatedAt: p.UpdatedAt.Format(time.RFC3339),
+			}
+		}
+		productByID := map[string]*product.Product{}
+		for _, p := range products {
+			productByID[p.ID] = p
+		}
+
+		peers := make(map[string][]pItemMenu)
 		peerOrder := []string{}
 		for _, p := range products {
+			if _, isSub := parentOf[p.ID]; isSub {
+				continue
+			}
 			pid := p.SourceNode
 			if pid == "" {
 				pid = n.PeerID()
@@ -48,13 +95,15 @@ func apiProductsByPeer(n *node.Node) http.HandlerFunc {
 			if _, ok := peers[pid]; !ok {
 				peerOrder = append(peerOrder, pid)
 			}
-			peers[pid] = append(peers[pid], pItem{
-				ID: p.ID, Marker: p.Marker, Title: p.Title, Status: p.Status,
-				TotalManifests: p.TotalManifests, TotalTasks: p.TotalTasks,
-				TotalTurns: p.TotalTurns, TotalCost: p.TotalCost,
-				CreatedAt: p.CreatedAt.Format(time.RFC3339),
-				UpdatedAt: p.UpdatedAt.Format(time.RFC3339),
-			})
+			item := itemFor(p)
+			if subIDs, ok := umbrellaSubs[p.ID]; ok {
+				for _, sid := range subIDs {
+					if sub, ok := productByID[sid]; ok {
+						item.SubProducts = append(item.SubProducts, itemFor(sub))
+					}
+				}
+			}
+			peers[pid] = append(peers[pid], item)
 		}
 		var result []peerGroup
 		for _, pid := range peerOrder {

--- a/internal/web/ui/views/products.js
+++ b/internal/web/ui/views/products.js
@@ -48,6 +48,48 @@
     try {
       var peerGroups = await fetchJSON('/api/products/by-peer');
 
+      // Product render config — reused for top-level products AND umbrella
+      // sub-products. An umbrella product (server-detected as "no manifests +
+      // outgoing product_dep edges") arrives with sub_products[] populated;
+      // children() returns those, the tree renders them nested. Sub-products
+      // are filtered from the top-level list server-side so each product
+      // appears in exactly one place.
+      var productLevel = {
+        label: function(p) { return esc(p.title); },
+        extra: function(p) {
+          var subCount = (p.sub_products || []).length;
+          return '<span class="session-uuid">' + esc(p.marker) + '</span>' +
+            (p.total_manifests > 0 ? '<span class="count">' + p.total_manifests + '</span>' : '') +
+            (subCount > 0 ? '<span class="count" style="background:var(--purple,#8b5cf6)">' + subCount + '</span>' : '');
+        },
+        dotColor: function(p) {
+          return p.status === 'open' ? 'green' : p.status === 'closed' ? 'red' : p.status === 'archive' ? 'red' : 'yellow';
+        },
+        expanded: false,
+        nodeAttrs: function(p) { return 'data-product-id="' + esc(p.id) + '"'; },
+        children: function(p) { return p.sub_products || []; },
+        renderContent: function(p) {
+          if ((p.sub_products || []).length > 0 && p.total_manifests === 0) return '';
+          var metaParts = [];
+          if (p.total_tasks > 0) metaParts.push(p.total_tasks + ' tasks');
+          if (p.total_turns > 0) metaParts.push(p.total_turns + ' turns');
+          if (p.total_cost > 0) metaParts.push('$' + p.total_cost.toFixed(2));
+          return '<div class="prod-manifests-placeholder" data-prod-manifests-for="' + esc(p.id) + '" style="margin-left:24px">' +
+            '<div style="padding:8px 12px;color:var(--text-muted);font-size:12px">' +
+              (metaParts.length ? metaParts.join(' &middot; ') : '') +
+              (p.total_manifests > 0 ? '<div style="margin-top:4px;font-style:italic">Loading manifests...</div>' : '<div style="margin-top:4px;font-style:italic">No manifests linked</div>') +
+            '</div>' +
+          '</div>';
+        },
+        onClick: function(node, childrenEl, nowExpanded, p) {
+          OL.loadProductDetail(p.id);
+          if (nowExpanded) {
+            var placeholder = childrenEl.querySelector('.prod-manifests-placeholder');
+            if (placeholder) loadProductManifests(p.id, placeholder);
+          }
+        },
+      };
+
       OL.renderTree(el, peerGroups, {
         prefix: 'prod',
         emptyMessage: 'No products yet. Create one to group your manifests.',
@@ -57,37 +99,8 @@
             count: function(pg) { return pg.count; },
             children: function(pg) { return pg.products; },
           },
-          {
-            label: function(p) { return esc(p.title); },
-            extra: function(p) {
-              return '<span class="session-uuid">' + esc(p.marker) + '</span>' +
-                (p.total_manifests > 0 ? '<span class="count">' + p.total_manifests + '</span>' : '');
-            },
-            dotColor: function(p) {
-              return p.status === 'open' ? 'green' : p.status === 'closed' ? 'red' : p.status === 'archive' ? 'red' : 'yellow';
-            },
-            expanded: false,
-            nodeAttrs: function(p) { return 'data-product-id="' + esc(p.id) + '"'; },
-            renderContent: function(p) {
-              var metaParts = [];
-              if (p.total_tasks > 0) metaParts.push(p.total_tasks + ' tasks');
-              if (p.total_turns > 0) metaParts.push(p.total_turns + ' turns');
-              if (p.total_cost > 0) metaParts.push('$' + p.total_cost.toFixed(2));
-              return '<div class="prod-manifests-placeholder" data-prod-manifests-for="' + esc(p.id) + '" style="margin-left:24px">' +
-                '<div style="padding:8px 12px;color:var(--text-muted);font-size:12px">' +
-                  (metaParts.length ? metaParts.join(' &middot; ') : '') +
-                  (p.total_manifests > 0 ? '<div style="margin-top:4px;font-style:italic">Loading manifests...</div>' : '<div style="margin-top:4px;font-style:italic">No manifests linked</div>') +
-                '</div>' +
-              '</div>';
-            },
-            onClick: function(node, childrenEl, nowExpanded, p) {
-              OL.loadProductDetail(p.id);
-              if (nowExpanded) {
-                var placeholder = childrenEl.querySelector('.prod-manifests-placeholder');
-                if (placeholder) loadProductManifests(p.id, placeholder);
-              }
-            },
-          }
+          productLevel,
+          productLevel,
         ],
         afterRender: function(container) {
           container.insertAdjacentHTML('afterbegin', '<div style="padding:8px 0;margin-bottom:8px"><button class="btn-search btn-action" id="btn-new-product">+ New Product</button></div>');


### PR DESCRIPTION
Sub-products of an umbrella (e.g. AOS/Kernel under Agentic OS) were flat-listed alongside the umbrella in the Peers & Products sidebar. Server now detects umbrellas by shape (no manifests + has outgoing product_dep) and nests sub-products under them. Sub-products filtered from top-level, appear once. Generic — not AOS-specific.