### PR TITLE
fix(portal-v2): default to :9876 — :8766 collides with sync server

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -420,9 +420,11 @@ func init() {
 	rootCmd.AddCommand(serveCmd)
 	serveCmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Don't open the dashboard in the browser")
 	// Portal V2 is the redesigned operator dashboard built fresh on shadcn-admin
-	// in `internal/web/ui/dashboard-v2/`. Defaults to :8766 alongside the legacy
-	// portal on :8765. Set 0 to disable while the v2 work is in flight.
-	serveCmd.Flags().IntVar(&portalV2Port, "portal-v2-port", 8766, "Portal V2 listener port (0 to disable)")
+	// in `internal/web/ui/dashboard-v2/`. Defaults to :9876 — well away from the
+	// :8765 (dashboard) / :8766 (sync) cluster so future config tweaks in the
+	// 87xx range can't create silent collisions. Set 0 to disable while the v2
+	// work is in flight.
+	serveCmd.Flags().IntVar(&portalV2Port, "portal-v2-port", 9876, "Portal V2 listener port (0 to disable)")
 }
 
 func openBrowser(url string) {


### PR DESCRIPTION
## Summary

The sync server (`cfg.Sync.Port`) defaults to 8766. Portal V2's listener also defaulted to 8766. On Go/macOS, both `net.Listen` calls succeeded but on different sockets — sync grabbed `*:8766` (IPv6 wildcard) while Portal V2 got `localhost:8766` (IPv4 only). Browsers resolving `localhost` to IPv6 first hit sync's 404 instead of the V2 stub.

Move Portal V2 to **:9876**, well away from the 87xx cluster, so future tweaks in the dashboard/sync range can't recreate this kind of silent collision. Portal A stays on 8765, Portal V2 lives on 9876.

Refs #256

## Test plan

- [ ] After serve restart: `curl -sI http://[::1]:9876/` → 200 (V2 stub)
- [ ] `curl -sI http://127.0.0.1:9876/` → 200
- [ ] Browser to `http://localhost:9876/` shows the stub (no IPv4/IPv6 mismatch)
- [ ] :8765 unchanged, :8766 unchanged (sync), :9876 = Portal V2

🤖 Generated with [Claude Code](https://claude.com/claude-code)