### PR TITLE
chore(release): v0.4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build clean run test test-ui help
 
-VERSION ?= 0.4.0
+VERSION ?= 0.4.1
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS = -ldflags "-X github.com/k8nstantin/OpenPraxis/cmd.Version=$(VERSION) \


### PR DESCRIPTION
Version bump for the v0.4.1 patch release. 38 commits since v0.4.0 — see commit message for highlights. Tagged after merge.