### PR TITLE
fix(portal-v2): unignore frontend data/ — sidebar-data.ts wasn't shipping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,10 @@ openloom
 *.test
 *.out
 
-# Data directory
-data/
+# Runtime data directory at repo root (anchored — DO NOT match nested
+# `data/` dirs inside the frontend tree, e.g. `dashboard-v2/src/components/
+# layout/data/sidebar-data.ts` which is template source code).
+/data/
 
 # GoReleaser output (top-level dist/ from `make build-all`)
 dist/

--- a/internal/web/ui/dashboard-v2/src/components/layout/data/sidebar-data.ts
+++ b/internal/web/ui/dashboard-v2/src/components/layout/data/sidebar-data.ts
@@ -1,0 +1,94 @@
+import {
+  Activity,
+  AlertTriangle,
+  Boxes,
+  Brain,
+  Command,
+  Inbox,
+  LayoutDashboard,
+  PlayCircle,
+  Settings,
+  TrendingUp,
+} from 'lucide-react'
+import { type SidebarData } from '../types'
+
+// OpenPraxis Portal V2 — 8 main tabs + 1 settings.
+//
+// Routes are file-based (TanStack Router) under src/routes/_authenticated/.
+// Each url here maps to a route file.
+export const sidebarData: SidebarData = {
+  user: {
+    name: 'operator',
+    email: 'operator@openpraxis',
+    avatar: '/avatars/shadcn.jpg',
+  },
+  teams: [
+    {
+      name: 'OpenPraxis',
+      logo: Command,
+      plan: 'Portal V2',
+    },
+  ],
+  navGroups: [
+    {
+      title: 'Operations',
+      items: [
+        {
+          title: 'Overview',
+          url: '/',
+          icon: LayoutDashboard,
+        },
+        {
+          title: 'Active',
+          url: '/active',
+          icon: PlayCircle,
+        },
+        {
+          title: 'Catalog',
+          url: '/catalog',
+          icon: Boxes,
+        },
+        {
+          title: 'Inbox',
+          url: '/inbox',
+          icon: Inbox,
+        },
+        {
+          title: 'Recall',
+          url: '/recall',
+          icon: Brain,
+        },
+      ],
+    },
+    {
+      title: 'Governance',
+      items: [
+        {
+          title: 'Productivity',
+          url: '/productivity',
+          icon: TrendingUp,
+        },
+        {
+          title: 'Audit',
+          url: '/audit',
+          icon: AlertTriangle,
+        },
+        {
+          title: 'Activity',
+          url: '/activity',
+          icon: Activity,
+        },
+      ],
+    },
+    {
+      title: 'Configuration',
+      items: [
+        {
+          title: 'Settings',
+          url: '/settings',
+          icon: Settings,
+        },
+      ],
+    },
+  ],
+}


### PR DESCRIPTION
Refs #256, follows #259. The root .gitignore's unanchored `data/` rule was greedy-matching the shadcn-admin template's `src/components/layout/data/` dir. `sidebar-data.ts` (the nav config for our 9 tabs) silently dropped at push time. Anchored to `/data/` and re-added the missing file.