### PR TITLE
feat(react2/products m1): full-parity port of /products tab

### DIFF
--- a/internal/web/ui/dashboard/LEGACY_INVENTORY.md
+++ b/internal/web/ui/dashboard/LEGACY_INVENTORY.md
@@ -1,0 +1,121 @@
+# Legacy Products Inventory — Parity Checklist for React 2 / Products M1
+
+Source: `internal/web/ui/views/products.js` (650 lines) + `internal/web/ui/views/product-dag.js` (330 lines).
+
+This file is the executable spec. Every row is a parity item the React port must match.
+
+## A. Sidebar (peer → product → sub-product tree)
+
+| # | Legacy element | API call | React owner |
+|---|---|---|---|
+| A1 | `+ New Product` button | — | `<NewProductDialog />` |
+| A2 | Search input (mounted via `OL.mountSearchInput`) | `GET /api/products/search?q=` | sidebar input + `useTypeahead` |
+| A3 | Peer group row (peer_id + count) | `GET /api/products/by-peer` | `<PeerGroup />` (TreeRow) |
+| A4 | Product row (status dot, marker, title, count badges) | — | `<ProductTreeRow />` (TreeRow) |
+| A5 | Sub-product row (recursive) | sub_products[] from same payload | `<ProductTreeRow level=2 />` |
+| A6 | Inline manifest list under expanded product | `GET /api/products/{id}/manifests` | `<ProductTreeManifestStub />` |
+| A7 | Click row → load detail + select | `GET /api/products/{id}` | `useNavigate(/products/:id)` |
+
+## B. Detail header (top of right panel)
+
+| # | Legacy element | API call | React owner |
+|---|---|---|---|
+| B1 | Title (`product-detail-title`) | — | `<ProductDetail h1>` |
+| B2 | Breadcrumb (peer → product) | — | `<ProductDetailBreadcrumb />` |
+| B3 | Marker + status badge + tag pills | — | `<ProductHeader />` |
+| B4 | Stats bar (Manifests / Tasks / Turns / Cost / created / updated) | — | `<ProductHeader />` |
+| B5 | Description toggle + markdown render | — | `<DescToggle />` + `<MarkdownRenderer />` |
+| B6 | Top toolbar: ✎ Edit / + New Manifest / + Link Manifest / + Depends On / + Link Idea / ◈ Product DAG / status pivots | — | `<ProductToolbar />` |
+| B7 | Status pivot buttons (draft/open/closed/archive) — active state & PUT on click | `PUT /api/products/{id} {status}` | `<StatusPivots />` |
+| B8 | Copy ref button | clipboard | `<IconButton>` |
+
+## C. Edit form (inline, replaces the body)
+
+| # | Legacy element | API call | React owner |
+|---|---|---|---|
+| C1 | Title input (required) | — | `<ProductEditForm />` (FormField) |
+| C2 | Description textarea (markdown) | — | `<ProductEditForm />` (FormField) |
+| C3 | Tags input (comma-separated → array) | — | `<ProductEditForm />` |
+| C4 | Save / Cancel | `PUT /api/products/{id}` | `useUpdateProduct()` |
+
+## D. New product / new sub-product dialogs
+
+| # | Legacy element | API call | React owner |
+|---|---|---|---|
+| D1 | + New Product → modal/form (title required, desc, tags) | `POST /api/products` | `<NewProductDialog />` |
+| D2 | + New Sub-Product (when a product is selected) | `POST /api/products` + `POST /api/products/{parent}/dependencies` | `<NewSubProductDialog />` |
+
+## E. Product dependencies section
+
+| # | Legacy element | API call | React owner |
+|---|---|---|---|
+| E1 | "Depends on" header + SATISFIED/WAITING-ON pill | `GET /api/products/{id}/dependencies?direction=both` | `<ProductDeps />` |
+| E2 | Dep pills (out edges) — marker + title + status + ✕ remove | `DELETE /api/products/{id}/dependencies/{depId}` | `<DepPill />` |
+| E3 | "Depended on by" pills (in edges) | same payload | `<DepPill readOnly />` |
+| E4 | + Depends On picker (select from available products, toggle) | `POST /api/products/{id}/dependencies` | `<AddDepPicker />` |
+
+## F. Linked manifests (right panel section)
+
+| # | Legacy element | API call | React owner |
+|---|---|---|---|
+| F1 | Linked Manifests heading + count | `GET /api/products/{id}/manifests` | `<LinkedManifests />` |
+| F2 | Manifest row → click navigates to /dashboard/manifests/:id | — | `<LinkedManifests />` |
+| F3 | Per-row ✕ unlink (PUT manifest with project_id="") | `PUT /api/manifests/{id} {project_id:""}` | `useUnlinkManifest()` |
+| F4 | + Link Manifest picker | `GET /api/manifests` filter unlinked + `PUT /api/manifests/{id} {project_id}` | `<LinkManifestPicker />` |
+| F5 | + New Manifest pre-linked to product | `POST /api/manifests {project_id}` | `<NewManifestDialog />` |
+
+## G. Linked ideas (bottom section)
+
+| # | Legacy element | API call | React owner |
+|---|---|---|---|
+| G1 | Linked Ideas heading + count | `GET /api/products/{id}/ideas` | `<LinkedIdeas />` |
+| G2 | Idea row (marker, status, priority, title) | — | `<LinkedIdeas />` |
+| G3 | Per-row ✕ unlink | `PUT /api/ideas/{id} {project_id:""}` | `useUnlinkIdea()` |
+| G4 | + Link Idea picker | `GET /api/ideas` filter unlinked + `PUT /api/ideas/{id}` | `<LinkIdeaPicker />` |
+
+## H. Product DAG overlay (already shipped in Foundation M1)
+
+| # | Legacy element | API call | React owner |
+|---|---|---|---|
+| H1 | Overlay header + back / Esc to close | — | `<ProductDagOverlay />` (existing) |
+| H2 | Cytoscape + dagre layout | `GET /api/products/{id}/hierarchy` | `<ProductDag />` (existing) |
+| H3 | Tooltip on node hover | client | `CytoscapeCanvas` |
+| H4 | Click node → navigate (product/manifest/task) | — | `onNodeClick` prop |
+
+## I. Comments / revisions / knobs (sub-sections, each its own mount)
+
+| # | Legacy element | API call | React owner |
+|---|---|---|---|
+| I1 | Comments section (`renderCommentsSection({type:'product'})`) | `GET /api/products/{id}/comments`, `POST /api/products/{id}/comments` | `<ProductCommentsSection />` (CommentsList + CommentEditor) |
+| I2 | Revisions section | description revisions API | DEFERRED to follow-up — out of M1 scope |
+| I3 | Knobs section | settings catalog | DEFERRED — out of M1 scope |
+
+## J. URL state + cross-tab redirect
+
+| # | Legacy element | API call | React owner |
+|---|---|---|---|
+| J1 | Hard-refresh restores selected product | `useParams<{id}>` + route `/products/:id` | already in `App.tsx` |
+| J2 | Per-tab v2 redirect knob | `GET /api/settings/resolve?scope=system` | already in `lib/featureFlags.ts` |
+
+## Acceptance mapping
+
+- Click-through parity with legacy /products → A–G + I1.
+- Every button works → B6, C, D, E4, F4-F5, G4.
+- Bundle delta ≤ 30 KB gzipped → measured before vs after, recorded in self_summary.
+- tsc + tests + build green → 5-gate exit protocol.
+
+## Out-of-scope / deferred
+
+- Revisions panel (I2) — needs `useDescRevisions` hook + UI; targeted at a follow-up manifest.
+- Knobs panel (I3) — needs settings/resolve typeahead UI.
+- Markdown editor (legacy `OL.mountEditor`) — Foundation ships only `MarkdownRenderer`; description edit uses a plain textarea. The renderer already handles both raw markup + html on read.
+- Inline-edit description revisions tracking on save — covered by server-side description versioning, no UI surface needed for parity.
+
+## Nit issues to address inline (#241–#245)
+
+These were referenced in the task body. Search for the issue numbers in commits or here:
+- #241 — Aria roles / labels on tree rows (TreeRow already wires role="button" + aria-label on chevron)
+- #242 — Status dot color tokens reused across sidebar + detail
+- #243 — Tags arr filtering (comma split + trim)
+- #244 — Picker click-outside dismiss
+- #245 — Manifest unlink confirm dialog (simple `confirm()` is fine for M1 parity)

--- a/internal/web/ui/dashboard/src/components/products/AddDepPicker.tsx
+++ b/internal/web/ui/dashboard/src/components/products/AddDepPicker.tsx
@@ -1,0 +1,53 @@
+import { useMemo } from 'react';
+import { Badge } from '@/components/ui/Badge';
+import {
+  useAddProductDependency,
+  useAllProductsFlat,
+} from '@/lib/queries/products';
+import type { Product, ProductDepEntry } from '@/lib/types';
+import { PickerDialog, type PickerDialogItem } from './PickerDialog';
+
+export interface AddDepPickerProps {
+  product: Product;
+  existingDeps: ProductDepEntry[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function AddDepPicker({ product, existingDeps, open, onOpenChange }: AddDepPickerProps) {
+  const all = useAllProductsFlat();
+  const add = useAddProductDependency(product.id);
+
+  const items: PickerDialogItem[] = useMemo(() => {
+    const depIds = new Set(existingDeps.map((d) => d.id));
+    const list = (all.data ?? []).filter(
+      (p) => p.id !== product.id && !depIds.has(p.id) && p.status !== 'archive',
+    );
+    return list.map((p) => ({
+      id: p.id,
+      search: `${p.marker} ${p.title} ${p.status}`,
+      render: (
+        <span className="picker-row">
+          <span className="marker">{p.marker}</span>
+          <Badge tone={p.status === 'open' ? 'success' : p.status === 'closed' ? 'neutral' : 'info'}>
+            {p.status}
+          </Badge>
+          <span className="picker-row__title">{p.title}</span>
+        </span>
+      ),
+    }));
+  }, [all.data, existingDeps, product.id]);
+
+  return (
+    <PickerDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={`Add dependency for ${product.title}`}
+      description="Select a product this product depends on."
+      busy={add.isPending}
+      items={items}
+      emptyMessage={all.isLoading ? 'Loading…' : 'No eligible products to depend on.'}
+      onPick={(depId) => add.mutate(depId, { onSuccess: () => onOpenChange(false) })}
+    />
+  );
+}

--- a/internal/web/ui/dashboard/src/components/products/LinkIdeaPicker.tsx
+++ b/internal/web/ui/dashboard/src/components/products/LinkIdeaPicker.tsx
@@ -1,0 +1,55 @@
+import { useMemo } from 'react';
+import { Badge } from '@/components/ui/Badge';
+import { useAllIdeas, useUpdateIdeaProject } from '@/lib/queries/ideas';
+import { PickerDialog, type PickerDialogItem } from './PickerDialog';
+
+export interface LinkIdeaPickerProps {
+  productId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function LinkIdeaPicker({ productId, open, onOpenChange }: LinkIdeaPickerProps) {
+  const all = useAllIdeas();
+  const link = useUpdateIdeaProject();
+
+  const items: PickerDialogItem[] = useMemo(() => {
+    const list = (all.data ?? []).filter((i) => i.project_id !== productId);
+    return list.map((idea) => ({
+      id: idea.id,
+      search: `${idea.marker} ${idea.title} ${idea.status} ${idea.priority}`,
+      render: (
+        <span className="picker-row">
+          <span className="marker">{idea.marker}</span>
+          <Badge>{idea.status}</Badge>
+          <Badge tone={idea.priority === 'critical' ? 'danger' : idea.priority === 'high' ? 'warn' : 'neutral'}>
+            {idea.priority}
+          </Badge>
+          <span className="picker-row__title">{idea.title}</span>
+        </span>
+      ),
+    }));
+  }, [all.data, productId]);
+
+  return (
+    <PickerDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Link idea to product"
+      description="Click an idea to link it to this product."
+      busy={link.isPending}
+      items={items}
+      emptyMessage={all.isLoading ? 'Loading…' : 'No ideas available to link.'}
+      onPick={(ideaId) => {
+        const idea = (all.data ?? []).find((i) => i.id === ideaId);
+        if (!idea) return;
+        link.mutate(
+          { idea, productId },
+          {
+            onSuccess: () => onOpenChange(false),
+          },
+        );
+      }}
+    />
+  );
+}

--- a/internal/web/ui/dashboard/src/components/products/LinkManifestPicker.tsx
+++ b/internal/web/ui/dashboard/src/components/products/LinkManifestPicker.tsx
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+import { Badge } from '@/components/ui/Badge';
+import { useAllManifests, useUpdateManifestProject } from '@/lib/queries/manifests';
+import { PickerDialog, type PickerDialogItem } from './PickerDialog';
+
+export interface LinkManifestPickerProps {
+  productId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function LinkManifestPicker({ productId, open, onOpenChange }: LinkManifestPickerProps) {
+  const all = useAllManifests();
+  const link = useUpdateManifestProject();
+
+  const items: PickerDialogItem[] = useMemo(() => {
+    const list = (all.data ?? []).filter((m) => m.project_id !== productId);
+    return list.map((m) => ({
+      id: m.id,
+      search: `${m.marker} ${m.title} ${m.status}`,
+      render: (
+        <span className="picker-row">
+          <span className="marker">{m.marker}</span>
+          <Badge tone={m.status === 'open' ? 'success' : m.status === 'closed' ? 'neutral' : 'info'}>{m.status}</Badge>
+          <span className="picker-row__title">{m.title}</span>
+        </span>
+      ),
+    }));
+  }, [all.data, productId]);
+
+  return (
+    <PickerDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Link manifest to product"
+      description="Click a manifest to link it to this product."
+      busy={link.isPending}
+      items={items}
+      emptyMessage={all.isLoading ? 'Loading…' : 'No manifests available to link.'}
+      onPick={(manifestId) =>
+        link.mutate(
+          { manifestId, productId },
+          {
+            onSuccess: () => onOpenChange(false),
+          },
+        )
+      }
+    />
+  );
+}

--- a/internal/web/ui/dashboard/src/components/products/LinkedIdeas.tsx
+++ b/internal/web/ui/dashboard/src/components/products/LinkedIdeas.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { Badge } from '@/components/ui/Badge';
+import { Button } from '@/components/ui/Button';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { useProductIdeas, useUpdateIdeaProject } from '@/lib/queries/ideas';
+import { LinkIdeaPicker } from './LinkIdeaPicker';
+
+export interface LinkedIdeasProps {
+  productId: string;
+}
+
+export function LinkedIdeas({ productId }: LinkedIdeasProps) {
+  const q = useProductIdeas(productId);
+  const unlink = useUpdateIdeaProject();
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  return (
+    <section className="linked-ideas" aria-labelledby="linked-ideas-title">
+      <header className="linked-manifests__header">
+        <h3 id="linked-ideas-title">
+          Linked Ideas {q.data ? <span className="sub-count">({q.data.length})</span> : null}
+        </h3>
+        <Button size="sm" variant="ghost" onClick={() => setPickerOpen(true)}>
+          + Link Idea
+        </Button>
+      </header>
+      {q.isLoading && <EmptyState message="Loading…" />}
+      {q.data && q.data.length === 0 && <EmptyState message="No ideas linked yet." />}
+      {q.data && q.data.length > 0 && (
+        <ul className="linked-ideas__list" role="list">
+          {q.data.map((idea) => (
+            <li key={idea.id} className="linked-ideas__row">
+              <span className="marker">{idea.marker}</span>
+              <Badge>{idea.status}</Badge>
+              <Badge tone={idea.priority === 'critical' ? 'danger' : idea.priority === 'high' ? 'warn' : 'neutral'}>
+                {idea.priority}
+              </Badge>
+              <span className="linked-ideas__title">{idea.title}</span>
+              <button
+                type="button"
+                className="linked-ideas__rm"
+                disabled={unlink.isPending}
+                aria-label={`Unlink idea ${idea.title}`}
+                onClick={() => {
+                  if (window.confirm(`Unlink idea "${idea.title}" from product?`)) {
+                    unlink.mutate({ idea, productId: '' });
+                  }
+                }}
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <LinkIdeaPicker productId={productId} open={pickerOpen} onOpenChange={setPickerOpen} />
+    </section>
+  );
+}

--- a/internal/web/ui/dashboard/src/components/products/LinkedManifests.tsx
+++ b/internal/web/ui/dashboard/src/components/products/LinkedManifests.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Badge } from '@/components/ui/Badge';
+import { Button } from '@/components/ui/Button';
+import { EmptyState } from '@/components/ui/EmptyState';
+import {
+  useProductManifests,
+} from '@/lib/queries/products';
+import { useUpdateManifestProject } from '@/lib/queries/manifests';
+import type { Manifest } from '@/lib/types';
+import { LinkManifestPicker } from './LinkManifestPicker';
+import { NewManifestDialog } from './NewManifestDialog';
+
+export interface LinkedManifestsProps {
+  productId: string;
+  productTitle: string;
+}
+
+export function LinkedManifests({ productId, productTitle }: LinkedManifestsProps) {
+  const q = useProductManifests(productId);
+  const unlink = useUpdateManifestProject();
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [newOpen, setNewOpen] = useState(false);
+  const navigate = useNavigate();
+
+  return (
+    <section className="linked-manifests" aria-labelledby="linked-manifests-title">
+      <header className="linked-manifests__header">
+        <h3 id="linked-manifests-title">
+          Linked Manifests {q.data ? <span className="sub-count">({q.data.length})</span> : null}
+        </h3>
+        <div className="linked-manifests__actions">
+          <Button size="sm" variant="ghost" onClick={() => setNewOpen(true)}>
+            + New Manifest
+          </Button>
+          <Button size="sm" variant="ghost" onClick={() => setPickerOpen(true)}>
+            + Link Manifest
+          </Button>
+        </div>
+      </header>
+      {q.isLoading && <EmptyState message="Loading…" />}
+      {q.data && q.data.length === 0 && <EmptyState message="No manifests linked yet." />}
+      {q.data && q.data.length > 0 && (
+        <ul className="linked-manifests__list" role="list">
+          {q.data.map((m) => (
+            <li key={m.id}>
+              <ManifestRow
+                manifest={m}
+                onOpen={() => navigate(`/manifests/${m.id}`)}
+                onUnlink={() => {
+                  if (window.confirm(`Unlink manifest "${m.title}" from product?`)) {
+                    unlink.mutate({ manifestId: m.id, productId: '' });
+                  }
+                }}
+                disabled={unlink.isPending}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+      <LinkManifestPicker productId={productId} open={pickerOpen} onOpenChange={setPickerOpen} />
+      <NewManifestDialog
+        productId={productId}
+        productTitle={productTitle}
+        open={newOpen}
+        onOpenChange={setNewOpen}
+      />
+    </section>
+  );
+}
+
+function ManifestRow({
+  manifest,
+  onOpen,
+  onUnlink,
+  disabled,
+}: {
+  manifest: Manifest;
+  onOpen: () => void;
+  onUnlink: () => void;
+  disabled: boolean;
+}) {
+  const m = manifest;
+  return (
+    <div className="manifest-row">
+      <button
+        type="button"
+        className="manifest-row__main"
+        onClick={onOpen}
+        aria-label={`Open manifest ${m.title}`}
+      >
+        <span className="marker">{m.marker}</span>
+        <Badge tone={m.status === 'open' ? 'success' : m.status === 'closed' ? 'neutral' : 'info'}>
+          {m.status}
+        </Badge>
+        <span className="manifest-title">{m.title}</span>
+        <span className="manifest-row__meta">
+          {(m.total_tasks ?? 0) > 0 && <span>{m.total_tasks} tasks</span>}
+          {(m.total_turns ?? 0) > 0 && <span>{m.total_turns} turns</span>}
+          {(m.total_cost ?? 0) > 0 && <span className="cost">${(m.total_cost ?? 0).toFixed(2)}</span>}
+        </span>
+      </button>
+      <button
+        type="button"
+        className="manifest-row__rm"
+        onClick={(e) => {
+          e.stopPropagation();
+          onUnlink();
+        }}
+        disabled={disabled}
+        aria-label={`Unlink ${m.title} from product`}
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/internal/web/ui/dashboard/src/components/products/NewManifestDialog.tsx
+++ b/internal/web/ui/dashboard/src/components/products/NewManifestDialog.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import { Dialog } from '@/components/ui/Dialog';
+import { Button } from '@/components/ui/Button';
+import { FormActions, FormError, FormField } from '@/components/forms';
+import { useCreateManifest } from '@/lib/queries/manifests';
+import type { Manifest } from '@/lib/types';
+
+export interface NewManifestDialogProps {
+  open: boolean;
+  productId: string;
+  productTitle: string;
+  onOpenChange: (open: boolean) => void;
+  onCreated?: (m: Manifest) => void;
+}
+
+export function NewManifestDialog({
+  open,
+  productId,
+  productTitle,
+  onOpenChange,
+  onCreated,
+}: NewManifestDialogProps) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const create = useCreateManifest();
+
+  const reset = () => {
+    setTitle('');
+    setDescription('');
+    setError(null);
+  };
+  const close = () => {
+    reset();
+    onOpenChange(false);
+  };
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const t = title.trim();
+    if (!t) {
+      setError('Title is required');
+      return;
+    }
+    setError(null);
+    create.mutate(
+      { title: t, description: description.trim(), project_id: productId },
+      {
+        onSuccess: (m) => {
+          onCreated?.(m);
+          close();
+        },
+        onError: (err) => setError(err.message),
+      },
+    );
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => (o ? onOpenChange(true) : close())}
+      title={`New Manifest under ${productTitle}`}
+      description="Manifest will be pre-linked to this product."
+    >
+      <form onSubmit={onSubmit} aria-label="New manifest form">
+        <FormField label="Title" htmlFor="new-manifest-title" required>
+          <input
+            id="new-manifest-title"
+            className="ui-input"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Manifest title"
+            autoFocus
+            required
+          />
+        </FormField>
+        <FormField label="Description" htmlFor="new-manifest-desc">
+          <textarea
+            id="new-manifest-desc"
+            className="ui-input ui-textarea"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Spec / scope / acceptance"
+            rows={6}
+          />
+        </FormField>
+        {error && <FormError>{error}</FormError>}
+        <FormActions>
+          <Button type="button" variant="ghost" onClick={close} disabled={create.isPending}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" loading={create.isPending}>
+            Create Manifest
+          </Button>
+        </FormActions>
+      </form>
+    </Dialog>
+  );
+}

--- a/internal/web/ui/dashboard/src/components/products/NewProductDialog.tsx
+++ b/internal/web/ui/dashboard/src/components/products/NewProductDialog.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react';
+import { Dialog } from '@/components/ui/Dialog';
+import { Button } from '@/components/ui/Button';
+import { FormActions, FormError, FormField } from '@/components/forms';
+import {
+  useAddProductDependency,
+  useCreateProduct,
+} from '@/lib/queries/products';
+import type { Product } from '@/lib/types';
+
+interface BaseProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated?: (p: Product) => void;
+}
+
+export interface NewProductDialogProps extends BaseProps {
+  parent?: { id: string; title: string };
+}
+
+export function NewProductDialog({ open, onOpenChange, onCreated, parent }: NewProductDialogProps) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [tags, setTags] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const create = useCreateProduct();
+  const addDep = useAddProductDependency(parent?.id);
+
+  const reset = () => {
+    setTitle('');
+    setDescription('');
+    setTags('');
+    setError(null);
+  };
+
+  const close = () => {
+    reset();
+    onOpenChange(false);
+  };
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const t = title.trim();
+    if (!t) {
+      setError('Title is required');
+      return;
+    }
+    setError(null);
+    create.mutate(
+      {
+        title: t,
+        description: description.trim(),
+        tags: tags
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean),
+      },
+      {
+        onSuccess: (p) => {
+          // Sub-product flow: wire the new product as a dependency edge
+          // from the parent so it appears nested in the tree (mirrors how
+          // the legacy umbrella → sub-product relationship works).
+          if (parent && p?.id) {
+            addDep.mutate(p.id, {
+              onSuccess: () => {
+                onCreated?.(p);
+                close();
+              },
+              onError: (err) => setError(err.message),
+            });
+          } else {
+            onCreated?.(p);
+            close();
+          }
+        },
+        onError: (err) => setError(err.message),
+      },
+    );
+  };
+
+  const busy = create.isPending || addDep.isPending;
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => (o ? onOpenChange(true) : close())}
+      title={parent ? `New Sub-Product under ${parent.title}` : 'New Product'}
+      description={
+        parent
+          ? 'Creates a new product and links it as a dependency of the current product.'
+          : 'Group your manifests under a top-level product.'
+      }
+      footer={null}
+    >
+      <form onSubmit={onSubmit} aria-label={parent ? 'New sub-product form' : 'New product form'}>
+        <FormField label="Title" htmlFor="new-product-title" required>
+          <input
+            id="new-product-title"
+            className="ui-input"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Product name"
+            autoFocus
+            required
+          />
+        </FormField>
+        <FormField label="Description" htmlFor="new-product-desc">
+          <textarea
+            id="new-product-desc"
+            className="ui-input ui-textarea"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="What is this product/project about?"
+            rows={4}
+          />
+        </FormField>
+        <FormField label="Tags (comma-separated)" htmlFor="new-product-tags">
+          <input
+            id="new-product-tags"
+            className="ui-input"
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+            placeholder="e.g. openpraxis, backend"
+          />
+        </FormField>
+        {error && <FormError>{error}</FormError>}
+        <FormActions>
+          <Button type="button" variant="ghost" onClick={close} disabled={busy}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" loading={busy}>
+            {parent ? 'Create Sub-Product' : 'Create Product'}
+          </Button>
+        </FormActions>
+      </form>
+    </Dialog>
+  );
+}

--- a/internal/web/ui/dashboard/src/components/products/PickerDialog.tsx
+++ b/internal/web/ui/dashboard/src/components/products/PickerDialog.tsx
@@ -1,0 +1,86 @@
+import { useMemo, useState, type ReactNode } from 'react';
+import { Dialog } from '@/components/ui/Dialog';
+import { EmptyState } from '@/components/ui/EmptyState';
+
+export interface PickerDialogItem {
+  id: string;
+  search: string;
+  render: ReactNode;
+}
+
+export interface PickerDialogProps {
+  open: boolean;
+  title: ReactNode;
+  description?: ReactNode;
+  items: PickerDialogItem[];
+  busy?: boolean;
+  emptyMessage?: string;
+  onOpenChange: (open: boolean) => void;
+  onPick: (id: string) => void;
+}
+
+/**
+ * Simple modal list picker. Used by Products M1 for "+ Link Manifest",
+ * "+ Link Idea", and "+ Depends On". Filters by case-insensitive substring
+ * over the item's `search` blob. Click-outside / Esc dismisses via the
+ * Dialog primitive (Radix).
+ */
+export function PickerDialog({
+  open,
+  title,
+  description,
+  items,
+  busy,
+  emptyMessage = 'Nothing available to link.',
+  onOpenChange,
+  onPick,
+}: PickerDialogProps) {
+  const [filter, setFilter] = useState('');
+  const filtered = useMemo(() => {
+    const f = filter.trim().toLowerCase();
+    if (!f) return items;
+    return items.filter((it) => it.search.toLowerCase().includes(f));
+  }, [filter, items]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        onOpenChange(o);
+        if (!o) setFilter('');
+      }}
+      title={title}
+      description={description}
+      size="md"
+    >
+      <input
+        type="search"
+        className="ui-input"
+        placeholder="Filter…"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        aria-label="Filter list"
+        autoFocus
+      />
+      <ul className="picker-list" role="listbox" aria-label="Available items">
+        {filtered.length === 0 && (
+          <li className="picker-list__empty">
+            <EmptyState message={items.length === 0 ? emptyMessage : 'No items match the filter.'} />
+          </li>
+        )}
+        {filtered.map((it) => (
+          <li key={it.id} className="picker-list__item">
+            <button
+              type="button"
+              className="picker-list__btn"
+              disabled={busy}
+              onClick={() => onPick(it.id)}
+            >
+              {it.render}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </Dialog>
+  );
+}

--- a/internal/web/ui/dashboard/src/components/products/ProductCommentsSection.tsx
+++ b/internal/web/ui/dashboard/src/components/products/ProductCommentsSection.tsx
@@ -1,0 +1,30 @@
+import { CommentEditor } from '@/components/comments/CommentEditor';
+import { CommentsList } from '@/components/comments/CommentsList';
+import { useAddComment, useComments } from '@/lib/queries/comments';
+
+export interface ProductCommentsSectionProps {
+  productId: string;
+}
+
+export function ProductCommentsSection({ productId }: ProductCommentsSectionProps) {
+  const list = useComments('products', productId);
+  const add = useAddComment('products', productId);
+
+  return (
+    <section className="product-comments" aria-labelledby="product-comments-title">
+      <h3 id="product-comments-title" className="product-comments__title">Comments</h3>
+      <CommentsList comments={list.data ?? []} loading={list.isLoading} />
+      <CommentEditor
+        busy={add.isPending}
+        onSubmit={(body) =>
+          new Promise<void>((resolve) => {
+            add.mutate(body, {
+              onSuccess: () => resolve(),
+              onError: () => resolve(),
+            });
+          })
+        }
+      />
+    </section>
+  );
+}

--- a/internal/web/ui/dashboard/src/components/products/ProductDeps.tsx
+++ b/internal/web/ui/dashboard/src/components/products/ProductDeps.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import { Badge } from '@/components/ui/Badge';
+import { Button } from '@/components/ui/Button';
+import {
+  useProductDependencies,
+  useRemoveProductDependency,
+} from '@/lib/queries/products';
+import type { Product, ProductDepEntry } from '@/lib/types';
+import { AddDepPicker } from './AddDepPicker';
+
+const TERMINAL_STATUSES = new Set(['closed', 'archive']);
+
+export interface ProductDepsProps {
+  product: Product;
+  onNavigate: (productId: string) => void;
+}
+
+export function ProductDeps({ product, onNavigate }: ProductDepsProps) {
+  const depsQ = useProductDependencies(product.id);
+  const remove = useRemoveProductDependency(product.id);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const deps = depsQ.data?.deps ?? [];
+  const dependents = depsQ.data?.dependents ?? [];
+  const unsatisfied = deps.filter((d) => !TERMINAL_STATUSES.has(d.status));
+  const satisfiedKind = deps.length === 0 ? 'none' : unsatisfied.length === 0 ? 'satisfied' : 'waiting';
+
+  return (
+    <section className="product-deps" aria-labelledby="product-deps-title">
+      <header className="product-deps__header">
+        <h3 id="product-deps-title" className="product-deps__title">Depends on</h3>
+        {satisfiedKind === 'satisfied' && (
+          <Badge tone="success" aria-label="all dependencies satisfied">
+            ✓ SATISFIED
+          </Badge>
+        )}
+        {satisfiedKind === 'waiting' && (
+          <Badge
+            tone="warn"
+            title={`Waiting on: ${unsatisfied.map((u) => u.marker).join(', ')}`}
+            aria-label={`waiting on ${unsatisfied.length} dependencies`}
+          >
+            ⏳ WAITING ON {unsatisfied.length}
+          </Badge>
+        )}
+        <Button size="sm" variant="ghost" onClick={() => setPickerOpen(true)}>
+          + Depends On
+        </Button>
+      </header>
+      <div className="product-deps__pills" aria-label="Dependencies">
+        {deps.length === 0 && (
+          <span className="product-deps__empty">No dependencies</span>
+        )}
+        {deps.map((d) => (
+          <DepPill
+            key={d.id}
+            dep={d}
+            onNav={() => onNavigate(d.id)}
+            onRemove={() => remove.mutate(d.id)}
+            removing={remove.isPending}
+          />
+        ))}
+      </div>
+      {dependents.length > 0 && (
+        <div className="product-deps__dependents">
+          <h4 className="product-deps__sub">Depended on by</h4>
+          <div className="product-deps__pills">
+            {dependents.map((d) => (
+              <DepPill key={d.id} dep={d} onNav={() => onNavigate(d.id)} />
+            ))}
+          </div>
+        </div>
+      )}
+      {pickerOpen && (
+        <AddDepPicker
+          product={product}
+          existingDeps={deps}
+          open={pickerOpen}
+          onOpenChange={setPickerOpen}
+        />
+      )}
+    </section>
+  );
+}
+
+function DepPill({
+  dep,
+  onNav,
+  onRemove,
+  removing,
+}: {
+  dep: ProductDepEntry;
+  onNav: () => void;
+  onRemove?: () => void;
+  removing?: boolean;
+}) {
+  return (
+    <span className={`product-dep-pill product-dep-pill--${dep.status}`}>
+      <button type="button" className="product-dep-pill__nav" onClick={onNav}>
+        {dep.marker}
+      </button>
+      <span className="product-dep-pill__title">{dep.title}</span>
+      <span className="product-dep-pill__status">{dep.status}</span>
+      {onRemove && (
+        <button
+          type="button"
+          className="product-dep-pill__rm"
+          aria-label={`Remove ${dep.marker} dependency`}
+          disabled={removing}
+          onClick={onRemove}
+        >
+          ×
+        </button>
+      )}
+    </span>
+  );
+}

--- a/internal/web/ui/dashboard/src/components/products/ProductEditForm.tsx
+++ b/internal/web/ui/dashboard/src/components/products/ProductEditForm.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { FormActions, FormError, FormField } from '@/components/forms';
+import { useUpdateProduct } from '@/lib/queries/products';
+import type { Product } from '@/lib/types';
+
+export interface ProductEditFormProps {
+  product: Product;
+  onCancel: () => void;
+  onSaved: () => void;
+}
+
+function tagsToString(tags: string[] | undefined): string {
+  return (tags ?? []).join(', ');
+}
+
+function parseTags(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+export function ProductEditForm({ product, onCancel, onSaved }: ProductEditFormProps) {
+  const [title, setTitle] = useState(product.title);
+  const [description, setDescription] = useState(product.description ?? '');
+  const [tags, setTags] = useState(tagsToString(product.tags));
+  const [error, setError] = useState<string | null>(null);
+  const update = useUpdateProduct();
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) {
+      setError('Title is required');
+      return;
+    }
+    setError(null);
+    update.mutate(
+      { id: product.id, title: title.trim(), description, tags: parseTags(tags) },
+      { onSuccess: onSaved, onError: (err) => setError(err.message) },
+    );
+  };
+
+  return (
+    <form className="product-edit-form" onSubmit={onSubmit} aria-label="Edit product">
+      <FormField label="Title" htmlFor="edit-product-title" required error={!title.trim() && error ? error : undefined}>
+        <input
+          id="edit-product-title"
+          className="ui-input"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          autoFocus
+        />
+      </FormField>
+      <FormField label="Description" htmlFor="edit-product-desc" hint="Markdown supported">
+        <textarea
+          id="edit-product-desc"
+          className="ui-input ui-textarea"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={8}
+        />
+      </FormField>
+      <FormField label="Tags (comma-separated)" htmlFor="edit-product-tags">
+        <input
+          id="edit-product-tags"
+          className="ui-input"
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+        />
+      </FormField>
+      {error && title.trim() && <FormError id="edit-product-error">{error}</FormError>}
+      <FormActions>
+        <Button type="button" variant="ghost" onClick={onCancel} disabled={update.isPending}>
+          Cancel
+        </Button>
+        <Button type="submit" variant="primary" loading={update.isPending}>
+          Save
+        </Button>
+      </FormActions>
+    </form>
+  );
+}

--- a/internal/web/ui/dashboard/src/components/products/ProductsSidebarSearch.tsx
+++ b/internal/web/ui/dashboard/src/components/products/ProductsSidebarSearch.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Badge } from '@/components/ui/Badge';
+import { useTypeahead } from '@/lib/hooks/useTypeahead';
+import { useProductSearch } from '@/lib/queries/products';
+import type { Product } from '@/lib/types';
+
+export function ProductsSidebarSearch() {
+  const fetcher = useProductSearch();
+  const ta = useTypeahead<Product>({ fetcher, minChars: 1, debounceMs: 200 });
+  const [focused, setFocused] = useState(false);
+  const navigate = useNavigate();
+  const showResults = focused && ta.query.length > 0;
+
+  return (
+    <div className="products-sidebar__search">
+      <input
+        type="search"
+        className="ui-input"
+        placeholder="Search products…"
+        value={ta.query}
+        onChange={(e) => ta.setQuery(e.target.value)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setTimeout(() => setFocused(false), 150)}
+        aria-label="Search products"
+      />
+      {showResults && (
+        <ul className="products-sidebar__search-results" role="listbox">
+          {ta.loading && <li className="products-sidebar__search-empty">Searching…</li>}
+          {!ta.loading && ta.results.length === 0 && (
+            <li className="products-sidebar__search-empty">No products found</li>
+          )}
+          {!ta.loading &&
+            ta.results.map((p) => (
+              <li key={p.id}>
+                <button
+                  type="button"
+                  className="products-sidebar__search-row"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    navigate(`/products/${p.id}`);
+                    ta.reset();
+                  }}
+                >
+                  <span className="marker">{p.marker}</span>
+                  <Badge tone={p.status === 'open' ? 'success' : p.status === 'closed' ? 'neutral' : 'info'}>
+                    {p.status}
+                  </Badge>
+                  <span className="products-sidebar__search-title">{p.title}</span>
+                </button>
+              </li>
+            ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/internal/web/ui/dashboard/src/components/products/StatusPivots.tsx
+++ b/internal/web/ui/dashboard/src/components/products/StatusPivots.tsx
@@ -1,0 +1,36 @@
+import clsx from 'clsx';
+import { useUpdateProduct } from '@/lib/queries/products';
+
+const STATUSES = ['draft', 'open', 'closed', 'archive'] as const;
+export type ProductStatus = (typeof STATUSES)[number];
+
+export interface StatusPivotsProps {
+  productId: string;
+  current: string;
+}
+
+export function StatusPivots({ productId, current }: StatusPivotsProps) {
+  const update = useUpdateProduct();
+  return (
+    <div className="status-pivots" role="group" aria-label="Product status">
+      {STATUSES.map((s) => {
+        const active = current === s;
+        return (
+          <button
+            key={s}
+            type="button"
+            data-status={s}
+            disabled={update.isPending}
+            aria-pressed={active}
+            className={clsx('status-pivot', `status-pivot--${s}`, active && 'is-active')}
+            onClick={() => {
+              if (!active) update.mutate({ id: productId, status: s });
+            }}
+          >
+            {s}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/internal/web/ui/dashboard/src/components/products/__tests__/PickerDialog.test.tsx
+++ b/internal/web/ui/dashboard/src/components/products/__tests__/PickerDialog.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { PickerDialog, type PickerDialogItem } from '../PickerDialog';
+
+const items: PickerDialogItem[] = [
+  { id: 'a', search: 'alpha apples', render: <span>Alpha</span> },
+  { id: 'b', search: 'beta bananas', render: <span>Beta</span> },
+  { id: 'c', search: 'gamma grapes', render: <span>Gamma</span> },
+];
+
+describe('PickerDialog', () => {
+  it('renders all items when filter is empty', () => {
+    render(
+      <PickerDialog
+        open
+        items={items}
+        title="Pick"
+        onOpenChange={() => {}}
+        onPick={() => {}}
+      />,
+    );
+    expect(screen.getByText('Alpha')).toBeTruthy();
+    expect(screen.getByText('Beta')).toBeTruthy();
+    expect(screen.getByText('Gamma')).toBeTruthy();
+  });
+
+  it('filters case-insensitively across the search blob', () => {
+    render(
+      <PickerDialog
+        open
+        items={items}
+        title="Pick"
+        onOpenChange={() => {}}
+        onPick={() => {}}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('Filter list'), { target: { value: 'BANAN' } });
+    expect(screen.queryByText('Alpha')).toBeNull();
+    expect(screen.getByText('Beta')).toBeTruthy();
+    expect(screen.queryByText('Gamma')).toBeNull();
+  });
+
+  it('fires onPick with the item id on click', () => {
+    const onPick = vi.fn();
+    render(
+      <PickerDialog
+        open
+        items={items}
+        title="Pick"
+        onOpenChange={() => {}}
+        onPick={onPick}
+      />,
+    );
+    fireEvent.click(screen.getByText('Beta'));
+    expect(onPick).toHaveBeenCalledWith('b');
+  });
+
+  it('shows "no items match" when filter excludes everything', () => {
+    render(
+      <PickerDialog
+        open
+        items={items}
+        title="Pick"
+        onOpenChange={() => {}}
+        onPick={() => {}}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('Filter list'), { target: { value: 'zzz' } });
+    expect(screen.getByText('No items match the filter.')).toBeTruthy();
+  });
+});

--- a/internal/web/ui/dashboard/src/components/products/__tests__/ProductEditForm.test.tsx
+++ b/internal/web/ui/dashboard/src/components/products/__tests__/ProductEditForm.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ProductEditForm } from '../ProductEditForm';
+import type { Product } from '@/lib/types';
+
+const sample: Product = {
+  id: 'p1',
+  marker: 'p1xxx',
+  title: 'Hello',
+  description: 'old desc',
+  status: 'open',
+  tags: ['one', 'two'],
+};
+
+function wrap(ui: React.ReactElement) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+describe('ProductEditForm', () => {
+  const originalFetch = global.fetch;
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => JSON.stringify({ ...sample, title: 'New' }),
+    } as Response);
+  });
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('pre-fills title, description, tags', () => {
+    wrap(<ProductEditForm product={sample} onCancel={() => {}} onSaved={() => {}} />);
+    expect((screen.getByLabelText(/Title/i) as HTMLInputElement).value).toBe('Hello');
+    expect((screen.getByLabelText(/Description/i) as HTMLTextAreaElement).value).toBe('old desc');
+    expect((screen.getByLabelText(/Tags/i) as HTMLInputElement).value).toBe('one, two');
+  });
+
+  it('submits PUT with parsed tag array on save', async () => {
+    const onSaved = vi.fn();
+    wrap(<ProductEditForm product={sample} onCancel={() => {}} onSaved={onSaved} />);
+    fireEvent.change(screen.getByLabelText(/Title/i), { target: { value: 'New' } });
+    fireEvent.change(screen.getByLabelText(/Tags/i), { target: { value: 'a, b ,, c' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe('/api/products/p1');
+    const init = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(init.method).toBe('PUT');
+    expect(JSON.parse(init.body)).toEqual({
+      title: 'New',
+      description: 'old desc',
+      tags: ['a', 'b', 'c'],
+    });
+  });
+
+  it('blocks submit with empty title', () => {
+    wrap(<ProductEditForm product={sample} onCancel={() => {}} onSaved={() => {}} />);
+    fireEvent.change(screen.getByLabelText(/Title/i), { target: { value: '   ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(screen.getByText('Title is required')).toBeTruthy();
+  });
+});

--- a/internal/web/ui/dashboard/src/components/products/__tests__/StatusPivots.test.tsx
+++ b/internal/web/ui/dashboard/src/components/products/__tests__/StatusPivots.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { StatusPivots } from '../StatusPivots';
+
+function wrap(ui: React.ReactElement) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+describe('StatusPivots', () => {
+  const originalFetch = global.fetch;
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => JSON.stringify({ id: 'p1', status: 'open' }),
+    } as Response);
+  });
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('renders all four status options with the current one active', () => {
+    wrap(<StatusPivots productId="p1" current="open" />);
+    expect(screen.getByText('draft')).toBeTruthy();
+    const open = screen.getByText('open');
+    expect(open.getAttribute('aria-pressed')).toBe('true');
+    const draft = screen.getByText('draft');
+    expect(draft.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('PUTs the new status on click of an inactive pivot', async () => {
+    wrap(<StatusPivots productId="p1" current="open" />);
+    fireEvent.click(screen.getByText('closed'));
+    // useMutation fires fetch async — flush microtasks once.
+    await Promise.resolve();
+    expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe('/api/products/p1');
+    const init = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(init.method).toBe('PUT');
+    expect(JSON.parse(init.body)).toEqual({ status: 'closed' });
+  });
+
+  it('does not fire when clicking the active pivot', () => {
+    wrap(<StatusPivots productId="p1" current="open" />);
+    fireEvent.click(screen.getByText('open'));
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/internal/web/ui/dashboard/src/lib/queries/comments.ts
+++ b/internal/web/ui/dashboard/src/lib/queries/comments.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { fetchJSON } from '../api';
+import type { Comment } from '../types';
+
+export type CommentScope = 'products' | 'manifests' | 'tasks' | 'ideas';
+
+export function useComments(scope: CommentScope, id: string | undefined) {
+  return useQuery({
+    queryKey: ['comments', scope, id],
+    queryFn: () => fetchJSON<Comment[]>(`/api/${scope}/${id}/comments`),
+    enabled: Boolean(id),
+  });
+}
+
+export function useAddComment(scope: CommentScope, id: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: string) =>
+      fetchJSON<Comment>(`/api/${scope}/${id}/comments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ author: 'operator', type: 'user_note', body }),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['comments', scope, id] });
+    },
+  });
+}

--- a/internal/web/ui/dashboard/src/lib/queries/ideas.ts
+++ b/internal/web/ui/dashboard/src/lib/queries/ideas.ts
@@ -1,0 +1,53 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { fetchJSON } from '../api';
+import type { Idea } from '../types';
+
+export function useProductIdeas(productId: string | undefined) {
+  return useQuery({
+    queryKey: ['product', productId, 'ideas'],
+    queryFn: () => fetchJSON<Idea[]>(`/api/products/${productId}/ideas`),
+    enabled: Boolean(productId),
+  });
+}
+
+export function useAllIdeas() {
+  return useQuery({
+    queryKey: ['ideas', 'all'],
+    queryFn: () => fetchJSON<Idea[]>('/api/ideas'),
+  });
+}
+
+export function useUpdateIdeaProject() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      idea,
+      productId,
+    }: {
+      idea: Idea;
+      productId: string;
+    }) =>
+      fetchJSON<Idea>(`/api/ideas/${idea.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        // The legacy endpoint requires the full idea body on PUT.
+        body: JSON.stringify({
+          project_id: productId,
+          title: idea.title,
+          description: idea.description ?? '',
+          status: idea.status,
+          priority: idea.priority,
+        }),
+      }),
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: ['ideas', 'all'] });
+      if (vars.productId) {
+        qc.invalidateQueries({ queryKey: ['product', vars.productId, 'ideas'] });
+        qc.invalidateQueries({ queryKey: ['products', 'by-peer'] });
+      }
+      if (vars.idea.project_id) {
+        qc.invalidateQueries({ queryKey: ['product', vars.idea.project_id, 'ideas'] });
+      }
+    },
+  });
+}

--- a/internal/web/ui/dashboard/src/lib/queries/manifests.ts
+++ b/internal/web/ui/dashboard/src/lib/queries/manifests.ts
@@ -1,0 +1,54 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { fetchJSON } from '../api';
+import type { Manifest } from '../types';
+
+export function useAllManifests() {
+  return useQuery({
+    queryKey: ['manifests', 'all'],
+    queryFn: () => fetchJSON<Manifest[]>('/api/manifests'),
+  });
+}
+
+export interface CreateManifestInput {
+  title: string;
+  description?: string;
+  project_id?: string;
+}
+
+export function useCreateManifest() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: CreateManifestInput) =>
+      fetchJSON<Manifest>('/api/manifests', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(vars),
+      }),
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: ['manifests', 'all'] });
+      if (vars.project_id) {
+        qc.invalidateQueries({ queryKey: ['product', vars.project_id, 'manifests'] });
+        qc.invalidateQueries({ queryKey: ['products', 'by-peer'] });
+      }
+    },
+  });
+}
+
+export function useUpdateManifestProject() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ manifestId, productId }: { manifestId: string; productId: string }) =>
+      fetchJSON<Manifest>(`/api/manifests/${manifestId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ project_id: productId }),
+      }),
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: ['manifests', 'all'] });
+      qc.invalidateQueries({ queryKey: ['products', 'by-peer'] });
+      if (vars.productId) {
+        qc.invalidateQueries({ queryKey: ['product', vars.productId, 'manifests'] });
+      }
+    },
+  });
+}

--- a/internal/web/ui/dashboard/src/lib/queries/products.ts
+++ b/internal/web/ui/dashboard/src/lib/queries/products.ts
@@ -1,6 +1,12 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { fetchJSON } from '../api';
-import type { Manifest, PeerProductGroup, Product, ProductHierarchy } from '../types';
+import type {
+  Manifest,
+  PeerProductGroup,
+  Product,
+  ProductDependencies,
+  ProductHierarchy,
+} from '../types';
 
 export function useProductsByPeer() {
   return useQuery({
@@ -31,4 +37,107 @@ export function useProductHierarchy(id: string | undefined) {
     queryFn: () => fetchJSON<ProductHierarchy>(`/api/products/${id}/hierarchy`),
     enabled: Boolean(id),
   });
+}
+
+export function useProductDependencies(id: string | undefined) {
+  return useQuery({
+    queryKey: ['product', id, 'dependencies'],
+    queryFn: () =>
+      fetchJSON<ProductDependencies>(
+        `/api/products/${id}/dependencies?direction=both`,
+      ),
+    enabled: Boolean(id),
+  });
+}
+
+export function useAllProductsFlat() {
+  const groups = useProductsByPeer();
+  const flat: Product[] = (groups.data ?? []).flatMap((g) => g.products ?? []);
+  return { ...groups, data: flat };
+}
+
+export interface CreateProductInput {
+  title: string;
+  description?: string;
+  tags?: string[];
+}
+
+export function useCreateProduct() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: CreateProductInput) =>
+      fetchJSON<Product>('/api/products', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(vars),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['products', 'by-peer'] });
+    },
+  });
+}
+
+export interface UpdateProductInput {
+  id: string;
+  title?: string;
+  description?: string;
+  tags?: string[];
+  status?: string;
+}
+
+export function useUpdateProduct() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, ...rest }: UpdateProductInput) =>
+      fetchJSON<Product>(`/api/products/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(rest),
+      }),
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: ['products', 'by-peer'] });
+      qc.invalidateQueries({ queryKey: ['product', vars.id] });
+    },
+  });
+}
+
+export function useAddProductDependency(productId: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (depId: string) =>
+      fetchJSON<unknown>(`/api/products/${productId}/dependencies`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ depends_on_id: depId }),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['product', productId, 'dependencies'] });
+      qc.invalidateQueries({ queryKey: ['products', 'by-peer'] });
+    },
+  });
+}
+
+export function useRemoveProductDependency(productId: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (depId: string) =>
+      fetchJSON<unknown>(
+        `/api/products/${productId}/dependencies/${depId}`,
+        { method: 'DELETE' },
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['product', productId, 'dependencies'] });
+      qc.invalidateQueries({ queryKey: ['products', 'by-peer'] });
+    },
+  });
+}
+
+export function useProductSearch() {
+  return async (query: string): Promise<Product[]> => {
+    if (!query.trim()) return [];
+    return fetchJSON<Product[]>(
+      `/api/products/search?q=${encodeURIComponent(query)}`,
+      { silent: true },
+    );
+  };
 }

--- a/internal/web/ui/dashboard/src/lib/types.ts
+++ b/internal/web/ui/dashboard/src/lib/types.ts
@@ -43,6 +43,30 @@ export interface Manifest {
   children?: Task[];
 }
 
+export interface Idea {
+  id: string;
+  marker: string;
+  title: string;
+  description?: string;
+  status: string;
+  priority: string;
+  project_id?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface ProductDepEntry {
+  id: string;
+  marker: string;
+  title: string;
+  status: string;
+}
+
+export interface ProductDependencies {
+  deps: ProductDepEntry[];
+  dependents: ProductDepEntry[];
+}
+
 export interface Task {
   id: string;
   marker: string;

--- a/internal/web/ui/dashboard/src/pages/Products.tsx
+++ b/internal/web/ui/dashboard/src/pages/Products.tsx
@@ -1,15 +1,33 @@
 import { lazy, Suspense, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useProductsByPeer, useProduct, useProductManifests, useProductHierarchy } from '../lib/queries/products';
-import type { PeerProductGroup, Product } from '../lib/types';
-import { TreeRow } from '../components/Tree';
+import {
+  useProduct,
+  useProductHierarchy,
+  useProductsByPeer,
+} from '@/lib/queries/products';
+import type { PeerProductGroup, Product } from '@/lib/types';
+import { Badge } from '@/components/ui/Badge';
+import { Button } from '@/components/ui/Button';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { StatusDot } from '@/components/ui/StatusDot';
+import { TreeRow } from '@/components/Tree';
+import { MarkdownRenderer } from '@/components/desc/MarkdownRenderer';
+import { LinkedIdeas } from '@/components/products/LinkedIdeas';
+import { LinkedManifests } from '@/components/products/LinkedManifests';
+import { NewProductDialog } from '@/components/products/NewProductDialog';
+import { ProductCommentsSection } from '@/components/products/ProductCommentsSection';
+import { ProductDeps } from '@/components/products/ProductDeps';
+import { ProductEditForm } from '@/components/products/ProductEditForm';
+import { ProductsSidebarSearch } from '@/components/products/ProductsSidebarSearch';
+import { StatusPivots } from '@/components/products/StatusPivots';
 
-const ProductDag = lazy(() => import('../components/ProductDag'));
+const ProductDag = lazy(() => import('@/components/ProductDag'));
 
 export default function Products() {
   const { id: selectedId } = useParams();
   const navigate = useNavigate();
   const peerGroupsQuery = useProductsByPeer();
+  const [newProductOpen, setNewProductOpen] = useState(false);
 
   const onSelect = (p: Product) => navigate(`/products/${p.id}`);
 
@@ -18,28 +36,44 @@ export default function Products() {
       <aside className="products-sidebar" data-testid="products-sidebar">
         <div className="sidebar-header">
           <h2>Products</h2>
-          <button className="btn-new" type="button" onClick={() => alert('TODO: New product (T2)')}>
+          <Button
+            size="sm"
+            variant="primary"
+            data-testid="btn-new-product"
+            onClick={() => setNewProductOpen(true)}
+          >
             + New Product
-          </button>
+          </Button>
         </div>
-        {peerGroupsQuery.isLoading && <div className="empty-state">Loading…</div>}
-        {peerGroupsQuery.error && <div className="empty-state error">Failed to load products</div>}
+        <ProductsSidebarSearch />
+        {peerGroupsQuery.isLoading && <EmptyState message="Loading…" />}
+        {peerGroupsQuery.error && <EmptyState tone="error" message="Failed to load products" />}
         {peerGroupsQuery.data && peerGroupsQuery.data.length === 0 && (
-          <div className="empty-state">No products yet. Create one to group your manifests.</div>
+          <EmptyState message="No products yet. Create one to group your manifests." />
         )}
-        {peerGroupsQuery.data && peerGroupsQuery.data.map((pg: PeerProductGroup) => (
-          <PeerGroup key={pg.peer_id} group={pg} selectedId={selectedId} onSelect={onSelect} />
-        ))}
+        {peerGroupsQuery.data &&
+          peerGroupsQuery.data.map((pg: PeerProductGroup) => (
+            <PeerGroup key={pg.peer_id} group={pg} selectedId={selectedId} onSelect={onSelect} />
+          ))}
+        <NewProductDialog
+          open={newProductOpen}
+          onOpenChange={setNewProductOpen}
+          onCreated={(p) => p?.id && navigate(`/products/${p.id}`)}
+        />
       </aside>
       <main className="products-detail">
-        {!selectedId && <div className="empty-state">Select a product to view details</div>}
+        {!selectedId && <EmptyState message="Select a product to view details" />}
         {selectedId && <ProductDetail id={selectedId} />}
       </main>
     </div>
   );
 }
 
-function PeerGroup({ group, selectedId, onSelect }: {
+function PeerGroup({
+  group,
+  selectedId,
+  onSelect,
+}: {
   group: PeerProductGroup;
   selectedId: string | undefined;
   onSelect: (p: Product) => void;
@@ -71,7 +105,12 @@ function PeerGroup({ group, selectedId, onSelect }: {
   );
 }
 
-function ProductTreeRow({ product, level, selectedId, onSelect }: {
+function ProductTreeRow({
+  product,
+  level,
+  selectedId,
+  onSelect,
+}: {
   product: Product;
   level: number;
   selectedId: string | undefined;
@@ -87,7 +126,7 @@ function ProductTreeRow({ product, level, selectedId, onSelect }: {
       rowKey={(p) => p.id}
       label={(p) => (
         <>
-          <span className={`status-dot status-${p.status}`} />
+          <StatusDot status={p.status} />
           <span className="product-title">{p.title}</span>
         </>
       )}
@@ -95,7 +134,9 @@ function ProductTreeRow({ product, level, selectedId, onSelect }: {
         <>
           <span className="marker">{p.marker}</span>
           {(p.total_manifests ?? 0) > 0 && <span className="count">{p.total_manifests}</span>}
-          {(p.sub_products?.length ?? 0) > 0 && <span className="count count-sub">{p.sub_products!.length}</span>}
+          {(p.sub_products?.length ?? 0) > 0 && (
+            <span className="count count-sub" title="Sub-products">{p.sub_products!.length}</span>
+          )}
         </>
       )}
       children={() => subs}
@@ -106,70 +147,122 @@ function ProductTreeRow({ product, level, selectedId, onSelect }: {
 
 function ProductDetail({ id }: { id: string }) {
   const productQ = useProduct(id);
-  const manifestsQ = useProductManifests(id);
+  const navigate = useNavigate();
   const [showDag, setShowDag] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [newSubOpen, setNewSubOpen] = useState(false);
 
-  if (productQ.isLoading) return <div className="empty-state">Loading…</div>;
-  if (productQ.error || !productQ.data) return <div className="empty-state error">Failed to load product</div>;
+  if (productQ.isLoading) return <EmptyState message="Loading…" />;
+  if (productQ.error || !productQ.data) {
+    return <EmptyState tone="error" message="Failed to load product" />;
+  }
   const p = productQ.data;
+
+  if (editing) {
+    return (
+      <div className="product-detail-body">
+        <header className="product-header">
+          <h1>Edit Product — {p.title}</h1>
+        </header>
+        <ProductEditForm
+          product={p}
+          onCancel={() => setEditing(false)}
+          onSaved={() => setEditing(false)}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="product-detail-body">
       <header className="product-header">
+        <nav className="breadcrumb" aria-label="Breadcrumb">
+          <button
+            type="button"
+            className="breadcrumb-link"
+            onClick={() => navigate('/products')}
+          >
+            {p.source_node ? p.source_node.substring(0, 12) : 'node'}
+          </button>
+          <span className="breadcrumb-sep"> → </span>
+          <span>{p.marker} {p.title}</span>
+        </nav>
         <h1>{p.title}</h1>
         <div className="meta-row">
           <span className="marker">{p.marker}</span>
-          <span className={`badge status-${p.status}`}>{p.status}</span>
-          {(p.tags || []).map((t) => <span key={t} className="badge tag">{t}</span>)}
+          <Badge tone={p.status === 'open' ? 'success' : p.status === 'closed' ? 'neutral' : p.status === 'archive' ? 'danger' : 'warn'}>
+            {p.status}
+          </Badge>
+          {(p.tags || []).map((t) => (
+            <Badge key={t} tone="tag">{t}</Badge>
+          ))}
         </div>
         <div className="stats">
-          <span>Manifests: <strong>{p.total_manifests ?? 0}</strong></span>
-          <span>Tasks: <strong>{p.total_tasks ?? 0}</strong></span>
-          <span>Turns: <strong>{p.total_turns ?? 0}</strong></span>
-          <span>Cost: <strong>${(p.total_cost ?? 0).toFixed(2)}</strong></span>
+          <span>Manifests<strong>{p.total_manifests ?? 0}</strong></span>
+          <span>Tasks<strong>{p.total_tasks ?? 0}</strong></span>
+          <span>Turns<strong>{p.total_turns ?? 0}</strong></span>
+          <span>Cost<strong>${(p.total_cost ?? 0).toFixed(2)}</strong></span>
+          {p.created_at && <span>Created<strong>{new Date(p.created_at).toLocaleDateString()}</strong></span>}
+          {p.updated_at && <span>Updated<strong>{new Date(p.updated_at).toLocaleDateString()}</strong></span>}
         </div>
-        <div className="toolbar">
-          <button type="button" onClick={() => setShowDag((v) => !v)}>
+        <div className="toolbar product-toolbar">
+          <Button size="sm" onClick={() => setEditing(true)}>✎ Edit</Button>
+          <Button size="sm" onClick={() => setNewSubOpen(true)}>+ New Sub-Product</Button>
+          <Button size="sm" onClick={() => setShowDag((v) => !v)}>
             {showDag ? 'Hide DAG' : '◈ Product DAG'}
-          </button>
+          </Button>
+          <StatusPivots productId={p.id} current={p.status} />
         </div>
       </header>
 
-      {p.description && <p className="product-description">{p.description}</p>}
+      {p.description && (
+        <div className="product-description-wrap">
+          <MarkdownRenderer source={p.description} html={p.description_html} className="product-description md-body" />
+        </div>
+      )}
+
+      <ProductDeps product={p} onNavigate={(pid) => navigate(`/products/${pid}`)} />
 
       {showDag && (
-        <Suspense fallback={<div className="empty-state">Loading diagram…</div>}>
+        <Suspense fallback={<EmptyState message="Loading diagram…" />}>
           <ProductDagOverlay productId={id} onClose={() => setShowDag(false)} />
         </Suspense>
       )}
 
-      <section className="linked-manifests">
-        <h3>Linked Manifests {manifestsQ.data ? `(${manifestsQ.data.length})` : ''}</h3>
-        {manifestsQ.isLoading && <div className="empty-state">Loading…</div>}
-        {manifestsQ.data && manifestsQ.data.length === 0 && (
-          <div className="empty-state">No manifests linked yet</div>
-        )}
-        {manifestsQ.data && manifestsQ.data.map((m) => (
-          <div key={m.id} className="manifest-row">
-            <span className="marker">{m.marker}</span>
-            <span className={`badge status-${m.status}`}>{m.status}</span>
-            <span className="manifest-title">{m.title}</span>
-          </div>
-        ))}
-      </section>
+      <LinkedManifests productId={p.id} productTitle={p.title} />
+      <LinkedIdeas productId={p.id} />
+      <ProductCommentsSection productId={p.id} />
+
+      <NewProductDialog
+        open={newSubOpen}
+        onOpenChange={setNewSubOpen}
+        parent={{ id: p.id, title: p.title }}
+        onCreated={(child) => child?.id && navigate(`/products/${child.id}`)}
+      />
     </div>
   );
 }
 
 function ProductDagOverlay({ productId, onClose }: { productId: string; onClose: () => void }) {
   const hierQ = useProductHierarchy(productId);
+  const navigate = useNavigate();
   return (
     <div className="dag-overlay">
       <div className="dag-overlay-header">
-        <button type="button" onClick={onClose}>← Close</button>
+        <Button size="sm" onClick={onClose}>← Close</Button>
         <span>Directed Acyclic Graph</span>
       </div>
-      {hierQ.data && <ProductDag data={hierQ.data} />}
+      {hierQ.data && (
+        <ProductDag
+          data={hierQ.data}
+          onNodeClick={(nodeId, type) => {
+            onClose();
+            if (type === 'product') navigate(`/products/${nodeId}`);
+            else if (type === 'manifest') navigate(`/manifests/${nodeId}`);
+            else if (type === 'task') navigate(`/tasks/${nodeId}`);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/internal/web/ui/dashboard/src/styles.css
+++ b/internal/web/ui/dashboard/src/styles.css
@@ -597,3 +597,246 @@ button:focus-visible,
 .form-actions { display: flex; gap: 8px; margin-top: 12px; }
 .form-actions--start { justify-content: flex-start; }
 .form-actions--end { justify-content: flex-end; }
+
+/* ============================================================
+ * Products M1 — port-specific widgets
+ * Tags / inputs / pickers / deps / sub-sections.
+ * ============================================================ */
+
+/* Inputs reused by product/manifest/idea forms + dialogs */
+.ui-input {
+  width: 100%;
+  padding: 6px 10px;
+  font-size: 13px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-family: inherit;
+}
+.ui-input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.ui-textarea {
+  resize: vertical;
+  min-height: 80px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  line-height: 1.5;
+}
+
+/* Sidebar search */
+.products-sidebar__search { padding: 4px 0 8px; position: relative; }
+.products-sidebar__search-results {
+  position: absolute;
+  top: 100%; left: 0; right: 0;
+  z-index: 5;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  list-style: none;
+  margin: 4px 0 0;
+  padding: 4px 0;
+  max-height: 280px;
+  overflow-y: auto;
+  font-size: 12px;
+}
+.products-sidebar__search-empty { padding: 8px 12px; color: var(--text-muted); }
+.products-sidebar__search-row {
+  display: flex; align-items: center; gap: 8px;
+  width: 100%; padding: 6px 10px; text-align: left;
+  background: transparent; color: var(--text-primary); border: 0;
+  cursor: pointer;
+}
+.products-sidebar__search-row:hover { background: var(--accent-soft); }
+.products-sidebar__search-title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* Detail breadcrumb */
+.breadcrumb {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+}
+.breadcrumb-link {
+  background: none; border: 0; padding: 0;
+  color: var(--accent); cursor: pointer; font: inherit;
+}
+.breadcrumb-link:hover { text-decoration: underline; }
+.breadcrumb-sep { margin: 0 4px; }
+
+/* Toolbar layout */
+.product-toolbar { gap: 8px; margin-top: 8px; }
+
+/* Status pivots */
+.status-pivots {
+  display: inline-flex; gap: 4px; margin-left: auto;
+}
+.status-pivot {
+  font: inherit; font-size: 11px;
+  padding: 4px 10px; cursor: pointer;
+  text-transform: uppercase; font-weight: 600;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: var(--radius-sm);
+  transition: background 80ms ease, color 80ms ease, border-color 80ms ease;
+}
+.status-pivot:hover { border-color: var(--accent); color: var(--text-primary); }
+.status-pivot.is-active { background: var(--accent); color: #0f0f17; border-color: var(--accent); }
+.status-pivot--draft.is-active { background: #f5c542; border-color: #f5c542; color: #1a1500; }
+.status-pivot--open.is-active { background: #00d97e; border-color: #00d97e; color: #00130a; }
+.status-pivot--closed.is-active { background: var(--text-muted); border-color: var(--text-muted); color: var(--bg-primary); }
+.status-pivot--archive.is-active { background: #b03a3a; border-color: #b03a3a; color: #fff; }
+
+/* Description block (replaces inline-styled legacy version) */
+.product-description-wrap { margin: 16px 0; }
+.product-description.md-body {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 14px 18px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+/* Dependencies section */
+.product-deps { margin: 18px 0; }
+.product-deps__header {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+.product-deps__title {
+  margin: 0; font-size: 12px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--text-secondary);
+}
+.product-deps__pills { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; min-height: 24px; }
+.product-deps__empty { font-size: 11px; color: var(--text-muted); font-style: italic; }
+.product-deps__dependents { margin-top: 12px; }
+.product-deps__sub {
+  margin: 0 0 4px; font-size: 11px; color: var(--text-muted);
+  font-weight: 500; text-transform: none; letter-spacing: 0;
+}
+
+.product-dep-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+}
+.product-dep-pill--open { border-color: #00d97e; }
+.product-dep-pill--closed { border-color: var(--text-muted); }
+.product-dep-pill--draft { border-color: #f5c542; }
+.product-dep-pill--archive { border-color: #b03a3a; }
+.product-dep-pill__nav {
+  background: transparent; border: 0; padding: 0;
+  color: var(--accent); cursor: pointer; font: inherit;
+}
+.product-dep-pill__nav:hover { text-decoration: underline; }
+.product-dep-pill__title { color: var(--text-primary); }
+.product-dep-pill__status {
+  font-size: 9px; text-transform: uppercase; font-weight: 600;
+  color: var(--text-muted);
+}
+.product-dep-pill__rm {
+  background: transparent; border: 0; color: #d65a5a;
+  cursor: pointer; font-size: 13px; padding: 0; line-height: 1;
+}
+.product-dep-pill__rm:disabled { opacity: 0.4; cursor: wait; }
+
+/* Linked manifests + ideas headers */
+.linked-manifests__header,
+.linked-ideas .linked-manifests__header {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 8px; margin-bottom: 10px;
+}
+.linked-manifests__actions { display: flex; gap: 6px; }
+.linked-manifests__list {
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.sub-count { color: var(--text-muted); font-weight: 400; margin-left: 4px; font-size: 12px; }
+
+.manifest-row { padding: 0; }
+.manifest-row__main {
+  flex: 1;
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 14px;
+  background: transparent; color: var(--text-primary);
+  border: 0; cursor: pointer;
+  text-align: left; font: inherit;
+}
+.manifest-row__main:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.manifest-row__meta {
+  margin-left: auto; display: flex; gap: 10px;
+  font-size: 11px; color: var(--text-muted);
+}
+.manifest-row__meta .cost { color: #00d97e; }
+.manifest-row__rm {
+  background: transparent; border: 0;
+  color: var(--text-muted); cursor: pointer; padding: 4px 10px;
+  font-size: 14px; line-height: 1;
+}
+.manifest-row__rm:hover { color: #d65a5a; }
+.manifest-row__rm:disabled { opacity: 0.4; cursor: wait; }
+
+/* Linked ideas list */
+.linked-ideas { margin-top: 28px; }
+.linked-ideas__list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.linked-ideas__row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  font-size: 12px;
+}
+.linked-ideas__title { flex: 1; color: var(--text-primary); }
+.linked-ideas__rm {
+  background: transparent; border: 0;
+  color: var(--text-muted); cursor: pointer;
+  font-size: 14px; line-height: 1; padding: 0 4px;
+}
+.linked-ideas__rm:hover { color: #d65a5a; }
+
+/* Comments section */
+.product-comments { margin-top: 32px; }
+.product-comments__title {
+  margin: 0 0 12px; font-size: 12px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--text-secondary);
+}
+
+/* Picker dialog list */
+.picker-list {
+  list-style: none; margin: 12px 0 0; padding: 0;
+  max-height: 360px; overflow-y: auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+}
+.picker-list__empty { padding: 12px; }
+.picker-list__item { border-bottom: 1px solid var(--border-subtle); }
+.picker-list__item:last-child { border-bottom: 0; }
+.picker-list__btn {
+  width: 100%; padding: 10px 12px;
+  background: transparent; border: 0; color: inherit;
+  text-align: left; font: inherit; cursor: pointer;
+  display: flex; align-items: center; gap: 8px;
+}
+.picker-list__btn:hover { background: var(--accent-soft); }
+.picker-list__btn:disabled { opacity: 0.5; cursor: wait; }
+.picker-row {
+  display: flex; align-items: center; gap: 8px;
+  width: 100%;
+}
+.picker-row__title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* Edit form layout */
+.product-edit-form { max-width: 760px; margin-top: 16px; }
+
+/* Stats with stacked label/value (the new <span><label/><strong/>) */
+.stats > span > strong { display: block; }


### PR DESCRIPTION
## Summary

Ports the legacy `/products` tab (`internal/web/ui/views/products.js` 650 LOC + `product-dag.js` 330 LOC) onto the Foundation M1 React primitives. Click-through parity with the legacy view, every button wired up.

## Side-by-side legacy → React parity

| Legacy element | React owner |
|---|---|
| `OL.loadProducts` peer→product→sub-product tree | `pages/Products.tsx` + `<TreeRow />` |
| `OL.loadProductDetail` header (marker, badge, tags, stats, toolbar) | `<ProductDetail />` header block |
| Status pivot buttons (`OL.updateProductStatus`) | `<StatusPivots />` (PUT /api/products/{id} {status}) |
| Inline edit form (`OL.editProduct`) | `<ProductEditForm />` using FormField |
| `OL.createProduct` dialog | `<NewProductDialog />` |
| Sub-product flow (parent → dep edge to new child) | `<NewProductDialog parent={…} />` |
| `OL.createManifest({productId})` | `<NewManifestDialog />` |
| `OL.linkManifestToProduct` / `unlinkManifestFromProduct` | `<LinkedManifests />` + `<LinkManifestPicker />` |
| `OL.linkIdeaToProduct` / `unlinkIdeaFromProduct` | `<LinkedIdeas />` + `<LinkIdeaPicker />` |
| Product deps section (Depends on / Depended on by + ✕ remove + + Add picker) | `<ProductDeps />` + `<AddDepPicker />` |
| `OL.renderCommentsSection({type:'product'})` | `<ProductCommentsSection />` (CommentsList + CommentEditor) |
| `OL.showProductDiagram` cytoscape overlay | `<ProductDagOverlay />` (already shipped in Foundation M1) lazy import |
| Sidebar search input (`OL.mountSearchInput`) | `<ProductsSidebarSearch />` w/ `useTypeahead` |
| `OL.descToggle(p.description)` markdown render | `<MarkdownRenderer />` |
| URL state (`OL.loadProductDetail(id)`) | `useParams<{id}>` + route `/products/:id` |
| Per-tab v2 redirect knob | `lib/featureFlags.ts` (Foundation M1) |

## Out-of-scope / deferred

- **Revisions panel** (`OL.renderRevisionsSection`) — not part of M1 acceptance, follow-up.
- **Knobs panel** (`OL.renderKnobSection`) — same.
- **Inline markdown editor** (`OL.mountEditor` toolbar/preview) — Foundation M1 ships only `MarkdownRenderer`; description edit uses a plain textarea. Read path keeps both `body` + `body_html`.

## Tests

49/49 passing (8 files). New tests:
- `StatusPivots.test.tsx` — current is aria-pressed, inactive click PUTs, active click no-ops.
- `PickerDialog.test.tsx` — filter narrows by search blob, pick fires onPick(id), empty match shows fallback.
- `ProductEditForm.test.tsx` — pre-fills, submits PUT with parsed tag array, blocks empty title.

## Bundle delta (gzipped)

| Chunk | Foundation | M1 | Δ |
|---|---|---|---|
| `index.js` | 90.06 | 90.22 | +0.16 KB |
| `Products.js` (lazy) | 6.07 | 57.10 | +51.03 KB |
| `index.css` | 3.61 | 4.55 | +0.94 KB |
| **total Δ** | | | **+52.13 KB** |

The +52 KB lazy-only delta is over the 30 KB target. Lives entirely in the lazy `Products.js` chunk so the home/index route is unaffected. Tracking as PARTIAL on the manifest acceptance — see self_summary on the task for details. Future trim candidates: lazy-load comment editor, drop `MarkdownRenderer` from the lazy graph (use `dangerouslySetInnerHTML` on `description_html`), tree-shake unused Radix subpaths.

## Test plan

- [x] `npm run check` (tsc --noEmit) green
- [x] `npm test` 49/49 green
- [x] `npm run build` green
- [x] `go test ./...` green
- [x] `make types-check` green
- [ ] Manual click-through against live serve (operator sign-off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)