### PR TITLE
feat(dashboard): Markup / Rendered toggle on descriptions

### DIFF
--- a/internal/web/ui/components/desc-toggle.js
+++ b/internal/web/ui/components/desc-toggle.js
@@ -1,0 +1,106 @@
+// Description / content view toggle — Markup vs Rendered.
+//
+// DV/M5 + #238 made agent-authored XML markup render as styled blocks
+// in the dashboard. But operators iterating on prompts want to see the
+// raw text the agent will receive, NOT the prettified version. This
+// component renders both views into the same surface and lets the
+// operator flip between them with two buttons; the choice persists
+// in localStorage so future loads default to whatever the operator
+// last picked.
+//
+// Default is "markup" (raw). The agent-readable surface is the source
+// of truth; the rendered view is a non-techie convenience.
+//
+// Usage:
+//   container.innerHTML = OL.descToggle(rawText, renderedHTML, opts)
+// where opts = { id?, className?, style? }.
+
+(function () {
+  'use strict';
+  var STORAGE_KEY = 'descMode';
+
+  function getMode() {
+    try {
+      return window.localStorage.getItem(STORAGE_KEY) || 'markup';
+    } catch (_) {
+      return 'markup';
+    }
+  }
+
+  function setMode(mode) {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, mode);
+    } catch (_) { /* localStorage disabled — non-fatal */ }
+  }
+
+  function descToggle(rawText, renderedHTML, opts) {
+    opts = opts || {};
+    var id = opts.id || ('desc-' + Math.random().toString(36).slice(2, 9));
+    var className = opts.className || 'md-body';
+    var style = opts.style || '';
+    var mode = getMode();
+
+    // Defensive: when raw is missing, render empty placeholder.
+    var raw = rawText == null ? '' : String(rawText);
+    var rendered = renderedHTML == null ? '' : String(renderedHTML);
+
+    return ''
+      + '<div class="desc-toggle-wrap" data-desc-id="' + id + '">'
+      +   '<div class="desc-toggle-controls">'
+      +     '<button class="desc-toggle-btn ' + (mode === 'markup' ? 'active' : '') + '" '
+      +            'data-mode="markup" data-target="' + id + '" type="button">Markup</button>'
+      +     '<button class="desc-toggle-btn ' + (mode === 'rendered' ? 'active' : '') + '" '
+      +            'data-mode="rendered" data-target="' + id + '" type="button">Rendered</button>'
+      +   '</div>'
+      +   '<pre id="' + id + '-markup" class="desc-markup" '
+      +        'style="display:' + (mode === 'markup' ? 'block' : 'none') + '">'
+      +     OL.esc(raw)
+      +   '</pre>'
+      +   '<div id="' + id + '-rendered" class="' + className + '" '
+      +        'style="display:' + (mode === 'rendered' ? 'block' : 'none') + ';' + style + '">'
+      +     rendered
+      +   '</div>'
+      + '</div>';
+  }
+
+  // Single delegated click handler. Survives view re-renders because
+  // it lives on document; new toggle wraps inserted later inherit it.
+  document.addEventListener('click', function (e) {
+    var btn = e.target.closest && e.target.closest('.desc-toggle-btn');
+    if (!btn) return;
+    var mode = btn.dataset.mode;
+    var targetId = btn.dataset.target;
+    var wrap = btn.closest('.desc-toggle-wrap');
+    if (!wrap || !mode || !targetId) return;
+
+    // Update active state on both buttons in this wrap.
+    wrap.querySelectorAll('.desc-toggle-btn').forEach(function (b) {
+      b.classList.toggle('active', b.dataset.mode === mode);
+    });
+    // Show/hide bodies.
+    var markupEl = document.getElementById(targetId + '-markup');
+    var renderedEl = document.getElementById(targetId + '-rendered');
+    if (markupEl) markupEl.style.display = mode === 'markup' ? 'block' : 'none';
+    if (renderedEl) renderedEl.style.display = mode === 'rendered' ? 'block' : 'none';
+
+    setMode(mode);
+
+    // If other toggles exist on the page, sync them so the whole
+    // dashboard reflects the operator's preferred view.
+    document.querySelectorAll('.desc-toggle-wrap').forEach(function (w) {
+      if (w === wrap) return;
+      var otherId = w.dataset.descId;
+      if (!otherId) return;
+      w.querySelectorAll('.desc-toggle-btn').forEach(function (b) {
+        b.classList.toggle('active', b.dataset.mode === mode);
+      });
+      var om = document.getElementById(otherId + '-markup');
+      var or_ = document.getElementById(otherId + '-rendered');
+      if (om) om.style.display = mode === 'markup' ? 'block' : 'none';
+      if (or_) or_.style.display = mode === 'rendered' ? 'block' : 'none';
+    });
+  });
+
+  window.OL = window.OL || {};
+  window.OL.descToggle = descToggle;
+})();

--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -772,6 +772,7 @@
   <script src="/task-status.js"></script>
   <script src="/tree.js"></script>
   <script src="/lifecycle.js"></script>
+  <script src="/components/desc-toggle.js"></script>
   <script src="/components/editor.js"></script>
   <script src="/components/knobs.js"></script>
   <script src="/components/comments.js"></script>

--- a/internal/web/ui/style.css
+++ b/internal/web/ui/style.css
@@ -1498,6 +1498,54 @@ mark {
 .md-body th { background: var(--bg-secondary); font-weight: 600; }
 .md-body hr { border: none; border-top: 1px solid var(--border); margin: 12px 0; }
 
+/* Description / content view toggle — Markup (default, raw text the
+   agent receives) vs Rendered (pretty view for non-tech readers).
+   See internal/web/ui/components/desc-toggle.js. */
+.desc-toggle-wrap { width: 100%; }
+.desc-toggle-controls {
+  display: flex;
+  justify-content: flex-end;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+.desc-toggle-btn {
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 3px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  font-family: var(--font-sans);
+}
+.desc-toggle-btn:hover {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+.desc-toggle-btn.active {
+  background: var(--accent);
+  color: var(--bg-primary);
+  border-color: var(--accent);
+}
+.desc-markup {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 10px 12px;
+  margin: 0;
+  overflow-x: auto;
+  max-height: 400px;
+}
+
 /* Agent prompt structural tags — DV/M5 (PR #237) lets agents author
    with semantic XML-shaped tags (<role>, <scope>, <calibration>, …)
    that pass through goldmark verbatim. Browsers render unknown

--- a/internal/web/ui/views/ideas.js
+++ b/internal/web/ui/views/ideas.js
@@ -152,8 +152,10 @@
             '<button class="btn-dismiss btn-action" onclick="OL.archiveIdea(\'' + esc(idea.id) + '\')">Archive</button>' +
           '</div>' +
           '<div id="idea-revisions-mount" style="margin-bottom:12px"></div>' +
-          '<div id="idea-desc-display" class="md-body" style="margin-bottom:12px">' +
-            (idea.description ? (idea.description_html || esc(idea.description)) : '<span style="color:var(--text-muted);font-style:italic">No description — click Edit to add</span>') +
+          '<div id="idea-desc-display" style="margin-bottom:12px">' +
+            (idea.description
+              ? OL.descToggle(idea.description, idea.description_html || esc(idea.description), { className: 'md-body' })
+              : '<span style="color:var(--text-muted);font-style:italic">No description — click Edit to add</span>') +
           '</div>' +
           '<div id="idea-desc-editor" style="display:none;margin-bottom:12px">' +
             '<textarea id="idea-desc-textarea" class="conv-search" style="width:100%;min-height:240px;font-family:var(--font-mono);font-size:13px;padding:10px;resize:vertical;line-height:1.5">' + esc(idea.description || '') + '</textarea>' +

--- a/internal/web/ui/views/manifests.js
+++ b/internal/web/ui/views/manifests.js
@@ -455,7 +455,7 @@
           <div style="margin-bottom:4px">
             <span style="font-size:12px;color:var(--text-muted);font-weight:500">Declaration</span>
           </div>
-          <div id="manifest-content-display" class="manifest-content md-body">${m.content_html || esc(m.content)}</div>
+          <div id="manifest-content-display" class="manifest-content">${OL.descToggle(m.content, m.content_html || esc(m.content), { className: 'md-body' })}</div>
           <div id="manifest-content-editor" style="display:none;margin-bottom:12px">
             <textarea id="manifest-content-textarea" class="conv-search" style="width:100%;min-height:300px;font-family:monospace;font-size:13px;padding:12px;resize:vertical;line-height:1.5">${esc(m.content)}</textarea>
             <div style="margin-top:6px;display:flex;gap:8px">

--- a/internal/web/ui/views/products.js
+++ b/internal/web/ui/views/products.js
@@ -391,7 +391,7 @@
             }).join('')}
           </div>
           <div id="product-revisions-mount" style="margin-bottom:12px"></div>
-          ${p.description ? `<div class="md-body" style="margin-bottom:12px">${p.description_html || esc(p.description)}</div>` : ''}
+          ${p.description ? `<div style="margin-bottom:12px">${OL.descToggle(p.description, p.description_html || esc(p.description), { className: 'md-body' })}</div>` : ''}
           ${productDepsHtml}
           ${manifestsHtml}
           <div id="product-knobs-mount" style="margin-top:16px"></div>

--- a/internal/web/ui/views/tasks.js
+++ b/internal/web/ui/views/tasks.js
@@ -478,7 +478,9 @@
             </div>
             <div id="task-instructions-display">
               ${t.description
-                ? `<div class="md-body" style="padding:10px 12px;border:1px solid var(--border);border-radius:6px;background:var(--bg-secondary);max-height:400px;overflow-y:auto">${t.description_html || esc(t.description)}</div>`
+                ? OL.descToggle(t.description, t.description_html || esc(t.description), {
+                    style: 'padding:10px 12px;border:1px solid var(--border);border-radius:6px;background:var(--bg-secondary);max-height:400px;overflow-y:auto'
+                  })
                 : `<div style="font-size:12px;color:var(--text-muted);font-style:italic">No instructions</div>`}
             </div>
             <div id="task-instructions-editor" style="display:none">


### PR DESCRIPTION
## Summary

Default view is now the raw markup the agent receives — operators iterating on prompts see exactly what gets sent. A "Rendered" toggle flips to the goldmark+CSS pretty view for non-tech readers ("so my mama can read the shit").

## Where it applies

- Task instructions (Tasks tab detail)
- Manifest content (Manifests tab detail)
- Product description (Products tab detail)
- Idea description (Ideas tab detail)

## How it works

- New `internal/web/ui/components/desc-toggle.js` exposes `OL.descToggle(rawText, renderedHTML, opts)` returning a wrap with two buttons (Markup / Rendered) and both bodies; one global click handler swaps `display: block`/`none`.
- `localStorage` key `descMode` persists the choice. Default is `markup` (the agent's source of truth).
- Multiple toggles on the same page sync so the whole dashboard reflects the operator's preference.
- `.desc-markup` uses `var(--font-mono)` + `white-space: pre-wrap` so XML tags render as visible text — exactly what the agent receives.

## Test plan

- [x] `go build ./...` clean
- [ ] Hard-refresh dashboard on Tasks tab, open Products T2 — Markup mode shows literal `<role>` / `<scope>` tags
- [ ] Click "Rendered" — switches to the labeled blocks (DV/M5 + PR #238 styling)
- [ ] Refresh page — preference persists
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)