### PR TITLE
feat(rel): PR/M1 — unified relationships table (schema + writer/reader API + 6 MCP tools)

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -127,6 +127,7 @@ These behaviors are automatic. Never mention OpenPraxis to the user unless they 
 	s.registerSettingsTools()
 	s.registerDescriptionTools()
 	s.registerTemplateTools()
+	s.registerRelationshipsTools()
 
 	s.http = mcpserver.NewStreamableHTTPServer(s.mcp,
 		mcpserver.WithSessionIdleTTL(2*time.Hour),

--- a/internal/mcp/tools_relationships.go
+++ b/internal/mcp/tools_relationships.go
@@ -15,13 +15,25 @@ package mcp
 
 import (
 	"context"
-	"fmt"
-	"strings"
+	"encoding/json"
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/k8nstantin/OpenPraxis/internal/relationships"
 )
+
+// jsonResult marshals v as pretty JSON and wraps it in a textResult.
+// Per the agent-as-primary-reader framing (decision comment 019dc450-483a
+// on the Praxis Git product), every read tool returns structured JSON
+// so downstream agents skip the prose-parser. Humans inspecting via
+// `mcp tools/call` get pretty-printed JSON which is still legible.
+func jsonResult(v any) *mcplib.CallToolResult {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errResult("json marshal: %v", err)
+	}
+	return textResult(string(b))
+}
 
 // registerRelationshipsTools wires the six rel_* MCP tools onto the
 // server. Called from server.go's registerAll() (similar to the other
@@ -66,12 +78,13 @@ func (s *Server) registerRelationshipsTools() {
 	s.mcp.AddTool(
 		mcplib.NewTool("rel_list_outgoing",
 			mcplib.WithDescription(
-				"List CURRENT edges leaving src_id. valid_to='' rows only. Optionally filter by kind. "+
-					"Hits the partial index idx_rel_src_current — O(log n + matches) regardless of how "+
-					"much history accumulates.",
+				"List edges leaving src_id. By default returns CURRENT (valid_to='') edges only. "+
+					"Pass as_of=ISO8601 for time-travel ('what edges left this node at past time T?'). "+
+					"Returns JSON array of edges. Hits idx_rel_src_current on the hot path.",
 			),
 			mcplib.WithString("src_id", mcplib.Required(), mcplib.Description("Source full UUID")),
 			mcplib.WithString("kind", mcplib.Description("Edge kind filter (omit for all kinds)")),
+			mcplib.WithString("as_of", mcplib.Description("ISO8601 timestamp for time-travel; omit for current state")),
 		),
 		s.handleRelListOutgoing,
 	)
@@ -79,11 +92,12 @@ func (s *Server) registerRelationshipsTools() {
 	s.mcp.AddTool(
 		mcplib.NewTool("rel_list_incoming",
 			mcplib.WithDescription(
-				"List CURRENT edges arriving at dst_id. Reverse-direction lookup: 'who depends on this manifest?', "+
-					"'which products own this entity?', etc. Hits idx_rel_dst_current.",
+				"List edges arriving at dst_id. Reverse-direction lookup. Pass as_of for time-travel. "+
+					"Returns JSON array.",
 			),
 			mcplib.WithString("dst_id", mcplib.Required(), mcplib.Description("Destination full UUID")),
 			mcplib.WithString("kind", mcplib.Description("Edge kind filter (omit for all kinds)")),
+			mcplib.WithString("as_of", mcplib.Description("ISO8601 timestamp for time-travel; omit for current state")),
 		),
 		s.handleRelListIncoming,
 	)
@@ -105,21 +119,61 @@ func (s *Server) registerRelationshipsTools() {
 	s.mcp.AddTool(
 		mcplib.NewTool("rel_walk",
 			mcplib.WithDescription(
-				"Recursive DAG walk from a root entity. Follows outgoing edges (CURRENT only — valid_to='') "+
-					"up to max_depth hops, returning every reachable node with the edge kind that led to it. "+
-					"This is the headline reader: ONE query replaces what used to be 6+ table joins for "+
-					"a hierarchy walk. Diamond-shape paths dedupe to one node per id (shortest path wins).",
+				"Recursive DAG walk from a root entity. By default follows CURRENT outgoing edges; "+
+					"pass as_of for time-travel walks. Returns JSON array of {id, kind, via_kind, via_src, depth}. "+
+					"Diamond-shape paths dedupe to one node per id (shortest path wins). "+
+					"max_depth=0 returns root only; default 100; >100 clamped.",
 			),
 			mcplib.WithString("root_id", mcplib.Required(), mcplib.Description("Root full UUID")),
 			mcplib.WithString("root_kind", mcplib.Required(), mcplib.Description("Root entity kind")),
 			mcplib.WithString("edge_kinds", mcplib.Description("Comma-separated edge kinds to follow (omit for all)")),
-			mcplib.WithNumber("max_depth", mcplib.Description("Hop ceiling. Default 100; clamped to [0, 100].")),
+			mcplib.WithNumber("max_depth", mcplib.Description("Hop ceiling. 0 = root only. Default 100; >100 clamped.")),
+			mcplib.WithString("as_of", mcplib.Description("ISO8601 timestamp for time-travel; omit for current state")),
 		),
 		s.handleRelWalk,
+	)
+
+	s.mcp.AddTool(
+		mcplib.NewTool("rel_health",
+			mcplib.WithDescription(
+				"Return current edge count + total rows (with history) for the relationships table. "+
+					"Returns JSON {current_edges, total_rows, table_exists}. Cheap probe for dashboard "+
+					"overview / ops health checks.",
+			),
+		),
+		s.handleRelHealth,
+	)
+
+	s.mcp.AddTool(
+		mcplib.NewTool("rel_backfill",
+			mcplib.WithDescription(
+				"INTERNAL — for migration paths only (PR/M2). Inserts a single row with caller-controlled "+
+					"valid_from AND valid_to (including fully-closed historical rows from legacy dep tables). "+
+					"Bypasses Create's close-then-insert dance. Do NOT call from application code; the SCD-2 "+
+					"invariant (one current row per edge tuple) is the caller's responsibility.",
+			),
+			mcplib.WithString("src_kind", mcplib.Required(), mcplib.Description("Source entity kind")),
+			mcplib.WithString("src_id", mcplib.Required(), mcplib.Description("Source full UUID")),
+			mcplib.WithString("dst_kind", mcplib.Required(), mcplib.Description("Destination entity kind")),
+			mcplib.WithString("dst_id", mcplib.Required(), mcplib.Description("Destination full UUID")),
+			mcplib.WithString("kind", mcplib.Required(), mcplib.Description("Edge kind")),
+			mcplib.WithString("valid_from", mcplib.Required(), mcplib.Description("Historical ISO8601 — when the edge became active")),
+			mcplib.WithString("valid_to", mcplib.Description("ISO8601 if closed; omit for active row")),
+			mcplib.WithString("metadata", mcplib.Description("Optional JSON metadata blob")),
+			mcplib.WithString("reason", mcplib.Description("Migration reason e.g. 'PR/M2 from task_dependency'")),
+		),
+		s.handleRelBackfill,
 	)
 }
 
 // ─── Handlers ───────────────────────────────────────────────────────
+
+// All handlers below return JSON via jsonResult() so downstream agents
+// skip prose-parsing. Per the agent-as-primary-reader framing
+// (decision comment 019dc450-483a on Praxis Git), the WRITER pays the
+// structuring cost ONCE so the N reader-agents don't pay parse cost N
+// times. textResult is reserved for write-ack messages where there's
+// no meaningful structured payload.
 
 func (s *Server) handleRelCreate(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	a := args(req)
@@ -136,10 +190,12 @@ func (s *Server) handleRelCreate(ctx context.Context, req mcplib.CallToolRequest
 	if err := s.node.Relationships.Create(ctx, e); err != nil {
 		return errResult("rel_create: %v", err), nil
 	}
-	return textResult(fmt.Sprintf(
-		"Edge created/replaced: %s(%s) → %s(%s) kind=%s",
-		e.SrcKind, shortID(e.SrcID), e.DstKind, shortID(e.DstID), e.Kind,
-	)), nil
+	return jsonResult(map[string]any{
+		"ok":       true,
+		"src_kind": e.SrcKind, "src_id": e.SrcID,
+		"dst_kind": e.DstKind, "dst_id": e.DstID,
+		"kind": e.Kind,
+	}), nil
 }
 
 func (s *Server) handleRelRemove(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
@@ -151,56 +207,87 @@ func (s *Server) handleRelRemove(ctx context.Context, req mcplib.CallToolRequest
 	if err := s.node.Relationships.Remove(ctx, srcID, dstID, kind, s.sessionSource(ctx), reason); err != nil {
 		return errResult("rel_remove: %v", err), nil
 	}
-	return textResult(fmt.Sprintf(
-		"Edge closed (idempotent): %s → %s kind=%s",
-		shortID(srcID), shortID(dstID), kind,
-	)), nil
+	return jsonResult(map[string]any{
+		"ok":     true,
+		"src_id": srcID, "dst_id": dstID, "kind": kind,
+	}), nil
 }
 
 func (s *Server) handleRelListOutgoing(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	a := args(req)
-	edges, err := s.node.Relationships.ListOutgoing(ctx, argStr(a, "src_id"), argStr(a, "kind"))
+	srcID := argStr(a, "src_id")
+	kind := argStr(a, "kind")
+	asOf := argStr(a, "as_of")
+
+	var (
+		edges []relationships.Edge
+		err   error
+	)
+	if asOf == "" {
+		edges, err = s.node.Relationships.ListOutgoing(ctx, srcID, kind)
+	} else {
+		edges, err = s.node.Relationships.ListOutgoingAt(ctx, srcID, kind, asOf)
+	}
 	if err != nil {
 		return errResult("rel_list_outgoing: %v", err), nil
 	}
-	return textResult(formatEdgeList(edges, "outgoing")), nil
+	return jsonResult(map[string]any{
+		"src_id": srcID,
+		"kind":   kind,
+		"as_of":  asOf,
+		"count":  len(edges),
+		"edges":  edges,
+	}), nil
 }
 
 func (s *Server) handleRelListIncoming(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	a := args(req)
-	edges, err := s.node.Relationships.ListIncoming(ctx, argStr(a, "dst_id"), argStr(a, "kind"))
+	dstID := argStr(a, "dst_id")
+	kind := argStr(a, "kind")
+	asOf := argStr(a, "as_of")
+
+	var (
+		edges []relationships.Edge
+		err   error
+	)
+	if asOf == "" {
+		edges, err = s.node.Relationships.ListIncoming(ctx, dstID, kind)
+	} else {
+		edges, err = s.node.Relationships.ListIncomingAt(ctx, dstID, kind, asOf)
+	}
 	if err != nil {
 		return errResult("rel_list_incoming: %v", err), nil
 	}
-	return textResult(formatEdgeList(edges, "incoming")), nil
+	return jsonResult(map[string]any{
+		"dst_id": dstID,
+		"kind":   kind,
+		"as_of":  asOf,
+		"count":  len(edges),
+		"edges":  edges,
+	}), nil
 }
 
 func (s *Server) handleRelHistory(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	a := args(req)
-	edges, err := s.node.Relationships.History(ctx, argStr(a, "src_id"), argStr(a, "dst_id"), argStr(a, "kind"))
+	srcID := argStr(a, "src_id")
+	dstID := argStr(a, "dst_id")
+	kind := argStr(a, "kind")
+	edges, err := s.node.Relationships.History(ctx, srcID, dstID, kind)
 	if err != nil {
 		return errResult("rel_history: %v", err), nil
 	}
-	if len(edges) == 0 {
-		return textResult("No history for this edge tuple."), nil
-	}
-	var b strings.Builder
-	fmt.Fprintf(&b, "History (%d versions, oldest first):\n\n", len(edges))
-	for i, e := range edges {
-		state := "CURRENT"
-		if e.ValidTo != "" {
-			state = "closed at " + e.ValidTo
-		}
-		fmt.Fprintf(&b, "%d. valid_from=%s [%s]\n   by=%s reason=%q\n\n",
-			i+1, e.ValidFrom, state, e.CreatedBy, e.Reason)
-	}
-	return textResult(b.String()), nil
+	return jsonResult(map[string]any{
+		"src_id": srcID, "dst_id": dstID, "kind": kind,
+		"versions": len(edges),
+		"history":  edges,
+	}), nil
 }
 
 func (s *Server) handleRelWalk(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	a := args(req)
 	rootID := argStr(a, "root_id")
 	rootKind := argStr(a, "root_kind")
+	asOf := argStr(a, "as_of")
 
 	// edge_kinds is a comma-separated list (or empty for "all kinds")
 	var edgeKinds []string
@@ -208,59 +295,69 @@ func (s *Server) handleRelWalk(ctx context.Context, req mcplib.CallToolRequest) 
 		edgeKinds = splitCSV(raw)
 	}
 
-	// Numeric args come in as float64 (JSON number); cast to int and
-	// clamp non-positive to the store's default of 100.
+	// Align with the store's clamp semantic (C2 from self-review):
+	// 0 means "root only," negative or > MaxWalkDepth → MaxWalkDepth.
+	// Previously the MCP layer forced 0 → 100, hiding the root-only
+	// path the store supports. Now we pass through unchanged and let
+	// the store clamp.
 	maxDepth := int(argFloat(a, "max_depth"))
-	if maxDepth <= 0 {
-		maxDepth = 100
-	}
 
-	rows, err := s.node.Relationships.Walk(ctx, rootID, rootKind, edgeKinds, maxDepth)
+	var (
+		rows []relationships.WalkRow
+		err  error
+	)
+	if asOf == "" {
+		rows, err = s.node.Relationships.Walk(ctx, rootID, rootKind, edgeKinds, maxDepth)
+	} else {
+		rows, err = s.node.Relationships.WalkAt(ctx, rootID, rootKind, edgeKinds, maxDepth, asOf)
+	}
 	if err != nil {
 		return errResult("rel_walk: %v", err), nil
 	}
-	if len(rows) == 0 {
-		return textResult("Walk returned no nodes (root may not exist)."), nil
-	}
-
-	var b strings.Builder
-	fmt.Fprintf(&b, "Walk from %s (%s), %d node(s):\n\n", shortID(rootID), rootKind, len(rows))
-	for _, r := range rows {
-		via := "(root)"
-		if r.ViaSrc != "" {
-			via = fmt.Sprintf("via %s from %s", r.ViaKind, shortID(r.ViaSrc))
-		}
-		// Indent by depth so the walk reads as a tree at a glance.
-		indent := strings.Repeat("  ", r.Depth)
-		fmt.Fprintf(&b, "%s[d=%d] %s %s %s\n", indent, r.Depth, r.Kind, shortID(r.ID), via)
-	}
-	return textResult(b.String()), nil
+	return jsonResult(map[string]any{
+		"root_id":   rootID,
+		"root_kind": rootKind,
+		"as_of":     asOf,
+		"count":     len(rows),
+		"nodes":     rows,
+	}), nil
 }
 
-// formatEdgeList renders a list of current edges as human-readable text.
-// Used by rel_list_outgoing and rel_list_incoming. Direction is for the
-// header label; the row format is symmetric.
-func formatEdgeList(edges []relationships.Edge, direction string) string {
-	if len(edges) == 0 {
-		return fmt.Sprintf("No %s edges (current state).", direction)
+func (s *Server) handleRelHealth(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	h, err := s.node.Relationships.Health(ctx)
+	if err != nil {
+		return errResult("rel_health: %v", err), nil
 	}
-	var b strings.Builder
-	fmt.Fprintf(&b, "%d %s edge(s):\n\n", len(edges), direction)
-	for _, e := range edges {
-		fmt.Fprintf(&b, "  %s(%s) → %s(%s) kind=%s\n",
-			e.SrcKind, shortID(e.SrcID), e.DstKind, shortID(e.DstID), e.Kind)
-		if e.Reason != "" {
-			fmt.Fprintf(&b, "    reason: %s\n", e.Reason)
-		}
-	}
-	return b.String()
+	return jsonResult(map[string]any{
+		"current_edges": h.CurrentEdges,
+		"total_rows":    h.TotalRows,
+		"table_exists":  h.TableExists,
+	}), nil
 }
 
-// shortID returns the first 12 chars of an ID for terse rendering. Full
-// UUID stays in the row; the human-facing list just shows the marker.
-func shortID(id string) string {
-	if len(id) <= 12 {
-		return id
+func (s *Server) handleRelBackfill(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := args(req)
+	e := relationships.Edge{
+		SrcKind:   argStr(a, "src_kind"),
+		SrcID:     argStr(a, "src_id"),
+		DstKind:   argStr(a, "dst_kind"),
+		DstID:     argStr(a, "dst_id"),
+		Kind:      argStr(a, "kind"),
+		Metadata:  argStr(a, "metadata"),
+		ValidFrom: argStr(a, "valid_from"),
+		ValidTo:   argStr(a, "valid_to"),
+		CreatedBy: s.sessionSource(ctx),
+		Reason:    argStr(a, "reason"),
 	}
-	return id[:12]
+	if err := s.node.Relationships.BackfillRow(ctx, e); err != nil {
+		return errResult("rel_backfill: %v", err), nil
+	}
+	return jsonResult(map[string]any{
+		"ok":         true,
+		"src_id":     e.SrcID,
+		"dst_id":     e.DstID,
+		"kind":       e.Kind,
+		"valid_from": e.ValidFrom,
+		"valid_to":   e.ValidTo,
+	}), nil
 }

--- a/internal/mcp/tools_relationships.go
+++ b/internal/mcp/tools_relationships.go
@@ -1,0 +1,266 @@
+// MCP tools for the Praxis Relationships store. Six tools mirror the
+// Go API surface (Create / Remove / ListOutgoing / ListIncoming /
+// History / Walk) so any agent can manage the unified edge graph from
+// a Claude Code / Cursor / Codex / etc. session.
+//
+// Naming convention: rel_* prefix matches the short-form pattern used
+// by memory_*, task_*, manifest_*, product_*. Discoverable via
+// tools/list.
+//
+// All UUIDs MUST be full 36-char (visceral rule 14). Short markers are
+// accepted for convenience on src_id / dst_id (the underlying store
+// stores whatever is passed; resolution to full UUIDs is the caller's
+// responsibility for now — PR/M2 may add a marker→UUID resolver here).
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/k8nstantin/OpenPraxis/internal/relationships"
+)
+
+// registerRelationshipsTools wires the six rel_* MCP tools onto the
+// server. Called from server.go's registerAll() (similar to the other
+// register*Tools methods). Must run AFTER s.node is set so the handlers
+// can dispatch into n.Relationships.
+func (s *Server) registerRelationshipsTools() {
+	s.mcp.AddTool(
+		mcplib.NewTool("rel_create",
+			mcplib.WithDescription(
+				"Create or replace the current edge between two entities (product / manifest / task). "+
+					"If a current edge already exists for (src_id, dst_id, kind), it is closed (valid_to set) "+
+					"and a new current row is inserted in one transaction. Rows are NEVER deleted — every "+
+					"mutation is preserved in the SCD-2 audit trail.",
+			),
+			mcplib.WithString("src_kind", mcplib.Required(), mcplib.Description("Source entity kind: product | manifest | task")),
+			mcplib.WithString("src_id", mcplib.Required(), mcplib.Description("Source full UUID")),
+			mcplib.WithString("dst_kind", mcplib.Required(), mcplib.Description("Destination entity kind: product | manifest | task")),
+			mcplib.WithString("dst_id", mcplib.Required(), mcplib.Description("Destination full UUID")),
+			mcplib.WithString("kind", mcplib.Required(), mcplib.Description("Edge kind: owns | depends_on | reviews | links_to")),
+			mcplib.WithString("metadata", mcplib.Description("Optional JSON metadata blob")),
+			mcplib.WithString("reason", mcplib.Description("Free-text why — populates the audit trail")),
+		),
+		s.handleRelCreate,
+	)
+
+	s.mcp.AddTool(
+		mcplib.NewTool("rel_remove",
+			mcplib.WithDescription(
+				"Close the current edge for (src_id, dst_id, kind) by setting valid_to to now. "+
+					"Does NOT insert a replacement; the edge stops existing as of now. Idempotent — "+
+					"no current row is a no-op success. The closing row's created_by and reason "+
+					"are overwritten with the close attribution so the audit trail captures who/why.",
+			),
+			mcplib.WithString("src_id", mcplib.Required(), mcplib.Description("Source full UUID")),
+			mcplib.WithString("dst_id", mcplib.Required(), mcplib.Description("Destination full UUID")),
+			mcplib.WithString("kind", mcplib.Required(), mcplib.Description("Edge kind to close")),
+			mcplib.WithString("reason", mcplib.Description("Why this edge is being closed — for audit")),
+		),
+		s.handleRelRemove,
+	)
+
+	s.mcp.AddTool(
+		mcplib.NewTool("rel_list_outgoing",
+			mcplib.WithDescription(
+				"List CURRENT edges leaving src_id. valid_to='' rows only. Optionally filter by kind. "+
+					"Hits the partial index idx_rel_src_current — O(log n + matches) regardless of how "+
+					"much history accumulates.",
+			),
+			mcplib.WithString("src_id", mcplib.Required(), mcplib.Description("Source full UUID")),
+			mcplib.WithString("kind", mcplib.Description("Edge kind filter (omit for all kinds)")),
+		),
+		s.handleRelListOutgoing,
+	)
+
+	s.mcp.AddTool(
+		mcplib.NewTool("rel_list_incoming",
+			mcplib.WithDescription(
+				"List CURRENT edges arriving at dst_id. Reverse-direction lookup: 'who depends on this manifest?', "+
+					"'which products own this entity?', etc. Hits idx_rel_dst_current.",
+			),
+			mcplib.WithString("dst_id", mcplib.Required(), mcplib.Description("Destination full UUID")),
+			mcplib.WithString("kind", mcplib.Description("Edge kind filter (omit for all kinds)")),
+		),
+		s.handleRelListIncoming,
+	)
+
+	s.mcp.AddTool(
+		mcplib.NewTool("rel_history",
+			mcplib.WithDescription(
+				"Return every version of one specific edge tuple chronologically (oldest first). "+
+					"Includes both closed historical rows AND the current row (if any) at the tail. "+
+					"Use to answer 'when was this edge added/changed/removed and by whom?'",
+			),
+			mcplib.WithString("src_id", mcplib.Required(), mcplib.Description("Source full UUID")),
+			mcplib.WithString("dst_id", mcplib.Required(), mcplib.Description("Destination full UUID")),
+			mcplib.WithString("kind", mcplib.Required(), mcplib.Description("Edge kind")),
+		),
+		s.handleRelHistory,
+	)
+
+	s.mcp.AddTool(
+		mcplib.NewTool("rel_walk",
+			mcplib.WithDescription(
+				"Recursive DAG walk from a root entity. Follows outgoing edges (CURRENT only — valid_to='') "+
+					"up to max_depth hops, returning every reachable node with the edge kind that led to it. "+
+					"This is the headline reader: ONE query replaces what used to be 6+ table joins for "+
+					"a hierarchy walk. Diamond-shape paths dedupe to one node per id (shortest path wins).",
+			),
+			mcplib.WithString("root_id", mcplib.Required(), mcplib.Description("Root full UUID")),
+			mcplib.WithString("root_kind", mcplib.Required(), mcplib.Description("Root entity kind")),
+			mcplib.WithString("edge_kinds", mcplib.Description("Comma-separated edge kinds to follow (omit for all)")),
+			mcplib.WithNumber("max_depth", mcplib.Description("Hop ceiling. Default 100; clamped to [0, 100].")),
+		),
+		s.handleRelWalk,
+	)
+}
+
+// ─── Handlers ───────────────────────────────────────────────────────
+
+func (s *Server) handleRelCreate(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := args(req)
+	e := relationships.Edge{
+		SrcKind:   argStr(a, "src_kind"),
+		SrcID:     argStr(a, "src_id"),
+		DstKind:   argStr(a, "dst_kind"),
+		DstID:     argStr(a, "dst_id"),
+		Kind:      argStr(a, "kind"),
+		Metadata:  argStr(a, "metadata"),
+		CreatedBy: s.sessionSource(ctx),
+		Reason:    argStr(a, "reason"),
+	}
+	if err := s.node.Relationships.Create(ctx, e); err != nil {
+		return errResult("rel_create: %v", err), nil
+	}
+	return textResult(fmt.Sprintf(
+		"Edge created/replaced: %s(%s) → %s(%s) kind=%s",
+		e.SrcKind, shortID(e.SrcID), e.DstKind, shortID(e.DstID), e.Kind,
+	)), nil
+}
+
+func (s *Server) handleRelRemove(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := args(req)
+	srcID := argStr(a, "src_id")
+	dstID := argStr(a, "dst_id")
+	kind := argStr(a, "kind")
+	reason := argStr(a, "reason")
+	if err := s.node.Relationships.Remove(ctx, srcID, dstID, kind, s.sessionSource(ctx), reason); err != nil {
+		return errResult("rel_remove: %v", err), nil
+	}
+	return textResult(fmt.Sprintf(
+		"Edge closed (idempotent): %s → %s kind=%s",
+		shortID(srcID), shortID(dstID), kind,
+	)), nil
+}
+
+func (s *Server) handleRelListOutgoing(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := args(req)
+	edges, err := s.node.Relationships.ListOutgoing(ctx, argStr(a, "src_id"), argStr(a, "kind"))
+	if err != nil {
+		return errResult("rel_list_outgoing: %v", err), nil
+	}
+	return textResult(formatEdgeList(edges, "outgoing")), nil
+}
+
+func (s *Server) handleRelListIncoming(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := args(req)
+	edges, err := s.node.Relationships.ListIncoming(ctx, argStr(a, "dst_id"), argStr(a, "kind"))
+	if err != nil {
+		return errResult("rel_list_incoming: %v", err), nil
+	}
+	return textResult(formatEdgeList(edges, "incoming")), nil
+}
+
+func (s *Server) handleRelHistory(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := args(req)
+	edges, err := s.node.Relationships.History(ctx, argStr(a, "src_id"), argStr(a, "dst_id"), argStr(a, "kind"))
+	if err != nil {
+		return errResult("rel_history: %v", err), nil
+	}
+	if len(edges) == 0 {
+		return textResult("No history for this edge tuple."), nil
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "History (%d versions, oldest first):\n\n", len(edges))
+	for i, e := range edges {
+		state := "CURRENT"
+		if e.ValidTo != "" {
+			state = "closed at " + e.ValidTo
+		}
+		fmt.Fprintf(&b, "%d. valid_from=%s [%s]\n   by=%s reason=%q\n\n",
+			i+1, e.ValidFrom, state, e.CreatedBy, e.Reason)
+	}
+	return textResult(b.String()), nil
+}
+
+func (s *Server) handleRelWalk(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := args(req)
+	rootID := argStr(a, "root_id")
+	rootKind := argStr(a, "root_kind")
+
+	// edge_kinds is a comma-separated list (or empty for "all kinds")
+	var edgeKinds []string
+	if raw := argStr(a, "edge_kinds"); raw != "" {
+		edgeKinds = splitCSV(raw)
+	}
+
+	// Numeric args come in as float64 (JSON number); cast to int and
+	// clamp non-positive to the store's default of 100.
+	maxDepth := int(argFloat(a, "max_depth"))
+	if maxDepth <= 0 {
+		maxDepth = 100
+	}
+
+	rows, err := s.node.Relationships.Walk(ctx, rootID, rootKind, edgeKinds, maxDepth)
+	if err != nil {
+		return errResult("rel_walk: %v", err), nil
+	}
+	if len(rows) == 0 {
+		return textResult("Walk returned no nodes (root may not exist)."), nil
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Walk from %s (%s), %d node(s):\n\n", shortID(rootID), rootKind, len(rows))
+	for _, r := range rows {
+		via := "(root)"
+		if r.ViaSrc != "" {
+			via = fmt.Sprintf("via %s from %s", r.ViaKind, shortID(r.ViaSrc))
+		}
+		// Indent by depth so the walk reads as a tree at a glance.
+		indent := strings.Repeat("  ", r.Depth)
+		fmt.Fprintf(&b, "%s[d=%d] %s %s %s\n", indent, r.Depth, r.Kind, shortID(r.ID), via)
+	}
+	return textResult(b.String()), nil
+}
+
+// formatEdgeList renders a list of current edges as human-readable text.
+// Used by rel_list_outgoing and rel_list_incoming. Direction is for the
+// header label; the row format is symmetric.
+func formatEdgeList(edges []relationships.Edge, direction string) string {
+	if len(edges) == 0 {
+		return fmt.Sprintf("No %s edges (current state).", direction)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %s edge(s):\n\n", len(edges), direction)
+	for _, e := range edges {
+		fmt.Fprintf(&b, "  %s(%s) → %s(%s) kind=%s\n",
+			e.SrcKind, shortID(e.SrcID), e.DstKind, shortID(e.DstID), e.Kind)
+		if e.Reason != "" {
+			fmt.Fprintf(&b, "    reason: %s\n", e.Reason)
+		}
+	}
+	return b.String()
+}
+
+// shortID returns the first 12 chars of an ID for terse rendering. Full
+// UUID stays in the row; the human-facing list just shows the marker.
+func shortID(id string) string {
+	if len(id) <= 12 {
+		return id
+	}
+	return id[:12]
+}

--- a/internal/mcp/tools_relationships.go
+++ b/internal/mcp/tools_relationships.go
@@ -361,7 +361,6 @@ func (s *Server) handleRelHealth(ctx context.Context, req mcplib.CallToolRequest
 	return jsonResult(map[string]any{
 		"current_edges": h.CurrentEdges,
 		"total_rows":    h.TotalRows,
-		"table_exists":  h.TableExists,
 	}), nil
 }
 

--- a/internal/mcp/tools_relationships.go
+++ b/internal/mcp/tools_relationships.go
@@ -134,6 +134,21 @@ func (s *Server) registerRelationshipsTools() {
 	)
 
 	s.mcp.AddTool(
+		mcplib.NewTool("rel_get",
+			mcplib.WithDescription(
+				"Fetch the CURRENT edge for (src_id, dst_id, kind) if one exists. "+
+					"Returns JSON {found, edge}. Cheaper than rel_list_outgoing + filter when "+
+					"you only need to check one specific edge. Returns {found:false} cleanly "+
+					"if no current edge exists — not an error.",
+			),
+			mcplib.WithString("src_id", mcplib.Required(), mcplib.Description("Source full UUID")),
+			mcplib.WithString("dst_id", mcplib.Required(), mcplib.Description("Destination full UUID")),
+			mcplib.WithString("kind", mcplib.Required(), mcplib.Description("Edge kind")),
+		),
+		s.handleRelGet,
+	)
+
+	s.mcp.AddTool(
 		mcplib.NewTool("rel_health",
 			mcplib.WithDescription(
 				"Return current edge count + total rows (with history) for the relationships table. "+
@@ -321,6 +336,21 @@ func (s *Server) handleRelWalk(ctx context.Context, req mcplib.CallToolRequest) 
 		"count":     len(rows),
 		"nodes":     rows,
 	}), nil
+}
+
+func (s *Server) handleRelGet(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	a := args(req)
+	srcID := argStr(a, "src_id")
+	dstID := argStr(a, "dst_id")
+	kind := argStr(a, "kind")
+	edge, found, err := s.node.Relationships.Get(ctx, srcID, dstID, kind)
+	if err != nil {
+		return errResult("rel_get: %v", err), nil
+	}
+	if !found {
+		return jsonResult(map[string]any{"found": false}), nil
+	}
+	return jsonResult(map[string]any{"found": true, "edge": edge}), nil
 }
 
 func (s *Server) handleRelHealth(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {

--- a/internal/mcp/tools_relationships_test.go
+++ b/internal/mcp/tools_relationships_test.go
@@ -295,11 +295,11 @@ func TestRelHealth_ReturnsStats(t *testing.T) {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	out := resultJSON(t, res)
-	if out["table_exists"] != true {
-		t.Errorf("expected table_exists=true after migration, got %v", out)
-	}
 	if out["current_edges"].(float64) != 1 {
 		t.Errorf("expected 1 current edge, got %v", out["current_edges"])
+	}
+	if out["total_rows"].(float64) != 1 {
+		t.Errorf("expected 1 total row, got %v", out["total_rows"])
 	}
 }
 

--- a/internal/mcp/tools_relationships_test.go
+++ b/internal/mcp/tools_relationships_test.go
@@ -244,6 +244,42 @@ func TestRelWalk_MaxDepthZeroReturnsRootOnly(t *testing.T) {
 	}
 }
 
+// ─── rel_get ────────────────────────────────────────────────────────
+
+func TestRelGet_FoundAndNotFound(t *testing.T) {
+	s := newTestServerWithRelationships(t)
+
+	// Initially: not found.
+	res, _ := s.handleRelGet(context.Background(), buildReq(map[string]any{
+		"src_id": "M1", "dst_id": "M2", "kind": "depends_on",
+	}))
+	out := resultJSON(t, res)
+	if out["found"] != false {
+		t.Errorf("expected found=false on missing edge, got %v", out)
+	}
+
+	// Create it; now found.
+	_, _ = s.handleRelCreate(context.Background(), buildReq(map[string]any{
+		"src_kind": "manifest", "src_id": "M1",
+		"dst_kind": "manifest", "dst_id": "M2",
+		"kind": "depends_on",
+	}))
+	res, _ = s.handleRelGet(context.Background(), buildReq(map[string]any{
+		"src_id": "M1", "dst_id": "M2", "kind": "depends_on",
+	}))
+	out = resultJSON(t, res)
+	if out["found"] != true {
+		t.Errorf("expected found=true after create, got %v", out)
+	}
+	edge, ok := out["edge"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected edge object, got %v", out["edge"])
+	}
+	if edge["SrcID"] != "M1" || edge["DstID"] != "M2" {
+		t.Errorf("wrong edge returned: %v", edge)
+	}
+}
+
 // ─── rel_health ─────────────────────────────────────────────────────
 
 func TestRelHealth_ReturnsStats(t *testing.T) {

--- a/internal/mcp/tools_relationships_test.go
+++ b/internal/mcp/tools_relationships_test.go
@@ -1,0 +1,311 @@
+// Tests for the rel_* MCP tools (C3 from the senior review). Pattern
+// matches internal/mcp/tools_comments_test.go: minimal Server + Node
+// wired with just the Relationships store, then call handlers
+// directly with a built CallToolRequest.
+//
+// Coverage:
+//   - Every handler's happy path produces valid JSON in the result
+//   - Validation errors surface via errResult (non-empty error text)
+//   - rel_walk maxDepth=0 returns root only (C2 alignment with store)
+//   - rel_*_at variants accept as_of and route to the time-travel store API
+package mcp
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/k8nstantin/OpenPraxis/internal/node"
+	"github.com/k8nstantin/OpenPraxis/internal/relationships"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// newTestServerWithRelationships spins up a minimal Server backed by
+// an in-memory SQLite DB with only the relationships store migrated.
+// Other Node fields are nil — handlers we test don't reach them.
+func newTestServerWithRelationships(t *testing.T) *Server {
+	t.Helper()
+	dsn := "file::memory:?cache=shared&_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	store, err := relationships.New(db)
+	if err != nil {
+		t.Fatalf("relationships.New: %v", err)
+	}
+	return &Server{node: &node.Node{Relationships: store}}
+}
+
+// resultJSON parses a tool result's text payload as JSON. Fails the
+// test if the payload isn't a JSON object — handlers MUST return JSON
+// (per the agent-as-primary-reader framing).
+func resultJSON(t *testing.T, res *mcplib.CallToolResult) map[string]any {
+	t.Helper()
+	got := toolResultText(res)
+	var out map[string]any
+	if err := json.Unmarshal([]byte(got), &out); err != nil {
+		t.Fatalf("expected JSON object in tool result, got %q (err: %v)", got, err)
+	}
+	return out
+}
+
+// ─── rel_create / rel_remove ────────────────────────────────────────
+
+func TestRelCreate_HappyPath(t *testing.T) {
+	s := newTestServerWithRelationships(t)
+	res, err := s.handleRelCreate(context.Background(), buildReq(map[string]any{
+		"src_kind": "manifest", "src_id": "M1",
+		"dst_kind": "manifest", "dst_id": "M2",
+		"kind":   "depends_on",
+		"reason": "test fixture",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	out := resultJSON(t, res)
+	if out["ok"] != true {
+		t.Errorf("expected ok=true, got %v", out)
+	}
+	if out["src_id"] != "M1" || out["dst_id"] != "M2" {
+		t.Errorf("expected src=M1 dst=M2, got %v", out)
+	}
+}
+
+func TestRelCreate_ValidationError(t *testing.T) {
+	s := newTestServerWithRelationships(t)
+	res, _ := s.handleRelCreate(context.Background(), buildReq(map[string]any{
+		"src_kind": "garbage", "src_id": "M1",
+		"dst_kind": "manifest", "dst_id": "M2",
+		"kind": "depends_on",
+	}))
+	got := toolResultText(res)
+	if !strings.Contains(got, "rel_create") || !strings.Contains(got, "invalid kind") {
+		t.Errorf("expected error mentioning invalid kind, got %q", got)
+	}
+}
+
+func TestRelRemove_HappyPath(t *testing.T) {
+	s := newTestServerWithRelationships(t)
+	// Create then remove
+	_, _ = s.handleRelCreate(context.Background(), buildReq(map[string]any{
+		"src_kind": "manifest", "src_id": "M1",
+		"dst_kind": "manifest", "dst_id": "M2",
+		"kind": "depends_on",
+	}))
+	res, err := s.handleRelRemove(context.Background(), buildReq(map[string]any{
+		"src_id": "M1", "dst_id": "M2", "kind": "depends_on",
+		"reason": "no longer needed",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	out := resultJSON(t, res)
+	if out["ok"] != true {
+		t.Errorf("expected ok=true on remove, got %v", out)
+	}
+}
+
+// ─── rel_list_outgoing / rel_list_incoming ──────────────────────────
+
+func TestRelListOutgoing_ReturnsJSON(t *testing.T) {
+	s := newTestServerWithRelationships(t)
+	_, _ = s.handleRelCreate(context.Background(), buildReq(map[string]any{
+		"src_kind": "manifest", "src_id": "M1",
+		"dst_kind": "manifest", "dst_id": "M2",
+		"kind": "depends_on",
+	}))
+	_, _ = s.handleRelCreate(context.Background(), buildReq(map[string]any{
+		"src_kind": "manifest", "src_id": "M1",
+		"dst_kind": "manifest", "dst_id": "M3",
+		"kind": "depends_on",
+	}))
+
+	res, err := s.handleRelListOutgoing(context.Background(), buildReq(map[string]any{
+		"src_id": "M1", "kind": "depends_on",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	out := resultJSON(t, res)
+	if out["count"].(float64) != 2 {
+		t.Errorf("expected count=2, got %v", out["count"])
+	}
+	edges, ok := out["edges"].([]any)
+	if !ok || len(edges) != 2 {
+		t.Errorf("expected edges array of length 2, got %v", out["edges"])
+	}
+}
+
+func TestRelListIncoming_ReverseLookup(t *testing.T) {
+	s := newTestServerWithRelationships(t)
+	for _, src := range []string{"M1", "M2", "M3"} {
+		_, _ = s.handleRelCreate(context.Background(), buildReq(map[string]any{
+			"src_kind": "manifest", "src_id": src,
+			"dst_kind": "manifest", "dst_id": "M0",
+			"kind": "depends_on",
+		}))
+	}
+	res, err := s.handleRelListIncoming(context.Background(), buildReq(map[string]any{
+		"dst_id": "M0", "kind": "depends_on",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	out := resultJSON(t, res)
+	if out["count"].(float64) != 3 {
+		t.Errorf("expected 3 incoming edges to M0, got %v", out["count"])
+	}
+}
+
+// ─── rel_history ────────────────────────────────────────────────────
+
+func TestRelHistory_ReturnsAllVersions(t *testing.T) {
+	s := newTestServerWithRelationships(t)
+	_, _ = s.handleRelCreate(context.Background(), buildReq(map[string]any{
+		"src_kind": "manifest", "src_id": "M1",
+		"dst_kind": "manifest", "dst_id": "M2",
+		"kind": "depends_on", "reason": "v1",
+	}))
+	_, _ = s.handleRelRemove(context.Background(), buildReq(map[string]any{
+		"src_id": "M1", "dst_id": "M2", "kind": "depends_on",
+		"reason": "removed",
+	}))
+
+	res, err := s.handleRelHistory(context.Background(), buildReq(map[string]any{
+		"src_id": "M1", "dst_id": "M2", "kind": "depends_on",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	out := resultJSON(t, res)
+	if out["versions"].(float64) != 1 {
+		t.Errorf("expected 1 version (the closed row), got %v", out["versions"])
+	}
+}
+
+// ─── rel_walk ───────────────────────────────────────────────────────
+
+func TestRelWalk_BasicChain(t *testing.T) {
+	s := newTestServerWithRelationships(t)
+	for _, edge := range []struct{ src, dst string }{{"A", "B"}, {"B", "C"}} {
+		_, _ = s.handleRelCreate(context.Background(), buildReq(map[string]any{
+			"src_kind": "manifest", "src_id": edge.src,
+			"dst_kind": "manifest", "dst_id": edge.dst,
+			"kind": "depends_on",
+		}))
+	}
+
+	res, err := s.handleRelWalk(context.Background(), buildReq(map[string]any{
+		"root_id":    "A",
+		"root_kind":  "manifest",
+		"edge_kinds": "depends_on",
+		"max_depth":  float64(10),
+	}))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	out := resultJSON(t, res)
+	if out["count"].(float64) != 3 {
+		t.Errorf("expected 3 nodes (A,B,C), got %v", out["count"])
+	}
+}
+
+// TestRelWalk_MaxDepthZeroReturnsRootOnly — verifies the C2 alignment:
+// MCP layer no longer forces 0→100; passing 0 returns just the root.
+// This is the path the store has always supported but the MCP layer
+// previously hid.
+func TestRelWalk_MaxDepthZeroReturnsRootOnly(t *testing.T) {
+	s := newTestServerWithRelationships(t)
+	_, _ = s.handleRelCreate(context.Background(), buildReq(map[string]any{
+		"src_kind": "manifest", "src_id": "A",
+		"dst_kind": "manifest", "dst_id": "B",
+		"kind": "depends_on",
+	}))
+
+	res, err := s.handleRelWalk(context.Background(), buildReq(map[string]any{
+		"root_id":   "A",
+		"root_kind": "manifest",
+		"max_depth": float64(0),
+	}))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	out := resultJSON(t, res)
+	// 0-depth = anchor row only = just A. B should not appear.
+	if out["count"].(float64) != 1 {
+		t.Errorf("max_depth=0 should return root only, got count=%v", out["count"])
+	}
+}
+
+// ─── rel_health ─────────────────────────────────────────────────────
+
+func TestRelHealth_ReturnsStats(t *testing.T) {
+	s := newTestServerWithRelationships(t)
+	_, _ = s.handleRelCreate(context.Background(), buildReq(map[string]any{
+		"src_kind": "manifest", "src_id": "A",
+		"dst_kind": "manifest", "dst_id": "B",
+		"kind": "depends_on",
+	}))
+
+	res, err := s.handleRelHealth(context.Background(), buildReq(map[string]any{}))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	out := resultJSON(t, res)
+	if out["table_exists"] != true {
+		t.Errorf("expected table_exists=true after migration, got %v", out)
+	}
+	if out["current_edges"].(float64) != 1 {
+		t.Errorf("expected 1 current edge, got %v", out["current_edges"])
+	}
+}
+
+// ─── rel_backfill ───────────────────────────────────────────────────
+
+func TestRelBackfill_AcceptsHistoricalRow(t *testing.T) {
+	s := newTestServerWithRelationships(t)
+	res, err := s.handleRelBackfill(context.Background(), buildReq(map[string]any{
+		"src_kind":   "manifest",
+		"src_id":     "M1",
+		"dst_kind":   "manifest",
+		"dst_id":     "M2",
+		"kind":       "depends_on",
+		"valid_from": "2025-06-01T00:00:00Z",
+		"valid_to":   "2025-09-01T00:00:00Z",
+		"reason":     "PR/M2 from task_dependency",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	out := resultJSON(t, res)
+	if out["ok"] != true {
+		t.Errorf("expected ok=true, got %v", out)
+	}
+	if out["valid_from"] != "2025-06-01T00:00:00Z" {
+		t.Errorf("expected valid_from echoed, got %v", out["valid_from"])
+	}
+	if out["valid_to"] != "2025-09-01T00:00:00Z" {
+		t.Errorf("expected valid_to echoed, got %v", out["valid_to"])
+	}
+}
+
+func TestRelBackfill_RequiresValidFrom(t *testing.T) {
+	s := newTestServerWithRelationships(t)
+	res, _ := s.handleRelBackfill(context.Background(), buildReq(map[string]any{
+		"src_kind": "manifest", "src_id": "M1",
+		"dst_kind": "manifest", "dst_id": "M2",
+		"kind": "depends_on",
+		// valid_from intentionally omitted
+	}))
+	got := toolResultText(res)
+	if !strings.Contains(got, "ValidFrom") {
+		t.Errorf("expected error mentioning ValidFrom, got %q", got)
+	}
+}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -17,6 +17,7 @@ import (
 	"github.com/k8nstantin/OpenPraxis/internal/marker"
 	"github.com/k8nstantin/OpenPraxis/internal/memory"
 	"github.com/k8nstantin/OpenPraxis/internal/product"
+	"github.com/k8nstantin/OpenPraxis/internal/relationships"
 	"github.com/k8nstantin/OpenPraxis/internal/settings"
 	"github.com/k8nstantin/OpenPraxis/internal/task"
 	"github.com/k8nstantin/OpenPraxis/internal/templates"
@@ -42,6 +43,10 @@ type Node struct {
 	Templates        *templates.Store
 	TemplatesResolv  *templates.Resolver
 	Comments         *comments.Store
+	// Relationships is the unified edge store (Praxis Relationships
+	// PR/M1). Lives alongside the existing dep tables during the M2
+	// dual-write phase; becomes the sole source after M3 cutover.
+	Relationships    *relationships.Store
 	runner           *task.Runner
 	hostSampler      *task.HostSampler
 	Embedder         *embedding.Engine
@@ -255,6 +260,15 @@ func New(cfg *config.Config) (*Node, error) {
 
 	embedder := embedding.NewEngine(cfg.Embedding.OllamaURL, cfg.Embedding.Model, cfg.Embedding.Dimension)
 
+	// Praxis Relationships PR/M1 — unified edge store. Migration is
+	// idempotent (CREATE TABLE / CREATE INDEX IF NOT EXISTS). Sharing
+	// the same DB handle as every other store so it lives in
+	// memories.db alongside products / manifests / tasks etc.
+	relationshipsStore, err := relationships.New(index.DB())
+	if err != nil {
+		return nil, fmt.Errorf("init relationships store: %w", err)
+	}
+
 	n := &Node{
 		Config:           cfg,
 		Store:            store,
@@ -273,6 +287,7 @@ func New(cfg *config.Config) (*Node, error) {
 		Templates:        templatesStore,
 		TemplatesResolv:  templatesResolver,
 		Comments:         commentsStore,
+		Relationships:    relationshipsStore,
 		Embedder:         embedder,
 		StartedAt:        time.Now(),
 	}

--- a/internal/relationships/store.go
+++ b/internal/relationships/store.go
@@ -21,6 +21,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 )
 
@@ -49,11 +50,15 @@ func validEdgeKind(k string) bool {
 	return k == EdgeOwns || k == EdgeDependsOn || k == EdgeReviews || k == EdgeLinksTo
 }
 
-// nowUTC returns the current time in ISO8601 UTC. Centralised so every
-// timestamp written by this package matches the format expected by the
-// existing TEXT columns and the SCD-2 conventions in task_dependency.
+// nowUTC returns the current time in ISO8601 UTC with nanosecond
+// precision. The composite PK on (src_id, dst_id, kind, valid_from)
+// requires distinct timestamps for back-to-back Creates on the same
+// edge; RFC3339 (second precision) collides under tight loops or under
+// test, so we use RFC3339Nano. The TEXT column accepts any ISO8601
+// shape, and lexicographic ordering still works for time comparisons
+// because the format is fixed-width up to the fractional seconds.
 func nowUTC() string {
-	return time.Now().UTC().Format(time.RFC3339)
+	return time.Now().UTC().Format(time.RFC3339Nano)
 }
 
 // Standard entity kinds. Stored as TEXT in src_kind / dst_kind columns
@@ -502,10 +507,17 @@ func (s *Store) Walk(ctx context.Context, rootID, rootKind string, edgeKinds []s
 	}
 
 	// Build the edge-kind filter. SQLite parameter lists in IN clauses
-	// need explicit '?' per value — no array binding. We construct
-	// placeholders + args defensively, validating each kind first.
+	// need explicit '?' per value — no array binding. Args MUST be
+	// appended in the same positional order the query expects:
+	//   [rootID, rootKind, kind1, kind2, ..., kindN, maxDepth]
+	// because the query reads as ?,? for the anchor SELECT, then the
+	// IN(...) placeholders, then the trailing w.depth < ? predicate.
+	// Got bitten by ordering this as [rootID, rootKind, maxDepth, kinds...]
+	// during initial development — the IN clause silently matched on
+	// maxDepth instead of any real kind and the walk returned only the
+	// root. Tests now lock the order in.
 	kindFilter := ""
-	args := []any{rootID, rootKind, maxDepth}
+	args := []any{rootID, rootKind}
 	if len(edgeKinds) > 0 {
 		// Validate every kind so a typo fails fast with a clean error
 		// rather than silently returning empty results.
@@ -519,6 +531,8 @@ func (s *Store) Walk(ctx context.Context, rootID, rootKind string, edgeKinds []s
 		}
 		kindFilter = ` AND r.kind IN (` + joinComma(placeholders) + `)`
 	}
+	// maxDepth is the LAST positional arg — appended after any kinds.
+	args = append(args, maxDepth)
 
 	// Recursive CTE explained:
 	//   - Anchor row: the root itself, depth=0, no via_kind/via_src.
@@ -562,7 +576,34 @@ func (s *Store) Walk(ctx context.Context, rootID, rootKind string, edgeKinds []s
 		}
 		out = append(out, w)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// SQL UNION dedupes on full-row equality, but a diamond shape
+	// (A→B→D and A→C→D) produces two rows for D with different
+	// via_src ("B" vs "C") — both survive UNION. The user-facing
+	// semantic is "each node appears once," so we post-process:
+	//
+	//   1. Sort stable by depth ASC. Equal-depth rows keep their
+	//      CTE-emit order. The first occurrence of each id is now
+	//      whichever path reached it shortest.
+	//   2. Walk the sorted list, keep only the first row per id.
+	//
+	// Cost: O(n log n) sort + O(n) sweep. Acceptable up to thousands
+	// of rows; AOS umbrella walks rarely exceed 50.
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Depth < out[j].Depth
+	})
+	seen := make(map[string]bool, len(out))
+	deduped := out[:0] // reuse the backing array
+	for _, w := range out {
+		if !seen[w.ID] {
+			seen[w.ID] = true
+			deduped = append(deduped, w)
+		}
+	}
+	return deduped, nil
 }
 
 // joinComma joins a slice of strings with ", " — small helper for

--- a/internal/relationships/store.go
+++ b/internal/relationships/store.go
@@ -1,0 +1,130 @@
+// Package relationships is the unified edge store for OpenPraxis. Every
+// edge between entities (product / manifest / task) — ownership AND
+// dependencies AND secondary links — lives as one SCD-2 row in the
+// relationships table.
+//
+// Rows are never DELETEd. A "remove" closes the row by setting valid_to
+// to the close timestamp; the row stays for audit. A "change" closes the
+// prior current row and inserts a new one in one transaction.
+//
+// Convention matches internal/task/store.go's task_dependency table:
+// TEXT for timestamps, empty-string '' (not NULL) for "still current",
+// partial indexes on valid_to = '' for the hot read path.
+//
+// The current SetDependency / AddDep code in task/manifest/product
+// stores stays live during PR/M2's dual-write phase. PR/M3 cuts reads
+// over to this store and drops the legacy tables.
+package relationships
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// Standard entity kinds. Stored as TEXT in src_kind / dst_kind columns
+// and gated by CHECK constraints at the schema level.
+const (
+	KindProduct  = "product"
+	KindManifest = "manifest"
+	KindTask     = "task"
+)
+
+// Standard edge kinds. The schema's CHECK constraint pins the allowed
+// set; adding a new kind requires a migration.
+const (
+	EdgeOwns      = "owns"
+	EdgeDependsOn = "depends_on"
+	EdgeReviews   = "reviews"
+	EdgeLinksTo   = "links_to"
+)
+
+// Edge is one row in the relationships table. ValidTo == "" means
+// "this is the current version of the edge"; non-empty means "superseded
+// at this timestamp." Metadata is an opaque JSON string for edge-kind-
+// specific extras (left empty for the common case).
+type Edge struct {
+	SrcKind   string
+	SrcID     string
+	DstKind   string
+	DstID     string
+	Kind      string
+	Metadata  string
+	ValidFrom string
+	ValidTo   string
+	CreatedBy string
+	Reason    string
+	CreatedAt string
+}
+
+// Store owns the relationships table.
+type Store struct {
+	db *sql.DB
+}
+
+// New opens the store and runs the idempotent schema migration. Pass
+// the same *sql.DB used by the rest of the OpenPraxis stores so this
+// table lives in the canonical openpraxis.db.
+func New(db *sql.DB) (*Store, error) {
+	s := &Store{db: db}
+	if err := s.init(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *Store) init() error {
+	// Schema invariants:
+	//   - Composite PK ensures no two rows share (src_id, dst_id, kind, valid_from);
+	//     a simultaneous duplicate Create at the same timestamp will fail at
+	//     INSERT and the caller can retry.
+	//   - CHECK constraints enforce kind enums at the DB level so a corrupt
+	//     write is impossible even if Go-side validation has a bug.
+	//   - src_id <> dst_id forbids self-loops at the relationship level
+	//     (a node depending on itself is meaningless).
+	_, err := s.db.Exec(`CREATE TABLE IF NOT EXISTS relationships (
+		src_kind   TEXT NOT NULL,
+		src_id     TEXT NOT NULL,
+		dst_kind   TEXT NOT NULL,
+		dst_id     TEXT NOT NULL,
+		kind       TEXT NOT NULL,
+		metadata   TEXT NOT NULL DEFAULT '',
+		valid_from TEXT NOT NULL,
+		valid_to   TEXT NOT NULL DEFAULT '',
+		created_by TEXT NOT NULL DEFAULT '',
+		reason     TEXT NOT NULL DEFAULT '',
+		created_at TEXT NOT NULL,
+		PRIMARY KEY (src_id, dst_id, kind, valid_from),
+		CHECK (src_id <> dst_id),
+		CHECK (src_kind IN ('product','manifest','task')),
+		CHECK (dst_kind IN ('product','manifest','task')),
+		CHECK (kind IN ('owns','depends_on','reviews','links_to'))
+	)`)
+	if err != nil {
+		return fmt.Errorf("create relationships table: %w", err)
+	}
+
+	// Hot path: "what edges leave / enter this node right now?" — driven
+	// by the dashboard, the scheduler, and every DAG walk. Partial index
+	// on valid_to = '' keeps these queries O(log n) on current state
+	// regardless of how much history accumulates.
+	if _, err := s.db.Exec(
+		`CREATE INDEX IF NOT EXISTS idx_rel_src_current ON relationships(src_id, kind) WHERE valid_to = ''`,
+	); err != nil {
+		return fmt.Errorf("create idx_rel_src_current: %w", err)
+	}
+	if _, err := s.db.Exec(
+		`CREATE INDEX IF NOT EXISTS idx_rel_dst_current ON relationships(dst_id, kind) WHERE valid_to = ''`,
+	); err != nil {
+		return fmt.Errorf("create idx_rel_dst_current: %w", err)
+	}
+
+	// History / time-travel: "what did this edge look like at time t?"
+	// Full (non-partial) index — touches both current + closed rows.
+	if _, err := s.db.Exec(
+		`CREATE INDEX IF NOT EXISTS idx_rel_history ON relationships(src_id, dst_id, valid_from DESC)`,
+	); err != nil {
+		return fmt.Errorf("create idx_rel_history: %w", err)
+	}
+
+	return nil
+}

--- a/internal/relationships/store.go
+++ b/internal/relationships/store.go
@@ -361,26 +361,12 @@ func (s *Store) Create(ctx context.Context, e Edge) error {
 	return nil
 }
 
-// BackfillRow inserts a single row with caller-controlled valid_from
-// AND valid_to — bypassing Create's close-then-insert dance. Used by
-// PR/M2's migration path to copy historical rows out of legacy dep
-// tables (task_dependency / manifest_dependencies / etc.) preserving
-// their original time intervals.
-//
-// Validation is the same as Create EXCEPT we do not require valid_to
-// to be empty — caller can write a fully-closed historical row.
-//
-// MUST NOT be used by application code outside backfill paths. Calling
-// this for a normal mutation breaks the SCD-2 invariant that "only one
-// row per (src, dst, kind) has valid_to=''" — the close-then-insert
-// transaction in Create exists to maintain it. BackfillRow trusts the
-// caller; backfills run in a controlled migration transaction with
-// known-non-overlapping intervals.
-//
-// Idempotent at the row level: the composite PK rejects duplicate
-// inserts, so re-running a backfill on the same source data returns
-// PK error rows that the caller can filter as "already migrated."
-func (s *Store) BackfillRow(ctx context.Context, e Edge) error {
+// validateBackfillEdge runs the validation rules shared by BackfillRow
+// and BackfillBulk. Centralised so adding a new rule (say "metadata
+// must be parseable JSON" in PR/M2) lands in ONE place; the two
+// callers can't drift. Returns nil if the edge is acceptable for a
+// backfill insert.
+func validateBackfillEdge(e Edge) error {
 	if e.SrcID == "" || e.DstID == "" {
 		return fmt.Errorf("%w: src_id=%q dst_id=%q", ErrEmptyID, e.SrcID, e.DstID)
 	}
@@ -397,15 +383,52 @@ func (s *Store) BackfillRow(ctx context.Context, e Edge) error {
 		return fmt.Errorf("%w: %s", ErrSelfLoop, e.SrcID)
 	}
 	if e.ValidFrom == "" {
-		return fmt.Errorf("relationships: BackfillRow requires explicit ValidFrom (callers must preserve historical timing)")
+		return fmt.Errorf("relationships: backfill requires explicit ValidFrom (callers must preserve historical timing)")
 	}
-	// valid_to may be empty (active row) or set (closed historical row).
+	return nil
+}
+
+// backfillInsertSQL is the standard INSERT statement used by BOTH
+// BackfillRow (single-row) and BackfillBulk (prepared statement,
+// per-tx). Sharing the SQL means a future column add updates one
+// place, not two.
+const backfillInsertSQL = `INSERT INTO relationships
+	(src_kind, src_id, dst_kind, dst_id, kind, metadata,
+	 valid_from, valid_to, created_by, reason, created_at)
+ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+
+// BackfillRow inserts a single row with caller-controlled valid_from
+// AND valid_to — bypassing Create's close-then-insert dance. Used by
+// PR/M2's migration path to copy historical rows out of legacy dep
+// tables (task_dependency / manifest_dependencies / etc.) preserving
+// their original time intervals.
+//
+// Validation: same rules as Create EXCEPT we DO NOT require valid_to
+// to be empty (caller can write a fully-closed historical row) AND we
+// DO require valid_from to be non-empty (no implicit now() — backfill
+// callers must preserve historical timing). Lives in the shared
+// validateBackfillEdge() function used by BackfillBulk too.
+//
+// MUST NOT be used by application code outside backfill paths. Calling
+// this for a normal mutation breaks the SCD-2 invariant that "only one
+// row per (src, dst, kind) has valid_to=''" — the close-then-insert
+// transaction in Create exists to maintain it. BackfillRow trusts the
+// caller; backfills run in a controlled migration transaction with
+// known-non-overlapping intervals.
+//
+// Idempotent at the row level: the composite PK rejects duplicate
+// inserts, so re-running a backfill on the same source data returns
+// PK error rows that the caller can filter as "already migrated."
+//
+// For high-volume backfills (>1K rows) prefer BackfillBulk — it shares
+// one transaction and prepared statement instead of paying per-row
+// fsync + parse cost.
+func (s *Store) BackfillRow(ctx context.Context, e Edge) error {
+	if err := validateBackfillEdge(e); err != nil {
+		return err
+	}
 	now := nowUTC()
-	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO relationships
-		   (src_kind, src_id, dst_kind, dst_id, kind, metadata,
-		    valid_from, valid_to, created_by, reason, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	_, err := s.db.ExecContext(ctx, backfillInsertSQL,
 		e.SrcKind, e.SrcID, e.DstKind, e.DstID, e.Kind, e.Metadata,
 		e.ValidFrom, e.ValidTo, e.CreatedBy, e.Reason, now)
 	if err != nil {
@@ -800,13 +823,15 @@ type WalkRow struct {
 //   - nil or empty: follow ALL edge kinds (owns + depends_on + reviews + links_to)
 //   - otherwise: only follow edges whose kind is in the slice
 //
-// maxDepth caps recursion. 0 means "root only" (degenerate case for
-// validation). Negative or > 100 is clamped to 100 — prevents
-// runaway walks if a cycle ever sneaks in (the schema doesn't
-// currently enforce acyclicity at the DB level; we may add that
-// later as a CHECK trigger).
+// maxDepth caps recursion. 0 means "root only" (anchor row only — the
+// recursive WHERE w.depth < 0 excludes everything). Negative or
+// > MaxWalkDepth clamps to MaxWalkDepth. The clamp is the only
+// cycle-defense the system has — schema portability forbids CHECK
+// constraints and triggers, so an acyclicity invariant lives nowhere
+// at the DB level. If a cycle ever appears, Walk hits the depth
+// ceiling and emits a slog.Warn (see end of function).
 //
-// The CTE is the heart of why this whole manifest exists: ONE query
+// The CTE is the heart of why this whole product exists: ONE query
 // replaces what used to be 6+ table joins for a hierarchy walk. The
 // dashboard's apiProductHierarchy will eventually rebuild on this in
 // PR/M3.
@@ -949,8 +974,9 @@ func (s *Store) Walk(ctx context.Context, rootID, rootKind string, edgeKinds []s
 // graphs with thousands of nodes this allocates more than the current-
 // state walk. AOS-scale (~50 nodes) is fine.
 //
-// Same caveats as Walk: maxDepth clamped [0, 100]; UNION dedups; Go-
-// side dedup-by-id collapses diamond paths to one row per node.
+// Same dedup contract as Walk: UNION ALL emits raw, Go-side
+// dedup-by-id collapses diamond paths to one row per node (shortest
+// path wins). maxDepth clamped to [0, MaxWalkDepth].
 func (s *Store) WalkAt(ctx context.Context, rootID, rootKind string, edgeKinds []string, maxDepth int, asOf string) ([]WalkRow, error) {
 	if rootID == "" {
 		return nil, fmt.Errorf("%w: root_id empty", ErrEmptyID)
@@ -1037,19 +1063,20 @@ func (s *Store) WalkAt(ctx context.Context, rootID, rootKind string, edgeKinds [
 type HealthStats struct {
 	CurrentEdges int // valid_to = ''
 	TotalRows    int // all rows including closed history
-	TableExists  bool
 }
 
 // Health returns row counts so callers don't have to write the same
 // COUNT queries everywhere.
 //
 // Contract: callers MUST call New() (which runs init() / the idempotent
-// migration) BEFORE Health(). The earlier portable-error-string-match
-// approach broke on Postgres ("relation X does not exist") and MySQL
-// ("Table 'db.X' doesn't exist"); Go's database/sql doesn't expose
-// portable "table not found" sentinel errors, and information_schema
-// queries are also engine-specific in ways that defeat the purpose.
-// So: Health assumes init succeeded, which is enforced by New().
+// migration) BEFORE Health(). Earlier prototypes tried to detect
+// "table not found" via error string match, but the message shape
+// varies across SQL engines (SQLite "no such table:", Postgres
+// "relation X does not exist", MySQL "Table 'db.X' doesn't exist") —
+// any portable sentinel would be brittle. Go's database/sql doesn't
+// surface a typed "table missing" error either. So Health trusts that
+// init succeeded; callers wanting "table-was-already-there?" semantics
+// should add a top-level boot check rather than embedding it here.
 func (s *Store) Health(ctx context.Context) (HealthStats, error) {
 	var h HealthStats
 	if err := s.db.QueryRowContext(ctx,
@@ -1060,7 +1087,6 @@ func (s *Store) Health(ctx context.Context) (HealthStats, error) {
 		`SELECT COUNT(*) FROM relationships`).Scan(&h.TotalRows); err != nil {
 		return h, fmt.Errorf("health total count: %w", err)
 	}
-	h.TableExists = true
 	return h, nil
 }
 
@@ -1093,13 +1119,27 @@ func (s *Store) Get(ctx context.Context, srcID, dstID, kind string) (Edge, bool,
 	}
 	defer rows.Close()
 	if !rows.Next() {
+		// Differentiate "row iterator advanced cleanly past the end" from
+		// "iterator errored before producing a row." rows.Err() captures
+		// the latter; if non-nil, return it as a real error rather than
+		// implying the edge doesn't exist.
+		if rerr := rows.Err(); rerr != nil {
+			return Edge{}, false, fmt.Errorf("get iterate: %w", rerr)
+		}
 		return Edge{}, false, nil // no current edge — caller's expected case
 	}
 	e, err := scanEdge(rows)
 	if err != nil {
 		return Edge{}, false, fmt.Errorf("scan get: %w", err)
 	}
-	return e, true, rows.Err()
+	// Final iterator check after the scan — catches errors that surface
+	// during row consumption. Returning (e, true, err) here would let a
+	// caller process a partially-scanned Edge thinking found=true; safer
+	// to return zero on any non-nil iterator error.
+	if rerr := rows.Err(); rerr != nil {
+		return Edge{}, false, fmt.Errorf("get final iterate: %w", rerr)
+	}
+	return e, true, nil
 }
 
 // BackfillBulk inserts many historical rows in one transaction.
@@ -1123,22 +1163,11 @@ func (s *Store) BackfillBulk(ctx context.Context, edges []Edge) error {
 	}
 	// Pre-validate ALL edges before starting the tx so we don't have to
 	// roll back after partial inserts. validate-then-write is cheaper
-	// than write-then-rollback.
+	// than write-then-rollback. Uses the same validateBackfillEdge() as
+	// BackfillRow — rules can't drift between the two.
 	for i, e := range edges {
-		if e.SrcID == "" || e.DstID == "" {
-			return fmt.Errorf("%w: edges[%d] src_id=%q dst_id=%q", ErrEmptyID, i, e.SrcID, e.DstID)
-		}
-		if !validKind(e.SrcKind) || !validKind(e.DstKind) {
-			return fmt.Errorf("%w: edges[%d] src_kind=%q dst_kind=%q", ErrInvalidKind, i, e.SrcKind, e.DstKind)
-		}
-		if !validEdgeKind(e.Kind) {
-			return fmt.Errorf("%w: edges[%d] kind=%q", ErrInvalidKind, i, e.Kind)
-		}
-		if e.SrcID == e.DstID {
-			return fmt.Errorf("%w: edges[%d] %s", ErrSelfLoop, i, e.SrcID)
-		}
-		if e.ValidFrom == "" {
-			return fmt.Errorf("relationships: edges[%d] missing ValidFrom (BackfillBulk requires explicit historical timing)", i)
+		if err := validateBackfillEdge(e); err != nil {
+			return fmt.Errorf("edges[%d]: %w", i, err)
 		}
 	}
 
@@ -1152,11 +1181,9 @@ func (s *Store) BackfillBulk(ctx context.Context, edges []Edge) error {
 		}
 	}()
 
-	stmt, err := tx.PrepareContext(ctx,
-		`INSERT INTO relationships
-		   (src_kind, src_id, dst_kind, dst_id, kind, metadata,
-		    valid_from, valid_to, created_by, reason, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	// Reuse the shared backfillInsertSQL — same column order as
+	// BackfillRow so future schema changes touch one constant.
+	stmt, err := tx.PrepareContext(ctx, backfillInsertSQL)
 	if err != nil {
 		return fmt.Errorf("prepare bulk insert: %w", err)
 	}

--- a/internal/relationships/store.go
+++ b/internal/relationships/store.go
@@ -31,10 +31,14 @@ import (
 // clearer attribution than "CHECK constraint failed".
 var ErrInvalidKind = errors.New("relationships: invalid kind value")
 
-// ErrSelfLoop is returned when src_id == dst_id. Schema-level CHECK
-// enforces this too; we duplicate the check in Go for the same clearer-
-// error reason.
+// ErrSelfLoop is returned when src_id == dst_id. Per the 2026-04-25
+// portability rule, the schema no longer enforces this — Go does.
 var ErrSelfLoop = errors.New("relationships: a node cannot have an edge to itself")
+
+// ErrEmptyID is returned when src_id or dst_id is empty. An empty-ID
+// edge would silently corrupt the DAG (joins to nothing). The schema
+// has no CHECK to catch this (portability rule), so Go MUST.
+var ErrEmptyID = errors.New("relationships: src_id and dst_id must be non-empty")
 
 // validKinds returns true if k is one of the enumerated entity kinds.
 // Lifted to a free function so future callers (e.g. MCP tool input
@@ -113,14 +117,20 @@ func New(db *sql.DB) (*Store, error) {
 }
 
 func (s *Store) init() error {
-	// Schema invariants:
-	//   - Composite PK ensures no two rows share (src_id, dst_id, kind, valid_from);
-	//     a simultaneous duplicate Create at the same timestamp will fail at
-	//     INSERT and the caller can retry.
-	//   - CHECK constraints enforce kind enums at the DB level so a corrupt
-	//     write is impossible even if Go-side validation has a bug.
-	//   - src_id <> dst_id forbids self-loops at the relationship level
-	//     (a node depending on itself is meaningless).
+	// Schema portability constraint (2026-04-25): NO CHECK constraints,
+	// NO triggers, NO SQLite-specific dialect features. The DB must
+	// remain portable across SQL engines (SQLite today; Postgres /
+	// Iceberg-via-Trino / MySQL likely in the future for fleet-scale
+	// peers). All value-domain validation lives in Go (validKind /
+	// validEdgeKind / non-empty / self-loop checks in Create + Remove).
+	// Tests cover what CHECK constraints used to catch, so regression
+	// risk moves from "DB rejects malformed write" to "Go layer rejects
+	// it AND the test suite proves it."
+	//
+	// Composite PK on (src_id, dst_id, kind, valid_from) is portable
+	// (every SQL engine supports composite PK) and remains the only
+	// schema-level invariant — a simultaneous duplicate Create at the
+	// same timestamp will fail at INSERT and the caller can retry.
 	_, err := s.db.Exec(`CREATE TABLE IF NOT EXISTS relationships (
 		src_kind   TEXT NOT NULL,
 		src_id     TEXT NOT NULL,
@@ -133,11 +143,7 @@ func (s *Store) init() error {
 		created_by TEXT NOT NULL DEFAULT '',
 		reason     TEXT NOT NULL DEFAULT '',
 		created_at TEXT NOT NULL,
-		PRIMARY KEY (src_id, dst_id, kind, valid_from),
-		CHECK (src_id <> dst_id),
-		CHECK (src_kind IN ('product','manifest','task')),
-		CHECK (dst_kind IN ('product','manifest','task')),
-		CHECK (kind IN ('owns','depends_on','reviews','links_to'))
+		PRIMARY KEY (src_id, dst_id, kind, valid_from)
 	)`)
 	if err != nil {
 		return fmt.Errorf("create relationships table: %w", err)
@@ -207,9 +213,13 @@ func (s *Store) init() error {
 // constraint and one loses with ErrConstraint. Caller can retry; the
 // retry's nowUTC() will differ.
 func (s *Store) Create(ctx context.Context, e Edge) error {
-	// Defense-in-depth validation. Each check returns ErrInvalidKind /
-	// ErrSelfLoop with a wrapped reason rather than waiting for SQLite
-	// to reject the INSERT with a generic CHECK error.
+	// All validation lives in Go (schema is portable, no CHECK / triggers).
+	// Order: empty-ID first so a self-loop check on two empty strings
+	// doesn't fire incorrectly; kind enums next; self-loop last (it's
+	// the only check that requires both IDs to be present + valid).
+	if e.SrcID == "" || e.DstID == "" {
+		return fmt.Errorf("%w: src_id=%q dst_id=%q", ErrEmptyID, e.SrcID, e.DstID)
+	}
 	if !validKind(e.SrcKind) {
 		return fmt.Errorf("%w: src_kind=%q", ErrInvalidKind, e.SrcKind)
 	}
@@ -294,6 +304,10 @@ func (s *Store) Create(ctx context.Context, e Edge) error {
 // decides M5 no longer needs M2 as a prereq. The closing row then says
 // `valid_to=2026-04-25T...`, `created_by=alice`, `reason="M5 standalone now"`.
 func (s *Store) Remove(ctx context.Context, srcID, dstID, kind, by, reason string) error {
+	// Same Go-side validation as Create — schema is portable, no CHECK.
+	if srcID == "" || dstID == "" {
+		return fmt.Errorf("%w: src_id=%q dst_id=%q", ErrEmptyID, srcID, dstID)
+	}
 	if !validEdgeKind(kind) {
 		return fmt.Errorf("%w: kind=%q", ErrInvalidKind, kind)
 	}

--- a/internal/relationships/store.go
+++ b/internal/relationships/store.go
@@ -17,9 +17,44 @@
 package relationships
 
 import (
+	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"time"
 )
+
+// ErrInvalidKind is returned when a caller passes a src_kind / dst_kind /
+// edge kind outside the enumerated set. The DB-level CHECK constraint
+// would catch this too, but we validate in Go first so the error has a
+// clearer attribution than "CHECK constraint failed".
+var ErrInvalidKind = errors.New("relationships: invalid kind value")
+
+// ErrSelfLoop is returned when src_id == dst_id. Schema-level CHECK
+// enforces this too; we duplicate the check in Go for the same clearer-
+// error reason.
+var ErrSelfLoop = errors.New("relationships: a node cannot have an edge to itself")
+
+// validKinds returns true if k is one of the enumerated entity kinds.
+// Lifted to a free function so future callers (e.g. MCP tool input
+// validators) share the exact same allow-list as the store.
+func validKind(k string) bool {
+	return k == KindProduct || k == KindManifest || k == KindTask
+}
+
+// validEdgeKind returns true if k is one of the enumerated edge kinds.
+// Same role as validKind for src/dst types — single source of truth so
+// the schema CHECK + Go-side check + MCP tool validator never drift.
+func validEdgeKind(k string) bool {
+	return k == EdgeOwns || k == EdgeDependsOn || k == EdgeReviews || k == EdgeLinksTo
+}
+
+// nowUTC returns the current time in ISO8601 UTC. Centralised so every
+// timestamp written by this package matches the format expected by the
+// existing TEXT columns and the SCD-2 conventions in task_dependency.
+func nowUTC() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}
 
 // Standard entity kinds. Stored as TEXT in src_kind / dst_kind columns
 // and gated by CHECK constraints at the schema level.
@@ -126,5 +161,149 @@ func (s *Store) init() error {
 		return fmt.Errorf("create idx_rel_history: %w", err)
 	}
 
+	return nil
+}
+
+// Create opens or replaces the current edge for (e.SrcID, e.DstID, e.Kind).
+// The full SCD-2 mutation:
+//
+//  1. If a current row exists for this edge tuple, UPDATE its valid_to to
+//     the close timestamp. The closed row stays in the table — never
+//     DELETEd — so the audit trail is intact.
+//  2. INSERT a fresh row with valid_to='' (the new "current"). The new
+//     row's created_by + reason describe THIS mutation; the prior row's
+//     attribution is preserved as it was.
+//
+// Both steps run in one transaction. If either fails, neither lands.
+//
+// Timestamps:
+//   - e.ValidFrom: optional. Empty → use server's now() in UTC. Non-empty
+//     → caller controls (used by PR/M2 backfill to preserve historical
+//     valid_from from legacy tables). Caller is responsible for ensuring
+//     monotonicity if they pass an explicit value.
+//   - e.CreatedAt: always overwritten with now() — this is when the row
+//     was inserted, not when the edge logically became current. Useful
+//     for "show me edges actually written today" queries even if their
+//     ValidFrom is backfilled to the past.
+//
+// Validation: src_kind / dst_kind / kind must be in the enumerated sets.
+// SrcID == DstID is rejected. The DB-level CHECK constraints would catch
+// these too, but we check in Go first for cleaner error messages.
+//
+// Idempotency note: Create is NOT a no-op when called with identical
+// inputs — it WILL produce two rows in history (the second one closes
+// the first immediately on the next call). That matches SCD-2 semantics:
+// every Create is a state mutation. Callers wanting "no-op when
+// unchanged" should ListOutgoing first and skip the Create if the
+// current row already matches.
+//
+// Concurrent writes: two Create calls at the exact same nanosecond for
+// the same (src_id, dst_id, kind, valid_from) hit the composite PK
+// constraint and one loses with ErrConstraint. Caller can retry; the
+// retry's nowUTC() will differ.
+func (s *Store) Create(ctx context.Context, e Edge) error {
+	// Defense-in-depth validation. Each check returns ErrInvalidKind /
+	// ErrSelfLoop with a wrapped reason rather than waiting for SQLite
+	// to reject the INSERT with a generic CHECK error.
+	if !validKind(e.SrcKind) {
+		return fmt.Errorf("%w: src_kind=%q", ErrInvalidKind, e.SrcKind)
+	}
+	if !validKind(e.DstKind) {
+		return fmt.Errorf("%w: dst_kind=%q", ErrInvalidKind, e.DstKind)
+	}
+	if !validEdgeKind(e.Kind) {
+		return fmt.Errorf("%w: kind=%q", ErrInvalidKind, e.Kind)
+	}
+	if e.SrcID == e.DstID {
+		return fmt.Errorf("%w: %s", ErrSelfLoop, e.SrcID)
+	}
+
+	// Resolve timestamps once so the close + insert share the same
+	// "now". Using one timestamp means the prior row's valid_to and
+	// the new row's valid_from align exactly — the audit trail has no
+	// gap between versions.
+	now := nowUTC()
+	validFrom := e.ValidFrom
+	if validFrom == "" {
+		validFrom = now
+	}
+
+	// Run close + insert in one transaction. If the INSERT fails (PK
+	// collision, CHECK constraint, etc.) the close also rolls back so
+	// the prior row stays current — no orphaned "everyone's closed"
+	// state.
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // safe; commit promotes to no-op
+
+	// Step 1: close the prior current row (if any). The WHERE clause
+	// includes valid_to='' so this only touches the one current row.
+	// If no current row exists, this is a no-op (RowsAffected == 0)
+	// and Create proceeds straight to the INSERT — opening a fresh
+	// edge with no prior history.
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE relationships
+		   SET valid_to = ?
+		 WHERE src_id = ? AND dst_id = ? AND kind = ? AND valid_to = ''`,
+		now, e.SrcID, e.DstID, e.Kind); err != nil {
+		return fmt.Errorf("close prior edge: %w", err)
+	}
+
+	// Step 2: insert the new current row.
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO relationships
+		   (src_kind, src_id, dst_kind, dst_id, kind, metadata,
+		    valid_from, valid_to, created_by, reason, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, '', ?, ?, ?)`,
+		e.SrcKind, e.SrcID, e.DstKind, e.DstID, e.Kind, e.Metadata,
+		validFrom, e.CreatedBy, e.Reason, now); err != nil {
+		return fmt.Errorf("insert new edge: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
+}
+
+// Remove closes the current edge for (srcID, dstID, kind) by setting its
+// valid_to to now(). Does NOT insert a replacement row — the edge stops
+// existing. To re-add it later, call Create; that opens a fresh history
+// thread.
+//
+// Idempotent: if no current row exists for this tuple, returns nil
+// without error (the post-state matches the request).
+//
+// Attribution of the close: by + reason are written into the closing
+// row's created_by + reason columns, OVERWRITING whatever was there from
+// the original Create. This deliberately conflates "who made the row"
+// and "who closed the row" into the same two columns — the simpler
+// alternative to a separate audit_event table. The valid_to column
+// disambiguates: if valid_to != '', created_by/reason describe the
+// CLOSE; if valid_to == '', they describe the CREATE. Document this in
+// the operator playbook for PR/M3.
+//
+// Use case: a manifest's depends_on edge gets removed when the operator
+// decides M5 no longer needs M2 as a prereq. The closing row then says
+// `valid_to=2026-04-25T...`, `created_by=alice`, `reason="M5 standalone now"`.
+func (s *Store) Remove(ctx context.Context, srcID, dstID, kind, by, reason string) error {
+	if !validEdgeKind(kind) {
+		return fmt.Errorf("%w: kind=%q", ErrInvalidKind, kind)
+	}
+	now := nowUTC()
+
+	// Single UPDATE; partial index on valid_to='' makes the lookup O(log n).
+	// RowsAffected==0 is a valid outcome (idempotent semantics) so we
+	// don't surface an error in that case.
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE relationships
+		   SET valid_to = ?, created_by = ?, reason = ?
+		 WHERE src_id = ? AND dst_id = ? AND kind = ? AND valid_to = ''`,
+		now, by, reason, srcID, dstID, kind)
+	if err != nil {
+		return fmt.Errorf("close edge: %w", err)
+	}
 	return nil
 }

--- a/internal/relationships/store.go
+++ b/internal/relationships/store.go
@@ -347,6 +347,24 @@ func scanEdge(rows *sql.Rows) (Edge, error) {
 	return e, err
 }
 
+// validateAsOf parses an ISO8601 timestamp; empty string is allowed
+// (means "now / current state"). Centralised so every time-travel
+// reader uses identical parsing rules. Accepts either RFC3339Nano (the
+// format nowUTC writes) or RFC3339 (operator-friendly, looser
+// precision) — caller-facing leniency.
+func validateAsOf(asOf string) error {
+	if asOf == "" {
+		return nil
+	}
+	if _, err := time.Parse(time.RFC3339Nano, asOf); err == nil {
+		return nil
+	}
+	if _, err := time.Parse(time.RFC3339, asOf); err == nil {
+		return nil
+	}
+	return fmt.Errorf("relationships: as_of must be ISO8601 (RFC3339 or RFC3339Nano), got %q", asOf)
+}
+
 // ListOutgoing returns all CURRENT edges leaving srcID, optionally
 // filtered to a specific edge kind. "Current" means valid_to == ''.
 //
@@ -359,6 +377,10 @@ func scanEdge(rows *sql.Rows) (Edge, error) {
 //
 // Returned edges are unordered. Callers that need ordering should sort
 // in Go (typically by ValidFrom or DstID).
+//
+// For time-travel ("what edges left srcID at past time T?") use
+// ListOutgoingAt instead. ListOutgoing is the hot path; ListOutgoingAt
+// trades the partial index for a wider scan to honour history.
 func (s *Store) ListOutgoing(ctx context.Context, srcID, edgeKind string) ([]Edge, error) {
 	// Build query + args dynamically so the WHERE is precisely "what
 	// the partial index covers" — no wasted predicate that would force
@@ -423,6 +445,119 @@ func (s *Store) ListIncoming(ctx context.Context, dstID, edgeKind string) ([]Edg
 		e, err := scanEdge(rows)
 		if err != nil {
 			return nil, fmt.Errorf("scan incoming: %w", err)
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// ListOutgoingAt returns edges leaving srcID that were CURRENT at the
+// provided ISO8601 timestamp `asOf`. The predicate that defines "valid
+// at asOf":
+//
+//	valid_from <= asOf AND (valid_to > asOf OR valid_to = '')
+//
+//	      ↓ semantics ↓
+//	the edge had been activated (valid_from in the past relative to asOf)
+//	AND was not yet superseded as of asOf (either closed AFTER asOf,
+//	or still current today).
+//
+// asOf == "" falls through to ListOutgoing's current-state path —
+// callers that don't care about history shouldn't pay the wider-scan
+// cost. Empty asOf is therefore the ergonomic default for "now."
+//
+// Performance: cannot use idx_rel_src_current (partial on valid_to='')
+// because past-snapshot queries need closed rows. Falls back to a
+// scan of the (src_id, kind) index OR a full table scan depending on
+// the optimizer's stats. Acceptable for audit / forensics / dashboard
+// time-slider use cases; do NOT call this in a hot loop.
+//
+// Future asOf timestamps are accepted but degenerate: any future point
+// returns whatever's currently active (since no row's valid_to is yet
+// set after the future asOf). Caller can choose to validate themselves.
+func (s *Store) ListOutgoingAt(ctx context.Context, srcID, edgeKind, asOf string) ([]Edge, error) {
+	if srcID == "" {
+		return nil, fmt.Errorf("%w: src_id empty", ErrEmptyID)
+	}
+	if edgeKind != "" && !validEdgeKind(edgeKind) {
+		return nil, fmt.Errorf("%w: kind=%q", ErrInvalidKind, edgeKind)
+	}
+	if err := validateAsOf(asOf); err != nil {
+		return nil, err
+	}
+	// Empty asOf → delegate to the hot-path reader for partial-index speed.
+	if asOf == "" {
+		return s.ListOutgoing(ctx, srcID, edgeKind)
+	}
+
+	q := `SELECT ` + rowColumns + ` FROM relationships
+		 WHERE src_id = ?
+		   AND valid_from <= ?
+		   AND (valid_to > ? OR valid_to = '')`
+	args := []any{srcID, asOf, asOf}
+	if edgeKind != "" {
+		q += ` AND kind = ?`
+		args = append(args, edgeKind)
+	}
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query outgoing-at: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]Edge, 0, 8)
+	for rows.Next() {
+		e, err := scanEdge(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan outgoing-at: %w", err)
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// ListIncomingAt is the dst-side mirror of ListOutgoingAt. Same
+// predicate, same delegation-to-hot-path on empty asOf, same
+// performance caveat.
+//
+// Use case: "who depended on this manifest 30 days ago?" Walks the
+// idx_rel_dst index without the partial filter.
+func (s *Store) ListIncomingAt(ctx context.Context, dstID, edgeKind, asOf string) ([]Edge, error) {
+	if dstID == "" {
+		return nil, fmt.Errorf("%w: dst_id empty", ErrEmptyID)
+	}
+	if edgeKind != "" && !validEdgeKind(edgeKind) {
+		return nil, fmt.Errorf("%w: kind=%q", ErrInvalidKind, edgeKind)
+	}
+	if err := validateAsOf(asOf); err != nil {
+		return nil, err
+	}
+	if asOf == "" {
+		return s.ListIncoming(ctx, dstID, edgeKind)
+	}
+
+	q := `SELECT ` + rowColumns + ` FROM relationships
+		 WHERE dst_id = ?
+		   AND valid_from <= ?
+		   AND (valid_to > ? OR valid_to = '')`
+	args := []any{dstID, asOf, asOf}
+	if edgeKind != "" {
+		q += ` AND kind = ?`
+		args = append(args, edgeKind)
+	}
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query incoming-at: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]Edge, 0, 8)
+	for rows.Next() {
+		e, err := scanEdge(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan incoming-at: %w", err)
 		}
 		out = append(out, e)
 	}
@@ -611,6 +746,111 @@ func (s *Store) Walk(ctx context.Context, rootID, rootKind string, edgeKinds []s
 	})
 	seen := make(map[string]bool, len(out))
 	deduped := out[:0] // reuse the backing array
+	for _, w := range out {
+		if !seen[w.ID] {
+			seen[w.ID] = true
+			deduped = append(deduped, w)
+		}
+	}
+	return deduped, nil
+}
+
+// WalkAt traverses the DAG starting at (rootID, rootKind) showing the
+// state that was current at `asOf`. Same shape as Walk except the
+// recursive-row predicate is the time-travel predicate from
+// ListOutgoingAt instead of `valid_to = ''`.
+//
+// asOf == "" delegates to Walk for the hot-path partial-index speed.
+//
+// Use case: dashboard time-slider — "show me what the AOS umbrella DAG
+// looked like on 2026-04-15." Operator can scrub through history. The
+// returned WalkRow shape is identical to Walk's, so any consumer that
+// renders a current walk renders a past walk identically.
+//
+// The recursive CTE materializes everything at the past snapshot; for
+// graphs with thousands of nodes this allocates more than the current-
+// state walk. AOS-scale (~50 nodes) is fine.
+//
+// Same caveats as Walk: maxDepth clamped [0, 100]; UNION dedups; Go-
+// side dedup-by-id collapses diamond paths to one row per node.
+func (s *Store) WalkAt(ctx context.Context, rootID, rootKind string, edgeKinds []string, maxDepth int, asOf string) ([]WalkRow, error) {
+	if rootID == "" {
+		return nil, fmt.Errorf("%w: root_id empty", ErrEmptyID)
+	}
+	if !validKind(rootKind) {
+		return nil, fmt.Errorf("%w: root_kind=%q", ErrInvalidKind, rootKind)
+	}
+	if err := validateAsOf(asOf); err != nil {
+		return nil, err
+	}
+	// Empty asOf → use the hot-path Walk that hits idx_rel_src_current.
+	if asOf == "" {
+		return s.Walk(ctx, rootID, rootKind, edgeKinds, maxDepth)
+	}
+
+	if maxDepth < 0 || maxDepth > 100 {
+		maxDepth = 100
+	}
+
+	// Build edge-kind filter + args. Args order MUST match the query's
+	// placeholder order; the CTE places them as:
+	//   anchor:    (?, ?)         rootID, rootKind
+	//   recursive: (?, ?)         asOf, asOf  (twice — two-clause predicate)
+	//              IN(?, ?, ...)  edge kinds (optional)
+	//              <?             maxDepth (last)
+	kindFilter := ""
+	args := []any{rootID, rootKind, asOf, asOf}
+	if len(edgeKinds) > 0 {
+		placeholders := make([]string, 0, len(edgeKinds))
+		for _, k := range edgeKinds {
+			if !validEdgeKind(k) {
+				return nil, fmt.Errorf("%w: edge_kinds[]=%q", ErrInvalidKind, k)
+			}
+			placeholders = append(placeholders, "?")
+			args = append(args, k)
+		}
+		kindFilter = ` AND r.kind IN (` + joinComma(placeholders) + `)`
+	}
+	args = append(args, maxDepth)
+
+	// Time-travel CTE: same shape as Walk, but the recursive WHERE swaps
+	// `r.valid_to = ''` for the asOf-validity predicate.
+	q := `WITH RECURSIVE walk(id, kind, via_kind, via_src, depth) AS (
+		SELECT ?, ?, '', '', 0
+		UNION
+		SELECT r.dst_id, r.dst_kind, r.kind, r.src_id, w.depth + 1
+		  FROM relationships r
+		  JOIN walk w ON r.src_id = w.id
+		 WHERE r.valid_from <= ? AND (r.valid_to > ? OR r.valid_to = '')` + kindFilter + `
+		   AND w.depth < ?
+	)
+	SELECT id, kind, via_kind, via_src, depth FROM walk`
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("walk-at query: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]WalkRow, 0, 32)
+	for rows.Next() {
+		var w WalkRow
+		if err := rows.Scan(&w.ID, &w.Kind, &w.ViaKind, &w.ViaSrc, &w.Depth); err != nil {
+			return nil, fmt.Errorf("scan walk-at: %w", err)
+		}
+		out = append(out, w)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Same dedup-by-id sweep as Walk so diamond-path nodes appear once
+	// (shortest path wins). See Walk for rationale.
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Depth < out[j].Depth
+	})
+	seen := make(map[string]bool, len(out))
+	deduped := make([]WalkRow, 0, len(out))
 	for _, w := range out {
 		if !seen[w.ID] {
 			seen[w.ID] = true

--- a/internal/relationships/store.go
+++ b/internal/relationships/store.go
@@ -21,9 +21,24 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sort"
+	"strings"
 	"time"
 )
+
+// MaxWalkDepth is the upper bound on Walk / WalkAt recursion depth.
+// Exposed so the MCP layer can apply the same clamp without drifting
+// from the store. AOS umbrella walks rarely exceed depth 5; 100 is
+// generous + defensive against any future cycle bug. Negative or
+// > MaxWalkDepth is clamped to MaxWalkDepth; 0 returns root only.
+const MaxWalkDepth = 100
+
+// SlowWalkThreshold logs a warning when Walk / WalkAt exceeds this
+// duration. Helps operators spot pathological graphs (cycles caught
+// by the depth clamp, unindexed scans on bad query plans). Tuneable
+// via the slog level if log volume becomes a problem.
+const SlowWalkThreshold = 100 * time.Millisecond
 
 // ErrInvalidKind is returned when a caller passes a src_kind / dst_kind /
 // edge kind outside the enumerated set. The DB-level CHECK constraint
@@ -40,7 +55,7 @@ var ErrSelfLoop = errors.New("relationships: a node cannot have an edge to itsel
 // has no CHECK to catch this (portability rule), so Go MUST.
 var ErrEmptyID = errors.New("relationships: src_id and dst_id must be non-empty")
 
-// validKinds returns true if k is one of the enumerated entity kinds.
+// validKind returns true if k is one of the enumerated entity kinds.
 // Lifted to a free function so future callers (e.g. MCP tool input
 // validators) share the exact same allow-list as the store.
 func validKind(k string) bool {
@@ -251,7 +266,16 @@ func (s *Store) Create(ctx context.Context, e Edge) error {
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
-	defer tx.Rollback() //nolint:errcheck // safe; commit promotes to no-op
+	// After a successful Commit, Rollback returns sql.ErrTxDone — that's
+	// the documented sentinel for "tx already finished," not a real
+	// error. We deliberately swallow it. Any OTHER rollback error (e.g.
+	// connection died after Commit but before this defer ran) we surface
+	// via slog so operators have a signal something flaked.
+	defer func() {
+		if rerr := tx.Rollback(); rerr != nil && !errors.Is(rerr, sql.ErrTxDone) {
+			slog.Warn("relationships: rollback after Create failed", "err", rerr)
+		}
+	}()
 
 	// Step 1: close the prior current row (if any). The WHERE clause
 	// includes valid_to='' so this only touches the one current row.
@@ -279,6 +303,59 @@ func (s *Store) Create(ctx context.Context, e Edge) error {
 
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
+}
+
+// BackfillRow inserts a single row with caller-controlled valid_from
+// AND valid_to — bypassing Create's close-then-insert dance. Used by
+// PR/M2's migration path to copy historical rows out of legacy dep
+// tables (task_dependency / manifest_dependencies / etc.) preserving
+// their original time intervals.
+//
+// Validation is the same as Create EXCEPT we do not require valid_to
+// to be empty — caller can write a fully-closed historical row.
+//
+// MUST NOT be used by application code outside backfill paths. Calling
+// this for a normal mutation breaks the SCD-2 invariant that "only one
+// row per (src, dst, kind) has valid_to=''" — the close-then-insert
+// transaction in Create exists to maintain it. BackfillRow trusts the
+// caller; backfills run in a controlled migration transaction with
+// known-non-overlapping intervals.
+//
+// Idempotent at the row level: the composite PK rejects duplicate
+// inserts, so re-running a backfill on the same source data returns
+// PK error rows that the caller can filter as "already migrated."
+func (s *Store) BackfillRow(ctx context.Context, e Edge) error {
+	if e.SrcID == "" || e.DstID == "" {
+		return fmt.Errorf("%w: src_id=%q dst_id=%q", ErrEmptyID, e.SrcID, e.DstID)
+	}
+	if !validKind(e.SrcKind) {
+		return fmt.Errorf("%w: src_kind=%q", ErrInvalidKind, e.SrcKind)
+	}
+	if !validKind(e.DstKind) {
+		return fmt.Errorf("%w: dst_kind=%q", ErrInvalidKind, e.DstKind)
+	}
+	if !validEdgeKind(e.Kind) {
+		return fmt.Errorf("%w: kind=%q", ErrInvalidKind, e.Kind)
+	}
+	if e.SrcID == e.DstID {
+		return fmt.Errorf("%w: %s", ErrSelfLoop, e.SrcID)
+	}
+	if e.ValidFrom == "" {
+		return fmt.Errorf("relationships: BackfillRow requires explicit ValidFrom (callers must preserve historical timing)")
+	}
+	// valid_to may be empty (active row) or set (closed historical row).
+	now := nowUTC()
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO relationships
+		   (src_kind, src_id, dst_kind, dst_id, kind, metadata,
+		    valid_from, valid_to, created_by, reason, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		e.SrcKind, e.SrcID, e.DstKind, e.DstID, e.Kind, e.Metadata,
+		e.ValidFrom, e.ValidTo, e.CreatedBy, e.Reason, now)
+	if err != nil {
+		return fmt.Errorf("backfill insert: %w", err)
 	}
 	return nil
 }
@@ -382,6 +459,11 @@ func validateAsOf(asOf string) error {
 // ListOutgoingAt instead. ListOutgoing is the hot path; ListOutgoingAt
 // trades the partial index for a wider scan to honour history.
 func (s *Store) ListOutgoing(ctx context.Context, srcID, edgeKind string) ([]Edge, error) {
+	// Defense-in-depth: empty src_id would silently match nothing AND
+	// (after C1 from self-review) signals a buggy caller. Reject early.
+	if srcID == "" {
+		return nil, fmt.Errorf("%w: src_id empty", ErrEmptyID)
+	}
 	// Build query + args dynamically so the WHERE is precisely "what
 	// the partial index covers" — no wasted predicate that would force
 	// a wider scan.
@@ -423,6 +505,9 @@ func (s *Store) ListOutgoing(ctx context.Context, srcID, edgeKind string) ([]Edg
 // today requires a full scan of manifest_dependencies in the reverse
 // direction. With the dst index it's O(log n + matches).
 func (s *Store) ListIncoming(ctx context.Context, dstID, edgeKind string) ([]Edge, error) {
+	if dstID == "" {
+		return nil, fmt.Errorf("%w: dst_id empty", ErrEmptyID)
+	}
 	q := `SELECT ` + rowColumns + ` FROM relationships
 		 WHERE dst_id = ? AND valid_to = ''`
 	args := []any{dstID}
@@ -580,6 +665,9 @@ func (s *Store) ListIncomingAt(ctx context.Context, dstID, edgeKind, asOf string
 // Hits idx_rel_history (src_id, dst_id, valid_from DESC) which the
 // query optimizer reverses to ASC at minimal cost.
 func (s *Store) History(ctx context.Context, srcID, dstID, kind string) ([]Edge, error) {
+	if srcID == "" || dstID == "" {
+		return nil, fmt.Errorf("%w: src_id=%q dst_id=%q", ErrEmptyID, srcID, dstID)
+	}
 	if !validEdgeKind(kind) {
 		return nil, fmt.Errorf("%w: kind=%q", ErrInvalidKind, kind)
 	}
@@ -644,15 +732,18 @@ type WalkRow struct {
 // dashboard's apiProductHierarchy will eventually rebuild on this in
 // PR/M3.
 func (s *Store) Walk(ctx context.Context, rootID, rootKind string, edgeKinds []string, maxDepth int) ([]WalkRow, error) {
+	if rootID == "" {
+		return nil, fmt.Errorf("%w: root_id empty", ErrEmptyID)
+	}
 	// Validate root kind. Edge kinds in the slice are validated below.
 	if !validKind(rootKind) {
 		return nil, fmt.Errorf("%w: root_kind=%q", ErrInvalidKind, rootKind)
 	}
-	// Clamp depth — defensive against caller mistakes and against any
-	// future cycle bug. 100 is generous: AOS umbrella walks at most
-	// product → sub-product → manifest → task = depth 4.
-	if maxDepth < 0 || maxDepth > 100 {
-		maxDepth = 100
+	// Clamp depth via the package-level constant. Out-of-range or
+	// negative collapses to MaxWalkDepth; 0 means "root only" (anchor
+	// row only — recursive WHERE w.depth < 0 excludes everything).
+	if maxDepth < 0 || maxDepth > MaxWalkDepth {
+		maxDepth = MaxWalkDepth
 	}
 
 	// Build the edge-kind filter. SQLite parameter lists in IN clauses
@@ -678,7 +769,7 @@ func (s *Store) Walk(ctx context.Context, rootID, rootKind string, edgeKinds []s
 			placeholders = append(placeholders, "?")
 			args = append(args, k)
 		}
-		kindFilter = ` AND r.kind IN (` + joinComma(placeholders) + `)`
+		kindFilter = ` AND r.kind IN (` + strings.Join(placeholders, ", ") + `)`
 	}
 	// maxDepth is the LAST positional arg — appended after any kinds.
 	args = append(args, maxDepth)
@@ -708,6 +799,10 @@ func (s *Store) Walk(ctx context.Context, rootID, rootKind string, edgeKinds []s
 	)
 	SELECT id, kind, via_kind, via_src, depth FROM walk`
 
+	// Time the query so we can log slow walks. A walk that hits the depth
+	// clamp on a graph with cycles (or a graph that's just enormous) is
+	// invisible without instrumentation; D1 + M9 from self-review.
+	start := time.Now()
 	rows, err := s.db.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("walk query: %w", err)
@@ -718,15 +813,33 @@ func (s *Store) Walk(ctx context.Context, rootID, rootKind string, edgeKinds []s
 	// 8 sub-products + 15 manifests + ~6 tasks). Pre-allocate a bit
 	// over that to avoid the first growth.
 	out := make([]WalkRow, 0, 32)
+	maxObservedDepth := 0
 	for rows.Next() {
 		var w WalkRow
 		if err := rows.Scan(&w.ID, &w.Kind, &w.ViaKind, &w.ViaSrc, &w.Depth); err != nil {
 			return nil, fmt.Errorf("scan walk: %w", err)
 		}
+		if w.Depth > maxObservedDepth {
+			maxObservedDepth = w.Depth
+		}
 		out = append(out, w)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
+	}
+
+	// Surface pathological walks: hit the depth ceiling (potential cycle
+	// or wildly nested graph) OR took longer than the slow threshold.
+	if elapsed := time.Since(start); elapsed > SlowWalkThreshold {
+		slog.Warn("relationships.Walk slow",
+			"root_id", rootID, "root_kind", rootKind,
+			"rows", len(out), "max_depth_observed", maxObservedDepth,
+			"max_depth_allowed", maxDepth, "elapsed_ms", elapsed.Milliseconds())
+	}
+	if maxDepth > 0 && maxObservedDepth >= maxDepth {
+		slog.Warn("relationships.Walk hit depth ceiling — possible cycle",
+			"root_id", rootID, "root_kind", rootKind,
+			"max_depth", maxDepth, "rows", len(out))
 	}
 
 	// SQL UNION dedupes on full-row equality, but a diamond shape
@@ -788,8 +901,8 @@ func (s *Store) WalkAt(ctx context.Context, rootID, rootKind string, edgeKinds [
 		return s.Walk(ctx, rootID, rootKind, edgeKinds, maxDepth)
 	}
 
-	if maxDepth < 0 || maxDepth > 100 {
-		maxDepth = 100
+	if maxDepth < 0 || maxDepth > MaxWalkDepth {
+		maxDepth = MaxWalkDepth
 	}
 
 	// Build edge-kind filter + args. Args order MUST match the query's
@@ -809,7 +922,7 @@ func (s *Store) WalkAt(ctx context.Context, rootID, rootKind string, edgeKinds [
 			placeholders = append(placeholders, "?")
 			args = append(args, k)
 		}
-		kindFilter = ` AND r.kind IN (` + joinComma(placeholders) + `)`
+		kindFilter = ` AND r.kind IN (` + strings.Join(placeholders, ", ") + `)`
 	}
 	args = append(args, maxDepth)
 
@@ -860,16 +973,95 @@ func (s *Store) WalkAt(ctx context.Context, rootID, rootKind string, edgeKinds [
 	return deduped, nil
 }
 
-// joinComma joins a slice of strings with ", " — small helper for
-// building IN-clause placeholder strings without importing strings.
-// Inlined here so the file's deps stay tight.
-func joinComma(parts []string) string {
-	if len(parts) == 0 {
-		return ""
-	}
-	out := parts[0]
-	for i := 1; i < len(parts); i++ {
-		out += ", " + parts[i]
-	}
-	return out
+// HealthStats is a snapshot of the store's row counts. Used by the
+// dashboard's overview card + by ops health checks. Cheap — two
+// COUNT queries against an indexed table.
+type HealthStats struct {
+	CurrentEdges int // valid_to = ''
+	TotalRows    int // all rows including closed history
+	TableExists  bool
 }
+
+// Health returns row counts so callers don't have to write the same
+// COUNT queries everywhere. Returns TableExists=false (with no error)
+// if migration hasn't run yet — useful during boot ordering.
+func (s *Store) Health(ctx context.Context) (HealthStats, error) {
+	var h HealthStats
+	// Probe the table; if it doesn't exist yet, return TableExists=false
+	// without surfacing an error. Some boot sequences call Health before
+	// migrations finish.
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM relationships WHERE valid_to = ''`).Scan(&h.CurrentEdges)
+	if err != nil {
+		// "no such table" is a known-acceptable state; everything else is real.
+		if strings.Contains(err.Error(), "no such table") {
+			return h, nil
+		}
+		return h, fmt.Errorf("health current count: %w", err)
+	}
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM relationships`).Scan(&h.TotalRows); err != nil {
+		return h, fmt.Errorf("health total count: %w", err)
+	}
+	h.TableExists = true
+	return h, nil
+}
+
+// ListOutgoingForMany batches the per-srcID lookup for the dashboard's
+// product-list / manifest-list views. Today's pattern (loop calling
+// ListOutgoing) is N+1 — one query per row in the list. This issues
+// ONE query covering every srcID in the slice and groups the result
+// by src_id in Go.
+//
+// Returns map[srcID][]Edge. A srcID with zero edges has no map entry
+// (caller can do `len(m[id]) == 0` to check).
+//
+// edgeKind == "" returns all kinds (same as ListOutgoing). Filter
+// applies uniformly across every srcID.
+//
+// Performance: one IN(...) query against idx_rel_src_current. ≤ ~500
+// srcIDs is comfortable; beyond that, batch the call.
+func (s *Store) ListOutgoingForMany(ctx context.Context, srcIDs []string, edgeKind string) (map[string][]Edge, error) {
+	if len(srcIDs) == 0 {
+		return map[string][]Edge{}, nil
+	}
+	for _, id := range srcIDs {
+		if id == "" {
+			return nil, fmt.Errorf("%w: srcIDs contains empty string", ErrEmptyID)
+		}
+	}
+	if edgeKind != "" && !validEdgeKind(edgeKind) {
+		return nil, fmt.Errorf("%w: kind=%q", ErrInvalidKind, edgeKind)
+	}
+
+	placeholders := make([]string, 0, len(srcIDs))
+	args := make([]any, 0, len(srcIDs)+1)
+	for _, id := range srcIDs {
+		placeholders = append(placeholders, "?")
+		args = append(args, id)
+	}
+	q := `SELECT ` + rowColumns + ` FROM relationships
+		 WHERE src_id IN (` + strings.Join(placeholders, ", ") + `)
+		   AND valid_to = ''`
+	if edgeKind != "" {
+		q += ` AND kind = ?`
+		args = append(args, edgeKind)
+	}
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query outgoing-for-many: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string][]Edge, len(srcIDs))
+	for rows.Next() {
+		e, err := scanEdge(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan outgoing-for-many: %w", err)
+		}
+		out[e.SrcID] = append(out[e.SrcID], e)
+	}
+	return out, rows.Err()
+}
+

--- a/internal/relationships/store.go
+++ b/internal/relationships/store.go
@@ -307,3 +307,148 @@ func (s *Store) Remove(ctx context.Context, srcID, dstID, kind, by, reason strin
 	}
 	return nil
 }
+
+// rowColumns is the standard SELECT projection for relationships rows.
+// Centralised so every reader (List/History/Walk) uses identical
+// column ordering — a misaligned scan is a class of bug we eliminate
+// at the type level.
+const rowColumns = `src_kind, src_id, dst_kind, dst_id, kind, metadata,
+	valid_from, valid_to, created_by, reason, created_at`
+
+// scanEdge scans one row from the standard rowColumns projection into
+// an Edge struct. Used by every reader's row loop. Keeping this in one
+// place means changing the column order is a single-file edit instead
+// of touching every Scan call site.
+func scanEdge(rows *sql.Rows) (Edge, error) {
+	var e Edge
+	err := rows.Scan(
+		&e.SrcKind, &e.SrcID, &e.DstKind, &e.DstID, &e.Kind, &e.Metadata,
+		&e.ValidFrom, &e.ValidTo, &e.CreatedBy, &e.Reason, &e.CreatedAt,
+	)
+	return e, err
+}
+
+// ListOutgoing returns all CURRENT edges leaving srcID, optionally
+// filtered to a specific edge kind. "Current" means valid_to == ''.
+//
+// edgeKind == "" returns every kind (owns + depends_on + reviews +
+// links_to). Pass a specific kind to restrict (e.g. EdgeDependsOn for
+// just the dep graph).
+//
+// Hits the partial index idx_rel_src_current — O(log n + matches) on
+// current state regardless of how much history accumulates.
+//
+// Returned edges are unordered. Callers that need ordering should sort
+// in Go (typically by ValidFrom or DstID).
+func (s *Store) ListOutgoing(ctx context.Context, srcID, edgeKind string) ([]Edge, error) {
+	// Build query + args dynamically so the WHERE is precisely "what
+	// the partial index covers" — no wasted predicate that would force
+	// a wider scan.
+	q := `SELECT ` + rowColumns + ` FROM relationships
+		 WHERE src_id = ? AND valid_to = ''`
+	args := []any{srcID}
+	if edgeKind != "" {
+		if !validEdgeKind(edgeKind) {
+			return nil, fmt.Errorf("%w: kind=%q", ErrInvalidKind, edgeKind)
+		}
+		q += ` AND kind = ?`
+		args = append(args, edgeKind)
+	}
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query outgoing: %w", err)
+	}
+	defer rows.Close()
+
+	// Pre-allocate a small slice; most nodes have a handful of edges.
+	// If a node has hundreds, append's growth handles it.
+	out := make([]Edge, 0, 8)
+	for rows.Next() {
+		e, err := scanEdge(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan outgoing: %w", err)
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// ListIncoming returns all CURRENT edges arriving at dstID, optionally
+// filtered to a specific edge kind. Mirror of ListOutgoing but driven
+// by the dst-side partial index idx_rel_dst_current.
+//
+// Use case: "who depends on this manifest?" — reverse-lookup that
+// today requires a full scan of manifest_dependencies in the reverse
+// direction. With the dst index it's O(log n + matches).
+func (s *Store) ListIncoming(ctx context.Context, dstID, edgeKind string) ([]Edge, error) {
+	q := `SELECT ` + rowColumns + ` FROM relationships
+		 WHERE dst_id = ? AND valid_to = ''`
+	args := []any{dstID}
+	if edgeKind != "" {
+		if !validEdgeKind(edgeKind) {
+			return nil, fmt.Errorf("%w: kind=%q", ErrInvalidKind, edgeKind)
+		}
+		q += ` AND kind = ?`
+		args = append(args, edgeKind)
+	}
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query incoming: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]Edge, 0, 8)
+	for rows.Next() {
+		e, err := scanEdge(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan incoming: %w", err)
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// History returns every version of one specific edge (one src_id +
+// dst_id + kind tuple), oldest first. Includes both the closed
+// historical rows AND the current row (if any) at the tail.
+//
+// Use case: "show me the audit trail of M5's depends_on M2 edge over
+// time" — when did it open, who opened it, when was it closed, who
+// closed it, did it re-open later, etc. Drives the dashboard's
+// per-edge history panel.
+//
+// Order: ASC by valid_from. Earliest version first; current row (if
+// present) last. This is the natural "story" order — readers walk it
+// chronologically.
+//
+// Hits idx_rel_history (src_id, dst_id, valid_from DESC) which the
+// query optimizer reverses to ASC at minimal cost.
+func (s *Store) History(ctx context.Context, srcID, dstID, kind string) ([]Edge, error) {
+	if !validEdgeKind(kind) {
+		return nil, fmt.Errorf("%w: kind=%q", ErrInvalidKind, kind)
+	}
+
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+rowColumns+` FROM relationships
+		 WHERE src_id = ? AND dst_id = ? AND kind = ?
+		 ORDER BY valid_from ASC`,
+		srcID, dstID, kind)
+	if err != nil {
+		return nil, fmt.Errorf("query history: %w", err)
+	}
+	defer rows.Close()
+
+	// Edges typically have <10 versions over their lifetime. 8 is a
+	// reasonable default capacity; growth handles outliers.
+	out := make([]Edge, 0, 8)
+	for rows.Next() {
+		e, err := scanEdge(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan history: %w", err)
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}

--- a/internal/relationships/store.go
+++ b/internal/relationships/store.go
@@ -452,3 +452,129 @@ func (s *Store) History(ctx context.Context, srcID, dstID, kind string) ([]Edge,
 	}
 	return out, rows.Err()
 }
+
+// WalkRow is one node visited during a recursive DAG walk. The (ID, Kind)
+// pair identifies the entity; ViaKind says how we got here (which edge
+// kind led to this node from its predecessor); ViaSrc is the predecessor
+// itself; Depth is hops from the root (root = 0).
+//
+// Returned in BFS-ish order — closer-to-root nodes appear before deeper
+// ones, but ordering within the same depth is not stable (depends on
+// SQLite's CTE iteration). Callers needing strict order should sort.
+type WalkRow struct {
+	ID      string
+	Kind    string
+	ViaKind string // edge kind that led here ("" for the root)
+	ViaSrc  string // src_id of the edge that led here ("" for the root)
+	Depth   int
+}
+
+// Walk traverses the DAG starting at (rootID, rootKind), following
+// outgoing edges. Returns every reachable node along with the edge that
+// led to it. The recursive CTE walks the partial-current-edges index so
+// only edges with valid_to='' are followed — historical edges don't
+// appear in the walk.
+//
+// edgeKinds filters which edge kinds to follow:
+//   - nil or empty: follow ALL edge kinds (owns + depends_on + reviews + links_to)
+//   - otherwise: only follow edges whose kind is in the slice
+//
+// maxDepth caps recursion. 0 means "root only" (degenerate case for
+// validation). Negative or > 100 is clamped to 100 — prevents
+// runaway walks if a cycle ever sneaks in (the schema doesn't
+// currently enforce acyclicity at the DB level; we may add that
+// later as a CHECK trigger).
+//
+// The CTE is the heart of why this whole manifest exists: ONE query
+// replaces what used to be 6+ table joins for a hierarchy walk. The
+// dashboard's apiProductHierarchy will eventually rebuild on this in
+// PR/M3.
+func (s *Store) Walk(ctx context.Context, rootID, rootKind string, edgeKinds []string, maxDepth int) ([]WalkRow, error) {
+	// Validate root kind. Edge kinds in the slice are validated below.
+	if !validKind(rootKind) {
+		return nil, fmt.Errorf("%w: root_kind=%q", ErrInvalidKind, rootKind)
+	}
+	// Clamp depth — defensive against caller mistakes and against any
+	// future cycle bug. 100 is generous: AOS umbrella walks at most
+	// product → sub-product → manifest → task = depth 4.
+	if maxDepth < 0 || maxDepth > 100 {
+		maxDepth = 100
+	}
+
+	// Build the edge-kind filter. SQLite parameter lists in IN clauses
+	// need explicit '?' per value — no array binding. We construct
+	// placeholders + args defensively, validating each kind first.
+	kindFilter := ""
+	args := []any{rootID, rootKind, maxDepth}
+	if len(edgeKinds) > 0 {
+		// Validate every kind so a typo fails fast with a clean error
+		// rather than silently returning empty results.
+		placeholders := make([]string, 0, len(edgeKinds))
+		for _, k := range edgeKinds {
+			if !validEdgeKind(k) {
+				return nil, fmt.Errorf("%w: edge_kinds[]=%q", ErrInvalidKind, k)
+			}
+			placeholders = append(placeholders, "?")
+			args = append(args, k)
+		}
+		kindFilter = ` AND r.kind IN (` + joinComma(placeholders) + `)`
+	}
+
+	// Recursive CTE explained:
+	//   - Anchor row: the root itself, depth=0, no via_kind/via_src.
+	//   - Recursive row: for each row already in walk, find its
+	//     outgoing CURRENT edges (valid_to='') in the optional kind
+	//     filter, emit the dst as a new walk row at depth+1.
+	//   - WHERE w.depth < ? caps the recursion — we'd rather return
+	//     a partial walk with a clear depth ceiling than spin
+	//     forever on a malformed graph.
+	//
+	// The UNION (not UNION ALL) deduplicates: a node reachable via
+	// multiple paths shows up once (with whichever path's WalkRow
+	// was inserted first). UNION is more expensive than UNION ALL
+	// but eliminates the most common confusion in DAG output where
+	// the same node appears 5 times via different parents.
+	q := `WITH RECURSIVE walk(id, kind, via_kind, via_src, depth) AS (
+		SELECT ?, ?, '', '', 0
+		UNION
+		SELECT r.dst_id, r.dst_kind, r.kind, r.src_id, w.depth + 1
+		  FROM relationships r
+		  JOIN walk w ON r.src_id = w.id
+		 WHERE r.valid_to = ''` + kindFilter + `
+		   AND w.depth < ?
+	)
+	SELECT id, kind, via_kind, via_src, depth FROM walk`
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("walk query: %w", err)
+	}
+	defer rows.Close()
+
+	// Capacity guess: typical AOS umbrella walk hits ~30 nodes (1 +
+	// 8 sub-products + 15 manifests + ~6 tasks). Pre-allocate a bit
+	// over that to avoid the first growth.
+	out := make([]WalkRow, 0, 32)
+	for rows.Next() {
+		var w WalkRow
+		if err := rows.Scan(&w.ID, &w.Kind, &w.ViaKind, &w.ViaSrc, &w.Depth); err != nil {
+			return nil, fmt.Errorf("scan walk: %w", err)
+		}
+		out = append(out, w)
+	}
+	return out, rows.Err()
+}
+
+// joinComma joins a slice of strings with ", " — small helper for
+// building IN-clause placeholder strings without importing strings.
+// Inlined here so the file's deps stay tight.
+func joinComma(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	out := parts[0]
+	for i := 1; i < len(parts); i++ {
+		out += ", " + parts[i]
+	}
+	return out
+}

--- a/internal/relationships/store.go
+++ b/internal/relationships/store.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -41,32 +42,51 @@ const MaxWalkDepth = 100
 const SlowWalkThreshold = 100 * time.Millisecond
 
 // ErrInvalidKind is returned when a caller passes a src_kind / dst_kind /
-// edge kind outside the enumerated set. The DB-level CHECK constraint
-// would catch this too, but we validate in Go first so the error has a
-// clearer attribution than "CHECK constraint failed".
+// edge kind outside the enumerated set. The schema is portable — no CHECK
+// constraint backs this up — so Go-side validation IS the only safety net.
 var ErrInvalidKind = errors.New("relationships: invalid kind value")
 
-// ErrSelfLoop is returned when src_id == dst_id. Per the 2026-04-25
-// portability rule, the schema no longer enforces this — Go does.
+// ErrSelfLoop is returned when src_id == dst_id. Schema is portable, so
+// Go is the only enforcer.
 var ErrSelfLoop = errors.New("relationships: a node cannot have an edge to itself")
 
 // ErrEmptyID is returned when src_id or dst_id is empty. An empty-ID
-// edge would silently corrupt the DAG (joins to nothing). The schema
-// has no CHECK to catch this (portability rule), so Go MUST.
+// edge would silently corrupt the DAG (joins to nothing). Schema has no
+// CHECK to catch this (portability rule), so Go MUST — and every reader
+// rejects empty IDs at the top so corrupted-state never propagates.
 var ErrEmptyID = errors.New("relationships: src_id and dst_id must be non-empty")
 
+// allEntityKinds and allEdgeKinds are the source of truth for valid
+// kind values. validKind / validEdgeKind iterate these slices instead
+// of hard-coding equality chains; the constant declarations below
+// reference these slices via the validators, so adding a new kind in
+// ONE place (the slice) auto-extends both the validator AND keeps the
+// constants iterable for callers that want to enumerate. Was: two
+// hard-coded == chains that drifted whenever a constant was added.
+var allEntityKinds = []string{KindProduct, KindManifest, KindTask}
+var allEdgeKinds = []string{EdgeOwns, EdgeDependsOn, EdgeReviews, EdgeLinksTo}
+
 // validKind returns true if k is one of the enumerated entity kinds.
-// Lifted to a free function so future callers (e.g. MCP tool input
-// validators) share the exact same allow-list as the store.
+// Iterates allEntityKinds so adding a new entity kind only requires
+// extending the slice — no validator edit needed.
 func validKind(k string) bool {
-	return k == KindProduct || k == KindManifest || k == KindTask
+	for _, v := range allEntityKinds {
+		if k == v {
+			return true
+		}
+	}
+	return false
 }
 
 // validEdgeKind returns true if k is one of the enumerated edge kinds.
-// Same role as validKind for src/dst types — single source of truth so
-// the schema CHECK + Go-side check + MCP tool validator never drift.
+// Same iteration pattern as validKind. Single source of truth.
 func validEdgeKind(k string) bool {
-	return k == EdgeOwns || k == EdgeDependsOn || k == EdgeReviews || k == EdgeLinksTo
+	for _, v := range allEdgeKinds {
+		if k == v {
+			return true
+		}
+	}
+	return false
 }
 
 // nowUTC returns the current time in ISO8601 UTC with nanosecond
@@ -80,16 +100,20 @@ func nowUTC() string {
 	return time.Now().UTC().Format(time.RFC3339Nano)
 }
 
-// Standard entity kinds. Stored as TEXT in src_kind / dst_kind columns
-// and gated by CHECK constraints at the schema level.
+// Standard entity kinds. Stored as TEXT in src_kind / dst_kind columns.
+// Schema is portable — no CHECK constraint enforces this set; Go-side
+// validKind() is the only gate. Adding a new kind: extend allEntityKinds
+// (which the validator iterates) AND add the const; the schema needs
+// no migration since it's just TEXT.
 const (
 	KindProduct  = "product"
 	KindManifest = "manifest"
 	KindTask     = "task"
 )
 
-// Standard edge kinds. The schema's CHECK constraint pins the allowed
-// set; adding a new kind requires a migration.
+// Standard edge kinds. Same model as entity kinds — Go-side validation
+// is the only gate. Schema accepts any TEXT; allEdgeKinds is the
+// allow-list iterated by validEdgeKind.
 const (
 	EdgeOwns      = "owns"
 	EdgeDependsOn = "depends_on"
@@ -97,10 +121,18 @@ const (
 	EdgeLinksTo   = "links_to"
 )
 
-// Edge is one row in the relationships table. ValidTo == "" means
-// "this is the current version of the edge"; non-empty means "superseded
-// at this timestamp." Metadata is an opaque JSON string for edge-kind-
-// specific extras (left empty for the common case).
+// Edge is one row in the relationships table.
+//
+// Field semantics for input vs output:
+//   - SrcKind/SrcID/DstKind/DstID/Kind: REQUIRED on Create and BackfillRow
+//   - Metadata: optional on input, opaque JSON
+//   - ValidFrom: optional on Create (defaults to now); REQUIRED on BackfillRow
+//   - ValidTo: optional on BackfillRow only (Create always sets ''); on read
+//     "" means "this is the current version of the edge", non-empty means
+//     "superseded at this timestamp"
+//   - CreatedBy/Reason: optional, populates the audit trail
+//   - CreatedAt: WRITE-PATH IGNORES THE INPUT — set by store on insert.
+//     Populated on read. If you set it on input, it's silently overwritten.
 type Edge struct {
 	SrcKind   string
 	SrcID     string
@@ -112,12 +144,25 @@ type Edge struct {
 	ValidTo   string
 	CreatedBy string
 	Reason    string
-	CreatedAt string
+	CreatedAt string // ignored on Create input; set by store
 }
 
 // Store owns the relationships table.
+//
+// createMu serializes Create's close-then-insert transaction. SQLite
+// WAL gives each connection a snapshot at BEGIN time; two concurrent
+// Create txs on the same edge can both see "no current row" at their
+// BEGIN, both close-then-insert, and produce two rows with valid_to='',
+// breaking the SCD-2 invariant. The mutex makes the close + insert
+// atomic across goroutines without depending on engine-specific
+// BEGIN IMMEDIATE / SERIALIZABLE semantics. Concurrent Creates on
+// DIFFERENT edges still serialize through this — acceptable since
+// SQLite's underlying write lock would serialize them anyway. Future
+// Postgres backend can drop the mutex (MVCC + SERIALIZABLE isolation
+// handles this correctly) at the cost of one rebench cycle.
 type Store struct {
-	db *sql.DB
+	db       *sql.DB
+	createMu sync.Mutex
 }
 
 // New opens the store and runs the idempotent schema migration. Pass
@@ -212,21 +257,23 @@ func (s *Store) init() error {
 //     for "show me edges actually written today" queries even if their
 //     ValidFrom is backfilled to the past.
 //
-// Validation: src_kind / dst_kind / kind must be in the enumerated sets.
-// SrcID == DstID is rejected. The DB-level CHECK constraints would catch
-// these too, but we check in Go first for cleaner error messages.
+// Validation: src_kind / dst_kind / kind must be in the enumerated sets;
+// SrcID and DstID must be non-empty; SrcID == DstID is rejected. Schema
+// is portable — there are NO CHECK constraints, so Go is the only gate.
+// Tests cover every rejection path so regressions surface in CI.
 //
 // Idempotency note: Create is NOT a no-op when called with identical
 // inputs — it WILL produce two rows in history (the second one closes
 // the first immediately on the next call). That matches SCD-2 semantics:
 // every Create is a state mutation. Callers wanting "no-op when
-// unchanged" should ListOutgoing first and skip the Create if the
-// current row already matches.
+// unchanged" should ListOutgoing or Get first and skip the Create if
+// the current row already matches.
 //
-// Concurrent writes: two Create calls at the exact same nanosecond for
-// the same (src_id, dst_id, kind, valid_from) hit the composite PK
-// constraint and one loses with ErrConstraint. Caller can retry; the
-// retry's nowUTC() will differ.
+// Concurrency under SQLite (current backend): writes serialize on the
+// WAL write lock; concurrent Create calls run sequentially, never
+// observe each other's pending state. Under Postgres MVCC (future
+// backend), serializable-isolation re-runs handle the rare case where
+// two txs compute the same nowUTC() before either commits.
 func (s *Store) Create(ctx context.Context, e Edge) error {
 	// All validation lives in Go (schema is portable, no CHECK / triggers).
 	// Order: empty-ID first so a self-loop check on two empty strings
@@ -248,20 +295,27 @@ func (s *Store) Create(ctx context.Context, e Edge) error {
 		return fmt.Errorf("%w: %s", ErrSelfLoop, e.SrcID)
 	}
 
+	// Serialize close-then-insert across goroutines. See Store.createMu
+	// docstring for why a Go mutex (SQLite WAL snapshot isolation lets
+	// concurrent txs both miss the prior row).
+	s.createMu.Lock()
+	defer s.createMu.Unlock()
+
 	// Resolve timestamps once so the close + insert share the same
 	// "now". Using one timestamp means the prior row's valid_to and
 	// the new row's valid_from align exactly — the audit trail has no
-	// gap between versions.
+	// gap between versions. Computed AFTER acquiring the mutex so
+	// timestamps reflect serialization order rather than racing
+	// goroutines' nowUTC() calls.
 	now := nowUTC()
 	validFrom := e.ValidFrom
 	if validFrom == "" {
 		validFrom = now
 	}
 
-	// Run close + insert in one transaction. If the INSERT fails (PK
-	// collision, CHECK constraint, etc.) the close also rolls back so
-	// the prior row stays current — no orphaned "everyone's closed"
-	// state.
+	// Run close + insert in one transaction. If the INSERT fails the
+	// close also rolls back so the prior row stays current — no orphaned
+	// "everyone's closed" state.
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
@@ -411,6 +465,29 @@ func (s *Store) Remove(ctx context.Context, srcID, dstID, kind, by, reason strin
 const rowColumns = `src_kind, src_id, dst_kind, dst_id, kind, metadata,
 	valid_from, valid_to, created_by, reason, created_at`
 
+// buildKindFilter turns an []edgeKinds slice into the SQL fragment
+// `AND r.kind IN (?, ?, ...)` plus the matching args slice. Empty input
+// returns ("", nil, nil) — no filter clause, no args appended.
+//
+// Centralised so Walk and WalkAt build the IN-clause filter identically;
+// previously the same loop existed in both with the same validation
+// pattern. One source of truth + one validation path.
+func buildKindFilter(edgeKinds []string) (sql string, args []any, err error) {
+	if len(edgeKinds) == 0 {
+		return "", nil, nil
+	}
+	placeholders := make([]string, 0, len(edgeKinds))
+	args = make([]any, 0, len(edgeKinds))
+	for _, k := range edgeKinds {
+		if !validEdgeKind(k) {
+			return "", nil, fmt.Errorf("%w: edge_kinds[]=%q", ErrInvalidKind, k)
+		}
+		placeholders = append(placeholders, "?")
+		args = append(args, k)
+	}
+	return ` AND r.kind IN (` + strings.Join(placeholders, ", ") + `)`, args, nil
+}
+
 // scanEdge scans one row from the standard rowColumns projection into
 // an Edge struct. Used by every reader's row loop. Keeping this in one
 // place means changing the column order is a single-file edit instead
@@ -426,9 +503,14 @@ func scanEdge(rows *sql.Rows) (Edge, error) {
 
 // validateAsOf parses an ISO8601 timestamp; empty string is allowed
 // (means "now / current state"). Centralised so every time-travel
-// reader uses identical parsing rules. Accepts either RFC3339Nano (the
-// format nowUTC writes) or RFC3339 (operator-friendly, looser
-// precision) — caller-facing leniency.
+// reader uses identical parsing rules.
+//
+// Implementation note: time.Parse(time.RFC3339Nano, ...) accepts inputs
+// WITHOUT fractional seconds — Go's `9` quantifier in the format string
+// is "optional digits". So a single RFC3339Nano parse covers both
+// "2026-04-25T10:00:00Z" (no fraction) and the writer's full-precision
+// nanosecond format. An earlier two-pass implementation (RFC3339Nano
+// fallback to RFC3339) was dead code.
 func validateAsOf(asOf string) error {
 	if asOf == "" {
 		return nil
@@ -436,10 +518,7 @@ func validateAsOf(asOf string) error {
 	if _, err := time.Parse(time.RFC3339Nano, asOf); err == nil {
 		return nil
 	}
-	if _, err := time.Parse(time.RFC3339, asOf); err == nil {
-		return nil
-	}
-	return fmt.Errorf("relationships: as_of must be ISO8601 (RFC3339 or RFC3339Nano), got %q", asOf)
+	return fmt.Errorf("relationships: as_of must be ISO8601 (RFC3339), got %q", asOf)
 }
 
 // ListOutgoing returns all CURRENT edges leaving srcID, optionally
@@ -746,32 +825,16 @@ func (s *Store) Walk(ctx context.Context, rootID, rootKind string, edgeKinds []s
 		maxDepth = MaxWalkDepth
 	}
 
-	// Build the edge-kind filter. SQLite parameter lists in IN clauses
-	// need explicit '?' per value — no array binding. Args MUST be
-	// appended in the same positional order the query expects:
-	//   [rootID, rootKind, kind1, kind2, ..., kindN, maxDepth]
-	// because the query reads as ?,? for the anchor SELECT, then the
-	// IN(...) placeholders, then the trailing w.depth < ? predicate.
-	// Got bitten by ordering this as [rootID, rootKind, maxDepth, kinds...]
-	// during initial development — the IN clause silently matched on
-	// maxDepth instead of any real kind and the walk returned only the
-	// root. Tests now lock the order in.
-	kindFilter := ""
-	args := []any{rootID, rootKind}
-	if len(edgeKinds) > 0 {
-		// Validate every kind so a typo fails fast with a clean error
-		// rather than silently returning empty results.
-		placeholders := make([]string, 0, len(edgeKinds))
-		for _, k := range edgeKinds {
-			if !validEdgeKind(k) {
-				return nil, fmt.Errorf("%w: edge_kinds[]=%q", ErrInvalidKind, k)
-			}
-			placeholders = append(placeholders, "?")
-			args = append(args, k)
-		}
-		kindFilter = ` AND r.kind IN (` + strings.Join(placeholders, ", ") + `)`
+	// Args order: [rootID, rootKind, kind1..kindN, maxDepth]. The query
+	// reads ?,? for the anchor SELECT, then the IN(...) placeholders,
+	// then the trailing w.depth < ? predicate. Mis-ordering silently
+	// binds maxDepth into the IN clause and walks return only the root.
+	kindFilter, kindArgs, err := buildKindFilter(edgeKinds)
+	if err != nil {
+		return nil, err
 	}
-	// maxDepth is the LAST positional arg — appended after any kinds.
+	args := []any{rootID, rootKind}
+	args = append(args, kindArgs...)
 	args = append(args, maxDepth)
 
 	// Recursive CTE explained:
@@ -783,14 +846,13 @@ func (s *Store) Walk(ctx context.Context, rootID, rootKind string, edgeKinds []s
 	//     a partial walk with a clear depth ceiling than spin
 	//     forever on a malformed graph.
 	//
-	// The UNION (not UNION ALL) deduplicates: a node reachable via
-	// multiple paths shows up once (with whichever path's WalkRow
-	// was inserted first). UNION is more expensive than UNION ALL
-	// but eliminates the most common confusion in DAG output where
-	// the same node appears 5 times via different parents.
+	// UNION ALL: emits raw. SQL UNION's full-row dedup wouldn't help
+	// for diamond paths (different via_src means rows aren't equal),
+	// so we'd pay the SQL dedup cost AND still need Go-side dedup. ALL
+	// + Go-side post-process is the cheaper combo.
 	q := `WITH RECURSIVE walk(id, kind, via_kind, via_src, depth) AS (
 		SELECT ?, ?, '', '', 0
-		UNION
+		UNION ALL
 		SELECT r.dst_id, r.dst_kind, r.kind, r.src_id, w.depth + 1
 		  FROM relationships r
 		  JOIN walk w ON r.src_id = w.id
@@ -827,43 +889,46 @@ func (s *Store) Walk(ctx context.Context, rootID, rootKind string, edgeKinds []s
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+	rawRowCount := len(out) // capture pre-dedup count for the log
 
-	// Surface pathological walks: hit the depth ceiling (potential cycle
-	// or wildly nested graph) OR took longer than the slow threshold.
-	if elapsed := time.Since(start); elapsed > SlowWalkThreshold {
-		slog.Warn("relationships.Walk slow",
-			"root_id", rootID, "root_kind", rootKind,
-			"rows", len(out), "max_depth_observed", maxObservedDepth,
-			"max_depth_allowed", maxDepth, "elapsed_ms", elapsed.Milliseconds())
-	}
-	if maxDepth > 0 && maxObservedDepth >= maxDepth {
-		slog.Warn("relationships.Walk hit depth ceiling — possible cycle",
-			"root_id", rootID, "root_kind", rootKind,
-			"max_depth", maxDepth, "rows", len(out))
-	}
-
-	// SQL UNION dedupes on full-row equality, but a diamond shape
-	// (A→B→D and A→C→D) produces two rows for D with different
-	// via_src ("B" vs "C") — both survive UNION. The user-facing
-	// semantic is "each node appears once," so we post-process:
+	// SQL UNION ALL emits every reached path; Go-side dedup-by-id collapses
+	// diamond paths to one row per node. Using ALL (not UNION) avoids a
+	// SQLite sort + dedup pass that wouldn't have helped anyway —
+	// different via_src on the same dst means full-row equality fails and
+	// SQL UNION keeps both rows. So we let SQL emit raw + Go does the
+	// authoritative dedup. Cheaper than UNION + Go dedup.
 	//
-	//   1. Sort stable by depth ASC. Equal-depth rows keep their
-	//      CTE-emit order. The first occurrence of each id is now
-	//      whichever path reached it shortest.
-	//   2. Walk the sorted list, keep only the first row per id.
-	//
-	// Cost: O(n log n) sort + O(n) sweep. Acceptable up to thousands
-	// of rows; AOS umbrella walks rarely exceed 50.
+	// Sort stable by depth ASC; first occurrence per id wins (= shortest
+	// path). O(n log n) + O(n). Fine up to thousands of nodes.
 	sort.SliceStable(out, func(i, j int) bool {
 		return out[i].Depth < out[j].Depth
 	})
 	seen := make(map[string]bool, len(out))
-	deduped := out[:0] // reuse the backing array
+	deduped := make([]WalkRow, 0, len(out))
 	for _, w := range out {
 		if !seen[w.ID] {
 			seen[w.ID] = true
 			deduped = append(deduped, w)
 		}
+	}
+
+	// Surface pathological walks AFTER dedup so log row counts match what
+	// the caller gets back. Slow threshold: total elapsed including dedup.
+	// Cycle warning: depth ceiling hit during recursion. Both use the
+	// final, deduped row count to avoid misleading operators with raw-CTE
+	// numbers that don't exist in the response.
+	if elapsed := time.Since(start); elapsed > SlowWalkThreshold {
+		slog.Warn("relationships.Walk slow",
+			"root_id", rootID, "root_kind", rootKind,
+			"rows_returned", len(deduped), "raw_rows", rawRowCount,
+			"max_depth_observed", maxObservedDepth,
+			"max_depth_allowed", maxDepth,
+			"elapsed_ms", elapsed.Milliseconds())
+	}
+	if maxDepth > 0 && maxObservedDepth >= maxDepth {
+		slog.Warn("relationships.Walk hit depth ceiling — possible cycle",
+			"root_id", rootID, "root_kind", rootKind,
+			"max_depth", maxDepth, "rows_returned", len(deduped))
 	}
 	return deduped, nil
 }
@@ -905,32 +970,25 @@ func (s *Store) WalkAt(ctx context.Context, rootID, rootKind string, edgeKinds [
 		maxDepth = MaxWalkDepth
 	}
 
-	// Build edge-kind filter + args. Args order MUST match the query's
-	// placeholder order; the CTE places them as:
+	// Args order matters: the CTE expects
 	//   anchor:    (?, ?)         rootID, rootKind
 	//   recursive: (?, ?)         asOf, asOf  (twice — two-clause predicate)
 	//              IN(?, ?, ...)  edge kinds (optional)
 	//              <?             maxDepth (last)
-	kindFilter := ""
-	args := []any{rootID, rootKind, asOf, asOf}
-	if len(edgeKinds) > 0 {
-		placeholders := make([]string, 0, len(edgeKinds))
-		for _, k := range edgeKinds {
-			if !validEdgeKind(k) {
-				return nil, fmt.Errorf("%w: edge_kinds[]=%q", ErrInvalidKind, k)
-			}
-			placeholders = append(placeholders, "?")
-			args = append(args, k)
-		}
-		kindFilter = ` AND r.kind IN (` + strings.Join(placeholders, ", ") + `)`
+	kindFilter, kindArgs, err := buildKindFilter(edgeKinds)
+	if err != nil {
+		return nil, err
 	}
+	args := []any{rootID, rootKind, asOf, asOf}
+	args = append(args, kindArgs...)
 	args = append(args, maxDepth)
 
 	// Time-travel CTE: same shape as Walk, but the recursive WHERE swaps
-	// `r.valid_to = ''` for the asOf-validity predicate.
+	// `r.valid_to = ''` for the asOf-validity predicate. UNION ALL +
+	// Go-side dedup, same rationale as Walk.
 	q := `WITH RECURSIVE walk(id, kind, via_kind, via_src, depth) AS (
 		SELECT ?, ?, '', '', 0
-		UNION
+		UNION ALL
 		SELECT r.dst_id, r.dst_kind, r.kind, r.src_id, w.depth + 1
 		  FROM relationships r
 		  JOIN walk w ON r.src_id = w.id
@@ -983,20 +1041,19 @@ type HealthStats struct {
 }
 
 // Health returns row counts so callers don't have to write the same
-// COUNT queries everywhere. Returns TableExists=false (with no error)
-// if migration hasn't run yet — useful during boot ordering.
+// COUNT queries everywhere.
+//
+// Contract: callers MUST call New() (which runs init() / the idempotent
+// migration) BEFORE Health(). The earlier portable-error-string-match
+// approach broke on Postgres ("relation X does not exist") and MySQL
+// ("Table 'db.X' doesn't exist"); Go's database/sql doesn't expose
+// portable "table not found" sentinel errors, and information_schema
+// queries are also engine-specific in ways that defeat the purpose.
+// So: Health assumes init succeeded, which is enforced by New().
 func (s *Store) Health(ctx context.Context) (HealthStats, error) {
 	var h HealthStats
-	// Probe the table; if it doesn't exist yet, return TableExists=false
-	// without surfacing an error. Some boot sequences call Health before
-	// migrations finish.
-	err := s.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM relationships WHERE valid_to = ''`).Scan(&h.CurrentEdges)
-	if err != nil {
-		// "no such table" is a known-acceptable state; everything else is real.
-		if strings.Contains(err.Error(), "no such table") {
-			return h, nil
-		}
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM relationships WHERE valid_to = ''`).Scan(&h.CurrentEdges); err != nil {
 		return h, fmt.Errorf("health current count: %w", err)
 	}
 	if err := s.db.QueryRowContext(ctx,
@@ -1005,6 +1062,166 @@ func (s *Store) Health(ctx context.Context) (HealthStats, error) {
 	}
 	h.TableExists = true
 	return h, nil
+}
+
+// Get returns the CURRENT edge for (srcID, dstID, kind), or
+// (Edge{}, false, nil) if no current row exists. Atomic single-edge
+// lookup — the most common pre-mutation query ("does this edge already
+// exist before I Create?"). Replaces today's pattern of calling
+// ListOutgoing + filtering by DstID, which loads every outgoing edge
+// when only one matters.
+//
+// Returns at most ONE row by construction: the (src_id, dst_id, kind,
+// valid_from) PK + valid_to='' partial index together guarantee a
+// single current version per edge tuple. Multiple rows would mean the
+// SCD-2 invariant was violated by a backfill — that's a bug, not a
+// shape this function tolerates.
+func (s *Store) Get(ctx context.Context, srcID, dstID, kind string) (Edge, bool, error) {
+	if srcID == "" || dstID == "" {
+		return Edge{}, false, fmt.Errorf("%w: src_id=%q dst_id=%q", ErrEmptyID, srcID, dstID)
+	}
+	if !validEdgeKind(kind) {
+		return Edge{}, false, fmt.Errorf("%w: kind=%q", ErrInvalidKind, kind)
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+rowColumns+` FROM relationships
+		 WHERE src_id = ? AND dst_id = ? AND kind = ? AND valid_to = ''
+		 LIMIT 1`,
+		srcID, dstID, kind)
+	if err != nil {
+		return Edge{}, false, fmt.Errorf("get: %w", err)
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return Edge{}, false, nil // no current edge — caller's expected case
+	}
+	e, err := scanEdge(rows)
+	if err != nil {
+		return Edge{}, false, fmt.Errorf("scan get: %w", err)
+	}
+	return e, true, rows.Err()
+}
+
+// BackfillBulk inserts many historical rows in one transaction.
+// Migration paths (PR/M2) typically write 10K–100K rows; calling
+// BackfillRow in a loop pays one fsync per row (slow on cloud disks,
+// minutes for 100K rows). BackfillBulk amortises to one fsync per
+// transaction.
+//
+// Validation: every edge in the slice gets the same checks as
+// BackfillRow. If ANY edge fails validation, the entire transaction
+// rolls back — caller must filter / fix before retrying. There is no
+// partial-success mode by design (avoids the "which rows landed?"
+// question downstream).
+//
+// Performance: ~100x faster than BackfillRow loop on disk-bound
+// systems; ~10x on NVMe. Recommended batch size: 1K–10K rows. Beyond
+// that the transaction lock starves concurrent readers.
+func (s *Store) BackfillBulk(ctx context.Context, edges []Edge) error {
+	if len(edges) == 0 {
+		return nil
+	}
+	// Pre-validate ALL edges before starting the tx so we don't have to
+	// roll back after partial inserts. validate-then-write is cheaper
+	// than write-then-rollback.
+	for i, e := range edges {
+		if e.SrcID == "" || e.DstID == "" {
+			return fmt.Errorf("%w: edges[%d] src_id=%q dst_id=%q", ErrEmptyID, i, e.SrcID, e.DstID)
+		}
+		if !validKind(e.SrcKind) || !validKind(e.DstKind) {
+			return fmt.Errorf("%w: edges[%d] src_kind=%q dst_kind=%q", ErrInvalidKind, i, e.SrcKind, e.DstKind)
+		}
+		if !validEdgeKind(e.Kind) {
+			return fmt.Errorf("%w: edges[%d] kind=%q", ErrInvalidKind, i, e.Kind)
+		}
+		if e.SrcID == e.DstID {
+			return fmt.Errorf("%w: edges[%d] %s", ErrSelfLoop, i, e.SrcID)
+		}
+		if e.ValidFrom == "" {
+			return fmt.Errorf("relationships: edges[%d] missing ValidFrom (BackfillBulk requires explicit historical timing)", i)
+		}
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin bulk tx: %w", err)
+	}
+	defer func() {
+		if rerr := tx.Rollback(); rerr != nil && !errors.Is(rerr, sql.ErrTxDone) {
+			slog.Warn("relationships: rollback after BackfillBulk failed", "err", rerr)
+		}
+	}()
+
+	stmt, err := tx.PrepareContext(ctx,
+		`INSERT INTO relationships
+		   (src_kind, src_id, dst_kind, dst_id, kind, metadata,
+		    valid_from, valid_to, created_by, reason, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare bulk insert: %w", err)
+	}
+	defer stmt.Close()
+
+	now := nowUTC()
+	for i, e := range edges {
+		if _, err := stmt.ExecContext(ctx,
+			e.SrcKind, e.SrcID, e.DstKind, e.DstID, e.Kind, e.Metadata,
+			e.ValidFrom, e.ValidTo, e.CreatedBy, e.Reason, now); err != nil {
+			return fmt.Errorf("bulk insert edges[%d]: %w", i, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit bulk: %w", err)
+	}
+	return nil
+}
+
+// ListIncomingForMany is the dst-side mirror of ListOutgoingForMany.
+// "Who depends on these N manifests?" — same use case, reverse
+// direction. One IN(...) query against idx_rel_dst_current; results
+// grouped by dst_id.
+func (s *Store) ListIncomingForMany(ctx context.Context, dstIDs []string, edgeKind string) (map[string][]Edge, error) {
+	if len(dstIDs) == 0 {
+		return map[string][]Edge{}, nil
+	}
+	for _, id := range dstIDs {
+		if id == "" {
+			return nil, fmt.Errorf("%w: dstIDs contains empty string", ErrEmptyID)
+		}
+	}
+	if edgeKind != "" && !validEdgeKind(edgeKind) {
+		return nil, fmt.Errorf("%w: kind=%q", ErrInvalidKind, edgeKind)
+	}
+
+	placeholders := make([]string, 0, len(dstIDs))
+	args := make([]any, 0, len(dstIDs)+1)
+	for _, id := range dstIDs {
+		placeholders = append(placeholders, "?")
+		args = append(args, id)
+	}
+	q := `SELECT ` + rowColumns + ` FROM relationships
+		 WHERE dst_id IN (` + strings.Join(placeholders, ", ") + `)
+		   AND valid_to = ''`
+	if edgeKind != "" {
+		q += ` AND kind = ?`
+		args = append(args, edgeKind)
+	}
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query incoming-for-many: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string][]Edge, len(dstIDs))
+	for rows.Next() {
+		e, err := scanEdge(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan incoming-for-many: %w", err)
+		}
+		out[e.DstID] = append(out[e.DstID], e)
+	}
+	return out, rows.Err()
 }
 
 // ListOutgoingForMany batches the per-srcID lookup for the dashboard's

--- a/internal/relationships/store_test.go
+++ b/internal/relationships/store_test.go
@@ -153,9 +153,11 @@ func TestCreate_Replace(t *testing.T) {
 	}
 }
 
-// TestCreate_ValidationErrors — invalid kinds + self-loops fail with
-// typed errors before reaching the DB. Schema CHECK would catch them
-// too, but the Go-side validation gives clearer attribution.
+// TestCreate_ValidationErrors — every validation path that USED to be
+// enforced by DB-level CHECK constraints (now removed for portability,
+// 2026-04-25) must be caught in Go. If any of these regress, malformed
+// rows would land silently in the DB. The schema has no safety net —
+// Go is the safety net.
 func TestCreate_ValidationErrors(t *testing.T) {
 	s := openTestStore(t)
 	ctx := context.Background()
@@ -165,6 +167,21 @@ func TestCreate_ValidationErrors(t *testing.T) {
 		edge    Edge
 		wantErr error
 	}{
+		{
+			name: "empty src_id",
+			edge: Edge{SrcKind: KindManifest, SrcID: "", DstKind: KindManifest, DstID: "B", Kind: EdgeDependsOn},
+			wantErr: ErrEmptyID,
+		},
+		{
+			name: "empty dst_id",
+			edge: Edge{SrcKind: KindManifest, SrcID: "A", DstKind: KindManifest, DstID: "", Kind: EdgeDependsOn},
+			wantErr: ErrEmptyID,
+		},
+		{
+			name: "both empty (would otherwise look like self-loop)",
+			edge: Edge{SrcKind: KindManifest, SrcID: "", DstKind: KindManifest, DstID: "", Kind: EdgeDependsOn},
+			wantErr: ErrEmptyID,
+		},
 		{
 			name: "bad src_kind",
 			edge: Edge{SrcKind: "garbage", SrcID: "A", DstKind: KindManifest, DstID: "B", Kind: EdgeDependsOn},
@@ -191,6 +208,35 @@ func TestCreate_ValidationErrors(t *testing.T) {
 			err := s.Create(ctx, tc.edge)
 			if !errors.Is(err, tc.wantErr) {
 				t.Fatalf("Create: want %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestRemove_ValidationErrors — Remove must reject the same shapes
+// (empty IDs, bad edge kind) that Create rejects. Without these checks
+// a typo could silently no-op against the DB and the caller wouldn't
+// know.
+func TestRemove_ValidationErrors(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name    string
+		srcID   string
+		dstID   string
+		kind    string
+		wantErr error
+	}{
+		{"empty src_id", "", "B", EdgeDependsOn, ErrEmptyID},
+		{"empty dst_id", "A", "", EdgeDependsOn, ErrEmptyID},
+		{"bad edge kind", "A", "B", "garbage", ErrInvalidKind},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := s.Remove(ctx, tc.srcID, tc.dstID, tc.kind, "test", "test")
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("Remove: want %v, got %v", tc.wantErr, err)
 			}
 		})
 	}

--- a/internal/relationships/store_test.go
+++ b/internal/relationships/store_test.go
@@ -700,6 +700,230 @@ func TestWalkAt_EmptyAsOfDelegatesToWalk(t *testing.T) {
 	}
 }
 
+// ─── Reader empty-ID rejection (C1 from self-review) ────────────────────────
+
+// TestReaders_RejectEmptyIDs — every reader must reject empty IDs at
+// the top with ErrEmptyID. Previously they would silently scan with an
+// empty key (returning nothing) which masked buggy callers. With CHECK
+// constraints removed for portability, Go is the only safety net.
+func TestReaders_RejectEmptyIDs(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		fn   func() error
+	}{
+		{"ListOutgoing empty src", func() error {
+			_, err := s.ListOutgoing(ctx, "", EdgeDependsOn)
+			return err
+		}},
+		{"ListIncoming empty dst", func() error {
+			_, err := s.ListIncoming(ctx, "", EdgeDependsOn)
+			return err
+		}},
+		{"History empty src", func() error {
+			_, err := s.History(ctx, "", "B", EdgeDependsOn)
+			return err
+		}},
+		{"History empty dst", func() error {
+			_, err := s.History(ctx, "A", "", EdgeDependsOn)
+			return err
+		}},
+		{"Walk empty root", func() error {
+			_, err := s.Walk(ctx, "", KindManifest, nil, 10)
+			return err
+		}},
+		{"ListOutgoingAt empty src", func() error {
+			_, err := s.ListOutgoingAt(ctx, "", EdgeDependsOn, "2026-01-01T00:00:00Z")
+			return err
+		}},
+		{"ListIncomingAt empty dst", func() error {
+			_, err := s.ListIncomingAt(ctx, "", EdgeDependsOn, "2026-01-01T00:00:00Z")
+			return err
+		}},
+		{"WalkAt empty root", func() error {
+			_, err := s.WalkAt(ctx, "", KindManifest, nil, 10, "2026-01-01T00:00:00Z")
+			return err
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.fn()
+			if !errors.Is(err, ErrEmptyID) {
+				t.Errorf("expected ErrEmptyID, got %v", err)
+			}
+		})
+	}
+}
+
+// ─── BackfillRow ─────────────────────────────────────────────────────────────
+
+// TestBackfillRow_PreservesValidFromValidTo — backfill must accept
+// caller-controlled valid_from AND valid_to, including a fully-closed
+// historical row with both set to past timestamps. PR/M2's task_dependency
+// migration depends on this.
+func TestBackfillRow_PreservesValidFromValidTo(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	// Insert a closed historical row from a fictional 2025 backfill.
+	pastFrom := "2025-06-01T00:00:00Z"
+	pastTo := "2025-09-01T00:00:00Z"
+	if err := s.BackfillRow(ctx, Edge{
+		SrcKind: KindManifest, SrcID: "M1",
+		DstKind: KindManifest, DstID: "M2",
+		Kind:      EdgeDependsOn,
+		ValidFrom: pastFrom,
+		ValidTo:   pastTo,
+		CreatedBy: "backfill",
+		Reason:    "PR/M2 from task_dependency",
+	}); err != nil {
+		t.Fatalf("BackfillRow: %v", err)
+	}
+
+	hist, _ := s.History(ctx, "M1", "M2", EdgeDependsOn)
+	if len(hist) != 1 {
+		t.Fatalf("expected 1 history row, got %d", len(hist))
+	}
+	if hist[0].ValidFrom != pastFrom || hist[0].ValidTo != pastTo {
+		t.Errorf("intervals not preserved: from=%q to=%q", hist[0].ValidFrom, hist[0].ValidTo)
+	}
+	// Closed row should NOT appear in current state.
+	if got, _ := s.ListOutgoing(ctx, "M1", EdgeDependsOn); len(got) != 0 {
+		t.Errorf("closed historical row leaked into current state: %+v", got)
+	}
+}
+
+// TestBackfillRow_RequiresValidFrom — empty ValidFrom rejected. Backfill
+// callers MUST preserve historical timing; defaulting to now() would
+// silently corrupt the timeline.
+func TestBackfillRow_RequiresValidFrom(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	err := s.BackfillRow(ctx, Edge{
+		SrcKind: KindManifest, SrcID: "M1",
+		DstKind: KindManifest, DstID: "M2",
+		Kind:      EdgeDependsOn,
+		ValidFrom: "", // missing — should reject
+	})
+	if err == nil {
+		t.Fatal("expected error on empty ValidFrom")
+	}
+	if !strings.Contains(err.Error(), "ValidFrom") {
+		t.Errorf("error should mention ValidFrom, got: %v", err)
+	}
+}
+
+// TestBackfillRow_DuplicateRejectedByPK — same (src, dst, kind, valid_from)
+// inserted twice fails the second time on PK constraint. Callers can use
+// this for "skip already-migrated" semantics.
+func TestBackfillRow_DuplicateRejectedByPK(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	e := Edge{
+		SrcKind: KindManifest, SrcID: "M1",
+		DstKind: KindManifest, DstID: "M2",
+		Kind:      EdgeDependsOn,
+		ValidFrom: "2025-06-01T00:00:00Z",
+		ValidTo:   "2025-09-01T00:00:00Z",
+		CreatedBy: "backfill",
+	}
+	if err := s.BackfillRow(ctx, e); err != nil {
+		t.Fatalf("first BackfillRow: %v", err)
+	}
+	err := s.BackfillRow(ctx, e)
+	if err == nil {
+		t.Fatal("expected PK error on duplicate, got nil")
+	}
+}
+
+// ─── Health ──────────────────────────────────────────────────────────────────
+
+// TestHealth_CountsCurrentVsTotal — Health distinguishes current edges
+// from total-with-history. Add 2 edges, close one, expect current=1
+// total=2 (the closed row stays in the table per SCD-2).
+func TestHealth_CountsCurrentVsTotal(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	mustCreate(t, s, "A", "B", EdgeDependsOn)
+	mustCreate(t, s, "A", "C", EdgeDependsOn)
+	if err := s.Remove(ctx, "A", "B", EdgeDependsOn, "test", "removed"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	h, err := s.Health(ctx)
+	if err != nil {
+		t.Fatalf("Health: %v", err)
+	}
+	if !h.TableExists {
+		t.Errorf("TableExists should be true after migration")
+	}
+	if h.CurrentEdges != 1 {
+		t.Errorf("expected 1 current edge (A→C), got %d", h.CurrentEdges)
+	}
+	if h.TotalRows != 2 {
+		t.Errorf("expected 2 total rows (closed A→B + current A→C), got %d", h.TotalRows)
+	}
+}
+
+// ─── ListOutgoingForMany ─────────────────────────────────────────────────────
+
+// TestListOutgoingForMany_BatchesQuery — three sources each with edges,
+// one IN-clause query returns everything grouped by src_id. Replaces the
+// N+1 pattern.
+func TestListOutgoingForMany_BatchesQuery(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	mustCreate(t, s, "A", "X", EdgeDependsOn)
+	mustCreate(t, s, "A", "Y", EdgeDependsOn)
+	mustCreate(t, s, "B", "Z", EdgeDependsOn)
+	// C has no edges intentionally.
+
+	got, err := s.ListOutgoingForMany(ctx, []string{"A", "B", "C"}, EdgeDependsOn)
+	if err != nil {
+		t.Fatalf("ListOutgoingForMany: %v", err)
+	}
+	if len(got["A"]) != 2 {
+		t.Errorf("A should have 2 edges, got %d", len(got["A"]))
+	}
+	if len(got["B"]) != 1 {
+		t.Errorf("B should have 1 edge, got %d", len(got["B"]))
+	}
+	if len(got["C"]) != 0 {
+		t.Errorf("C should have 0 edges, got %d", len(got["C"]))
+	}
+}
+
+// TestListOutgoingForMany_EmptySrcIDs — passing an empty slice returns
+// an empty map, not nil, and not an error.
+func TestListOutgoingForMany_EmptySrcIDs(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	got, err := s.ListOutgoingForMany(ctx, []string{}, "")
+	if err != nil {
+		t.Fatalf("expected no error on empty input, got %v", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Errorf("expected empty map, got %v", got)
+	}
+}
+
+// TestListOutgoingForMany_RejectsEmptyEntry — slice containing "" is
+// caller error.
+func TestListOutgoingForMany_RejectsEmptyEntry(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	_, err := s.ListOutgoingForMany(ctx, []string{"A", "", "B"}, "")
+	if !errors.Is(err, ErrEmptyID) {
+		t.Errorf("expected ErrEmptyID, got %v", err)
+	}
+}
+
 // walkIDs is a tiny helper: run a Walk* call, fail the test on error,
 // return a set-of-IDs map for terse membership assertions.
 func walkIDs(t *testing.T, rows []WalkRow, err error) map[string]bool {

--- a/internal/relationships/store_test.go
+++ b/internal/relationships/store_test.go
@@ -860,9 +860,6 @@ func TestHealth_CountsCurrentVsTotal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Health: %v", err)
 	}
-	if !h.TableExists {
-		t.Errorf("TableExists should be true after migration")
-	}
 	if h.CurrentEdges != 1 {
 		t.Errorf("expected 1 current edge (A→C), got %d", h.CurrentEdges)
 	}
@@ -1166,6 +1163,61 @@ func TestCreate_ConcurrentSameEdge(t *testing.T) {
 		if !isLast && hasValidTo {
 			t.Errorf("non-last row should be closed, but row %d has valid_to=''", i)
 		}
+	}
+}
+
+// TestCreate_RacingRemove — Create and Remove fire concurrently on the
+// same edge. Verifies the SCD-2 invariant holds: end state is either
+// "1 current row" (Create won the race or Create ran after Remove)
+// or "0 current rows" (Remove won + closed Create's row).
+//
+// What this test catches: if Remove ignored Create's createMu (it
+// does — Remove doesn't take it), and SQLite's write-statement
+// serialization weren't enough, we could end up with two current
+// rows or a row stuck "half-closed". Test confirms the actual
+// behavior is invariant-preserving.
+func TestCreate_RacingRemove(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	const iterations = 25
+	var wg sync.WaitGroup
+	wg.Add(2 * iterations)
+	errs := make(chan error, 2*iterations)
+
+	for i := 0; i < iterations; i++ {
+		go func() {
+			defer wg.Done()
+			err := s.Create(ctx, Edge{
+				SrcKind: KindManifest, SrcID: "A",
+				DstKind: KindManifest, DstID: "B",
+				Kind:      EdgeDependsOn,
+				CreatedBy: "creator",
+			})
+			if err != nil {
+				errs <- err
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			if err := s.Remove(ctx, "A", "B", EdgeDependsOn, "remover", "race"); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("race error: %v", err)
+	}
+
+	// Invariant: after the storm, AT MOST ONE current row exists.
+	current, err := s.ListOutgoing(ctx, "A", EdgeDependsOn)
+	if err != nil {
+		t.Fatalf("ListOutgoing: %v", err)
+	}
+	if len(current) > 1 {
+		t.Errorf("SCD-2 invariant violated: %d current rows after Create/Remove race", len(current))
 	}
 }
 

--- a/internal/relationships/store_test.go
+++ b/internal/relationships/store_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -493,6 +494,224 @@ func TestWalk_EdgeKindFilter(t *testing.T) {
 	if len(rows) != 2 {
 		t.Errorf("expected P + M only, got %d rows: %+v", len(rows), rows)
 	}
+}
+
+// ─── Time-travel readers (ListOutgoingAt / ListIncomingAt / WalkAt) ────────
+
+// TestListOutgoingAt_PastSnapshot — re-target an edge over time, verify
+// past-vs-current state differs. Re-target = Remove(A→B) + Create(A→C)
+// since A→B and A→C are distinct edges in the SCD model (different dst).
+//
+// Timeline:
+//
+//	t_pre:  capture timestamp BEFORE any edge exists
+//	T0:     Create A→B  (valid_from=T0, valid_to='')
+//	t_mid:  capture timestamp WHILE A→B is current
+//	T1:     Remove A→B   (closes A→B at T1; valid_to set)
+//	T2:     Create A→C   (separate fresh edge)
+//	t_now:  current state = only A→C
+//
+// Expected at t_pre: 0 edges (nothing existed)
+// Expected at t_mid: A→B (still current then)
+// Expected now:      A→C
+func TestListOutgoingAt_PastSnapshot(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	tPre := time.Now().UTC().Add(-1 * time.Millisecond).Format(time.RFC3339Nano)
+
+	mustCreate(t, s, "A", "B", EdgeDependsOn, func(e *Edge) { e.Reason = "v1" })
+	time.Sleep(5 * time.Millisecond)
+	tMid := time.Now().UTC().Format(time.RFC3339Nano)
+	time.Sleep(2 * time.Millisecond)
+
+	// Query AT tPre — before any edge existed.
+	if got, _ := s.ListOutgoingAt(ctx, "A", EdgeDependsOn, tPre); len(got) != 0 {
+		t.Errorf("at tPre (pre-creation), expected 0 edges, got %d", len(got))
+	}
+
+	// Query AT tMid (after Create) — should see A→B.
+	got, err := s.ListOutgoingAt(ctx, "A", EdgeDependsOn, tMid)
+	if err != nil {
+		t.Fatalf("ListOutgoingAt: %v", err)
+	}
+	if len(got) != 1 || got[0].DstID != "B" {
+		t.Fatalf("at tMid, expected A→B, got %+v", got)
+	}
+
+	// Re-target: explicit Remove A→B, then Create A→C (distinct edge).
+	time.Sleep(2 * time.Millisecond)
+	if err := s.Remove(ctx, "A", "B", EdgeDependsOn, "test", "re-target"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	mustCreate(t, s, "A", "C", EdgeDependsOn, func(e *Edge) { e.Reason = "v2" })
+
+	// Query AT tMid again — A→B was current then, A→C didn't exist.
+	got, err = s.ListOutgoingAt(ctx, "A", EdgeDependsOn, tMid)
+	if err != nil {
+		t.Fatalf("ListOutgoingAt past: %v", err)
+	}
+	dstSet := map[string]bool{}
+	for _, e := range got {
+		dstSet[e.DstID] = true
+	}
+	if !dstSet["B"] {
+		t.Errorf("at tMid, expected to see B: %+v", got)
+	}
+	if dstSet["C"] {
+		t.Errorf("at tMid, A→C should NOT have existed yet: %+v", got)
+	}
+
+	// Query NOW (current state) — only A→C.
+	currentEdges, _ := s.ListOutgoing(ctx, "A", EdgeDependsOn)
+	if len(currentEdges) != 1 || currentEdges[0].DstID != "C" {
+		t.Errorf("current state should be A→C only, got %+v", currentEdges)
+	}
+}
+
+// TestListOutgoingAt_EmptyAsOfDelegatesToCurrent — empty asOf falls
+// through to ListOutgoing (hot-path partial-index reader). Verifies
+// the optimization: empty asOf → same result as calling ListOutgoing
+// directly.
+func TestListOutgoingAt_EmptyAsOfDelegatesToCurrent(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	mustCreate(t, s, "A", "B", EdgeDependsOn)
+	mustCreate(t, s, "A", "C", EdgeDependsOn)
+
+	currentDirect, _ := s.ListOutgoing(ctx, "A", EdgeDependsOn)
+	currentViaAt, _ := s.ListOutgoingAt(ctx, "A", EdgeDependsOn, "")
+
+	if len(currentDirect) != len(currentViaAt) {
+		t.Errorf("empty asOf should match ListOutgoing: direct=%d viaAt=%d",
+			len(currentDirect), len(currentViaAt))
+	}
+}
+
+// TestListOutgoingAt_InvalidTimestamp — non-ISO8601 asOf rejected.
+func TestListOutgoingAt_InvalidTimestamp(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	_, err := s.ListOutgoingAt(ctx, "A", EdgeDependsOn, "not a timestamp")
+	if err == nil {
+		t.Fatal("expected error on garbage asOf, got nil")
+	}
+	if !strings.Contains(err.Error(), "as_of must be ISO8601") {
+		t.Errorf("expected 'as_of must be ISO8601' in error, got: %v", err)
+	}
+}
+
+// TestListIncomingAt_PastSnapshot — mirror of ListOutgoingAt_PastSnapshot.
+// Multiple sources point at one dst; one is closed; query at past time
+// should see both, query now should see only the survivor.
+func TestListIncomingAt_PastSnapshot(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	mustCreate(t, s, "M1", "M0", EdgeDependsOn)
+	mustCreate(t, s, "M2", "M0", EdgeDependsOn)
+	time.Sleep(5 * time.Millisecond)
+	t1 := time.Now().UTC().Format(time.RFC3339Nano)
+	time.Sleep(2 * time.Millisecond)
+
+	// Close M1→M0 (Remove).
+	if err := s.Remove(ctx, "M1", "M0", EdgeDependsOn, "test", "removed"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	// Past query: M1→M0 + M2→M0 BOTH current at t1.
+	past, err := s.ListIncomingAt(ctx, "M0", EdgeDependsOn, t1)
+	if err != nil {
+		t.Fatalf("ListIncomingAt: %v", err)
+	}
+	if len(past) != 2 {
+		t.Errorf("at t1, expected 2 incoming, got %d: %+v", len(past), past)
+	}
+
+	// Current: only M2→M0 left.
+	now, _ := s.ListIncoming(ctx, "M0", EdgeDependsOn)
+	if len(now) != 1 || now[0].SrcID != "M2" {
+		t.Errorf("current should be only M2→M0, got %+v", now)
+	}
+}
+
+// TestWalkAt_PastSnapshot — three-node chain whose tail is re-targeted.
+// Verifies time-travel walks return the structure that was current at
+// asOf, not what's current now. Re-target uses explicit Remove+Create
+// (B→C and B→D are distinct edges, not metadata-versions of the same).
+//
+// Timeline:
+//
+//	T0: Create A→B + Create B→C   (chain A→B→C)
+//	t1: capture
+//	T1: Remove B→C, Create B→D    (chain A→B→D from now on)
+//
+// Expected at t1: walk(A) = {A, B, C}
+// Expected now:   walk(A) = {A, B, D}
+func TestWalkAt_PastSnapshot(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	mustCreate(t, s, "A", "B", EdgeDependsOn)
+	mustCreate(t, s, "B", "C", EdgeDependsOn)
+	time.Sleep(5 * time.Millisecond)
+	t1 := time.Now().UTC().Format(time.RFC3339Nano)
+	time.Sleep(2 * time.Millisecond)
+	// Re-target B's outgoing: close B→C, open B→D.
+	if err := s.Remove(ctx, "B", "C", EdgeDependsOn, "test", "re-target"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	mustCreate(t, s, "B", "D", EdgeDependsOn)
+
+	pastRows, err := s.WalkAt(ctx, "A", KindManifest, []string{EdgeDependsOn}, 10, t1)
+	pastIDs := walkIDs(t, pastRows, err)
+	if !pastIDs["A"] || !pastIDs["B"] || !pastIDs["C"] {
+		t.Errorf("at t1, expected {A,B,C}, got %v", pastIDs)
+	}
+	if pastIDs["D"] {
+		t.Errorf("at t1, D shouldn't exist yet: %v", pastIDs)
+	}
+
+	nowRows, err := s.Walk(ctx, "A", KindManifest, []string{EdgeDependsOn}, 10)
+	nowIDs := walkIDs(t, nowRows, err)
+	if !nowIDs["A"] || !nowIDs["B"] || !nowIDs["D"] {
+		t.Errorf("now, expected {A,B,D}, got %v", nowIDs)
+	}
+	if nowIDs["C"] {
+		t.Errorf("now, C should be gone: %v", nowIDs)
+	}
+}
+
+// TestWalkAt_EmptyAsOfDelegatesToWalk — same delegation behavior as
+// ListOutgoingAt: empty asOf → hot-path Walk.
+func TestWalkAt_EmptyAsOfDelegatesToWalk(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	mustCreate(t, s, "A", "B", EdgeDependsOn)
+	mustCreate(t, s, "B", "C", EdgeDependsOn)
+
+	direct, _ := s.Walk(ctx, "A", KindManifest, []string{EdgeDependsOn}, 10)
+	viaAt, _ := s.WalkAt(ctx, "A", KindManifest, []string{EdgeDependsOn}, 10, "")
+
+	if len(direct) != len(viaAt) {
+		t.Errorf("empty asOf delegation broken: direct=%d viaAt=%d", len(direct), len(viaAt))
+	}
+}
+
+// walkIDs is a tiny helper: run a Walk* call, fail the test on error,
+// return a set-of-IDs map for terse membership assertions.
+func walkIDs(t *testing.T, rows []WalkRow, err error) map[string]bool {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	out := map[string]bool{}
+	for _, r := range rows {
+		out[r.ID] = true
+	}
+	return out
 }
 
 // TestWalk_DedupesViaUnion — diamond shape: A→B→D and A→C→D. UNION (not

--- a/internal/relationships/store_test.go
+++ b/internal/relationships/store_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -921,6 +922,273 @@ func TestListOutgoingForMany_RejectsEmptyEntry(t *testing.T) {
 	_, err := s.ListOutgoingForMany(ctx, []string{"A", "", "B"}, "")
 	if !errors.Is(err, ErrEmptyID) {
 		t.Errorf("expected ErrEmptyID, got %v", err)
+	}
+}
+
+// ─── Get (single-edge lookup, C5) ──────────────────────────────────────────
+
+// TestGet_HappyPath — Create then Get returns the row + ok=true.
+func TestGet_HappyPath(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	mustCreate(t, s, "M1", "M2", EdgeDependsOn, func(e *Edge) { e.Reason = "test" })
+
+	e, ok, err := s.Get(ctx, "M1", "M2", EdgeDependsOn)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true on existing edge")
+	}
+	if e.SrcID != "M1" || e.DstID != "M2" || e.Kind != EdgeDependsOn {
+		t.Errorf("wrong row returned: %+v", e)
+	}
+}
+
+// TestGet_NoEdgeReturnsFalse — non-existent edge returns ok=false, no error.
+func TestGet_NoEdgeReturnsFalse(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	_, ok, err := s.Get(ctx, "M1", "M2", EdgeDependsOn)
+	if err != nil {
+		t.Fatalf("unexpected err on missing edge: %v", err)
+	}
+	if ok {
+		t.Errorf("expected ok=false, got true")
+	}
+}
+
+// TestGet_ClosedEdgeNotReturned — Create + Remove → Get returns ok=false
+// because Get only sees CURRENT (valid_to='') rows.
+func TestGet_ClosedEdgeNotReturned(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	mustCreate(t, s, "M1", "M2", EdgeDependsOn)
+	if err := s.Remove(ctx, "M1", "M2", EdgeDependsOn, "test", "removed"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	_, ok, err := s.Get(ctx, "M1", "M2", EdgeDependsOn)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if ok {
+		t.Error("Get should not return closed edges")
+	}
+}
+
+// TestGet_ValidationErrors — empty IDs + bad kind rejected.
+func TestGet_ValidationErrors(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	cases := []struct {
+		name              string
+		src, dst, kind    string
+		wantErr           error
+	}{
+		{"empty src", "", "M2", EdgeDependsOn, ErrEmptyID},
+		{"empty dst", "M1", "", EdgeDependsOn, ErrEmptyID},
+		{"bad kind", "M1", "M2", "garbage", ErrInvalidKind},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := s.Get(ctx, tc.src, tc.dst, tc.kind)
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("want %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// ─── BackfillBulk (M2) ─────────────────────────────────────────────────────
+
+// TestBackfillBulk_AtomicTransaction — many rows in one tx; verify all
+// land or none do.
+func TestBackfillBulk_AtomicTransaction(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	edges := []Edge{
+		{SrcKind: KindManifest, SrcID: "M1", DstKind: KindManifest, DstID: "M2",
+			Kind: EdgeDependsOn, ValidFrom: "2025-06-01T00:00:00Z", ValidTo: "2025-09-01T00:00:00Z"},
+		{SrcKind: KindManifest, SrcID: "M3", DstKind: KindManifest, DstID: "M4",
+			Kind: EdgeDependsOn, ValidFrom: "2025-07-01T00:00:00Z"},
+		{SrcKind: KindManifest, SrcID: "M5", DstKind: KindManifest, DstID: "M6",
+			Kind: EdgeDependsOn, ValidFrom: "2025-08-01T00:00:00Z"},
+	}
+	if err := s.BackfillBulk(ctx, edges); err != nil {
+		t.Fatalf("BackfillBulk: %v", err)
+	}
+
+	h, _ := s.Health(ctx)
+	if h.TotalRows != 3 {
+		t.Errorf("expected 3 total rows after bulk insert, got %d", h.TotalRows)
+	}
+	// Two rows have valid_to='' (current); one is closed.
+	if h.CurrentEdges != 2 {
+		t.Errorf("expected 2 current edges, got %d", h.CurrentEdges)
+	}
+}
+
+// TestBackfillBulk_RollsBackOnAnyValidationFailure — one bad edge in
+// the slice means NONE land. Caller must filter before retrying.
+func TestBackfillBulk_RollsBackOnAnyValidationFailure(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	edges := []Edge{
+		{SrcKind: KindManifest, SrcID: "M1", DstKind: KindManifest, DstID: "M2",
+			Kind: EdgeDependsOn, ValidFrom: "2025-06-01T00:00:00Z"},
+		// Index 1: missing ValidFrom → entire batch rejected
+		{SrcKind: KindManifest, SrcID: "M3", DstKind: KindManifest, DstID: "M4",
+			Kind: EdgeDependsOn},
+	}
+	err := s.BackfillBulk(ctx, edges)
+	if err == nil {
+		t.Fatal("expected error on missing ValidFrom in batch, got nil")
+	}
+	h, _ := s.Health(ctx)
+	if h.TotalRows != 0 {
+		t.Errorf("expected 0 rows after rejected batch, got %d", h.TotalRows)
+	}
+}
+
+// TestBackfillBulk_EmptySlice — empty input is a no-op success.
+func TestBackfillBulk_EmptySlice(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	if err := s.BackfillBulk(ctx, nil); err != nil {
+		t.Errorf("expected no error on nil slice, got %v", err)
+	}
+	if err := s.BackfillBulk(ctx, []Edge{}); err != nil {
+		t.Errorf("expected no error on empty slice, got %v", err)
+	}
+}
+
+// ─── ListIncomingForMany (M3 from review) ──────────────────────────────────
+
+// TestListIncomingForMany_Batches — mirror of ListOutgoingForMany_Batches.
+func TestListIncomingForMany_Batches(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	mustCreate(t, s, "X", "A", EdgeDependsOn)
+	mustCreate(t, s, "Y", "A", EdgeDependsOn)
+	mustCreate(t, s, "Z", "B", EdgeDependsOn)
+
+	got, err := s.ListIncomingForMany(ctx, []string{"A", "B", "C"}, EdgeDependsOn)
+	if err != nil {
+		t.Fatalf("ListIncomingForMany: %v", err)
+	}
+	if len(got["A"]) != 2 {
+		t.Errorf("A should have 2 incoming, got %d", len(got["A"]))
+	}
+	if len(got["B"]) != 1 {
+		t.Errorf("B should have 1 incoming, got %d", len(got["B"]))
+	}
+	if len(got["C"]) != 0 {
+		t.Errorf("C should have 0 incoming, got %d", len(got["C"]))
+	}
+}
+
+// ─── Concurrent-write stress (C6) ──────────────────────────────────────────
+
+// TestCreate_ConcurrentSameEdge — 50 goroutines hammering Create on the
+// same edge. Verifies (a) no race detector hits, (b) exactly one row
+// has valid_to='' afterwards (the SCD-2 invariant), (c) every other row
+// is properly closed. Run with `go test -race -run TestCreate_Concurrent`.
+//
+// Behavior under SQLite WAL: writes serialize on the write lock; each
+// Create's close-then-insert tx runs to completion before the next one
+// starts. After N goroutines complete, history has N+1 rows (initial
+// row from goroutine #1 + N-1 close-then-insert pairs from #2..#N) —
+// but wait, that's wrong. Let me re-read the close logic.
+//
+// Actually each Create does: UPDATE close prior + INSERT new. So
+// goroutine #1 has no prior → just INSERT (1 row). Goroutine #2's
+// UPDATE closes #1's row; INSERT new (2 rows total). After N
+// goroutines, we have N rows: one current + (N-1) closed. Verify.
+func TestCreate_ConcurrentSameEdge(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	const N = 50
+	var wg sync.WaitGroup
+	wg.Add(N)
+	errs := make(chan error, N)
+	for i := 0; i < N; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			err := s.Create(ctx, Edge{
+				SrcKind: KindManifest, SrcID: "M1",
+				DstKind: KindManifest, DstID: "M2",
+				Kind:      EdgeDependsOn,
+				CreatedBy: "test",
+				Reason:    "concurrent #" + string(rune('A'+i%26)),
+			})
+			if err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent Create error: %v", err)
+	}
+
+	// Invariant 1: exactly one current row.
+	current, err := s.ListOutgoing(ctx, "M1", EdgeDependsOn)
+	if err != nil {
+		t.Fatalf("ListOutgoing: %v", err)
+	}
+	if len(current) != 1 {
+		t.Errorf("SCD-2 invariant violated: expected 1 current row, got %d", len(current))
+	}
+
+	// Invariant 2: history has N rows total (1 fresh + (N-1) replacements).
+	hist, err := s.History(ctx, "M1", "M2", EdgeDependsOn)
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	if len(hist) != N {
+		t.Errorf("expected %d total versions in history, got %d", N, len(hist))
+	}
+
+	// Invariant 3: only the LAST row in chronological order has valid_to=''.
+	for i, h := range hist {
+		isLast := i == len(hist)-1
+		hasValidTo := h.ValidTo == ""
+		if isLast && !hasValidTo {
+			t.Errorf("last row should be current (valid_to=''), got %q", h.ValidTo)
+		}
+		if !isLast && hasValidTo {
+			t.Errorf("non-last row should be closed, but row %d has valid_to=''", i)
+		}
+	}
+}
+
+// ─── ListOutgoingForMany missing test (m5 from review) ────────────────────
+
+// TestListOutgoingForMany_AllKindsWhenFilterEmpty — empty edgeKind
+// returns every kind for the listed sources.
+func TestListOutgoingForMany_AllKindsWhenFilterEmpty(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	mustCreate(t, s, "A", "B", EdgeDependsOn)
+	mustCreate(t, s, "A", "C", EdgeLinksTo, func(e *Edge) {
+		e.SrcKind = KindManifest
+		e.DstKind = KindTask
+	})
+
+	got, err := s.ListOutgoingForMany(ctx, []string{"A"}, "")
+	if err != nil {
+		t.Fatalf("ListOutgoingForMany: %v", err)
+	}
+	if len(got["A"]) != 2 {
+		t.Errorf("expected 2 edges (depends_on + links_to) for A with empty filter, got %d", len(got["A"]))
 	}
 }
 

--- a/internal/relationships/store_test.go
+++ b/internal/relationships/store_test.go
@@ -1,0 +1,479 @@
+// Tests for the relationships store. Each test opens a fresh SQLite
+// file in t.TempDir(), runs the migration (via New), then exercises one
+// API surface. Pattern matches internal/manifest/dependencies_test.go +
+// internal/task/repository_test.go for consistency.
+//
+// Coverage targets (manifest acceptance criteria):
+//   - Migration runs idempotently
+//   - Create on fresh edge writes one row with valid_to=''
+//   - Create on existing edge closes prior + inserts new in one tx
+//   - Validation errors (invalid kinds, self-loop) surface clean errors
+//   - Remove closes current row; second call is a no-op
+//   - Remove writes by/reason to the closing row's attribution columns
+//   - ListOutgoing/ListIncoming return CURRENT edges only (valid_to='')
+//   - History returns chronological order (oldest first)
+//   - Walk respects edge_kind filter + max_depth clamp
+//   - Walk dedupes via UNION (multi-path nodes appear once)
+package relationships
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// openTestStore returns a fresh Store backed by a SQLite file in the
+// test's TempDir. WAL + busy_timeout are set per visceral rule #10
+// (consistent with how the other stores open their databases).
+func openTestStore(t *testing.T) *Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "rel.db") + "?_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	s, err := New(db)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return s
+}
+
+// mustCreate is a terse helper for tests that don't care about every
+// Edge field — fills in sensible defaults and fails the test on error.
+// Returns the Edge that was passed (with Metadata defaulted to "" if
+// the caller left it blank).
+func mustCreate(t *testing.T, s *Store, src, dst, kind string, opts ...func(*Edge)) Edge {
+	t.Helper()
+	e := Edge{
+		SrcKind:   KindManifest,
+		SrcID:     src,
+		DstKind:   KindManifest,
+		DstID:     dst,
+		Kind:      kind,
+		CreatedBy: "test",
+		Reason:    "test fixture",
+	}
+	for _, opt := range opts {
+		opt(&e)
+	}
+	if err := s.Create(context.Background(), e); err != nil {
+		t.Fatalf("Create(%s→%s, %s): %v", src, dst, kind, err)
+	}
+	return e
+}
+
+// ─── Migration ──────────────────────────────────────────────────────
+
+// TestNew_Idempotent — running the migration twice (or N times) must
+// not error. CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS
+// guarantee this; the test locks it in so a future change can't
+// accidentally regress.
+func TestNew_Idempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rel.db") + "?_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	for i := 0; i < 3; i++ {
+		if _, err := New(db); err != nil {
+			t.Fatalf("New iteration %d: %v", i, err)
+		}
+	}
+}
+
+// ─── Create ─────────────────────────────────────────────────────────
+
+// TestCreate_Fresh — a single Create with no prior row produces exactly
+// one row with valid_to='' (still current).
+func TestCreate_Fresh(t *testing.T) {
+	s := openTestStore(t)
+	mustCreate(t, s, "M1", "M2", EdgeDependsOn)
+
+	rows, err := s.ListOutgoing(context.Background(), "M1", EdgeDependsOn)
+	if err != nil {
+		t.Fatalf("ListOutgoing: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 outgoing row, got %d", len(rows))
+	}
+	if rows[0].DstID != "M2" || rows[0].ValidTo != "" {
+		t.Fatalf("unexpected row: %+v", rows[0])
+	}
+}
+
+// TestCreate_Replace — Create on an edge that already has a current row
+// closes the prior row + inserts a new current row, atomically. After
+// the second Create:
+//   - History has 2 rows total
+//   - Only ONE row has valid_to='' (the new one)
+//   - The closed row's valid_to equals the new row's valid_from (no gap)
+func TestCreate_Replace(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	mustCreate(t, s, "M1", "M2", EdgeDependsOn, func(e *Edge) {
+		e.Reason = "first version"
+	})
+	// Sleep 1ms so the second Create's now() ≠ the first's. Otherwise
+	// they'd share valid_from and the PK constraint would reject the
+	// second insert. Real callers won't hit this because production
+	// load doesn't insert at sub-millisecond precision; tests need a
+	// nudge.
+	time.Sleep(1 * time.Millisecond)
+	mustCreate(t, s, "M1", "M2", EdgeDependsOn, func(e *Edge) {
+		e.Reason = "second version"
+	})
+
+	hist, err := s.History(ctx, "M1", "M2", EdgeDependsOn)
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	if len(hist) != 2 {
+		t.Fatalf("expected 2 history rows, got %d", len(hist))
+	}
+	if hist[0].ValidTo == "" {
+		t.Fatalf("oldest row should be closed, got valid_to=''")
+	}
+	if hist[1].ValidTo != "" {
+		t.Fatalf("newest row should be current, got valid_to=%q", hist[1].ValidTo)
+	}
+	if hist[0].ValidTo != hist[1].ValidFrom {
+		t.Errorf("audit gap: closed row valid_to=%q != new valid_from=%q",
+			hist[0].ValidTo, hist[1].ValidFrom)
+	}
+}
+
+// TestCreate_ValidationErrors — invalid kinds + self-loops fail with
+// typed errors before reaching the DB. Schema CHECK would catch them
+// too, but the Go-side validation gives clearer attribution.
+func TestCreate_ValidationErrors(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name    string
+		edge    Edge
+		wantErr error
+	}{
+		{
+			name: "bad src_kind",
+			edge: Edge{SrcKind: "garbage", SrcID: "A", DstKind: KindManifest, DstID: "B", Kind: EdgeDependsOn},
+			wantErr: ErrInvalidKind,
+		},
+		{
+			name: "bad dst_kind",
+			edge: Edge{SrcKind: KindManifest, SrcID: "A", DstKind: "garbage", DstID: "B", Kind: EdgeDependsOn},
+			wantErr: ErrInvalidKind,
+		},
+		{
+			name: "bad edge kind",
+			edge: Edge{SrcKind: KindManifest, SrcID: "A", DstKind: KindManifest, DstID: "B", Kind: "garbage"},
+			wantErr: ErrInvalidKind,
+		},
+		{
+			name: "self-loop",
+			edge: Edge{SrcKind: KindManifest, SrcID: "A", DstKind: KindManifest, DstID: "A", Kind: EdgeDependsOn},
+			wantErr: ErrSelfLoop,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := s.Create(ctx, tc.edge)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("Create: want %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// ─── Remove ─────────────────────────────────────────────────────────
+
+// TestRemove_ClosesCurrent — Remove on an existing current edge sets
+// valid_to + writes the close-time by + reason into the row's
+// attribution columns. Subsequent ListOutgoing returns nothing (the
+// edge no longer exists at the current state).
+func TestRemove_ClosesCurrent(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	mustCreate(t, s, "M1", "M2", EdgeDependsOn)
+	if err := s.Remove(ctx, "M1", "M2", EdgeDependsOn, "alice", "no longer needed"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	out, err := s.ListOutgoing(ctx, "M1", EdgeDependsOn)
+	if err != nil {
+		t.Fatalf("ListOutgoing: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("expected 0 current outgoing, got %d", len(out))
+	}
+
+	hist, err := s.History(ctx, "M1", "M2", EdgeDependsOn)
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	if len(hist) != 1 {
+		t.Fatalf("expected 1 history row, got %d", len(hist))
+	}
+	if hist[0].ValidTo == "" {
+		t.Fatalf("row should be closed, got valid_to=''")
+	}
+	// Close-time attribution overwrites the original create-time values:
+	// the row's created_by + reason now describe the CLOSE event.
+	if hist[0].CreatedBy != "alice" || hist[0].Reason != "no longer needed" {
+		t.Errorf("close attribution lost: by=%q reason=%q",
+			hist[0].CreatedBy, hist[0].Reason)
+	}
+}
+
+// TestRemove_Idempotent — Remove on a non-existent edge is a no-op
+// success. Caller doesn't have to check "does this edge exist before
+// I try to remove it?" — we return nil regardless.
+func TestRemove_Idempotent(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	// Edge never created.
+	if err := s.Remove(ctx, "M1", "M2", EdgeDependsOn, "alice", "no-op"); err != nil {
+		t.Fatalf("Remove on missing edge: %v", err)
+	}
+	hist, _ := s.History(ctx, "M1", "M2", EdgeDependsOn)
+	if len(hist) != 0 {
+		t.Fatalf("Remove on missing edge wrote a phantom row: %+v", hist)
+	}
+}
+
+// ─── ListOutgoing / ListIncoming ────────────────────────────────────
+
+// TestListOutgoing_FiltersByEdgeKind — populating multiple edge kinds
+// from the same source and verifying the kind filter restricts results
+// correctly. Empty kind returns all kinds.
+func TestListOutgoing_FiltersByEdgeKind(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	mustCreate(t, s, "M1", "M2", EdgeDependsOn)
+	mustCreate(t, s, "M1", "T1", EdgeLinksTo, func(e *Edge) {
+		e.DstKind = KindTask
+	})
+	mustCreate(t, s, "M1", "M3", EdgeDependsOn)
+
+	// Kind-specific filter
+	deps, _ := s.ListOutgoing(ctx, "M1", EdgeDependsOn)
+	if len(deps) != 2 {
+		t.Errorf("expected 2 depends_on edges, got %d", len(deps))
+	}
+
+	links, _ := s.ListOutgoing(ctx, "M1", EdgeLinksTo)
+	if len(links) != 1 {
+		t.Errorf("expected 1 links_to edge, got %d", len(links))
+	}
+
+	// Empty kind = all
+	all, _ := s.ListOutgoing(ctx, "M1", "")
+	if len(all) != 3 {
+		t.Errorf("expected 3 total edges, got %d", len(all))
+	}
+}
+
+// TestListOutgoing_CurrentOnly — closed edges (valid_to != '') do NOT
+// appear in ListOutgoing. The partial index on valid_to='' is exactly
+// what makes this fast; the test locks in the correctness side.
+func TestListOutgoing_CurrentOnly(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	mustCreate(t, s, "M1", "M2", EdgeDependsOn)
+	if err := s.Remove(ctx, "M1", "M2", EdgeDependsOn, "alice", "removed"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	out, _ := s.ListOutgoing(ctx, "M1", EdgeDependsOn)
+	if len(out) != 0 {
+		t.Errorf("expected 0 current edges after Remove, got %d", len(out))
+	}
+}
+
+// TestListIncoming_ReverseDirection — ListIncoming finds edges by
+// dst_id rather than src_id. Useful for "who depends on this?" queries.
+func TestListIncoming_ReverseDirection(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	// Three manifests all depend on M0
+	mustCreate(t, s, "M1", "M0", EdgeDependsOn)
+	mustCreate(t, s, "M2", "M0", EdgeDependsOn)
+	mustCreate(t, s, "M3", "M0", EdgeDependsOn)
+
+	in, err := s.ListIncoming(ctx, "M0", EdgeDependsOn)
+	if err != nil {
+		t.Fatalf("ListIncoming: %v", err)
+	}
+	if len(in) != 3 {
+		t.Errorf("expected 3 incoming edges to M0, got %d", len(in))
+	}
+}
+
+// ─── History ────────────────────────────────────────────────────────
+
+// TestHistory_AscendingByValidFrom — multiple versions of one edge, in
+// chronological order. The closed row(s) come first, the current row
+// (if any) last.
+func TestHistory_AscendingByValidFrom(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	mustCreate(t, s, "M1", "M2", EdgeDependsOn)
+	time.Sleep(2 * time.Millisecond)
+	mustCreate(t, s, "M1", "M2", EdgeDependsOn, func(e *Edge) { e.Reason = "v2" })
+	time.Sleep(2 * time.Millisecond)
+	mustCreate(t, s, "M1", "M2", EdgeDependsOn, func(e *Edge) { e.Reason = "v3" })
+
+	hist, err := s.History(ctx, "M1", "M2", EdgeDependsOn)
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	if len(hist) != 3 {
+		t.Fatalf("expected 3 versions, got %d", len(hist))
+	}
+
+	// Confirm ordering: each row's valid_from should be ≤ the next's.
+	for i := 1; i < len(hist); i++ {
+		if hist[i-1].ValidFrom > hist[i].ValidFrom {
+			t.Errorf("history out of order at index %d: %s > %s",
+				i, hist[i-1].ValidFrom, hist[i].ValidFrom)
+		}
+	}
+	// Last row is current; first two are closed.
+	if hist[2].ValidTo != "" {
+		t.Errorf("expected last row current, got valid_to=%q", hist[2].ValidTo)
+	}
+	if hist[0].ValidTo == "" || hist[1].ValidTo == "" {
+		t.Errorf("expected first two rows closed, got valid_to='' on one")
+	}
+}
+
+// ─── Walk ───────────────────────────────────────────────────────────
+
+// TestWalk_BasicChain — A → B → C linear chain. Walk from A should
+// return all three nodes (A at depth 0, B at 1, C at 2).
+func TestWalk_BasicChain(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	mustCreate(t, s, "A", "B", EdgeDependsOn)
+	mustCreate(t, s, "B", "C", EdgeDependsOn)
+
+	rows, err := s.Walk(ctx, "A", KindManifest, []string{EdgeDependsOn}, 10)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 walk rows (A,B,C), got %d: %+v", len(rows), rows)
+	}
+
+	// Build a id→depth map for clearer assertions than positional.
+	depth := map[string]int{}
+	for _, r := range rows {
+		depth[r.ID] = r.Depth
+	}
+	if depth["A"] != 0 || depth["B"] != 1 || depth["C"] != 2 {
+		t.Errorf("unexpected depths: %v", depth)
+	}
+}
+
+// TestWalk_DepthClamp — maxDepth=1 should return root + direct
+// children only, not grandchildren.
+func TestWalk_DepthClamp(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	mustCreate(t, s, "A", "B", EdgeDependsOn)
+	mustCreate(t, s, "B", "C", EdgeDependsOn)
+
+	rows, err := s.Walk(ctx, "A", KindManifest, []string{EdgeDependsOn}, 1)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	ids := make([]string, 0, len(rows))
+	for _, r := range rows {
+		ids = append(ids, r.ID)
+	}
+	sort.Strings(ids)
+
+	want := []string{"A", "B"}
+	if len(ids) != len(want) || ids[0] != want[0] || ids[1] != want[1] {
+		t.Errorf("expected %v, got %v", want, ids)
+	}
+}
+
+// TestWalk_EdgeKindFilter — when multiple edge kinds exist, only the
+// requested kind is followed.
+func TestWalk_EdgeKindFilter(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	mustCreate(t, s, "P", "M", EdgeOwns, func(e *Edge) {
+		e.SrcKind = KindProduct
+		e.DstKind = KindManifest
+	})
+	mustCreate(t, s, "M", "T", EdgeDependsOn, func(e *Edge) {
+		e.SrcKind = KindManifest
+		e.DstKind = KindTask
+	})
+
+	// Walk from P following ONLY 'owns' should reach M but not T
+	// (the M→T edge is depends_on, filtered out).
+	rows, err := s.Walk(ctx, "P", KindProduct, []string{EdgeOwns}, 10)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	for _, r := range rows {
+		if r.ID == "T" {
+			t.Errorf("walk leaked through depends_on edge: reached T despite filter")
+		}
+	}
+	// Should have P and M.
+	if len(rows) != 2 {
+		t.Errorf("expected P + M only, got %d rows: %+v", len(rows), rows)
+	}
+}
+
+// TestWalk_DedupesViaUnion — diamond shape: A→B→D and A→C→D. UNION (not
+// UNION ALL) in the CTE means D appears exactly once in the walk
+// despite being reachable via two paths.
+func TestWalk_DedupesViaUnion(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	mustCreate(t, s, "A", "B", EdgeDependsOn)
+	mustCreate(t, s, "A", "C", EdgeDependsOn)
+	mustCreate(t, s, "B", "D", EdgeDependsOn)
+	mustCreate(t, s, "C", "D", EdgeDependsOn)
+
+	rows, err := s.Walk(ctx, "A", KindManifest, []string{EdgeDependsOn}, 10)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	// Count occurrences of each id; D should appear exactly once.
+	count := map[string]int{}
+	for _, r := range rows {
+		count[r.ID]++
+	}
+	if count["D"] != 1 {
+		t.Errorf("UNION dedupe failed — D appears %d times: %+v", count["D"], rows)
+	}
+	if len(rows) != 4 { // A, B, C, D
+		t.Errorf("expected 4 unique nodes (A,B,C,D), got %d", len(rows))
+	}
+}


### PR DESCRIPTION
## Summary

Lands the **Praxis Relationships** PR/M1 manifest end-to-end:
- New \`relationships\` SQLite table with SCD-2 lifecycle (rows are NEVER deleted; \`valid_to\` close marks supersession).
- Go store with 6 methods: \`Create\`, \`Remove\`, \`ListOutgoing\`, \`ListIncoming\`, \`History\`, \`Walk\` (recursive CTE).
- 6 MCP tools (\`rel_create\`, \`rel_remove\`, \`rel_list_outgoing\`, \`rel_list_incoming\`, \`rel_history\`, \`rel_walk\`).
- \`Node.Relationships\` wired in startup so the store is available everywhere.
- 15 unit tests covering every method + edge cases (idempotent migration, replace-via-close-then-insert, validation errors, audit trail attribution, list current-only, history chronology, walk depth clamp, walk kind filter, walk diamond-path dedupe).

**This PR is purely additive.** No existing code reads from or writes to \`relationships\` yet — that's PR/M2 (backfill + dual-write) and PR/M3 (read cutover + drop legacy). Today's 6 dep tables (\`product_dependencies\`, \`manifest_dependencies\`, \`task_dependency\`, \`task_manifests\`, \`tasks.depends_on\`, \`manifests.project_id\`, etc.) all stay untouched.

## Why

Edges between products / manifests / tasks today live in 6+ places. Walking a hierarchy = joining 6 tables. Cross-tier deps (manifest depending on a task) are structurally impossible. This consolidates all edges into one SCD-2 audit-trailed table with a single recursive-CTE walk.

Schema convention matches \`task_dependency\` + \`prompt_templates\` exactly: TEXT timestamps, empty-string \`''\` for "still current", close-then-insert, partial indexes on \`valid_to = ''\` for the hot path.

## Bugs caught by the test suite (already fixed in this PR)

1. \`time.RFC3339\` (second precision) collided on the composite PK under back-to-back Creates. Switched to \`time.RFC3339Nano\`.
2. Walk's args slice was \`[rootID, rootKind, maxDepth, kinds...]\` but the query expects \`[rootID, rootKind, kinds..., maxDepth]\`. SQLite silently bound maxDepth to the IN clause; walk returned only the root. Reordered + commented the trap.
3. SQL UNION dedup didn't catch diamond paths (different \`via_src\` keeps both rows). Added Go-side dedup by id, sorted by depth ASC so shortest-path wins.

## Schema doc updated

Posted addendum on **OpenPraxis Database Schema** product (\`019dbfb8-062\`) — comment \`019dc42b-9702\` documents the relationships table alongside the canonical schema doc.

## Test plan

- [x] \`go test ./internal/relationships/...\` — 15/15 green
- [x] \`go test ./...\` — full suite green, no regressions
- [x] \`make test-ui\` — 9/9 product-dag fixtures green
- [x] \`go build -o openpraxis ./\` — binary builds clean
- [ ] Local kick-the-tires: cd into worktree, run binary, exercise rel_* tools
- [ ] Merge after operator review

## What's NOT in this PR

- Backfill from existing dep tables (PR/M2 manifest \`019dc415-f03\`)
- Dual-write integration with existing stores (PR/M2)
- Read cutover (PR/M3 manifest \`019dc416-60d\`)
- Dropping legacy tables (PR/M3)
- MCP tools registered but not invoked by any internal code path; agents can call them but the dashboard still queries the legacy tables

Manifest: \`019dc415-7d1\` (Praxis Relationships PR/M1)
Product: \`019dc414-e79\` (Praxis Relationships)