### PR TITLE
fix(portal-v2): default to :9766 — leading-digit mirror of :8765

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -420,11 +420,11 @@ func init() {
 	rootCmd.AddCommand(serveCmd)
 	serveCmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Don't open the dashboard in the browser")
 	// Portal V2 is the redesigned operator dashboard built fresh on shadcn-admin
-	// in `internal/web/ui/dashboard-v2/`. Defaults to :9876 — well away from the
-	// :8765 (dashboard) / :8766 (sync) cluster so future config tweaks in the
-	// 87xx range can't create silent collisions. Set 0 to disable while the v2
-	// work is in flight.
-	serveCmd.Flags().IntVar(&portalV2Port, "portal-v2-port", 9876, "Portal V2 listener port (0 to disable)")
+	// in `internal/web/ui/dashboard-v2/`. Default :9766 mirrors Portal A's :8765
+	// with the leading 8→9 swap (Portal A on 8, Portal V2 on 9, same trailing
+	// digits as the sync :8766 cluster). Set 0 to disable while the v2 work is
+	// in flight.
+	serveCmd.Flags().IntVar(&portalV2Port, "portal-v2-port", 9766, "Portal V2 listener port (0 to disable)")
 }
 
 func openBrowser(url string) {


### PR DESCRIPTION
Refs #256. Portal A on 8765, Portal V2 on 9766 — same trailing 765, swap leading 8→9. Memorable mirror.