### PR TITLE
fix(react/products css): port legacy visual language

### DIFF
--- a/internal/web/ui/dashboard/src/styles.css
+++ b/internal/web/ui/dashboard/src/styles.css
@@ -1,81 +1,137 @@
+/* OpenPraxis dashboard v2 — React app styling.
+   Pulls visual language from internal/web/ui/style.css (legacy) so the
+   new surface feels like the same product. Design tokens match the
+   legacy ones; component styles are simplified for the React shell. */
+
 :root {
   --bg-primary: #0f0f17;
   --bg-secondary: #1a1a26;
+  --bg-elevated: #20202d;
+  --bg-input: #15151f;
   --border: #2a2a3a;
+  --border-subtle: #1f1f2c;
   --text-primary: #e4e4f0;
   --text-secondary: #c4c4d4;
   --text-muted: #8888a0;
   --accent: #6db8ff;
+  --accent-soft: rgba(109, 184, 255, 0.12);
+  --accent-strong: rgba(109, 184, 255, 0.22);
   --green: #00d97e;
   --yellow: #f5c542;
   --red: #e63757;
   --purple: #8b5cf6;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
 }
 
 * { box-sizing: border-box; }
+html, body, #app { height: 100%; }
+
 body {
   margin: 0;
   background: var(--bg-primary);
   color: var(--text-primary);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  font-family: var(--font-sans);
   font-size: 14px;
   line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-.page-loading, .empty-state {
-  padding: 16px;
+/* ───────────────── Loading / empty states ───────────────── */
+
+.page-loading,
+.empty-state {
+  padding: 24px;
   color: var(--text-muted);
   font-size: 13px;
 }
-.empty-state.error { color: var(--red); }
+.empty-state.error {
+  color: var(--red);
+  background: rgba(230, 55, 87, 0.06);
+  border: 1px solid rgba(230, 55, 87, 0.25);
+  border-radius: var(--radius-md);
+  padding: 12px 16px;
+}
+
+/* ───────────────── Home ───────────────── */
 
 .page-home {
   max-width: 720px;
-  margin: 48px auto;
+  margin: 64px auto;
   padding: 0 24px;
 }
-.page-home h1 { margin: 0 0 16px 0; }
-.page-home a { color: var(--accent); }
+.page-home h1 {
+  margin: 0 0 16px 0;
+  font-size: 22px;
+  font-weight: 600;
+}
+.page-home a { color: var(--accent); text-decoration: none; }
+.page-home a:hover { text-decoration: underline; }
+
+/* ───────────────── Products page ───────────────── */
 
 .page-products {
   display: grid;
   grid-template-columns: 360px 1fr;
   height: 100vh;
+  background: var(--bg-primary);
 }
+
 .products-sidebar {
   border-right: 1px solid var(--border);
   overflow-y: auto;
-  padding: 12px;
+  padding: 14px 12px 24px;
+  background: var(--bg-primary);
 }
+.products-sidebar::-webkit-scrollbar { width: 8px; }
+.products-sidebar::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
+.products-sidebar::-webkit-scrollbar-track { background: transparent; }
+
 .sidebar-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 8px;
+  margin: 0 4px 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border-subtle);
 }
-.btn-new {
-  background: transparent;
-  border: 1px solid var(--border);
-  color: var(--text-primary);
-  padding: 4px 12px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 12px;
+.sidebar-header h2 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
 }
-.btn-new:hover { border-color: var(--accent); color: var(--accent); }
 
+/* ── Tree ── */
+
+.tree-node { display: block; }
 .tree-row {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 8px;
+  padding: 6px 10px 6px 6px;
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   outline: none;
+  border-left: 3px solid transparent;
+  font-size: 13px;
+  user-select: none;
+  transition: background 80ms ease;
 }
-.tree-row:focus { background: rgba(109,184,255,0.08); }
-.tree-row:hover { background: rgba(109,184,255,0.06); }
-.tree-row.is-selected { background: rgba(109,184,255,0.18); }
+.tree-row:focus { background: var(--accent-soft); }
+.tree-row:hover { background: rgba(255, 255, 255, 0.03); }
+.tree-row.is-selected {
+  background: var(--accent-soft);
+  border-left-color: var(--accent);
+}
+.tree-row.is-selected .tree-label { color: var(--text-primary); }
+
 .tree-chevron {
   display: inline-block;
   width: 14px;
@@ -83,11 +139,36 @@ body {
   color: var(--text-muted);
   font-size: 11px;
   user-select: none;
+  cursor: pointer;
 }
+.tree-chevron:hover { color: var(--text-primary); }
 .tree-chevron.is-empty { visibility: hidden; }
-.tree-label { flex: 1; }
-.tree-extra { color: var(--text-muted); font-size: 12px; display: flex; gap: 6px; }
-.tree-content { padding: 4px 0; }
+
+.tree-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-secondary);
+}
+.tree-extra {
+  color: var(--text-muted);
+  font-size: 11px;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-shrink: 0;
+}
+.tree-content { padding: 2px 0 4px; }
+
+.product-title {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Status dots & badges ── */
 
 .status-dot {
   display: inline-block;
@@ -96,6 +177,8 @@ body {
   border-radius: 50%;
   background: var(--text-muted);
   margin-right: 6px;
+  flex-shrink: 0;
+  box-shadow: 0 0 0 2px var(--bg-primary);
 }
 .status-dot.status-open { background: var(--green); }
 .status-dot.status-closed { background: var(--text-muted); }
@@ -103,76 +186,191 @@ body {
 .status-dot.status-draft { background: var(--yellow); }
 
 .marker {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
+  font-family: var(--font-mono);
+  font-size: 10px;
   color: var(--text-muted);
+  letter-spacing: -0.02em;
 }
+
 .count {
   background: var(--border);
   color: var(--text-secondary);
-  padding: 0 6px;
-  border-radius: 8px;
+  padding: 1px 7px;
+  border-radius: 9px;
   font-size: 10px;
   font-weight: 600;
+  letter-spacing: 0.02em;
+  min-width: 18px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
 }
 .count.count-sub { background: var(--purple); color: #fff; }
 
-.products-detail {
-  overflow-y: auto;
-  padding: 24px;
-}
-.product-header h1 { margin: 0 0 12px 0; }
-.meta-row, .stats, .toolbar {
-  display: flex;
-  gap: 12px;
-  align-items: center;
-  flex-wrap: wrap;
-  margin-bottom: 12px;
-}
 .badge {
   background: var(--bg-secondary);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   padding: 2px 8px;
-  font-size: 11px;
+  font-size: 10px;
   text-transform: uppercase;
   font-weight: 600;
+  letter-spacing: 0.06em;
   color: var(--text-secondary);
+  font-family: var(--font-sans);
+  white-space: nowrap;
 }
-.badge.status-open { color: var(--green); border-color: var(--green); }
+.badge.status-open { color: var(--green); border-color: var(--green); background: rgba(0, 217, 126, 0.08); }
 .badge.status-closed { color: var(--text-muted); }
-.badge.status-archive { color: var(--red); border-color: var(--red); }
-.badge.status-draft { color: var(--yellow); border-color: var(--yellow); }
-.badge.tag { color: var(--accent); border-color: var(--accent); }
+.badge.status-archive { color: var(--red); border-color: var(--red); background: rgba(230, 55, 87, 0.08); }
+.badge.status-draft { color: var(--yellow); border-color: var(--yellow); background: rgba(245, 197, 66, 0.06); }
+.badge.tag { color: var(--accent); border-color: rgba(109, 184, 255, 0.5); background: var(--accent-soft); }
 
-.toolbar button {
+/* ── Buttons ── */
+
+.btn-new,
+.toolbar button,
+.dag-overlay-header button {
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   color: var(--text-primary);
-  padding: 6px 12px;
-  border-radius: 4px;
+  padding: 5px 12px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: 12px;
+  font-family: var(--font-sans);
+  transition: border-color 80ms ease, color 80ms ease, background 80ms ease;
+  white-space: nowrap;
 }
-.toolbar button:hover { border-color: var(--accent); color: var(--accent); }
+.btn-new:hover,
+.toolbar button:hover,
+.dag-overlay-header button:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+.btn-new:active,
+.toolbar button:active,
+.dag-overlay-header button:active { background: var(--accent-strong); }
+
+/* ── Detail panel ── */
+
+.products-detail {
+  overflow-y: auto;
+  padding: 24px 32px 48px;
+}
+.products-detail::-webkit-scrollbar { width: 10px; }
+.products-detail::-webkit-scrollbar-thumb { background: var(--border); border-radius: 5px; }
+
+.product-detail-body { max-width: 1080px; }
+
+.product-header {
+  margin-bottom: 24px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.product-header h1 {
+  margin: 0 0 10px 0;
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+}
+
+.meta-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+}
+
+.stats {
+  display: flex;
+  gap: 12px;
+  align-items: stretch;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+.stats > span {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 14px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  min-width: 88px;
+}
+.stats strong {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-transform: none;
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.toolbar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
 
 .product-description {
   white-space: pre-wrap;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 12px 16px;
+  border-radius: var(--radius-md);
+  padding: 14px 18px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  margin: 16px 0;
 }
 
-.linked-manifests h3 { margin: 24px 0 8px; font-size: 14px; }
+/* ── Linked manifests ── */
+
+.linked-manifests { margin-top: 28px; }
+.linked-manifests h3 {
+  margin: 0 0 12px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+}
 .manifest-row {
   display: flex;
   gap: 12px;
   align-items: center;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--border);
+  padding: 10px 14px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  margin-bottom: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: border-color 80ms ease, background 80ms ease;
 }
-.manifest-row:hover { background: rgba(109,184,255,0.06); }
+.manifest-row:hover {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.manifest-row .marker { flex-shrink: 0; min-width: 92px; }
+.manifest-title {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+}
+
+/* ── DAG overlay ── */
 
 .dag-overlay {
   position: fixed;
@@ -184,22 +382,34 @@ body {
 }
 .dag-overlay-header {
   display: flex;
-  gap: 12px;
+  gap: 14px;
   align-items: center;
   padding: 12px 20px;
   border-bottom: 1px solid var(--border);
   background: var(--bg-secondary);
+  font-size: 13px;
+  color: var(--text-secondary);
 }
-.dag-overlay-header button {
-  background: var(--bg-primary);
-  border: 1px solid var(--border);
+.dag-overlay-header button { background: var(--bg-primary); }
+.product-dag-canvas { flex: 1; width: 100%; background: var(--bg-primary); }
+
+/* ── Peer group ── */
+
+.peer-group-products {
+  padding: 4px 0 4px 4px;
+  border-left: 1px dashed var(--border-subtle);
+  margin-left: 8px;
+}
+
+/* ── A11y ── */
+
+button:focus-visible,
+[role="button"]:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+::selection {
+  background: var(--accent-strong);
   color: var(--text-primary);
-  padding: 6px 12px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 12px;
-}
-.product-dag-canvas {
-  flex: 1;
-  width: 100%;
 }


### PR DESCRIPTION
## Summary

PR #240 shipped the React Products tab functional but visually bare. This pass pulls the design tokens + component styling from the legacy `internal/web/ui/style.css` so the new surface reads as the same product.

CSS only — no logic, no markup, no tests touched.

## Changes

- Sidebar tree: left-border accent on selected, hover/focus states, scoped scrollbar, uppercase header label
- Status dots: ring shadow against the dark background
- Stat cards: boxed Manifests / Tasks / Turns / Cost with tabular-numbers
- Manifest rows: clickable cards with hover accent
- Buttons: proper transitions + active states
- Badges: status + tag with tinted backgrounds
- Empty / error states: consistent with legacy UI
- DAG overlay header chrome
- Peer group: dashed left border so children visually nest under the peer
- A11y: focus-visible rings, selection styling

## Test plan

- [x] `npm run build` clean
- [ ] Hard-refresh `/dashboard/products` after merge + restart — sidebar/detail look like the legacy UI's polish level
- [ ] CI green