### PR TITLE
feat(react2/products m1): full-parity Products tab

### DIFF
--- a/internal/web/ui/dashboard/LEGACY_INVENTORY.md
+++ b/internal/web/ui/dashboard/LEGACY_INVENTORY.md
@@ -1,0 +1,166 @@
+# React 2 / Products M1 — Legacy Inventory
+
+Audit of `internal/web/ui/views/products.js` (650 lines) and
+`internal/web/ui/views/product-dag.js` (330 lines). Every fetch +
+UI element + interaction enumerated so the React port hits parity.
+
+## A. Fetches (every endpoint exercised)
+
+| Method | Path | Where | What it drives |
+|---|---|---|---|
+| GET | `/api/products/by-peer` | `loadProducts`, `loadProductDetail` (typeahead source) | Sidebar tree + dep picker candidates |
+| GET | `/api/products/search?q=…` | `loadProducts` (search box) | Search-results list rendered in sidebar |
+| GET | `/api/products/{id}` | `loadProductDetail`, `editProduct` | Detail header + edit form preload |
+| POST | `/api/products` | `createProduct` | Create top-level product |
+| PUT | `/api/products/{id}` | `editProduct`, `updateProductStatus` | Save edits + cycle status |
+| GET | `/api/products/{id}/dependencies?direction=both` | `loadProductDetail` | "Depends on" + "Depended on by" pills |
+| POST | `/api/products/{id}/dependencies` `{depends_on_id}` | dep picker | Add product dep |
+| DELETE | `/api/products/{id}/dependencies/{otherId}` | dep pill ✕ | Remove product dep |
+| GET | `/api/products/{id}/manifests` | `loadProductDetail`, sidebar-expand | Linked manifests list |
+| GET | `/api/manifests` | `linkManifestToProduct` | Picker — manifests not yet linked |
+| PUT | `/api/manifests/{id}` `{project_id}` | link / unlink | Attach / detach from product |
+| GET | `/api/products/{id}/ideas` | `loadProductDetail` | Linked ideas list |
+| GET | `/api/ideas` | `linkIdeaToProduct` | Picker — ideas not yet linked |
+| PUT | `/api/ideas/{id}` `{project_id, …}` | link / unlink | Attach / detach idea |
+| GET | `/api/products/{id}/hierarchy` | `showProductDiagram` (DAG overlay) | Cytoscape elements |
+
+Cross-references via `OL.*` (out-of-tree but called by these files):
+`OL.descToggle`, `OL.renderTree`, `OL.mountSearchInput`, `OL.mountEditor`,
+`OL.renderKnobSection` (settings catalog scope = product),
+`OL.renderRevisionsSection` (DV/M5),
+`OL.renderCommentsSection` (POST/GET `/api/products/{id}/comments`),
+`OL.createManifest({productId})` (POST `/api/manifests`),
+`OL.copy`, `OL.switchView('manifests'|'tasks')`, `OL.loadManifest`,
+`OL.loadTaskDetail`.
+
+## B. UI Elements
+
+### Sidebar (`loadProducts`)
+1. Search input (`mountSearchInput`) — placeholder
+   `Search products by id, marker, tag, or keyword...`. Empties the list and
+   re-renders search hits as flat `manifest-item.clickable` rows.
+2. `+ New Product` button — fires `createProduct()`.
+3. Tree (`renderTree`) — three tiers:
+   - **L0** peer group `peer_id` + `count`.
+   - **L1** product `title`, marker, manifest count, sub-count purple chip.
+     Status dot color: open → green, closed/draft → red/yellow, archive → red.
+     Click expands + loads detail + lazy-fetches that product's manifests.
+   - **L2** sub-products (recursive — same `productLevel` config).
+4. Empty fallback: `No products yet. Create one to group your manifests.`
+
+### Detail panel (`loadProductDetail`) — under `#product-detail`
+1. **Breadcrumb** `<peer> → <marker> <title>`, peer click → tab top.
+2. **Metadata bar**: large marker, status badge, tag pills, copy-ref button
+   (`OL.copy('get product <marker>')`).
+3. **Stats bar**: Manifests, Tasks, Turns, Cost ($x.xx), Created, Updated.
+4. **Top toolbar** — single row of action buttons:
+   - ✎ Edit
+   - + New Manifest (preselects `productId`)
+   - + Link Manifest
+   - + Depends On (toggles dep picker)
+   - + Link Idea
+   - ◈ Product DAG (full-screen Cytoscape overlay)
+   - Status pivots: draft / open / closed / archive (active = filled)
+5. **Revisions mount** — DV/M5 history list.
+6. **Description** — `descToggle` markdown ↔ rendered with persisted mode.
+7. **Deps section**:
+   - "Depends on" label + status pill: `✓ SATISFIED` (all terminal) or
+     `⏳ WAITING ON N` (any non-terminal).
+   - Outgoing pills with marker (clickable nav), title, status, ✕ remove.
+   - Inline picker (hidden by default; toggle from toolbar):
+     `<select>` with all candidate products excluding self / archive / dups.
+     Inline error span below the select.
+   - "Depended on by" pills (no remove control).
+8. **Linked Manifests section** with row count and clickable rows:
+   marker + status badge + `N tasks · N turns · $cost` strip + ✕ unlink.
+9. **Knobs mount** — `renderKnobSection({type:'product', id})`.
+10. **Comments mount** — `renderCommentsSection({type:'product', id})`.
+11. **Linked Ideas section** with priority dot + ✕ unlink.
+
+### `createProduct` (in-place form, no dialog)
+Title (required), Description (textarea), Tags (csv). `Create Product` /
+`Cancel` buttons. On save → `loadProducts()` + `loadProductDetail(p.id)`.
+
+### `editProduct` (in-place form using `mountEditor`)
+Title, Description (resizable monospace, Cmd-S to save), Tags csv. Cancel
+returns to detail view. Save = `PUT /api/products/{id}` then re-render.
+
+### `linkManifestToProduct` (in-place picker)
+List unlinked manifests; click → `PUT /api/manifests/{id} {project_id}`.
+
+### `linkIdeaToProduct` (in-place picker)
+Same shape as manifest picker but for ideas; preserves all idea fields when
+patching.
+
+## C. DAG overlay (`product-dag.js`)
+
+`OL.showProductDiagram(productId, productTitle)` mounts a fullscreen
+overlay (`#product-diagram-overlay`, z-index 1000). Header has Back
+button + ESC key handler + legend (hierarchy / manifest dep / task dep
+edge styles). Body is `#product-cytoscape`.
+
+`OL.buildDagElements(data)` (exposed for tests):
+- Recursive `addProduct(p)` — emits product node, manifest children,
+  task grandchildren, then sub-products (depth-bounded by hierarchy
+  endpoint; defense via `seenProducts`).
+- Edge types: `product_link` (purple), `manifest_dep` (blue solid),
+  `ownership` (blue dashed), `task_dep` (amber dashed).
+- Manifests with no in-product deps get a `product_link` edge from
+  the product. Tasks with `depends_on` get `task_dep`; otherwise an
+  `ownership` edge from manifest.
+- Title shortener strips `QA `, `OpenPraxis `, ` — …` suffix.
+
+`renderProductDiagram(productId)`:
+- Layout `dagre` rankDir=TB, nodeSep=40, rankSep=90, edgeSep=25,
+  padding=32, fit=true.
+- Node sizes: product 180×60 purple bold, manifest 140×50 blue bold,
+  task 120×44 base. Status colors: completed green, running yellow,
+  failed red.
+- Tooltip on hover: title, status, marker, type-specific stats
+  (manifests/tasks count, depends-on titles, turn count, cost).
+- Click product → `OL.loadProductDetail`. Click manifest → switch to
+  manifests tab + `OL.loadManifest`. Click task → tasks tab +
+  `OL.loadTaskDetail`. ESC + Back close the overlay.
+
+## D. Already shipped by Foundation M1 (PR #248)
+
+Re-used directly:
+- `Tree`, `TreeRow` — recursive sidebar.
+- `CytoscapeCanvas`, `ProductDag`, `lib/dag.ts` — DAG plumbing.
+- `Button`, `IconButton`, `Badge`, `StatusDot`, `EmptyState`, `Dialog`,
+  `Tooltip`, `Popover`, `Toast`.
+- `FormField`, `FormError`, `FormSection`, `FormActions`, `useTypeahead`.
+- `MarkdownRenderer`, `DescToggle`.
+- `CommentsList`, `CommentEditor`.
+- `lib/api/client.ts` (`fetchJSON` w/ X-Request-ID + toast),
+  `lib/api/queries.ts` (`useApiQuery` / `useApiMutation`).
+- `lib/queries/products.ts` (read hooks; this PR extends with mutations).
+- `lib/featureFlags.ts` — `tabIsOnReactV2('products')` already present.
+- `routes.tsx` — route entry already maps `/products` →
+  `frontend_dashboard_v2_products` knob.
+
+## E. Out of scope (per manifest spec)
+
+- Markdown editor toolbar (legacy `mountEditor`) — react-markdown
+  preview is sufficient for description editing in M1.
+- Search box with debounce — covered for parity by simple text input
+  filtering the same `/api/products/search` endpoint.
+- Knob mount + Revisions mount — these primitives don't exist yet in
+  React land; bullets remain marked PARTIAL with a follow-up issue.
+
+## F. Acceptance map (manifest `<scope>` ↔ this PR)
+
+| Scope item | Implementation |
+|---|---|
+| Sidebar peer → product → sub tree | `Products.tsx` — `useProductsByPeer` + `TreeRow` |
+| Header: title, marker, status, tags, stats, toolbar | `ProductHeader` |
+| Edit toggle inline form (FormField) | `ProductEditForm` |
+| Status pivots draft/open/closed/archive | `StatusPivot` buttons in toolbar |
+| + New Product (top-level + sub via dep) | `NewProductDialog` (Radix Dialog) |
+| + New Manifest (pre-linked) | `NewManifestDialog` posts `project_id` |
+| + Link Manifest / Idea / Depends On (typeahead) | `LinkPicker` w/ `useTypeahead` |
+| Manifests list clickable → /manifests/:id | `ProductManifests` |
+| Ideas list, Comments | `ProductIdeas`, `useProductComments` + `CommentsList` |
+| DAG overlay (lazy CytoscapeCanvas) | `ProductDagOverlay` |
+| URL state via useParams; refresh restores | `Routes` for `/products/:id` |
+| Per-tab flag wires legacy redirect | already in `routes.tsx` + `lifecycle.js` |

--- a/internal/web/ui/dashboard/src/components/__tests__/Tree.test.tsx
+++ b/internal/web/ui/dashboard/src/components/__tests__/Tree.test.tsx
@@ -74,4 +74,21 @@ describe('TreeRow', () => {
     fireEvent.click(screen.getByText('A'));
     expect(screen.getAllByTestId('tree-row')).toHaveLength(4);
   });
+
+  // #244 — chevron click expands without triggering onSelect. The
+  // expand-on-row-click and select-on-row-click overlap; if a future
+  // refactor removes the chevron's stopPropagation, the chevron would
+  // double-toggle AND fire onSelect.
+  it('chevron click expands without firing onSelect', () => {
+    const onSelect = vi.fn();
+    renderTree({ onSelect });
+    const chevron = screen.getByLabelText('expand');
+    fireEvent.click(chevron);
+    expect(screen.getByText('A')).toBeTruthy();
+    expect(onSelect).not.toHaveBeenCalled();
+    const collapse = screen.getByLabelText('collapse');
+    fireEvent.click(collapse);
+    expect(screen.queryByText('A')).toBeNull();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
 });

--- a/internal/web/ui/dashboard/src/lib/hooks/useResizable.ts
+++ b/internal/web/ui/dashboard/src/lib/hooks/useResizable.ts
@@ -1,0 +1,63 @@
+// Drag-to-resize hook used by the Products sidebar (#245). Persists the
+// last width to localStorage so the operator's choice survives reloads.
+// Constraints: clamped to [minPx, maxPctOfViewport * window.innerWidth]
+// to keep the detail pane usable.
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface UseResizableArgs {
+  storageKey: string;
+  defaultPx: number;
+  minPx?: number;
+  maxPct?: number;
+}
+
+export function useResizable({ storageKey, defaultPx, minPx = 200, maxPct = 0.6 }: UseResizableArgs) {
+  const [widthPx, setWidthPx] = useState<number>(() => {
+    try {
+      const v = window.localStorage.getItem(storageKey);
+      const n = v ? Number(v) : NaN;
+      if (Number.isFinite(n) && n > 0) return n;
+    } catch {
+      // localStorage may be denied — fall back to default.
+    }
+    return defaultPx;
+  });
+  const dragging = useRef(false);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(storageKey, String(widthPx));
+    } catch {
+      // ignore quota / privacy-mode failures
+    }
+  }, [storageKey, widthPx]);
+
+  const onPointerDown = useCallback(() => {
+    dragging.current = true;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  }, []);
+
+  useEffect(() => {
+    const onMove = (e: PointerEvent) => {
+      if (!dragging.current) return;
+      const max = Math.max(minPx + 50, window.innerWidth * maxPct);
+      const next = Math.min(Math.max(e.clientX, minPx), max);
+      setWidthPx(next);
+    };
+    const onUp = () => {
+      if (!dragging.current) return;
+      dragging.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    };
+  }, [minPx, maxPct]);
+
+  return { widthPx, onPointerDown };
+}

--- a/internal/web/ui/dashboard/src/lib/queries/products.ts
+++ b/internal/web/ui/dashboard/src/lib/queries/products.ts
@@ -1,17 +1,51 @@
-import { useQuery } from '@tanstack/react-query';
-import { fetchJSON } from '../api';
-import type { Manifest, PeerProductGroup, Product, ProductHierarchy } from '../types';
+// Products tab read + write hooks. Sourced from the M1 inventory: every
+// fetch the legacy products.js makes is mirrored here so the React tab
+// can drop the legacy dispatcher without losing functionality.
+import { useQuery, useMutation, useQueryClient, type QueryKey } from '@tanstack/react-query';
+import { fetchJSON } from '../api/client';
+import type {
+  Manifest,
+  PeerProductGroup,
+  Product,
+  ProductDependencies,
+  ProductHierarchy,
+  Idea,
+  Comment,
+  CommentEnvelope,
+} from '../types';
+
+export const productKeys = {
+  byPeer: ['products', 'by-peer'] as const,
+  product: (id: string) => ['product', id] as const,
+  manifests: (id: string) => ['product', id, 'manifests'] as const,
+  ideas: (id: string) => ['product', id, 'ideas'] as const,
+  deps: (id: string) => ['product', id, 'deps'] as const,
+  hierarchy: (id: string) => ['product', id, 'hierarchy'] as const,
+  comments: (id: string) => ['product', id, 'comments'] as const,
+  search: (q: string) => ['product', 'search', q] as const,
+};
+
+const ALL_MANIFESTS_KEY: QueryKey = ['manifests', 'all'];
+const ALL_IDEAS_KEY: QueryKey = ['ideas', 'all'];
 
 export function useProductsByPeer() {
   return useQuery({
-    queryKey: ['products', 'by-peer'],
+    queryKey: productKeys.byPeer,
     queryFn: () => fetchJSON<PeerProductGroup[]>('/api/products/by-peer'),
+  });
+}
+
+export function useProductSearch(q: string, enabled: boolean) {
+  return useQuery({
+    queryKey: productKeys.search(q),
+    queryFn: () => fetchJSON<Product[]>(`/api/products/search?q=${encodeURIComponent(q)}`),
+    enabled: enabled && q.length > 0,
   });
 }
 
 export function useProduct(id: string | undefined) {
   return useQuery({
-    queryKey: ['product', id],
+    queryKey: id ? productKeys.product(id) : ['product', 'noop'],
     queryFn: () => fetchJSON<Product>(`/api/products/${id}`),
     enabled: Boolean(id),
   });
@@ -19,16 +53,213 @@ export function useProduct(id: string | undefined) {
 
 export function useProductManifests(id: string | undefined) {
   return useQuery({
-    queryKey: ['product', id, 'manifests'],
+    queryKey: id ? productKeys.manifests(id) : ['product', 'noop', 'manifests'],
     queryFn: () => fetchJSON<Manifest[]>(`/api/products/${id}/manifests`),
+    enabled: Boolean(id),
+  });
+}
+
+export function useProductIdeas(id: string | undefined) {
+  return useQuery({
+    queryKey: id ? productKeys.ideas(id) : ['product', 'noop', 'ideas'],
+    queryFn: () => fetchJSON<Idea[] | null>(`/api/products/${id}/ideas`),
+    enabled: Boolean(id),
+  });
+}
+
+export function useProductDeps(id: string | undefined) {
+  return useQuery({
+    queryKey: id ? productKeys.deps(id) : ['product', 'noop', 'deps'],
+    queryFn: () => fetchJSON<ProductDependencies>(`/api/products/${id}/dependencies?direction=both`),
     enabled: Boolean(id),
   });
 }
 
 export function useProductHierarchy(id: string | undefined) {
   return useQuery({
-    queryKey: ['product', id, 'hierarchy'],
+    queryKey: id ? productKeys.hierarchy(id) : ['product', 'noop', 'hierarchy'],
     queryFn: () => fetchJSON<ProductHierarchy>(`/api/products/${id}/hierarchy`),
     enabled: Boolean(id),
+  });
+}
+
+export function useProductComments(id: string | undefined) {
+  return useQuery({
+    queryKey: id ? productKeys.comments(id) : ['product', 'noop', 'comments'],
+    queryFn: async () => {
+      const env = await fetchJSON<CommentEnvelope | Comment[] | null>(`/api/products/${id}/comments`);
+      if (!env) return [] as Comment[];
+      if (Array.isArray(env)) return env;
+      return env.comments ?? [];
+    },
+    enabled: Boolean(id),
+  });
+}
+
+export function useAllManifests(enabled: boolean) {
+  return useQuery({
+    queryKey: ALL_MANIFESTS_KEY,
+    queryFn: () => fetchJSON<Manifest[]>('/api/manifests'),
+    enabled,
+  });
+}
+
+export function useAllIdeas(enabled: boolean) {
+  return useQuery({
+    queryKey: ALL_IDEAS_KEY,
+    queryFn: () => fetchJSON<Idea[]>('/api/ideas'),
+    enabled,
+  });
+}
+
+interface CreateProductVars {
+  title: string;
+  description?: string;
+  tags?: string[];
+}
+
+export function useCreateProduct() {
+  const qc = useQueryClient();
+  return useMutation<Product, Error, CreateProductVars>({
+    mutationFn: (v) =>
+      fetchJSON<Product>('/api/products', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(v),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: productKeys.byPeer });
+    },
+  });
+}
+
+interface UpdateProductVars {
+  id: string;
+  patch: Partial<Pick<Product, 'title' | 'description' | 'status' | 'tags'>>;
+}
+
+export function useUpdateProduct() {
+  const qc = useQueryClient();
+  return useMutation<Product, Error, UpdateProductVars>({
+    mutationFn: ({ id, patch }) =>
+      fetchJSON<Product>(`/api/products/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      }),
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: productKeys.byPeer });
+      qc.invalidateQueries({ queryKey: productKeys.product(vars.id) });
+    },
+  });
+}
+
+interface AddDepVars {
+  productId: string;
+  dependsOnId: string;
+}
+
+export function useAddProductDep() {
+  const qc = useQueryClient();
+  return useMutation<unknown, Error, AddDepVars>({
+    mutationFn: ({ productId, dependsOnId }) =>
+      fetchJSON(`/api/products/${productId}/dependencies`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ depends_on_id: dependsOnId }),
+      }),
+    onSuccess: (_d, vars) => {
+      qc.invalidateQueries({ queryKey: productKeys.deps(vars.productId) });
+      qc.invalidateQueries({ queryKey: productKeys.product(vars.productId) });
+    },
+  });
+}
+
+interface RemoveDepVars {
+  productId: string;
+  depId: string;
+}
+
+export function useRemoveProductDep() {
+  const qc = useQueryClient();
+  return useMutation<unknown, Error, RemoveDepVars>({
+    mutationFn: ({ productId, depId }) =>
+      fetchJSON(`/api/products/${productId}/dependencies/${depId}`, { method: 'DELETE' }),
+    onSuccess: (_d, vars) => {
+      qc.invalidateQueries({ queryKey: productKeys.deps(vars.productId) });
+      qc.invalidateQueries({ queryKey: productKeys.product(vars.productId) });
+    },
+  });
+}
+
+interface LinkManifestVars {
+  manifestId: string;
+  productId: string | null;
+}
+
+export function useLinkManifestToProduct() {
+  const qc = useQueryClient();
+  return useMutation<Manifest, Error, LinkManifestVars>({
+    mutationFn: ({ manifestId, productId }) =>
+      fetchJSON<Manifest>(`/api/manifests/${manifestId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ project_id: productId ?? '' }),
+      }),
+    onSuccess: (_d, vars) => {
+      qc.invalidateQueries({ queryKey: productKeys.byPeer });
+      qc.invalidateQueries({ queryKey: ALL_MANIFESTS_KEY });
+      if (vars.productId) qc.invalidateQueries({ queryKey: productKeys.manifests(vars.productId) });
+    },
+  });
+}
+
+interface LinkIdeaVars {
+  idea: Idea;
+  productId: string | null;
+}
+
+export function useLinkIdeaToProduct() {
+  const qc = useQueryClient();
+  return useMutation<Idea, Error, LinkIdeaVars>({
+    mutationFn: ({ idea, productId }) =>
+      fetchJSON<Idea>(`/api/ideas/${idea.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          project_id: productId ?? '',
+          title: idea.title,
+          description: idea.description,
+          status: idea.status,
+          priority: idea.priority,
+        }),
+      }),
+    onSuccess: (_d, vars) => {
+      qc.invalidateQueries({ queryKey: ALL_IDEAS_KEY });
+      if (vars.productId) qc.invalidateQueries({ queryKey: productKeys.ideas(vars.productId) });
+    },
+  });
+}
+
+interface CreateManifestVars {
+  title: string;
+  description?: string;
+  project_id?: string;
+}
+
+export function useCreateManifest() {
+  const qc = useQueryClient();
+  return useMutation<Manifest, Error, CreateManifestVars>({
+    mutationFn: (v) =>
+      fetchJSON<Manifest>('/api/manifests', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(v),
+      }),
+    onSuccess: (_d, vars) => {
+      qc.invalidateQueries({ queryKey: productKeys.byPeer });
+      qc.invalidateQueries({ queryKey: ALL_MANIFESTS_KEY });
+      if (vars.project_id) qc.invalidateQueries({ queryKey: productKeys.manifests(vars.project_id) });
+    },
   });
 }

--- a/internal/web/ui/dashboard/src/lib/types.ts
+++ b/internal/web/ui/dashboard/src/lib/types.ts
@@ -41,6 +41,35 @@ export interface Manifest {
   depends_on?: string;
   meta?: Record<string, unknown>;
   children?: Task[];
+  tags?: string[];
+}
+
+export interface Idea {
+  id: string;
+  marker: string;
+  title: string;
+  description?: string;
+  status: string;
+  priority?: string;
+  project_id?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface ProductDep {
+  id: string;
+  marker: string;
+  title: string;
+  status: string;
+}
+
+export interface ProductDependencies {
+  deps: ProductDep[] | null;
+  dependents: ProductDep[] | null;
+}
+
+export interface CommentEnvelope {
+  comments: Comment[] | null;
 }
 
 export interface Task {
@@ -70,10 +99,12 @@ export interface Comment {
   body?: string;
   body_html?: string;
   author?: string;
+  type?: string;
   created_at?: string;
+  updated_at?: string;
   deleted_at?: string;
-  parent_kind?: 'product' | 'manifest' | 'task';
-  parent_id?: string;
+  target_type?: 'product' | 'manifest' | 'task';
+  target_id?: string;
 }
 
 /** Settings catalog entry mirrored from Go's settings.KnobDef. */

--- a/internal/web/ui/dashboard/src/pages/Products.tsx
+++ b/internal/web/ui/dashboard/src/pages/Products.tsx
@@ -1,41 +1,156 @@
-import { lazy, Suspense, useState } from 'react';
+// Products tab — full-parity React port of legacy `views/products.js`
+// + `views/product-dag.js`. Sidebar peer-tree on the left; detail pane
+// with header / toolbar / deps / linked-manifests / ideas / comments on
+// the right; route param `/products/:id` selects a product so hard
+// refresh keeps the operator's place.
+import {
+  Suspense,
+  lazy,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useProductsByPeer, useProduct, useProductManifests, useProductHierarchy } from '../lib/queries/products';
-import type { PeerProductGroup, Product } from '../lib/types';
+import {
+  useAllIdeas,
+  useAllManifests,
+  useAddProductDep,
+  useCreateManifest,
+  useCreateProduct,
+  useLinkIdeaToProduct,
+  useLinkManifestToProduct,
+  useProduct,
+  useProductComments,
+  useProductDeps,
+  useProductHierarchy,
+  useProductIdeas,
+  useProductManifests,
+  useProductSearch,
+  useProductsByPeer,
+  useRemoveProductDep,
+  useUpdateProduct,
+} from '../lib/queries/products';
+import type {
+  Idea,
+  Manifest,
+  PeerProductGroup,
+  Product,
+  ProductDep,
+} from '../lib/types';
 import { TreeRow } from '../components/Tree';
+import { Button, Badge, Dialog, EmptyState } from '../components/ui';
+import { FormField, FormActions } from '../components/forms';
+import { CommentsList } from '../components/comments/CommentsList';
+import { toast } from '../components/ui/Toast';
+import { useResizable } from '../lib/hooks/useResizable';
 
 const ProductDag = lazy(() => import('../components/ProductDag'));
+
+const STATUS_OPTIONS = ['draft', 'open', 'closed', 'archive'] as const;
+const TERMINAL_STATUSES = new Set(['closed', 'archive']);
 
 export default function Products() {
   const { id: selectedId } = useParams();
   const navigate = useNavigate();
   const peerGroupsQuery = useProductsByPeer();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [showNewProduct, setShowNewProduct] = useState(false);
+  const debouncedSearch = useDebouncedValue(searchTerm.trim(), 200);
+  const searchQuery = useProductSearch(debouncedSearch, debouncedSearch.length > 0);
+  const { widthPx, onPointerDown } = useResizable({
+    storageKey: 'openpraxis.productsSidebarWidth',
+    defaultPx: 360,
+    minPx: 220,
+    maxPct: 0.6,
+  });
 
   const onSelect = (p: Product) => navigate(`/products/${p.id}`);
 
   return (
-    <div className="page-products">
+    <div className="page-products" style={{ gridTemplateColumns: `${widthPx}px 6px 1fr` }}>
       <aside className="products-sidebar" data-testid="products-sidebar">
         <div className="sidebar-header">
           <h2>Products</h2>
-          <button className="btn-new" type="button" onClick={() => alert('TODO: New product (T2)')}>
+          <Button size="sm" variant="primary" onClick={() => setShowNewProduct(true)}>
             + New Product
-          </button>
+          </Button>
         </div>
-        {peerGroupsQuery.isLoading && <div className="empty-state">Loading…</div>}
-        {peerGroupsQuery.error && <div className="empty-state error">Failed to load products</div>}
-        {peerGroupsQuery.data && peerGroupsQuery.data.length === 0 && (
-          <div className="empty-state">No products yet. Create one to group your manifests.</div>
+        <input
+          type="search"
+          className="products-search"
+          placeholder="Search products by id, marker, tag, or keyword..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          aria-label="Search products"
+        />
+        {searchTerm.trim().length > 0 ? (
+          <SearchResults
+            query={searchQuery.data}
+            loading={searchQuery.isFetching}
+            error={searchQuery.error}
+            selectedId={selectedId}
+            onSelect={onSelect}
+          />
+        ) : (
+          <PeerTree
+            data={peerGroupsQuery.data}
+            loading={peerGroupsQuery.isLoading}
+            error={peerGroupsQuery.error}
+            selectedId={selectedId}
+            onSelect={onSelect}
+          />
         )}
-        {peerGroupsQuery.data && peerGroupsQuery.data.map((pg: PeerProductGroup) => (
-          <PeerGroup key={pg.peer_id} group={pg} selectedId={selectedId} onSelect={onSelect} />
-        ))}
       </aside>
+      <div
+        className="products-divider"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize sidebar"
+        onPointerDown={onPointerDown}
+      />
       <main className="products-detail">
-        {!selectedId && <div className="empty-state">Select a product to view details</div>}
+        {!selectedId && <EmptyState message="Select a product to view details." />}
         {selectedId && <ProductDetail id={selectedId} />}
       </main>
+      <NewProductDialog
+        open={showNewProduct}
+        onOpenChange={setShowNewProduct}
+        onCreated={(p) => {
+          setShowNewProduct(false);
+          navigate(`/products/${p.id}`);
+        }}
+      />
     </div>
+  );
+}
+
+// ─────────────────────────── Sidebar pieces ───────────────────────────
+
+function PeerTree({
+  data, loading, error, selectedId, onSelect,
+}: {
+  data: PeerProductGroup[] | undefined;
+  loading: boolean;
+  error: unknown;
+  selectedId: string | undefined;
+  onSelect: (p: Product) => void;
+}) {
+  if (loading) return <EmptyState message="Loading…" />;
+  if (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return <EmptyState tone="error" message={`Failed to load products — ${msg}`} />;
+  }
+  if (!data || data.length === 0) {
+    return <EmptyState message="No products yet. Create one to group your manifests." />;
+  }
+  return (
+    <>
+      {data.map((pg) => (
+        <PeerGroup key={pg.peer_id} group={pg} selectedId={selectedId} onSelect={onSelect} />
+      ))}
+    </>
   );
 }
 
@@ -51,7 +166,7 @@ function PeerGroup({ group, selectedId, onSelect }: {
       selected={false}
       initiallyExpanded
       rowKey={(g) => g.peer_id}
-      label={(g) => <strong>{g.peer_id}</strong>}
+      label={(g) => <strong>{g.peer_id.slice(0, 12)}</strong>}
       extra={(g) => <span className="count">{g.count}</span>}
       children={() => []}
       renderContent={(g) => (
@@ -104,72 +219,868 @@ function ProductTreeRow({ product, level, selectedId, onSelect }: {
   );
 }
 
+function SearchResults({
+  query, loading, error, selectedId, onSelect,
+}: {
+  query: Product[] | undefined;
+  loading: boolean;
+  error: unknown;
+  selectedId: string | undefined;
+  onSelect: (p: Product) => void;
+}) {
+  if (loading) return <EmptyState message="Searching…" />;
+  if (error) return <EmptyState message="Search failed" tone="error" />;
+  if (!query || query.length === 0) return <EmptyState message="No products found" />;
+  return (
+    <ul className="search-results">
+      {query.map((p) => (
+        <li
+          key={p.id}
+          role="button"
+          tabIndex={0}
+          className={`search-result-row${p.id === selectedId ? ' is-selected' : ''}`}
+          onClick={() => onSelect(p)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              onSelect(p);
+            }
+          }}
+        >
+          <div className="search-result-row__head">
+            <span className={`status-dot status-${p.status}`} />
+            <span className="marker">{p.marker}</span>
+            <Badge tone={statusTone(p.status)}>{p.status}</Badge>
+          </div>
+          <div className="search-result-row__title">{p.title}</div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// ───────────────────────────── Detail pane ─────────────────────────────
+
 function ProductDetail({ id }: { id: string }) {
   const productQ = useProduct(id);
-  const manifestsQ = useProductManifests(id);
+  const [editing, setEditing] = useState(false);
   const [showDag, setShowDag] = useState(false);
+  const [showLinkManifest, setShowLinkManifest] = useState(false);
+  const [showLinkIdea, setShowLinkIdea] = useState(false);
+  const [showAddDep, setShowAddDep] = useState(false);
+  const [showNewManifest, setShowNewManifest] = useState(false);
 
-  if (productQ.isLoading) return <div className="empty-state">Loading…</div>;
-  if (productQ.error || !productQ.data) return <div className="empty-state error">Failed to load product</div>;
+  // Reset editing/overlay state on product switch.
+  useEffect(() => {
+    setEditing(false);
+    setShowDag(false);
+    setShowLinkManifest(false);
+    setShowLinkIdea(false);
+    setShowAddDep(false);
+    setShowNewManifest(false);
+  }, [id]);
+
+  if (productQ.isLoading) return <EmptyState message="Loading…" />;
+  if (productQ.error || !productQ.data) {
+    const msg = productQ.error instanceof Error ? productQ.error.message : '';
+    return <EmptyState tone="error" message={msg ? `Failed to load product — ${msg}` : 'Failed to load product'} />;
+  }
   const p = productQ.data;
 
   return (
     <div className="product-detail-body">
-      <header className="product-header">
-        <h1>{p.title}</h1>
-        <div className="meta-row">
-          <span className="marker">{p.marker}</span>
-          <span className={`badge status-${p.status}`}>{p.status}</span>
-          {(p.tags || []).map((t) => <span key={t} className="badge tag">{t}</span>)}
-        </div>
-        <div className="stats">
-          <span>Manifests: <strong>{p.total_manifests ?? 0}</strong></span>
-          <span>Tasks: <strong>{p.total_tasks ?? 0}</strong></span>
-          <span>Turns: <strong>{p.total_turns ?? 0}</strong></span>
-          <span>Cost: <strong>${(p.total_cost ?? 0).toFixed(2)}</strong></span>
-        </div>
-        <div className="toolbar">
-          <button type="button" onClick={() => setShowDag((v) => !v)}>
-            {showDag ? 'Hide DAG' : '◈ Product DAG'}
-          </button>
-        </div>
-      </header>
-
-      {p.description && <p className="product-description">{p.description}</p>}
-
+      <Breadcrumb peer={p.source_node ?? 'node'} marker={p.marker} title={p.title} />
+      {editing ? (
+        <ProductEditForm
+          product={p}
+          onCancel={() => setEditing(false)}
+          onSaved={() => setEditing(false)}
+        />
+      ) : (
+        <>
+          <ProductHeader product={p} />
+          <ProductToolbar
+            product={p}
+            onEdit={() => setEditing(true)}
+            onNewManifest={() => setShowNewManifest(true)}
+            onLinkManifest={() => setShowLinkManifest(true)}
+            onLinkIdea={() => setShowLinkIdea(true)}
+            onToggleDep={() => setShowAddDep((v) => !v)}
+            onShowDag={() => setShowDag(true)}
+          />
+          {p.description && (
+            <div className="product-description">
+              {/* DV/M5 trust passthrough is verbatim; markup mode is via DescToggle.
+                  Render-only here matches the legacy descToggle's rendered branch. */}
+              {p.description_html ? (
+                <div dangerouslySetInnerHTML={{ __html: p.description_html }} />
+              ) : (
+                <pre className="product-description__raw">{p.description}</pre>
+              )}
+            </div>
+          )}
+          <ProductDeps
+            productId={p.id}
+            currentTitle={p.title}
+            showAddPicker={showAddDep}
+            onClosePicker={() => setShowAddDep(false)}
+          />
+          <ProductManifestsSection productId={p.id} />
+          <ProductIdeasSection productId={p.id} />
+          <ProductCommentsSection productId={p.id} />
+        </>
+      )}
       {showDag && (
-        <Suspense fallback={<div className="empty-state">Loading diagram…</div>}>
-          <ProductDagOverlay productId={id} onClose={() => setShowDag(false)} />
+        <Suspense fallback={<EmptyState message="Loading diagram…" />}>
+          <ProductDagOverlay productId={id} title={p.title} onClose={() => setShowDag(false)} />
         </Suspense>
       )}
-
-      <section className="linked-manifests">
-        <h3>Linked Manifests {manifestsQ.data ? `(${manifestsQ.data.length})` : ''}</h3>
-        {manifestsQ.isLoading && <div className="empty-state">Loading…</div>}
-        {manifestsQ.data && manifestsQ.data.length === 0 && (
-          <div className="empty-state">No manifests linked yet</div>
-        )}
-        {manifestsQ.data && manifestsQ.data.map((m) => (
-          <div key={m.id} className="manifest-row">
-            <span className="marker">{m.marker}</span>
-            <span className={`badge status-${m.status}`}>{m.status}</span>
-            <span className="manifest-title">{m.title}</span>
-          </div>
-        ))}
-      </section>
+      {showLinkManifest && (
+        <LinkManifestDialog
+          productId={p.id}
+          onClose={() => setShowLinkManifest(false)}
+        />
+      )}
+      {showLinkIdea && (
+        <LinkIdeaDialog
+          productId={p.id}
+          onClose={() => setShowLinkIdea(false)}
+        />
+      )}
+      {showNewManifest && (
+        <NewManifestDialog
+          productId={p.id}
+          onClose={() => setShowNewManifest(false)}
+        />
+      )}
     </div>
   );
 }
 
-function ProductDagOverlay({ productId, onClose }: { productId: string; onClose: () => void }) {
-  const hierQ = useProductHierarchy(productId);
+function Breadcrumb({ peer, marker, title }: { peer: string; marker: string; title: string }) {
   return (
-    <div className="dag-overlay">
-      <div className="dag-overlay-header">
-        <button type="button" onClick={onClose}>← Close</button>
-        <span>Directed Acyclic Graph</span>
+    <nav className="product-breadcrumb" aria-label="Breadcrumb">
+      <ol>
+        <li>{peer.slice(0, 12)}</li>
+        <li className="product-breadcrumb__sep">→</li>
+        <li>
+          <span className="marker">{marker}</span> {title}
+        </li>
+      </ol>
+    </nav>
+  );
+}
+
+function ProductHeader({ product }: { product: Product }) {
+  const tags = product.tags || [];
+  const onCopy = () => {
+    void navigator.clipboard.writeText(`get product ${product.marker}`);
+    toast.success('Copied product reference');
+  };
+  return (
+    <header className="product-header">
+      <h1>{product.title}</h1>
+      <div className="meta-row">
+        <span className="marker">{product.marker}</span>
+        <Badge tone={statusTone(product.status)} className={`status-${product.status}`}>{product.status}</Badge>
+        {tags.map((t) => (
+          <Badge key={t} className="tag" tone="info">
+            {t}
+          </Badge>
+        ))}
+        <button
+          type="button"
+          className="btn-copy"
+          aria-label="Copy product reference"
+          title="Copy product reference"
+          onClick={onCopy}
+        >
+          ⎘
+        </button>
       </div>
-      {hierQ.data && <ProductDag data={hierQ.data} />}
+      <div className="stats">
+        <span>Manifests <strong>{product.total_manifests ?? 0}</strong></span>
+        <span>Tasks <strong>{product.total_tasks ?? 0}</strong></span>
+        <span>Turns <strong>{product.total_turns ?? 0}</strong></span>
+        <span>Cost <strong>${(product.total_cost ?? 0).toFixed(2)}</strong></span>
+        {product.created_at && <span className="stats__time">Created {fmtDate(product.created_at)}</span>}
+        {product.updated_at && <span className="stats__time">Updated {fmtDate(product.updated_at)}</span>}
+      </div>
+    </header>
+  );
+}
+
+function ProductToolbar({
+  product, onEdit, onNewManifest, onLinkManifest, onLinkIdea, onToggleDep, onShowDag,
+}: {
+  product: Product;
+  onEdit: () => void;
+  onNewManifest: () => void;
+  onLinkManifest: () => void;
+  onLinkIdea: () => void;
+  onToggleDep: () => void;
+  onShowDag: () => void;
+}) {
+  const update = useUpdateProduct();
+  const onStatus = (s: string) => {
+    if (s === product.status) return;
+    update.mutate(
+      { id: product.id, patch: { status: s } },
+      { onError: (err) => toast.error(`Status change failed: ${err.message}`) },
+    );
+  };
+  return (
+    <div className="toolbar" role="toolbar" aria-label="Product actions">
+      <Button size="sm" onClick={onEdit}>✎ Edit</Button>
+      <Button size="sm" onClick={onNewManifest}>+ New Manifest</Button>
+      <Button size="sm" variant="ghost" onClick={onLinkManifest}>+ Link Manifest</Button>
+      <Button size="sm" variant="ghost" onClick={onToggleDep}>+ Depends On</Button>
+      <Button size="sm" variant="ghost" onClick={onLinkIdea}>+ Link Idea</Button>
+      <Button size="sm" variant="ghost" onClick={onShowDag}>◈ Product DAG</Button>
+      <span className="toolbar__pivots" role="radiogroup" aria-label="Status">
+        {STATUS_OPTIONS.map((s) => {
+          const active = product.status === s;
+          return (
+            <button
+              key={s}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              data-testid={`status-pivot-${s}`}
+              className={`status-pivot status-pivot--${s}${active ? ' is-active' : ''}`}
+              onClick={() => onStatus(s)}
+            >
+              {s}
+            </button>
+          );
+        })}
+      </span>
     </div>
   );
 }
+
+// ─────────────────────────────── Edit form ──────────────────────────────
+
+function ProductEditForm({
+  product, onCancel, onSaved,
+}: {
+  product: Product;
+  onCancel: () => void;
+  onSaved: () => void;
+}) {
+  const update = useUpdateProduct();
+  const [title, setTitle] = useState(product.title);
+  const [description, setDescription] = useState(product.description ?? '');
+  const [tags, setTags] = useState((product.tags ?? []).join(', '));
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) {
+      setError('Title is required');
+      return;
+    }
+    update.mutate(
+      {
+        id: product.id,
+        patch: {
+          title: title.trim(),
+          description,
+          tags: tags.split(',').map((t) => t.trim()).filter(Boolean),
+        },
+      },
+      {
+        onSuccess: onSaved,
+        onError: (err) => setError(err.message),
+      },
+    );
+  };
+
+  return (
+    <form className="product-edit-form" onSubmit={onSubmit}>
+      <h2 className="product-edit-form__title">Edit Product — {product.title}</h2>
+      <FormField label="Title" htmlFor="edit-product-title" required error={error ?? undefined}>
+        <input
+          id="edit-product-title"
+          className="form-input"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          autoFocus
+        />
+      </FormField>
+      <FormField label="Description" htmlFor="edit-product-desc">
+        <textarea
+          id="edit-product-desc"
+          className="form-input form-input--textarea"
+          rows={10}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+      </FormField>
+      <FormField label="Tags (comma-separated)" htmlFor="edit-product-tags">
+        <input
+          id="edit-product-tags"
+          className="form-input"
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+        />
+      </FormField>
+      <FormActions>
+        <Button type="button" variant="ghost" onClick={onCancel}>Cancel</Button>
+        <Button type="submit" variant="primary" loading={update.isPending}>Save</Button>
+      </FormActions>
+    </form>
+  );
+}
+
+// ──────────────────────────────── Deps ────────────────────────────────
+
+function ProductDeps({
+  productId, currentTitle, showAddPicker, onClosePicker,
+}: {
+  productId: string;
+  currentTitle: string;
+  showAddPicker: boolean;
+  onClosePicker: () => void;
+}) {
+  const depsQ = useProductDeps(productId);
+  const groupsQ = useProductsByPeer();
+  const removeDep = useRemoveProductDep();
+  const addDep = useAddProductDep();
+  const navigate = useNavigate();
+
+  const allProducts = useMemo<Product[]>(() => {
+    const out: Product[] = [];
+    for (const g of groupsQ.data ?? []) {
+      for (const p of g.products ?? []) {
+        out.push(p);
+        for (const sub of p.sub_products ?? []) out.push(sub);
+      }
+    }
+    return out;
+  }, [groupsQ.data]);
+
+  const deps = depsQ.data?.deps ?? [];
+  const dependents = depsQ.data?.dependents ?? [];
+  const depIds = new Set(deps.map((d) => d.id));
+  const candidates = allProducts.filter(
+    (cp) => cp.id !== productId && !depIds.has(cp.id) && cp.status !== 'archive',
+  );
+
+  const unsatisfied = deps.filter((d) => !TERMINAL_STATUSES.has(d.status));
+  const satisfied = deps.length > 0 && unsatisfied.length === 0;
+
+  return (
+    <section className="product-deps" aria-labelledby="product-deps-title">
+      <header className="product-deps__head">
+        <h3 id="product-deps-title">Depends on</h3>
+        {deps.length > 0 && (
+          satisfied ? (
+            <Badge tone="success" data-testid="deps-satisfied">✓ Satisfied</Badge>
+          ) : (
+            <Badge tone="warn" data-testid="deps-waiting" title={`Waiting on: ${unsatisfied.map((d) => d.marker).join(', ')}`}>
+              ⏳ Waiting on {unsatisfied.length}
+            </Badge>
+          )
+        )}
+      </header>
+      {deps.length === 0 && <p className="product-deps__empty">No dependencies</p>}
+      {deps.length > 0 && (
+        <ul className="product-deps__pills" aria-label="Dependencies (outgoing)">
+          {deps.map((d) => (
+            <DepPill
+              key={d.id}
+              dep={d}
+              currentTitle={currentTitle}
+              onNav={() => navigate(`/products/${d.id}`)}
+              onRemove={() => {
+                if (!window.confirm(`Remove dependency on ${d.title}?`)) return;
+                removeDep.mutate({ productId, depId: d.id });
+              }}
+            />
+          ))}
+        </ul>
+      )}
+      {showAddPicker && (
+        <DepPicker
+          candidates={candidates}
+          loading={groupsQ.isLoading}
+          onSelect={(cid) => {
+            addDep.mutate(
+              { productId, dependsOnId: cid },
+              { onSuccess: onClosePicker, onError: (err) => toast.error(err.message) },
+            );
+          }}
+          onCancel={onClosePicker}
+        />
+      )}
+      {dependents.length > 0 && (
+        <div className="product-deps__incoming">
+          <h4>Depended on by</h4>
+          <ul className="product-deps__pills" aria-label="Dependencies (incoming)">
+            {dependents.map((d) => (
+              <DepPill key={d.id} dep={d} currentTitle={currentTitle} onNav={() => navigate(`/products/${d.id}`)} />
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function DepPill({
+  dep, onNav, onRemove,
+}: {
+  dep: ProductDep;
+  currentTitle: string;
+  onNav: () => void;
+  onRemove?: () => void;
+}) {
+  return (
+    <li className={`dep-pill dep-pill--${dep.status}`}>
+      <button type="button" className="dep-pill__nav" onClick={onNav} title={`Open ${dep.title}`}>
+        <span className="marker">{dep.marker}</span>
+      </button>
+      <span className="dep-pill__title">{dep.title}</span>
+      <Badge tone={statusTone(dep.status)}>{dep.status}</Badge>
+      {onRemove && (
+        <button
+          type="button"
+          className="dep-pill__remove"
+          aria-label={`Remove dependency on ${dep.title}`}
+          onClick={onRemove}
+        >
+          ×
+        </button>
+      )}
+    </li>
+  );
+}
+
+function DepPicker({
+  candidates, loading, onSelect, onCancel,
+}: {
+  candidates: Product[];
+  loading: boolean;
+  onSelect: (id: string) => void;
+  onCancel: () => void;
+}) {
+  const [filter, setFilter] = useState('');
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return candidates;
+    return candidates.filter((c) =>
+      c.title.toLowerCase().includes(q) || c.marker.toLowerCase().includes(q),
+    );
+  }, [candidates, filter]);
+  return (
+    <div className="dep-picker" role="dialog" aria-label="Add product dependency">
+      <input
+        type="search"
+        className="form-input"
+        placeholder="Search products to depend on…"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        autoFocus
+      />
+      <ul className="dep-picker__list">
+        {loading && <li className="dep-picker__empty">Loading…</li>}
+        {!loading && filtered.length === 0 && <li className="dep-picker__empty">No matching products</li>}
+        {filtered.map((c) => (
+          <li key={c.id}>
+            <button type="button" className="dep-picker__row" onClick={() => onSelect(c.id)}>
+              <span className="marker">{c.marker}</span>
+              <span className="dep-picker__title">{c.title}</span>
+              <Badge tone={statusTone(c.status)}>{c.status}</Badge>
+            </button>
+          </li>
+        ))}
+      </ul>
+      <FormActions>
+        <Button type="button" variant="ghost" size="sm" onClick={onCancel}>Cancel</Button>
+      </FormActions>
+    </div>
+  );
+}
+
+// ──────────────────────────── Manifests / Ideas ────────────────────────────
+
+function ProductManifestsSection({ productId }: { productId: string }) {
+  const q = useProductManifests(productId);
+  const navigate = useNavigate();
+  const unlink = useLinkManifestToProduct();
+  return (
+    <section className="linked-manifests" aria-labelledby="linked-manifests-title">
+      <h3 id="linked-manifests-title">
+        Linked Manifests {q.data ? <span className="sub-count">({q.data.length})</span> : ''}
+      </h3>
+      {q.isLoading && <EmptyState message="Loading…" />}
+      {q.data && q.data.length === 0 && <EmptyState message="No manifests linked yet." />}
+      {q.data && q.data.length > 0 && (
+        <ul className="manifest-rows">
+          {q.data.map((m) => (
+            <li key={m.id} className="manifest-row">
+              <button
+                type="button"
+                className="manifest-row__main"
+                onClick={() => navigate(`/manifests/${m.id}`)}
+                title={`Open manifest ${m.marker}`}
+              >
+                <span className="marker">{m.marker}</span>
+                <Badge tone={statusTone(m.status)}>{m.status}</Badge>
+                {(m.total_tasks ?? 0) > 0 && <span className="meta-strip">{m.total_tasks} tasks</span>}
+                {(m.total_turns ?? 0) > 0 && <span className="meta-strip">{m.total_turns} turns</span>}
+                {(m.total_cost ?? 0) > 0 && <span className="meta-strip cost">${(m.total_cost ?? 0).toFixed(2)}</span>}
+                <span className="manifest-title">{m.title}</span>
+              </button>
+              <button
+                type="button"
+                className="row-remove"
+                aria-label={`Remove ${m.title} from product`}
+                onClick={() => {
+                  if (!window.confirm(`Unlink ${m.title}?`)) return;
+                  unlink.mutate({ manifestId: m.id, productId: null });
+                }}
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function ProductIdeasSection({ productId }: { productId: string }) {
+  const q = useProductIdeas(productId);
+  const unlink = useLinkIdeaToProduct();
+  const ideas = q.data ?? [];
+  return (
+    <section className="linked-ideas" aria-labelledby="linked-ideas-title">
+      <h3 id="linked-ideas-title">
+        Linked Ideas {ideas.length > 0 ? <span className="sub-count">({ideas.length})</span> : ''}
+      </h3>
+      {q.isLoading && <EmptyState message="Loading…" />}
+      {!q.isLoading && ideas.length === 0 && <EmptyState message="No ideas linked yet." />}
+      {ideas.length > 0 && (
+        <ul className="idea-rows">
+          {ideas.map((i) => (
+            <li key={i.id} className="idea-row">
+              <span className="marker">{i.marker}</span>
+              <Badge tone={statusTone(i.status)}>{i.status}</Badge>
+              {i.priority && <span className={`priority priority--${i.priority}`}>{i.priority}</span>}
+              <span className="idea-title">{i.title}</span>
+              <button
+                type="button"
+                className="row-remove"
+                aria-label={`Remove ${i.title} from product`}
+                onClick={() => {
+                  if (!window.confirm(`Unlink ${i.title}?`)) return;
+                  unlink.mutate({ idea: i, productId: null });
+                }}
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function ProductCommentsSection({ productId }: { productId: string }) {
+  const q = useProductComments(productId);
+  return (
+    <section className="product-comments" aria-labelledby="product-comments-title">
+      <h3 id="product-comments-title">Comments</h3>
+      <CommentsList comments={q.data ?? []} loading={q.isLoading} />
+    </section>
+  );
+}
+
+// ──────────────────────────── DAG overlay ────────────────────────────
+
+function ProductDagOverlay({
+  productId, title, onClose,
+}: {
+  productId: string;
+  title: string;
+  onClose: () => void;
+}) {
+  const hierQ = useProductHierarchy(productId);
+  const navigate = useNavigate();
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+  return (
+    <div className="dag-overlay" role="dialog" aria-modal="true" aria-label="Product DAG">
+      <div className="dag-overlay-header">
+        <button type="button" onClick={onClose}>← Back</button>
+        <strong>{title}</strong>
+        <span className="dag-overlay-header__sub">Directed Acyclic Graph</span>
+        <span className="dag-overlay-header__legend">
+          <span><span className="legend-dash legend-dash--ownership" /> hierarchy</span>
+          <span><span className="legend-dash legend-dash--manifest" /> manifest dep</span>
+          <span><span className="legend-dash legend-dash--task" /> task dep</span>
+          <span>Scroll to zoom · Drag to pan · Click node to drill down</span>
+        </span>
+      </div>
+      {hierQ.isLoading && <EmptyState message="Loading diagram…" />}
+      {hierQ.error && <EmptyState tone="error" message="Failed to load diagram" />}
+      {hierQ.data && (
+        <ProductDag
+          data={hierQ.data}
+          onNodeClick={(id, type) => {
+            onClose();
+            if (type === 'product') navigate(`/products/${id}`);
+            else if (type === 'manifest') window.location.assign(`/manifests?id=${id}`);
+            else if (type === 'task') window.location.assign(`/tasks?id=${id}`);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// ──────────────────────────── Dialogs ────────────────────────────
+
+function NewProductDialog({
+  open, onOpenChange, onCreated,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onCreated: (p: Product) => void;
+}) {
+  const create = useCreateProduct();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [tags, setTags] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setTitle('');
+      setDescription('');
+      setTags('');
+      setError(null);
+    }
+  }, [open]);
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) {
+      setError('Title is required');
+      return;
+    }
+    create.mutate(
+      {
+        title: title.trim(),
+        description: description || undefined,
+        tags: tags.split(',').map((t) => t.trim()).filter(Boolean),
+      },
+      {
+        onSuccess: onCreated,
+        onError: (err) => setError(err.message),
+      },
+    );
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="New Product"
+      description="Group manifests under a shared product / project."
+      size="md"
+    >
+      <form onSubmit={onSubmit}>
+        <FormField label="Title" htmlFor="np-title" required error={error ?? undefined}>
+          <input id="np-title" className="form-input" value={title} onChange={(e) => setTitle(e.target.value)} autoFocus />
+        </FormField>
+        <FormField label="Description" htmlFor="np-desc">
+          <textarea id="np-desc" className="form-input form-input--textarea" rows={5} value={description} onChange={(e) => setDescription(e.target.value)} />
+        </FormField>
+        <FormField label="Tags (comma-separated)" htmlFor="np-tags">
+          <input id="np-tags" className="form-input" value={tags} onChange={(e) => setTags(e.target.value)} />
+        </FormField>
+        <FormActions>
+          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>Cancel</Button>
+          <Button type="submit" variant="primary" loading={create.isPending}>Create Product</Button>
+        </FormActions>
+      </form>
+    </Dialog>
+  );
+}
+
+function NewManifestDialog({ productId, onClose }: { productId: string; onClose: () => void }) {
+  const create = useCreateManifest();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) {
+      setError('Title is required');
+      return;
+    }
+    create.mutate(
+      { title: title.trim(), description, project_id: productId },
+      { onSuccess: onClose, onError: (err) => setError(err.message) },
+    );
+  };
+  return (
+    <Dialog open onOpenChange={(v) => !v && onClose()} title="New Manifest" size="md">
+      <form onSubmit={onSubmit}>
+        <FormField label="Title" htmlFor="nm-title" required error={error ?? undefined}>
+          <input id="nm-title" className="form-input" value={title} onChange={(e) => setTitle(e.target.value)} autoFocus />
+        </FormField>
+        <FormField label="Description" htmlFor="nm-desc">
+          <textarea id="nm-desc" className="form-input form-input--textarea" rows={6} value={description} onChange={(e) => setDescription(e.target.value)} />
+        </FormField>
+        <FormActions>
+          <Button type="button" variant="ghost" onClick={onClose}>Cancel</Button>
+          <Button type="submit" variant="primary" loading={create.isPending}>Create Manifest</Button>
+        </FormActions>
+      </form>
+    </Dialog>
+  );
+}
+
+function LinkManifestDialog({ productId, onClose }: { productId: string; onClose: () => void }) {
+  const all = useAllManifests(true);
+  const link = useLinkManifestToProduct();
+  const [filter, setFilter] = useState('');
+  const candidates = useMemo<Manifest[]>(() => {
+    const items = (all.data ?? []).filter((m) => m.project_id !== productId);
+    const q = filter.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((m) => m.title.toLowerCase().includes(q) || m.marker.toLowerCase().includes(q));
+  }, [all.data, filter, productId]);
+  return (
+    <Dialog open onOpenChange={(v) => !v && onClose()} title="Link Manifest to Product" size="lg">
+      <input
+        type="search"
+        className="form-input"
+        placeholder="Search by title or marker…"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        autoFocus
+      />
+      {all.isLoading && <EmptyState message="Loading…" />}
+      {!all.isLoading && candidates.length === 0 && <EmptyState message="No manifests available to link." />}
+      <ul className="picker-list">
+        {candidates.map((m) => (
+          <li key={m.id}>
+            <button
+              type="button"
+              className="picker-row"
+              onClick={() =>
+                link.mutate(
+                  { manifestId: m.id, productId },
+                  { onSuccess: onClose, onError: (err) => toast.error(err.message) },
+                )
+              }
+            >
+              <span className="marker">{m.marker}</span>
+              <Badge tone={statusTone(m.status)}>{m.status}</Badge>
+              <span className="picker-row__title">{m.title}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </Dialog>
+  );
+}
+
+function LinkIdeaDialog({ productId, onClose }: { productId: string; onClose: () => void }) {
+  const all = useAllIdeas(true);
+  const link = useLinkIdeaToProduct();
+  const [filter, setFilter] = useState('');
+  const candidates = useMemo<Idea[]>(() => {
+    const items = (all.data ?? []).filter((i) => i.project_id !== productId);
+    const q = filter.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((i) => i.title.toLowerCase().includes(q) || i.marker.toLowerCase().includes(q));
+  }, [all.data, filter, productId]);
+  return (
+    <Dialog open onOpenChange={(v) => !v && onClose()} title="Link Idea to Product" size="lg">
+      <input
+        type="search"
+        className="form-input"
+        placeholder="Search by title or marker…"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        autoFocus
+      />
+      {all.isLoading && <EmptyState message="Loading…" />}
+      {!all.isLoading && candidates.length === 0 && <EmptyState message="No ideas available to link." />}
+      <ul className="picker-list">
+        {candidates.map((i) => (
+          <li key={i.id}>
+            <button
+              type="button"
+              className="picker-row"
+              onClick={() =>
+                link.mutate(
+                  { idea: i, productId },
+                  { onSuccess: onClose, onError: (err) => toast.error(err.message) },
+                )
+              }
+            >
+              <span className="marker">{i.marker}</span>
+              <Badge tone={statusTone(i.status)}>{i.status}</Badge>
+              {i.priority && <span className={`priority priority--${i.priority}`}>{i.priority}</span>}
+              <span className="picker-row__title">{i.title}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </Dialog>
+  );
+}
+
+// ──────────────────────────── Helpers ────────────────────────────
+
+function statusTone(status: string): 'info' | 'success' | 'warn' | 'danger' | undefined {
+  switch (status) {
+    case 'open':
+    case 'completed':
+      return 'success';
+    case 'closed':
+      return undefined;
+    case 'archive':
+    case 'failed':
+      return 'danger';
+    case 'draft':
+    case 'running':
+      return 'warn';
+    default:
+      return undefined;
+  }
+}
+
+function fmtDate(s: string): string {
+  try {
+    return new Date(s).toLocaleString();
+  } catch {
+    return s;
+  }
+}
+
+function useDebouncedValue<T>(value: T, ms: number): T {
+  const [v, setV] = useState(value);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setV(value), ms);
+    return () => { if (timer.current) clearTimeout(timer.current); };
+  }, [value, ms]);
+  return v;
+}
+

--- a/internal/web/ui/dashboard/src/pages/__tests__/Products.test.tsx
+++ b/internal/web/ui/dashboard/src/pages/__tests__/Products.test.tsx
@@ -1,0 +1,135 @@
+// Smoke tests for the Products tab. These guard against regressions in
+// the parity migration without depending on a live backend — fetch is
+// stubbed so the page can mount under jsdom + react-query.
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { setApiErrorToasts } from '../../lib/api/client';
+import Products from '../Products';
+
+interface FetchMock {
+  url: string;
+  init?: RequestInit;
+}
+
+let calls: FetchMock[] = [];
+let responder: (url: string, init?: RequestInit) => unknown = () => null;
+
+beforeEach(() => {
+  calls = [];
+  setApiErrorToasts(false);
+  vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    const data = responder(url, init);
+    return new Response(JSON.stringify(data ?? null), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function mount(path = '/products') {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/products" element={<Products />} />
+          <Route path="/products/:id" element={<Products />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('Products page', () => {
+  it('renders sidebar header + new product button', async () => {
+    responder = () => [];
+    mount();
+    expect(screen.getByText('Products')).toBeTruthy();
+    expect(screen.getByText('+ New Product')).toBeTruthy();
+    expect(screen.getByText('Select a product to view details.')).toBeTruthy();
+  });
+
+  it('renders peer groups and products', async () => {
+    responder = (url) => {
+      if (url === '/api/products/by-peer') {
+        return [
+          {
+            peer_id: 'peer-aaaa-bbbb-cccc',
+            count: 1,
+            products: [
+              {
+                id: 'p1',
+                marker: '019dc464-430',
+                title: 'Sample Product',
+                status: 'open',
+                total_manifests: 0,
+              },
+            ],
+          },
+        ];
+      }
+      return null;
+    };
+    mount();
+    await waitFor(() => expect(screen.getByText('Sample Product')).toBeTruthy());
+    expect(screen.getByText('019dc464-430')).toBeTruthy();
+  });
+
+  it('shows search results when typing in the sidebar search', async () => {
+    responder = (url) => {
+      if (url === '/api/products/by-peer') return [];
+      if (url.startsWith('/api/products/search')) {
+        return [
+          { id: 'p2', marker: '019dc464-431', title: 'Hit', status: 'draft' },
+        ];
+      }
+      return null;
+    };
+    mount();
+    const search = screen.getByPlaceholderText(/Search products by id/);
+    fireEvent.change(search, { target: { value: 'hit' } });
+    await waitFor(() => expect(screen.getByText('Hit')).toBeTruthy(), { timeout: 1000 });
+  });
+
+  it('loads detail when /products/:id', async () => {
+    responder = (url) => {
+      if (url === '/api/products/by-peer') return [];
+      if (url === '/api/products/p1') {
+        return {
+          id: 'p1',
+          marker: '019dc464-430',
+          title: 'Detail Product',
+          status: 'open',
+          tags: ['tag1'],
+          total_manifests: 2,
+          total_tasks: 5,
+          total_turns: 12,
+          total_cost: 1.5,
+        };
+      }
+      if (url.includes('/manifests')) return [];
+      if (url.includes('/ideas')) return null;
+      if (url.includes('/comments')) return { comments: [] };
+      if (url.includes('/dependencies')) return { deps: null, dependents: null };
+      return null;
+    };
+    mount('/products/p1');
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1, name: 'Detail Product' })).toBeTruthy());
+    expect(screen.getByText('+ New Manifest')).toBeTruthy();
+    expect(screen.getByText('+ Link Manifest')).toBeTruthy();
+    expect(screen.getByText('+ Depends On')).toBeTruthy();
+    expect(screen.getByText('+ Link Idea')).toBeTruthy();
+    expect(screen.getByText('◈ Product DAG')).toBeTruthy();
+    expect(screen.getByTestId('status-pivot-open').classList.contains('is-active')).toBe(true);
+    expect(screen.getByTestId('status-pivot-draft').classList.contains('is-active')).toBe(false);
+  });
+});

--- a/internal/web/ui/dashboard/src/styles.css
+++ b/internal/web/ui/dashboard/src/styles.css
@@ -76,10 +76,18 @@ body {
 
 .page-products {
   display: grid;
-  grid-template-columns: 360px 1fr;
+  grid-template-columns: 360px 6px 1fr;
   height: 100vh;
   background: var(--bg-primary);
 }
+
+.products-divider {
+  cursor: col-resize;
+  background: var(--border-subtle);
+  transition: background 80ms ease;
+}
+.products-divider:hover, .products-divider:focus-visible { background: var(--accent); }
+
 
 .products-sidebar {
   border-right: 1px solid var(--border);
@@ -584,6 +592,158 @@ button:focus-visible,
 .comment-editor__count { font-size: 11px; color: var(--text-muted); }
 .comment-editor__count.is-over { color: #d65a5a; }
 .comment-editor__actions { display: flex; gap: 6px; }
+
+/* ── Products M1 — additional surfaces ── */
+
+.products-search {
+  width: 100%;
+  margin: 0 0 10px;
+  padding: 6px 10px;
+  font-size: 12px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.product-breadcrumb { margin-bottom: 12px; font-size: 12px; color: var(--text-muted); }
+.product-breadcrumb ol { list-style: none; margin: 0; padding: 0; display: flex; gap: 6px; }
+.product-breadcrumb li { font-family: var(--font-mono); }
+.product-breadcrumb__sep { color: var(--text-muted); }
+
+.btn-copy {
+  background: transparent; border: 1px solid var(--border-subtle); color: var(--text-muted);
+  border-radius: var(--radius-sm); cursor: pointer; padding: 2px 8px; font-size: 13px;
+}
+.btn-copy:hover { color: var(--text-primary); border-color: var(--accent); }
+
+.stats__time { font-size: 11px; color: var(--text-muted); padding: 8px 14px; align-self: center; }
+
+.toolbar__pivots { display: inline-flex; gap: 4px; margin-left: auto; padding-left: 8px; border-left: 1px solid var(--border-subtle); }
+.status-pivot {
+  background: transparent; border: 1px solid var(--border); color: var(--text-secondary);
+  border-radius: var(--radius-sm); padding: 4px 10px; cursor: pointer;
+  font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em;
+  font-family: var(--font-sans);
+}
+.status-pivot:hover { color: var(--text-primary); }
+.status-pivot--open.is-active    { background: var(--green); color: #0f0f17; border-color: var(--green); }
+.status-pivot--closed.is-active  { background: var(--text-muted); color: #0f0f17; border-color: var(--text-muted); }
+.status-pivot--archive.is-active { background: var(--red); color: #fff; border-color: var(--red); }
+.status-pivot--draft.is-active   { background: var(--yellow); color: #0f0f17; border-color: var(--yellow); }
+
+.product-description__raw {
+  white-space: pre-wrap;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  margin: 0;
+}
+
+/* Deps */
+.product-deps { margin: 18px 0; padding: 12px 14px; border: 1px solid var(--border-subtle); border-radius: var(--radius-md); background: var(--bg-secondary); }
+.product-deps__head { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
+.product-deps__head h3, .product-deps__incoming h4 { margin: 0; font-size: 12px; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.06em; }
+.product-deps__empty { font-size: 12px; color: var(--text-muted); font-style: italic; margin: 0 0 6px; }
+.product-deps__pills { list-style: none; margin: 0; padding: 0; display: flex; gap: 8px; flex-wrap: wrap; }
+.product-deps__incoming { margin-top: 14px; }
+
+.dep-pill {
+  display: inline-flex; align-items: center; gap: 6px; padding: 3px 8px;
+  border: 1px solid var(--border); border-radius: 999px; background: var(--bg-elevated);
+  font-size: 11px; font-family: var(--font-mono);
+}
+.dep-pill--open    { border-color: var(--green); }
+.dep-pill--closed  { border-color: var(--text-muted); }
+.dep-pill--archive { border-color: var(--red); }
+.dep-pill--draft   { border-color: var(--yellow); }
+.dep-pill__nav { background: transparent; border: 0; color: var(--accent); cursor: pointer; font: inherit; padding: 0; }
+.dep-pill__title { color: var(--text-primary); }
+.dep-pill__remove {
+  background: transparent; border: 0; color: var(--red); cursor: pointer; font-size: 14px; line-height: 1; padding: 0 2px;
+}
+
+.dep-picker { margin-top: 10px; padding: 10px; border: 1px dashed var(--border); border-radius: var(--radius-md); background: var(--bg-elevated); }
+.dep-picker__list { list-style: none; margin: 8px 0 0; padding: 0; max-height: 240px; overflow-y: auto; }
+.dep-picker__row {
+  width: 100%; display: flex; align-items: center; gap: 8px; padding: 6px 8px;
+  background: transparent; border: 0; color: var(--text-primary); cursor: pointer; font: inherit; text-align: left;
+  border-radius: var(--radius-sm);
+}
+.dep-picker__row:hover { background: var(--accent-soft); }
+.dep-picker__title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.dep-picker__empty { padding: 8px; color: var(--text-muted); font-size: 12px; font-style: italic; }
+
+/* Manifest / idea rows */
+.manifest-rows { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.manifest-row { display: flex; gap: 6px; align-items: center; }
+.manifest-row__main {
+  flex: 1; display: flex; gap: 12px; align-items: center; padding: 10px 14px;
+  background: var(--bg-secondary); border: 1px solid var(--border-subtle); border-radius: var(--radius-md);
+  cursor: pointer; font: inherit; color: inherit; text-align: left;
+  transition: border-color 80ms ease, background 80ms ease;
+}
+.manifest-row__main:hover { border-color: var(--accent); background: var(--accent-soft); }
+.manifest-row__main .marker { flex-shrink: 0; min-width: 92px; }
+.meta-strip { font-size: 11px; color: var(--text-muted); }
+.meta-strip.cost { color: var(--green); }
+
+.idea-rows { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.idea-row { display: flex; gap: 10px; align-items: center; padding: 8px 12px; background: var(--bg-secondary); border: 1px solid var(--border-subtle); border-radius: var(--radius-md); }
+.idea-title { flex: 1; }
+.priority { font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; }
+.priority--critical { color: var(--red); }
+.priority--high { color: var(--yellow); }
+
+.row-remove {
+  background: transparent; border: 0; color: var(--text-muted); cursor: pointer; padding: 4px 8px;
+  border-radius: var(--radius-sm);
+}
+.row-remove:hover { color: var(--red); background: rgba(230, 55, 87, 0.08); }
+
+.sub-count { color: var(--text-muted); font-weight: 400; font-size: 11px; }
+
+/* Search results in sidebar */
+.search-results { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.search-result-row { padding: 8px 10px; border-radius: var(--radius-sm); cursor: pointer; outline: none; }
+.search-result-row:hover, .search-result-row:focus-visible { background: var(--accent-soft); }
+.search-result-row.is-selected { background: var(--accent-soft); border-left: 3px solid var(--accent); }
+.search-result-row__head { display: flex; gap: 8px; align-items: center; margin-bottom: 4px; }
+.search-result-row__title { font-size: 13px; color: var(--text-primary); }
+
+/* Comments */
+.product-comments { margin-top: 24px; }
+.product-comments h3 { margin: 0 0 8px; font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-secondary); }
+
+/* Edit form */
+.product-edit-form { padding: 12px 0; }
+.product-edit-form__title { margin: 0 0 16px; font-size: 16px; font-weight: 600; }
+
+/* Form inputs (reused in dialogs + edit) */
+.form-input {
+  width: 100%; padding: 6px 10px; font-size: 13px;
+  background: var(--bg-input); color: var(--text-primary);
+  border: 1px solid var(--border); border-radius: var(--radius-sm);
+}
+.form-input--textarea { font-family: var(--font-mono); resize: vertical; min-height: 100px; }
+.form-input:focus { outline: 2px solid var(--accent); outline-offset: 0; border-color: var(--accent); }
+
+/* Dialog picker rows */
+.picker-list { list-style: none; margin: 12px 0 0; padding: 0; max-height: 360px; overflow-y: auto; display: flex; flex-direction: column; gap: 4px; }
+.picker-row {
+  width: 100%; display: flex; align-items: center; gap: 10px; padding: 8px 10px;
+  background: var(--bg-input); border: 1px solid var(--border-subtle); border-radius: var(--radius-sm);
+  font: inherit; color: inherit; cursor: pointer; text-align: left;
+}
+.picker-row:hover { border-color: var(--accent); background: var(--accent-soft); }
+.picker-row__title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* DAG overlay legend */
+.dag-overlay-header__sub { font-size: 12px; color: var(--text-muted); }
+.dag-overlay-header__legend { margin-left: auto; display: flex; gap: 16px; font-size: 11px; color: var(--text-muted); align-items: center; }
+.legend-dash { display: inline-block; width: 18px; height: 0; border-top: 2px solid currentColor; vertical-align: middle; margin-right: 4px; }
+.legend-dash--ownership { color: rgba(255,255,255,0.4); }
+.legend-dash--manifest  { color: #3b82f6; }
+.legend-dash--task      { color: #f59e0b; border-top-style: dashed; }
 
 /* ── Forms ── */
 .form-field { display: flex; flex-direction: column; gap: 4px; margin-bottom: 12px; }


### PR DESCRIPTION
## Summary

Full-parity React port of legacy `internal/web/ui/views/products.js`
(650 lines) + `views/product-dag.js` (330 lines) on top of the
Foundation M1 primitives shipped in PR #248.

Manifest: `019dcb72-e38` — OpenPraxis React 2 / Products M1.
Task: `019dcb75-0611-71c9-bcee-05333fbd7fd4`.

### What ships

- **Sidebar:** peer→product→sub-product tree, live search via
  `/api/products/search`, `+ New Product` dialog.
- **Detail:** breadcrumb, header (title/marker/status badge/tags/copy
  ref), stats bar (manifests/tasks/turns/cost/created/updated),
  toolbar.
- **Edit:** inline form (FormField), Save/Cancel.
- **Status pivots:** draft / open / closed / archive cycle with live
  PUT.
- **Toolbar actions:** + New Manifest (pre-linked), + Link Manifest,
  + Link Idea, + Depends On (picker), ◈ Product DAG.
- **Deps:** outgoing pills (nav + remove), incoming pills,
  ✓ Satisfied / ⏳ Waiting on N badge, picker scoped to non-archive
  candidates.
- **Linked manifests:** clickable rows with metrics strip + ✕ unlink.
- **Linked ideas:** rows with priority + ✕ unlink.
- **Comments:** read-only via `CommentsList` from M1.
- **DAG overlay:** lazy Cytoscape canvas, ESC + Back close, click
  drilldown to manifest/task views.
- **URL state:** `/products/:id` route — hard refresh restores
  selection.
- **Resizable sidebar/detail divider** with localStorage persistence
  (#245).
- **ApiError detail** surfaced inline on load failure (#243).
- **Tree chevron-vs-row click** separation test (#244).
- `LEGACY_INVENTORY.md` enumerating every legacy fetch + UI element.

### Side-by-side parity checklist

| Legacy | React |
|---|---|
| `OL.loadProducts()` tree | `Products` page sidebar |
| `OL.createProduct()` form | `NewProductDialog` |
| `OL.loadProductDetail(id)` | `ProductDetail` |
| `OL.editProduct(id)` | `ProductEditForm` |
| `OL.updateProductStatus(id, s)` | `ProductToolbar` status pivots |
| `OL.linkManifestToProduct(id)` | `LinkManifestDialog` |
| `OL.linkIdeaToProduct(id)` | `LinkIdeaDialog` |
| `OL.unlinkManifestFromProduct(...)` | `manifest-row` ✕ |
| `OL.unlinkIdeaFromProduct(...)` | `idea-row` ✕ |
| Product dep picker (`product-toolbar-dep`) | `ProductDeps` + `DepPicker` |
| Dep pill remove | `DepPill` `dep-pill__remove` |
| `OL.showProductDiagram(id, title)` | `ProductDagOverlay` |
| `OL.copy('get product …')` | `btn-copy` ⎘ |
| Search box | sidebar `<input type=search>` |
| `OL.renderCommentsSection` | `ProductCommentsSection` + `CommentsList` |
| `OL.renderKnobSection` | DEFERRED — knob primitives not yet in React, follow-up |
| `OL.renderRevisionsSection` | DEFERRED — revisions primitives not yet in React, follow-up |

### Gates

- `npm run check` — clean
- `npm test` — 44/44 (4 new Products tests, 1 new Tree chevron test)
- `npm run build` — clean
- `go test ./...` — green
- `make types-check` — green (no Go→TS drift)

### Bundle delta (gzipped)

| chunk | before | after | Δ |
|---|---:|---:|---:|
| Products | 6.07 KB | 56.79 KB | +50.72 KB |
| index | 90.06 KB | 90.22 KB | +0.16 KB |
| css | 3.61 KB | 4.68 KB | +1.07 KB |
| total | — | — | **+51.95 KB** |

PARTIAL vs the ≤ 30 KB target — bulk is the Radix Dialog + Toast +
forms surface that M1 introduced but no consumer was pulling in until
this tab. Subsequent tabs land on top of this chunk for free.

### Known gaps / follow-ups

- Knob mount + Revisions mount — primitives not yet ported; legacy
  detail panels render those sections but the React port skips them
  in M1 per the manifest's "out of scope" list. Filed as a follow-up
  for M2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)