### PR TITLE
feat(render): DV/M5 — render raw HTML + XML tags verbatim (no more agent/operator divergence)

### DIFF
--- a/internal/render/markdown.go
+++ b/internal/render/markdown.go
@@ -1,0 +1,64 @@
+// Package render is the markdown → HTML pipeline used by every dashboard
+// surface (product / manifest / task / idea / comment descriptions).
+//
+// Single-user, single-node policy: render whatever the operator + their
+// agents wrote. Raw HTML and custom XML-shaped tags (<role>, <scope>,
+// <calibration>, …) pass through verbatim so the dashboard shows EXACTLY
+// what the agent will receive — no render divergence between human and
+// agent view of the same body.
+//
+// Threat model: there isn't one in v1. There's one user (the operator) on
+// a local node; everything in the database is content the operator or
+// their agents wrote. If multi-user / multi-tenant ever lands, we'll add a
+// trust-aware sanitizer back (see DV/M5 manifest 019dc953-b12 for the
+// design we deferred).
+package render
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+	rendererhtml "github.com/yuin/goldmark/renderer/html"
+)
+
+var (
+	once sync.Once
+	md   goldmark.Markdown
+)
+
+func initRenderer() {
+	md = goldmark.New(
+		goldmark.WithExtensions(extension.GFM),
+		goldmark.WithRendererOptions(
+			rendererhtml.WithXHTML(),
+			rendererhtml.WithUnsafe(), // raw HTML / custom tags pass through
+		),
+	)
+}
+
+// Render converts a markdown body to HTML, preserving raw HTML and custom
+// XML-shaped tags verbatim. On goldmark error falls back to the body
+// wrapped in an escaped <p> so the caller never has to handle a
+// partial-render path.
+func Render(body string) string {
+	once.Do(initRenderer)
+
+	var buf bytes.Buffer
+	if err := md.Convert([]byte(body), &buf); err != nil {
+		return "<p>" + escape(body) + "</p>"
+	}
+	return buf.String()
+}
+
+func escape(s string) string {
+	return strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		`"`, "&quot;",
+		"'", "&#39;",
+	).Replace(s)
+}

--- a/internal/render/markdown_test.go
+++ b/internal/render/markdown_test.go
@@ -1,0 +1,109 @@
+package render
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRender_KeepsStructuralAgentTags(t *testing.T) {
+	body := "<role>You are a reviewer</role>\n\n<scope>review the diff</scope>\n\n## Heading\n- bullet"
+	got := Render(body)
+	for _, want := range []string{"<role>", "</role>", "<scope>", "</scope>", "<h2>Heading</h2>", "<li>bullet</li>"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in output; got: %q", want, got)
+		}
+	}
+}
+
+func TestRender_KeepsAllPromptTags(t *testing.T) {
+	// Block-level: each tag on its own line so goldmark sees them as HTML blocks.
+	body := "<role>R</role>\n\n<scope>S</scope>\n\n<calibration>C</calibration>\n\n<reference>X</reference>\n\n<context>K</context>"
+	got := Render(body)
+	for _, tag := range []string{"<role>", "<scope>", "<calibration>", "<reference>", "<context>"} {
+		if !strings.Contains(got, tag) {
+			t.Errorf("expected %q; got: %q", tag, got)
+		}
+	}
+}
+
+func TestRender_KeepsXMLLikeNestedStructure(t *testing.T) {
+	// Realistic agent prompt shape — the actual case from the React T2
+	// descriptions that triggered DV/M5.
+	body := `<role>
+You are an experienced developer reviewing the React/Products tab.
+</role>
+
+<scope>
+- Read the work delivered in T1
+- Run the watcher audit
+</scope>
+
+<calibration>
+Push back on premature abstractions.
+</calibration>`
+	got := Render(body)
+	for _, want := range []string{
+		"<role>", "</role>",
+		"<scope>", "</scope>",
+		"<calibration>", "</calibration>",
+		"experienced developer",
+		"watcher audit",
+		"premature abstractions",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in agent-prompt-shaped output; got: %q", want, got)
+		}
+	}
+}
+
+func TestRender_MarkdownHeadingsWork(t *testing.T) {
+	got := Render("# H1\n\n## H2\n\n- bullet")
+	for _, want := range []string{"<h1>H1</h1>", "<h2>H2</h2>", "<li>bullet</li>"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q; got: %q", want, got)
+		}
+	}
+}
+
+func TestRender_GFMTablesWork(t *testing.T) {
+	got := Render("| a | b |\n|---|---|\n| 1 | 2 |")
+	if !strings.Contains(got, "<table>") {
+		t.Fatalf("GFM tables must render; got: %q", got)
+	}
+}
+
+func TestRender_CodeBlocksWork(t *testing.T) {
+	got := Render("```go\nfunc f() {}\n```")
+	if !strings.Contains(got, "<pre>") || !strings.Contains(got, "<code") {
+		t.Fatalf("code blocks must render; got: %q", got)
+	}
+}
+
+func TestRender_DetailsAndSummary(t *testing.T) {
+	body := "<details><summary>click</summary>hidden</details>"
+	got := Render(body)
+	for _, want := range []string{"<details>", "<summary>click</summary>"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q; got: %q", want, got)
+		}
+	}
+}
+
+func TestRender_InlineHTMLPassesThrough(t *testing.T) {
+	// Mixed markdown + inline raw HTML — both should render.
+	got := Render("**bold** and <em>italic</em> together")
+	for _, want := range []string{"<strong>bold</strong>", "<em>italic</em>"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q; got: %q", want, got)
+		}
+	}
+}
+
+func TestRender_EmptyInput(t *testing.T) {
+	got := Render("")
+	if got != "" {
+		// Empty input may yield empty body — verify we don't panic and
+		// don't emit unexpected wrappers.
+		t.Logf("empty input produced: %q", got)
+	}
+}

--- a/internal/web/handlers_comments.go
+++ b/internal/web/handlers_comments.go
@@ -1,7 +1,6 @@
 package web
 
 import (
-	"bytes"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -12,23 +11,10 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/yuin/goldmark"
-	"github.com/yuin/goldmark/extension"
-	"github.com/yuin/goldmark/renderer/html"
 
 	"github.com/k8nstantin/OpenPraxis/internal/comments"
 	"github.com/k8nstantin/OpenPraxis/internal/node"
-)
-
-// markdownRenderer is the shared goldmark instance used to render comment
-// bodies to HTML. GFM extensions are enabled (tables, task lists, strike,
-// autolinks). Raw HTML in source is ALWAYS escaped — html.WithUnsafe() is
-// deliberately omitted. See TestPOST_Comment_XSSEscape.
-var markdownRenderer = goldmark.New(
-	goldmark.WithExtensions(extension.GFM),
-	goldmark.WithRendererOptions(
-		html.WithXHTML(),
-	),
+	"github.com/k8nstantin/OpenPraxis/internal/render"
 )
 
 // EnrichWithHTML augments an entity payload with rendered HTML fields so
@@ -55,27 +41,13 @@ func EnrichWithHTML(entity any, mdFields map[string]string) map[string]any {
 	return out
 }
 
-// renderMarkdown converts a raw comment body to safe HTML. Returns the raw
-// body wrapped in a <p> on goldmark error so the UI always has something to
-// display.
+// renderMarkdown converts a raw body to HTML via the shared renderer in
+// internal/render. Raw HTML and custom XML-shaped tags (<role>, <scope>,
+// <calibration>, …) pass through verbatim — see DV/M5 (019dc953-b12) for
+// why we eliminated the strip-by-default pipeline that mangled
+// agent-authored prompts.
 func renderMarkdown(src string) string {
-	var buf bytes.Buffer
-	if err := markdownRenderer.Convert([]byte(src), &buf); err != nil {
-		return "<p>" + escapeHTML(src) + "</p>"
-	}
-	return buf.String()
-}
-
-// escapeHTML is a tiny helper for the renderMarkdown fallback path.
-func escapeHTML(s string) string {
-	r := strings.NewReplacer(
-		"&", "&amp;",
-		"<", "&lt;",
-		">", "&gt;",
-		`"`, "&quot;",
-		"'", "&#39;",
-	)
-	return r.Replace(s)
+	return render.Render(src)
 }
 
 // M2-T5 — HTTP surface for comments. Thin wrapper over comments.Store;

--- a/internal/web/handlers_comments_test.go
+++ b/internal/web/handlers_comments_test.go
@@ -428,26 +428,26 @@ func TestPOST_Comment_BodyHTMLGFMTable(t *testing.T) {
 	}
 }
 
-// TestPOST_Comment_XSSEscape is the acceptance-criteria XSS test: raw
-// <script> in body must be escaped in body_html.
-func TestPOST_Comment_XSSEscape(t *testing.T) {
+// TestPOST_Comment_RawHTMLPassesThrough — DV/M5 reverses the prior
+// XSS-strip behavior. Single-user, single-node OpenPraxis renders raw
+// HTML / custom tags verbatim so the operator's view matches what their
+// agents will consume. If / when multi-user lands, the trust-tier
+// sanitizer designed in DV/M5's manifest comes back and a new test
+// asserts the strip behavior under the appropriate trust level.
+func TestPOST_Comment_RawHTMLPassesThrough(t *testing.T) {
 	env := newCommentsTestEnv(t)
 	resp, body := env.do(t, "POST", "/api/products/p1/comments", addCommentRequest{
 		Author: "a", Type: string(comments.TypeUserNote),
-		Body: "<script>alert(1)</script>",
+		Body: "<role>reviewer</role>\n\n<scope>verify</scope>",
 	})
 	if resp.StatusCode != 200 {
 		t.Fatalf("status: %d body=%s", resp.StatusCode, body)
 	}
 	c := decodeComment(t, body)
-	// goldmark with WithUnsafe() OFF drops raw HTML entirely (replaces with
-	// an "<!-- raw HTML omitted -->" comment). The security property we
-	// enforce: no executable <script> tag survives into body_html.
-	if strings.Contains(c.BodyHTML, "<script>") {
-		t.Fatalf("raw <script> tag leaked into body_html: %q", c.BodyHTML)
-	}
-	if strings.Contains(c.BodyHTML, "alert(1)") {
-		t.Fatalf("script payload leaked into body_html: %q", c.BodyHTML)
+	for _, want := range []string{"<role>", "</role>", "<scope>", "</scope>"} {
+		if !strings.Contains(c.BodyHTML, want) {
+			t.Fatalf("expected %q in body_html (DV/M5 pass-through); got: %q", want, c.BodyHTML)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the render-divergence bug where the operator's view of a description differs from the body the agent will actually receive. Goldmark's default strips raw HTML for XSS protection — correct in a multi-tenant world, wrong for OpenPraxis (single-user, single-node), where it silently mangles agent-authored prompts using structured tags like `<role>`, `<scope>`, `<calibration>`.

The 18 React/* T2 task descriptions written this session demonstrated the bug: operators saw a single orphan "Validate:" list while agents received the full senior-reviewer prompt. Approving / rejecting based on what the operator sees is unreliable when the operator can't see what the agent actually consumes.

## What changed

- **New `internal/render` package** — single `Render(body)` function: goldmark + GFM + `WithUnsafe()`, no sanitizer, no trust derivation. Raw HTML and custom XML-shaped tags pass through verbatim.
- **`handlers_comments.go`** — drops the local `markdownRenderer` + `renderMarkdown` + `escapeHTML` helpers, delegates to `render.Render`. Every existing dashboard surface (product / manifest / task / idea / comment) picks up the new behavior automatically because `EnrichWithHTML` calls through `renderMarkdown`.
- **Retired `TestPOST_Comment_XSSEscape`** — asserted the old strip-by-default behavior. Replaced with `TestPOST_Comment_RawHTMLPassesThrough`.

## Threat model

There isn't one in v1. There's one user (the operator) on a local node; everything in the database is content the operator or their agents wrote. The `bluemonday` trust-tier sanitizer designed earlier in this branch was deferred — if / when multi-user / peer-shared rendering lands, see manifest [`DV/M5` (019dc953-b12)](https://localhost:8765/dashboard/manifests) for the design we shelved.

## Verification

- `go test ./internal/render/...` → 9 tests green (structural tags, all prompt tags, realistic agent prompt body, markdown headings, GFM tables, code blocks, `<details>`/`<summary>`, mixed inline HTML)
- `go test ./internal/web/...` → green (incl. the new pass-through test)
- After merge + serve restart: re-PATCH any of the 18 React/* T2 task descriptions and the `<role>`/`<scope>`/`<calibration>` blocks render visibly in the dashboard, identical to what the agent receives.

## Test plan

- [x] `go test ./internal/render/...` green
- [x] `go test ./internal/web/...` green
- [x] `go build ./...` clean
- [ ] CI green
- [ ] After merge: hard-refresh dashboard on a React/* T2 detail and confirm the senior-reviewer prompt renders fully

🤖 Generated with [Claude Code](https://claude.com/claude-code)