### PR TITLE
fix(manifest): List(limit=0) is unbounded — fixes Tasks sidebar 'Unknown' labels

### DIFF
--- a/internal/manifest/list_unbounded_test.go
+++ b/internal/manifest/list_unbounded_test.go
@@ -1,0 +1,62 @@
+package manifest
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// TestList_LimitZeroIsUnbounded — regression test for the bulk-fetch
+// bug. Insert 75 manifests (more than the old 50-cap), call List("", 0),
+// expect 75 returned. Was: silently truncated to 50, breaking the
+// apiTasksByPeer bulk-fetch optimization which then synthesised
+// "Unknown" labels for tasks beyond the 50th manifest.
+func TestList_LimitZeroIsUnbounded(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "m.db") + "?_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	s, err := NewStore(db)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	const N = 75
+	for i := 0; i < N; i++ {
+		if _, err := s.Create("title", "", "", "open", "test", "node", "", "", nil, nil); err != nil {
+			t.Fatalf("Create %d: %v", i, err)
+		}
+	}
+
+	// limit=0: must return ALL manifests, not silently cap at 50.
+	all, err := s.List("", 0)
+	if err != nil {
+		t.Fatalf("List(0): %v", err)
+	}
+	if len(all) != N {
+		t.Errorf("limit=0 should return all %d manifests, got %d (was the bug)", N, len(all))
+	}
+
+	// Positive limit still caps as documented.
+	page, err := s.List("", 25)
+	if err != nil {
+		t.Fatalf("List(25): %v", err)
+	}
+	if len(page) != 25 {
+		t.Errorf("limit=25 should return 25 manifests, got %d", len(page))
+	}
+
+	// Negative limit defensively falls back to 50.
+	defensive, err := s.List("", -1)
+	if err != nil {
+		t.Fatalf("List(-1): %v", err)
+	}
+	if len(defensive) != 50 {
+		t.Errorf("limit<0 should fall back to 50, got %d", len(defensive))
+	}
+}

--- a/internal/manifest/store.go
+++ b/internal/manifest/store.go
@@ -242,9 +242,22 @@ func (s *Store) ListByProject(projectID string, limit int) ([]*Manifest, error) 
 }
 
 // List returns manifests sorted by updated_at.
+//
+// limit semantics:
+//   - limit > 0  → cap at that many rows
+//   - limit == 0 → UNBOUNDED (return every matching row). The caller is
+//     declaring "I want everything." Used by apiTasksByPeer's bulk-
+//     fetch optimization which needs every manifest to resolve task
+//     groupings; without unbounded support, the handler silently
+//     synthesised "Unknown" labels for tasks beyond the 50-row cap.
+//   - limit < 0  → defensively treated as 50 (likely a caller bug)
+//
+// Was: any limit <= 0 collapsed to 50, which silently truncated the
+// "give me all manifests" intent. 50-cap is fine for paginated views;
+// it broke the bulk-fetch caller. 2026-04-25.
 func (s *Store) List(status string, limit int) ([]*Manifest, error) {
-	if limit <= 0 {
-		limit = 50
+	if limit < 0 {
+		limit = 50 // defensive — negative is ambiguous, fall back to a sane cap
 	}
 
 	query := `SELECT id, title, description, content, status, jira_refs, tags, author, source_node, project_id, depends_on, version, created_at, updated_at FROM manifests WHERE deleted_at = ''`
@@ -255,8 +268,11 @@ func (s *Store) List(status string, limit int) ([]*Manifest, error) {
 		args = append(args, status)
 	}
 
-	query += ` ORDER BY CASE status WHEN 'draft' THEN 0 WHEN 'open' THEN 1 WHEN 'closed' THEN 2 WHEN 'archive' THEN 3 ELSE 4 END, updated_at DESC LIMIT ?`
-	args = append(args, limit)
+	query += ` ORDER BY CASE status WHEN 'draft' THEN 0 WHEN 'open' THEN 1 WHEN 'closed' THEN 2 WHEN 'archive' THEN 3 ELSE 4 END, updated_at DESC`
+	if limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, limit)
+	}
 
 	rows, err := s.db.Query(query, args...)
 	if err != nil {


### PR DESCRIPTION
Tasks sidebar showed every manifest beyond the 50th as "Unknown" because manifest.Store.List silently capped limit=0 at 50, breaking apiTasksByPeer's bulk-fetch optimization with 179 manifests in the DB. Honor 0 as unbounded. Regression test included.