### PR TITLE
feat(portal-v2): shared API + WS on :9766 + Overview wiring proof

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -191,7 +191,7 @@ var serveCmd = &cobra.Command{
 			v2Addr := fmt.Sprintf("%s:%d", cfg.Server.Host, portalV2Port)
 			portalV2Server = &http.Server{
 				Addr:         v2Addr,
-				Handler:      web.HandlerV2(),
+				Handler:      web.HandlerV2(deps),
 				ReadTimeout:  30 * time.Second,
 				WriteTimeout: 30 * time.Second,
 			}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -152,7 +152,20 @@ var serveCmd = &cobra.Command{
 		chatTools := chat.NewChatTools(bridge)
 
 		// --- Main HTTP server (dashboard + MCP + API) ---
-		handler := web.Handler(n, mcp, hub, peerRegistry, chatRouter, chatContext, chatTools)
+		// ServerDeps bundles the cross-cutting services every HTTP route in
+		// the web package needs. Both Portal A (Handler) and Portal V2
+		// (HandlerV2 in a later commit) take the same struct so the
+		// dependency surface stays in lockstep as we add new services.
+		deps := web.ServerDeps{
+			Node:         n,
+			MCP:          mcp,
+			Hub:          hub,
+			PeerRegistry: peerRegistry,
+			ChatRouter:   chatRouter,
+			ChatCtx:      chatContext,
+			ChatTools:    chatTools,
+		}
+		handler := web.Handler(deps)
 		addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
 		httpServer := &http.Server{
 			Addr:         addr,

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -34,8 +34,32 @@ var uiFS embed.FS
 //go:embed all:ui/dashboard/dist
 var dashboardFS embed.FS
 
-// Handler creates the main HTTP handler with all routes.
-func Handler(n *node.Node, mcpServer *mcp.Server, hub *Hub, peerRegistry *peer.Registry, chatRouter *chat.Router, chatCtx *chat.ContextBuilder, chatTools *chat.ChatTools) http.Handler {
+// ServerDeps bundles the long list of cross-cutting services every HTTP
+// handler in this package needs (DB-backed stores via Node, the MCP
+// server, the WebSocket hub, the peer registry, and chat plumbing). All
+// fields are non-nil at runtime; tests construct a minimal ServerDeps
+// directly. Both Handler() (Portal A) and HandlerV2() (Portal V2) take
+// the same struct so the dependency surface stays in lockstep as we
+// add new services.
+type ServerDeps struct {
+	Node         *node.Node
+	MCP          *mcp.Server
+	Hub          *Hub
+	PeerRegistry *peer.Registry
+	ChatRouter   *chat.Router
+	ChatCtx      *chat.ContextBuilder
+	ChatTools    *chat.ChatTools
+}
+
+// Handler creates the main HTTP handler for Portal A on :8765 — legacy
+// vanilla-JS dashboard at `/`, React v1 experiment at `/dashboard/*`,
+// plus the full backend (`/api/*`, `/mcp`, `/ws`).
+//
+// Portal V2 on :9766 (HandlerV2) shares the API + WebSocket via the
+// same mountAPI / mountWS helpers so both ports talk to the same Node,
+// same DB, same hub. /mcp is Portal-A only because agent configs point
+// at :8765 and there's no value in duplicating the agent endpoint.
+func Handler(deps ServerDeps) http.Handler {
 	r := mux.NewRouter()
 
 	// Dashboard UI (embedded static files)
@@ -95,182 +119,19 @@ func Handler(n *node.Node, mcpServer *mcp.Server, hub *Hub, peerRegistry *peer.R
 	}
 	r.PathPrefix("/dashboard").HandlerFunc(serveDashboard(dashboardContent))
 
-	// WebSocket
-	r.HandleFunc("/ws", hub.HandleWS)
+	// WebSocket — broadcast hub. Mounted on Portal A and Portal V2 (via
+	// HandlerV2 → mountWS) so React on either port can subscribe to the
+	// same event stream.
+	mountWS(r, deps)
 
-	// MCP endpoint with request logging
-	mcpHandler := http.StripPrefix("/mcp", mcpServer.Handler())
-	r.PathPrefix("/mcp").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		slog.Debug("MCP request", "method", r.Method, "path", r.URL.Path, "from", r.RemoteAddr, "session", r.Header.Get("Mcp-Session-Id"))
-		mcpHandler.ServeHTTP(w, r)
-	})
+	// MCP endpoint — agent-facing. Mounted on Portal A only because
+	// `~/.claude/settings.json` and similar agent configs point at
+	// :8765/mcp; duplicating it on :9766 adds surface no caller needs.
+	mountMCP(r, deps)
 
 	// Dashboard REST API
 	api := r.PathPrefix("/api").Subrouter()
-	api.HandleFunc("/status", apiStatus(n, mcpServer, peerRegistry)).Methods("GET")
-	// Per-tab scoped search (M2). Registered before /{id} routes because
-	// gorilla/mux matches in registration order — otherwise "search" would
-	// be swallowed by /products/{id}, /ideas/{id}, /actions/{id}.
-	api.HandleFunc("/tasks/search", apiTasksSearch(n)).Methods("GET")
-	api.HandleFunc("/products/search", apiProductsSearch(n)).Methods("GET")
-	api.HandleFunc("/ideas/search", apiIdeasSearch(n)).Methods("GET")
-	api.HandleFunc("/actions/search", apiActionsSearch(n)).Methods("GET")
-	api.HandleFunc("/manifests/search", apiManifestsSearchGET(n)).Methods("GET")
-	api.HandleFunc("/memories", apiMemories(n)).Methods("GET")
-	api.HandleFunc("/memories/search", apiSearch(n)).Methods("POST")
-	api.HandleFunc("/memories/search", apiMemoriesSearchGET(n)).Methods("GET")
-	api.HandleFunc("/memories/tree", apiTree(n)).Methods("GET")
-	api.HandleFunc("/memories/by-session", apiMemoriesBySession(n)).Methods("GET")
-	api.HandleFunc("/memories/by-peer", apiMemoriesByPeer(n)).Methods("GET")
-	api.HandleFunc("/memories/{id}", apiMemory(n)).Methods("GET")
-	api.HandleFunc("/memories/{id}", apiMemoryDelete(n)).Methods("DELETE")
-	api.HandleFunc("/peers", apiPeers(n, mcpServer, peerRegistry)).Methods("GET")
-	api.HandleFunc("/agents", apiAgents(mcpServer)).Methods("GET")
-	api.HandleFunc("/activity", apiActivity(n)).Methods("GET")
-	api.HandleFunc("/activity/by-peer", apiActivityByPeer(n)).Methods("GET")
-	api.HandleFunc("/conversations", apiConversations(n)).Methods("GET")
-	api.HandleFunc("/conversations/by-peer", apiConversationsByPeer(n)).Methods("GET")
-	api.HandleFunc("/conversations/search", apiConversationSearch(n)).Methods("POST")
-	api.HandleFunc("/conversations/search", apiConversationsSearchGET(n)).Methods("GET")
-	api.HandleFunc("/conversations/{id}/actions", apiConversationActions(n)).Methods("GET")
-	api.HandleFunc("/conversations/{id}", apiConversation(n)).Methods("GET")
-	api.HandleFunc("/markers", apiMarkers(n)).Methods("GET")
-	api.HandleFunc("/markers/{id}/seen", apiMarkerSeen(n)).Methods("POST")
-	api.HandleFunc("/markers/{id}/done", apiMarkerDone(n)).Methods("POST")
-	// Hook endpoint for Claude Code conversation capture
-	api.HandleFunc("/hook", apiHook(n)).Methods("POST")
-
-	api.HandleFunc("/actions", apiActions(n)).Methods("GET")
-	api.HandleFunc("/actions/by-peer", apiActionsByPeer(n)).Methods("GET")
-	api.HandleFunc("/actions/{id}", apiAction(n)).Methods("GET")
-	api.HandleFunc("/amnesia/by-peer", apiAmnesiaByPeer(n)).Methods("GET")
-	api.HandleFunc("/amnesia", apiAmnesia(n)).Methods("GET")
-	api.HandleFunc("/amnesia/{id}/confirm", apiAmnesiaUpdate(n, "confirmed")).Methods("POST")
-	api.HandleFunc("/amnesia/{id}/dismiss", apiAmnesiaUpdate(n, "dismissed")).Methods("POST")
-	api.HandleFunc("/ideas/by-peer", apiIdeasByPeer(n)).Methods("GET")
-	api.HandleFunc("/ideas", apiIdeaList(n)).Methods("GET")
-	api.HandleFunc("/ideas", apiIdeaCreate(n)).Methods("POST")
-	api.HandleFunc("/ideas/{id}", apiIdeaGet(n)).Methods("GET")
-	api.HandleFunc("/ideas/{id}", apiIdeaUpdate(n)).Methods("PUT")
-	api.HandleFunc("/ideas/{id}", apiIdeaDelete(n)).Methods("DELETE")
-	api.HandleFunc("/products/by-peer", apiProductsByPeer(n)).Methods("GET")
-	api.HandleFunc("/products", apiProductList(n)).Methods("GET")
-	api.HandleFunc("/products", apiProductCreate(n)).Methods("POST")
-	api.HandleFunc("/products/{id}/hierarchy", apiProductHierarchy(n)).Methods("GET")
-	api.HandleFunc("/products/{id}/manifests", apiProductManifests(n)).Methods("GET")
-	api.HandleFunc("/products/{id}/ideas", apiProductIdeas(n)).Methods("GET")
-	api.HandleFunc("/products/{id}/dependencies", apiProductDepList(n)).Methods("GET")
-	api.HandleFunc("/products/{id}/dependencies", apiProductDepAdd(n)).Methods("POST")
-	api.HandleFunc("/products/{id}/dependencies/{depId}", apiProductDepRemove(n)).Methods("DELETE")
-	api.HandleFunc("/products/{id}", apiProductGet(n)).Methods("GET")
-	api.HandleFunc("/products/{id}", apiProductUpdate(n)).Methods("PUT")
-	api.HandleFunc("/products/{id}", apiProductDelete(n)).Methods("DELETE")
-	api.HandleFunc("/manifests/by-peer", apiManifestsByPeer(n)).Methods("GET")
-	api.HandleFunc("/manifests", apiManifestList(n)).Methods("GET")
-	api.HandleFunc("/manifests", apiManifestCreate(n)).Methods("POST")
-	api.HandleFunc("/manifests/search", apiManifestSearch(n)).Methods("POST")
-	api.HandleFunc("/ideas/{id}/manifests", apiIdeasManifests(n)).Methods("GET")
-	api.HandleFunc("/manifests/{id}/ideas", apiManifestIdeas(n)).Methods("GET")
-	api.HandleFunc("/link", apiLink(n)).Methods("POST")
-	api.HandleFunc("/unlink", apiUnlink(n)).Methods("POST")
-	api.HandleFunc("/delusions/by-peer", apiDelusionsByPeer(n)).Methods("GET")
-	api.HandleFunc("/delusions", apiDelusions(n)).Methods("GET")
-	api.HandleFunc("/delusions/{id}/confirm", apiDelusionUpdate(n, "confirmed")).Methods("POST")
-	api.HandleFunc("/delusions/{id}/dismiss", apiDelusionUpdate(n, "dismissed")).Methods("POST")
-	api.HandleFunc("/manifests/{id}/tasks", apiManifestTasks(n)).Methods("GET")
-	api.HandleFunc("/manifests/{id}/dependencies", apiManifestDepList(n)).Methods("GET")
-	api.HandleFunc("/manifests/{id}/dependencies", apiManifestDepAdd(n)).Methods("POST")
-	api.HandleFunc("/manifests/{id}/dependencies/{depId}", apiManifestDepRemove(n)).Methods("DELETE")
-	api.HandleFunc("/manifests/{id}", apiManifestGet(n)).Methods("GET")
-	api.HandleFunc("/manifests/{id}", apiManifestUpdate(n)).Methods("PUT")
-	api.HandleFunc("/manifests/{id}", apiManifestDelete(n)).Methods("DELETE")
-	api.HandleFunc("/tasks/by-peer", apiTasksByPeer(n)).Methods("GET")
-	api.HandleFunc("/tasks/running", apiRunningTasks(n)).Methods("GET")
-	api.HandleFunc("/tasks/stats", apiTaskStats(n)).Methods("GET")
-	// Heavy panels split off the polled stats endpoint — loaded on view-show
-	// only, not on every 10s tick. See handlers_task.go for context.
-	api.HandleFunc("/tasks/today-top", apiTodayTopTasks(n)).Methods("GET")
-	api.HandleFunc("/tasks/pending", apiPendingTasks(n)).Methods("GET")
-	api.HandleFunc("/tasks/cost-history", apiCostHistory(n)).Methods("GET")
-	api.HandleFunc("/tasks/cost-agents", apiCostAgents(n)).Methods("GET")
-	api.HandleFunc("/tasks/cost-trend", apiCostTrend(n)).Methods("GET")
-	api.HandleFunc("/tasks/productivity", apiProductivity(n)).Methods("GET")
-	api.HandleFunc("/tasks", apiTaskList(n)).Methods("GET")
-	api.HandleFunc("/tasks", apiTaskCreate(n)).Methods("POST")
-	api.HandleFunc("/tasks/{id}", apiTaskGet(n)).Methods("GET")
-	api.HandleFunc("/tasks/{id}", apiTaskUpdate(n)).Methods("PATCH")
-	api.HandleFunc("/tasks/{id}", apiTaskDelete(n)).Methods("DELETE")
-	api.HandleFunc("/tasks/{id}/actions", apiTaskActions(n)).Methods("GET")
-	api.HandleFunc("/tasks/{id}/amnesia", apiTaskAmnesia(n)).Methods("GET")
-	api.HandleFunc("/tasks/{id}/delusions", apiTaskDelusions(n)).Methods("GET")
-	api.HandleFunc("/tasks/{id}/runs", apiTaskRuns(n)).Methods("GET")
-	api.HandleFunc("/tasks/{id}/runs/{runId}", apiTaskRunGet(n)).Methods("GET")
-	api.HandleFunc("/task_runs/{runId}/host_samples", apiTaskRunHostSamples(n)).Methods("GET")
-	// Live host CPU/RSS — feeds the node stats chip on the overview.
-	api.HandleFunc("/host/stats", apiHostStats()).Methods("GET")
-	api.HandleFunc("/tasks/{id}/start", apiTaskStart(n)).Methods("POST")
-	api.HandleFunc("/tasks/{id}/cancel", apiTaskUpdateStatus(n, "cancelled")).Methods("POST")
-	api.HandleFunc("/tasks/{id}/reject", apiTaskReject(n)).Methods("POST")
-	api.HandleFunc("/tasks/{id}/approve", apiTaskApprove(n)).Methods("POST")
-	api.HandleFunc("/tasks/{id}/review", apiTaskReviewStatus(n)).Methods("GET")
-	api.HandleFunc("/tasks/{id}/kill", apiTaskKill(n)).Methods("POST")
-	api.HandleFunc("/tasks/{id}/pause", apiTaskPause(n)).Methods("POST")
-	api.HandleFunc("/tasks/{id}/resume", apiTaskResume(n)).Methods("POST")
-	api.HandleFunc("/tasks/{id}/reschedule", apiTaskReschedule(n)).Methods("POST")
-	api.HandleFunc("/tasks/{id}/output", apiTaskOutput(n)).Methods("GET")
-	api.HandleFunc("/tasks/{id}/link-manifest", apiTaskLinkManifest(n)).Methods("POST")
-	api.HandleFunc("/tasks/{id}/unlink-manifest", apiTaskUnlinkManifest(n)).Methods("POST")
-	api.HandleFunc("/tasks/{id}/set-manifest", apiTaskSetManifest(n)).Methods("PUT")
-	api.HandleFunc("/tasks/{id}/manifests", apiTaskManifests(n)).Methods("GET")
-	api.HandleFunc("/tasks/{id}/dependency", apiTaskSetDependency(n)).Methods("PUT")
-	api.HandleFunc("/visceral/by-peer", apiVisceralByPeer(n)).Methods("GET")
-	api.HandleFunc("/visceral", apiVisceralList(n)).Methods("GET")
-	api.HandleFunc("/visceral/confirmations", apiVisceralConfirmations(n)).Methods("GET")
-	api.HandleFunc("/visceral", apiVisceralAdd(n)).Methods("POST")
-	api.HandleFunc("/visceral/{id}", apiVisceralDelete(n)).Methods("DELETE")
-	api.HandleFunc("/visceral/patterns", apiRulePatterns(n)).Methods("GET")
-	api.HandleFunc("/visceral/patterns/{rule_id}", apiRulePatternGet(n)).Methods("GET")
-	api.HandleFunc("/visceral/patterns/{rule_id}", apiRulePatternUpdate(n)).Methods("PUT")
-	// Watcher — independent task execution audits
-	api.HandleFunc("/watcher/audits", apiWatcherList(n)).Methods("GET")
-	api.HandleFunc("/watcher/stats", apiWatcherStats(n)).Methods("GET")
-	api.HandleFunc("/watcher/audits/{id}", apiWatcherGet(n)).Methods("GET")
-	api.HandleFunc("/watcher/tasks/{id}", apiWatcherForTask(n)).Methods("GET")
-	api.HandleFunc("/watcher/audit/{id}", apiWatcherTrigger(n)).Methods("POST")
-	// Recall — soft-deleted items
-	api.HandleFunc("/recall", apiRecall(n)).Methods("GET")
-	api.HandleFunc("/recall/{type}/{id}/restore", apiRestore(n)).Methods("POST")
-
-	// Hierarchical execution-controls settings (M2-T6) — registered before
-	// the profile/agents/chat /settings/* routes because gorilla/mux matches
-	// paths in registration order. catalog + scope-keyed endpoints share the
-	// /settings prefix without colliding (different verbs / suffixes).
-	registerSettingsExecRoutes(api, n)
-	registerCommentsRoutesFromNode(api, n)
-	registerDescriptionRoutes(api, n)
-	registerTemplateRoutes(api, n)
-
-	api.HandleFunc("/settings/profile", apiProfileGet(n)).Methods("GET")
-	api.HandleFunc("/settings/profile", apiProfileUpdate(n)).Methods("PUT")
-	api.HandleFunc("/settings/agents", apiSettingsAgents()).Methods("GET")
-	api.HandleFunc("/settings/agents/{id}/connect", apiAgentConnect()).Methods("POST")
-	api.HandleFunc("/settings/agents/{id}/disconnect", apiAgentDisconnect()).Methods("POST")
-	api.HandleFunc("/settings/chat", apiChatSettingsGet(n)).Methods("GET")
-	api.HandleFunc("/settings/chat", apiChatSettingsUpdate(n, chatRouter)).Methods("PUT")
-	api.HandleFunc("/settings/chat/test", apiChatSettingsTest()).Methods("POST")
-
-	// Chat API
-	api.HandleFunc("/chat", apiChatSend(n, chatRouter, chatCtx, chatTools)).Methods("POST")
-	api.HandleFunc("/chat/models", apiChatModels(chatRouter)).Methods("GET")
-	api.HandleFunc("/chat/sessions", apiChatSessionList(n)).Methods("GET")
-	api.HandleFunc("/chat/sessions", apiChatSessionCreate(n, chatRouter)).Methods("POST")
-	api.HandleFunc("/chat/sessions/{id}", apiChatSessionGet(n)).Methods("GET")
-	api.HandleFunc("/chat/sessions/{id}", apiChatSessionDelete(n)).Methods("DELETE")
-	api.HandleFunc("/chat/sessions/{id}/reset", apiChatSessionReset(n)).Methods("POST")
-	api.HandleFunc("/chat/sessions/{id}/title", apiChatSessionUpdateTitle(n)).Methods("PUT")
-	api.HandleFunc("/chat/sessions/{id}/model", apiChatSessionUpdateModel(n)).Methods("PUT")
-	api.HandleFunc("/chat/sessions/{id}/thinking", apiChatSessionUpdateThinking(n)).Methods("PUT")
-	api.HandleFunc("/chat/sessions/{id}/restore", apiChatSessionRestore(n)).Methods("POST")
+	mountAPI(api, deps)
 
 	// Dashboard index (catch-all)
 	r.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -689,3 +550,206 @@ func apiActivityByPeer(n *node.Node) http.HandlerFunc {
 }
 
 // writeJSON, writeError, decodeBody are in helpers.go
+
+
+// mountWS registers the WebSocket broadcast endpoint on the given
+// router. Both Portal A and Portal V2 mount it so React on either port
+// can subscribe to the same hub broadcasts.
+func mountWS(r *mux.Router, deps ServerDeps) {
+	r.HandleFunc("/ws", deps.Hub.HandleWS)
+}
+
+// mountMCP registers the agent-facing MCP HTTP endpoint with request
+// logging. Mounted on Portal A only — agent configs (Claude Code,
+// Cursor, etc.) point at :8765/mcp and duplicating the endpoint on
+// :9766 adds surface no caller actually uses.
+func mountMCP(r *mux.Router, deps ServerDeps) {
+	mcpHandler := http.StripPrefix("/mcp", deps.MCP.Handler())
+	r.PathPrefix("/mcp").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		slog.Debug("MCP request", "method", r.Method, "path", r.URL.Path, "from", r.RemoteAddr, "session", r.Header.Get("Mcp-Session-Id"))
+		mcpHandler.ServeHTTP(w, r)
+	})
+}
+
+// mountAPI registers every /api/* route on the given subrouter. Both
+// Portal A and Portal V2 call this so the dynamic backend (status,
+// tasks, products, manifests, comments, descriptions, templates,
+// settings, chat, etc.) is identical on both ports.
+//
+// Route order matters: gorilla/mux matches in registration order, so
+// scoped-search routes are registered BEFORE the /{id} catch-all
+// patterns that would otherwise swallow them. Don't reorder without
+// re-verifying with curl probes against the affected paths.
+func mountAPI(api *mux.Router, deps ServerDeps) {
+	n := deps.Node
+	mcpServer := deps.MCP
+	peerRegistry := deps.PeerRegistry
+	chatRouter := deps.ChatRouter
+	chatCtx := deps.ChatCtx
+	chatTools := deps.ChatTools
+
+	api.HandleFunc("/status", apiStatus(n, mcpServer, peerRegistry)).Methods("GET")
+	// Per-tab scoped search (M2). Registered before /{id} routes because
+	// gorilla/mux matches in registration order — otherwise "search" would
+	// be swallowed by /products/{id}, /ideas/{id}, /actions/{id}.
+	api.HandleFunc("/tasks/search", apiTasksSearch(n)).Methods("GET")
+	api.HandleFunc("/products/search", apiProductsSearch(n)).Methods("GET")
+	api.HandleFunc("/ideas/search", apiIdeasSearch(n)).Methods("GET")
+	api.HandleFunc("/actions/search", apiActionsSearch(n)).Methods("GET")
+	api.HandleFunc("/manifests/search", apiManifestsSearchGET(n)).Methods("GET")
+	api.HandleFunc("/memories", apiMemories(n)).Methods("GET")
+	api.HandleFunc("/memories/search", apiSearch(n)).Methods("POST")
+	api.HandleFunc("/memories/search", apiMemoriesSearchGET(n)).Methods("GET")
+	api.HandleFunc("/memories/tree", apiTree(n)).Methods("GET")
+	api.HandleFunc("/memories/by-session", apiMemoriesBySession(n)).Methods("GET")
+	api.HandleFunc("/memories/by-peer", apiMemoriesByPeer(n)).Methods("GET")
+	api.HandleFunc("/memories/{id}", apiMemory(n)).Methods("GET")
+	api.HandleFunc("/memories/{id}", apiMemoryDelete(n)).Methods("DELETE")
+	api.HandleFunc("/peers", apiPeers(n, mcpServer, peerRegistry)).Methods("GET")
+	api.HandleFunc("/agents", apiAgents(mcpServer)).Methods("GET")
+	api.HandleFunc("/activity", apiActivity(n)).Methods("GET")
+	api.HandleFunc("/activity/by-peer", apiActivityByPeer(n)).Methods("GET")
+	api.HandleFunc("/conversations", apiConversations(n)).Methods("GET")
+	api.HandleFunc("/conversations/by-peer", apiConversationsByPeer(n)).Methods("GET")
+	api.HandleFunc("/conversations/search", apiConversationSearch(n)).Methods("POST")
+	api.HandleFunc("/conversations/search", apiConversationsSearchGET(n)).Methods("GET")
+	api.HandleFunc("/conversations/{id}/actions", apiConversationActions(n)).Methods("GET")
+	api.HandleFunc("/conversations/{id}", apiConversation(n)).Methods("GET")
+	api.HandleFunc("/markers", apiMarkers(n)).Methods("GET")
+	api.HandleFunc("/markers/{id}/seen", apiMarkerSeen(n)).Methods("POST")
+	api.HandleFunc("/markers/{id}/done", apiMarkerDone(n)).Methods("POST")
+	// Hook endpoint for Claude Code conversation capture
+	api.HandleFunc("/hook", apiHook(n)).Methods("POST")
+
+	api.HandleFunc("/actions", apiActions(n)).Methods("GET")
+	api.HandleFunc("/actions/by-peer", apiActionsByPeer(n)).Methods("GET")
+	api.HandleFunc("/actions/{id}", apiAction(n)).Methods("GET")
+	api.HandleFunc("/amnesia/by-peer", apiAmnesiaByPeer(n)).Methods("GET")
+	api.HandleFunc("/amnesia", apiAmnesia(n)).Methods("GET")
+	api.HandleFunc("/amnesia/{id}/confirm", apiAmnesiaUpdate(n, "confirmed")).Methods("POST")
+	api.HandleFunc("/amnesia/{id}/dismiss", apiAmnesiaUpdate(n, "dismissed")).Methods("POST")
+	api.HandleFunc("/ideas/by-peer", apiIdeasByPeer(n)).Methods("GET")
+	api.HandleFunc("/ideas", apiIdeaList(n)).Methods("GET")
+	api.HandleFunc("/ideas", apiIdeaCreate(n)).Methods("POST")
+	api.HandleFunc("/ideas/{id}", apiIdeaGet(n)).Methods("GET")
+	api.HandleFunc("/ideas/{id}", apiIdeaUpdate(n)).Methods("PUT")
+	api.HandleFunc("/ideas/{id}", apiIdeaDelete(n)).Methods("DELETE")
+	api.HandleFunc("/products/by-peer", apiProductsByPeer(n)).Methods("GET")
+	api.HandleFunc("/products", apiProductList(n)).Methods("GET")
+	api.HandleFunc("/products", apiProductCreate(n)).Methods("POST")
+	api.HandleFunc("/products/{id}/hierarchy", apiProductHierarchy(n)).Methods("GET")
+	api.HandleFunc("/products/{id}/manifests", apiProductManifests(n)).Methods("GET")
+	api.HandleFunc("/products/{id}/ideas", apiProductIdeas(n)).Methods("GET")
+	api.HandleFunc("/products/{id}/dependencies", apiProductDepList(n)).Methods("GET")
+	api.HandleFunc("/products/{id}/dependencies", apiProductDepAdd(n)).Methods("POST")
+	api.HandleFunc("/products/{id}/dependencies/{depId}", apiProductDepRemove(n)).Methods("DELETE")
+	api.HandleFunc("/products/{id}", apiProductGet(n)).Methods("GET")
+	api.HandleFunc("/products/{id}", apiProductUpdate(n)).Methods("PUT")
+	api.HandleFunc("/products/{id}", apiProductDelete(n)).Methods("DELETE")
+	api.HandleFunc("/manifests/by-peer", apiManifestsByPeer(n)).Methods("GET")
+	api.HandleFunc("/manifests", apiManifestList(n)).Methods("GET")
+	api.HandleFunc("/manifests", apiManifestCreate(n)).Methods("POST")
+	api.HandleFunc("/manifests/search", apiManifestSearch(n)).Methods("POST")
+	api.HandleFunc("/ideas/{id}/manifests", apiIdeasManifests(n)).Methods("GET")
+	api.HandleFunc("/manifests/{id}/ideas", apiManifestIdeas(n)).Methods("GET")
+	api.HandleFunc("/link", apiLink(n)).Methods("POST")
+	api.HandleFunc("/unlink", apiUnlink(n)).Methods("POST")
+	api.HandleFunc("/delusions/by-peer", apiDelusionsByPeer(n)).Methods("GET")
+	api.HandleFunc("/delusions", apiDelusions(n)).Methods("GET")
+	api.HandleFunc("/delusions/{id}/confirm", apiDelusionUpdate(n, "confirmed")).Methods("POST")
+	api.HandleFunc("/delusions/{id}/dismiss", apiDelusionUpdate(n, "dismissed")).Methods("POST")
+	api.HandleFunc("/manifests/{id}/tasks", apiManifestTasks(n)).Methods("GET")
+	api.HandleFunc("/manifests/{id}/dependencies", apiManifestDepList(n)).Methods("GET")
+	api.HandleFunc("/manifests/{id}/dependencies", apiManifestDepAdd(n)).Methods("POST")
+	api.HandleFunc("/manifests/{id}/dependencies/{depId}", apiManifestDepRemove(n)).Methods("DELETE")
+	api.HandleFunc("/manifests/{id}", apiManifestGet(n)).Methods("GET")
+	api.HandleFunc("/manifests/{id}", apiManifestUpdate(n)).Methods("PUT")
+	api.HandleFunc("/manifests/{id}", apiManifestDelete(n)).Methods("DELETE")
+	api.HandleFunc("/tasks/by-peer", apiTasksByPeer(n)).Methods("GET")
+	api.HandleFunc("/tasks/running", apiRunningTasks(n)).Methods("GET")
+	api.HandleFunc("/tasks/stats", apiTaskStats(n)).Methods("GET")
+	// Heavy panels split off the polled stats endpoint — loaded on view-show
+	// only, not on every 10s tick. See handlers_task.go for context.
+	api.HandleFunc("/tasks/today-top", apiTodayTopTasks(n)).Methods("GET")
+	api.HandleFunc("/tasks/pending", apiPendingTasks(n)).Methods("GET")
+	api.HandleFunc("/tasks/cost-history", apiCostHistory(n)).Methods("GET")
+	api.HandleFunc("/tasks/cost-agents", apiCostAgents(n)).Methods("GET")
+	api.HandleFunc("/tasks/cost-trend", apiCostTrend(n)).Methods("GET")
+	api.HandleFunc("/tasks/productivity", apiProductivity(n)).Methods("GET")
+	api.HandleFunc("/tasks", apiTaskList(n)).Methods("GET")
+	api.HandleFunc("/tasks", apiTaskCreate(n)).Methods("POST")
+	api.HandleFunc("/tasks/{id}", apiTaskGet(n)).Methods("GET")
+	api.HandleFunc("/tasks/{id}", apiTaskUpdate(n)).Methods("PATCH")
+	api.HandleFunc("/tasks/{id}", apiTaskDelete(n)).Methods("DELETE")
+	api.HandleFunc("/tasks/{id}/actions", apiTaskActions(n)).Methods("GET")
+	api.HandleFunc("/tasks/{id}/amnesia", apiTaskAmnesia(n)).Methods("GET")
+	api.HandleFunc("/tasks/{id}/delusions", apiTaskDelusions(n)).Methods("GET")
+	api.HandleFunc("/tasks/{id}/runs", apiTaskRuns(n)).Methods("GET")
+	api.HandleFunc("/tasks/{id}/runs/{runId}", apiTaskRunGet(n)).Methods("GET")
+	api.HandleFunc("/task_runs/{runId}/host_samples", apiTaskRunHostSamples(n)).Methods("GET")
+	// Live host CPU/RSS — feeds the node stats chip on the overview.
+	api.HandleFunc("/host/stats", apiHostStats()).Methods("GET")
+	api.HandleFunc("/tasks/{id}/start", apiTaskStart(n)).Methods("POST")
+	api.HandleFunc("/tasks/{id}/cancel", apiTaskUpdateStatus(n, "cancelled")).Methods("POST")
+	api.HandleFunc("/tasks/{id}/reject", apiTaskReject(n)).Methods("POST")
+	api.HandleFunc("/tasks/{id}/approve", apiTaskApprove(n)).Methods("POST")
+	api.HandleFunc("/tasks/{id}/review", apiTaskReviewStatus(n)).Methods("GET")
+	api.HandleFunc("/tasks/{id}/kill", apiTaskKill(n)).Methods("POST")
+	api.HandleFunc("/tasks/{id}/pause", apiTaskPause(n)).Methods("POST")
+	api.HandleFunc("/tasks/{id}/resume", apiTaskResume(n)).Methods("POST")
+	api.HandleFunc("/tasks/{id}/reschedule", apiTaskReschedule(n)).Methods("POST")
+	api.HandleFunc("/tasks/{id}/output", apiTaskOutput(n)).Methods("GET")
+	api.HandleFunc("/tasks/{id}/link-manifest", apiTaskLinkManifest(n)).Methods("POST")
+	api.HandleFunc("/tasks/{id}/unlink-manifest", apiTaskUnlinkManifest(n)).Methods("POST")
+	api.HandleFunc("/tasks/{id}/set-manifest", apiTaskSetManifest(n)).Methods("PUT")
+	api.HandleFunc("/tasks/{id}/manifests", apiTaskManifests(n)).Methods("GET")
+	api.HandleFunc("/tasks/{id}/dependency", apiTaskSetDependency(n)).Methods("PUT")
+	api.HandleFunc("/visceral/by-peer", apiVisceralByPeer(n)).Methods("GET")
+	api.HandleFunc("/visceral", apiVisceralList(n)).Methods("GET")
+	api.HandleFunc("/visceral/confirmations", apiVisceralConfirmations(n)).Methods("GET")
+	api.HandleFunc("/visceral", apiVisceralAdd(n)).Methods("POST")
+	api.HandleFunc("/visceral/{id}", apiVisceralDelete(n)).Methods("DELETE")
+	api.HandleFunc("/visceral/patterns", apiRulePatterns(n)).Methods("GET")
+	api.HandleFunc("/visceral/patterns/{rule_id}", apiRulePatternGet(n)).Methods("GET")
+	api.HandleFunc("/visceral/patterns/{rule_id}", apiRulePatternUpdate(n)).Methods("PUT")
+	// Watcher — independent task execution audits
+	api.HandleFunc("/watcher/audits", apiWatcherList(n)).Methods("GET")
+	api.HandleFunc("/watcher/stats", apiWatcherStats(n)).Methods("GET")
+	api.HandleFunc("/watcher/audits/{id}", apiWatcherGet(n)).Methods("GET")
+	api.HandleFunc("/watcher/tasks/{id}", apiWatcherForTask(n)).Methods("GET")
+	api.HandleFunc("/watcher/audit/{id}", apiWatcherTrigger(n)).Methods("POST")
+	// Recall — soft-deleted items
+	api.HandleFunc("/recall", apiRecall(n)).Methods("GET")
+	api.HandleFunc("/recall/{type}/{id}/restore", apiRestore(n)).Methods("POST")
+
+	// Hierarchical execution-controls settings (M2-T6) — registered before
+	// the profile/agents/chat /settings/* routes because gorilla/mux matches
+	// paths in registration order. catalog + scope-keyed endpoints share the
+	// /settings prefix without colliding (different verbs / suffixes).
+	registerSettingsExecRoutes(api, n)
+	registerCommentsRoutesFromNode(api, n)
+	registerDescriptionRoutes(api, n)
+	registerTemplateRoutes(api, n)
+
+	api.HandleFunc("/settings/profile", apiProfileGet(n)).Methods("GET")
+	api.HandleFunc("/settings/profile", apiProfileUpdate(n)).Methods("PUT")
+	api.HandleFunc("/settings/agents", apiSettingsAgents()).Methods("GET")
+	api.HandleFunc("/settings/agents/{id}/connect", apiAgentConnect()).Methods("POST")
+	api.HandleFunc("/settings/agents/{id}/disconnect", apiAgentDisconnect()).Methods("POST")
+	api.HandleFunc("/settings/chat", apiChatSettingsGet(n)).Methods("GET")
+	api.HandleFunc("/settings/chat", apiChatSettingsUpdate(n, chatRouter)).Methods("PUT")
+	api.HandleFunc("/settings/chat/test", apiChatSettingsTest()).Methods("POST")
+
+	// Chat API
+	api.HandleFunc("/chat", apiChatSend(n, chatRouter, chatCtx, chatTools)).Methods("POST")
+	api.HandleFunc("/chat/models", apiChatModels(chatRouter)).Methods("GET")
+	api.HandleFunc("/chat/sessions", apiChatSessionList(n)).Methods("GET")
+	api.HandleFunc("/chat/sessions", apiChatSessionCreate(n, chatRouter)).Methods("POST")
+	api.HandleFunc("/chat/sessions/{id}", apiChatSessionGet(n)).Methods("GET")
+	api.HandleFunc("/chat/sessions/{id}", apiChatSessionDelete(n)).Methods("DELETE")
+	api.HandleFunc("/chat/sessions/{id}/reset", apiChatSessionReset(n)).Methods("POST")
+	api.HandleFunc("/chat/sessions/{id}/title", apiChatSessionUpdateTitle(n)).Methods("PUT")
+	api.HandleFunc("/chat/sessions/{id}/model", apiChatSessionUpdateModel(n)).Methods("PUT")
+	api.HandleFunc("/chat/sessions/{id}/thinking", apiChatSessionUpdateThinking(n)).Methods("PUT")
+	api.HandleFunc("/chat/sessions/{id}/restore", apiChatSessionRestore(n)).Methods("POST")
+}

--- a/internal/web/handler_v2.go
+++ b/internal/web/handler_v2.go
@@ -1,17 +1,18 @@
-// Portal V2 handler — dual-port plumbing stub.
+// Portal V2 handler — dual-port architecture.
 //
-// Listens on its own port (default :8766, set by the --portal-v2-port flag
-// in cmd/serve.go) and serves the Vite-style static bundle from
-// `ui/dashboard-v2/dist`. Same Go binary, same database, same MCP server —
-// different frontend tree.
+// Listens on its own port (default :9766, set by the --portal-v2-port
+// flag in cmd/serve.go) and serves:
 //
-// Foundation V2 hasn't shipped yet; for now this returns a hand-rolled
-// stub at `/` so the dual-port architecture can be verified end-to-end
-// before any React work lands.
+//   - The Vite-built React shell from `ui/dashboard-v2/dist` at `/`
+//     (with SPA fallback so HashRouter deep-links survive reload).
+//   - `/api/*` — the same dynamic backend Portal A exposes, mounted
+//     via the shared mountAPI helper. Same Node, same DB, same data.
+//   - `/ws` — the same WebSocket broadcast hub. Both portals see the
+//     same event stream.
 //
-// When the real shadcn-admin scaffold lands in a later chunk, the API +
-// /mcp + /ws routes from `Handler(...)` get factored into a shared mux
-// builder so both portals expose the full backend on their own port.
+// `/mcp` is deliberately NOT mounted here. Agent configs (Claude Code,
+// Cursor, etc.) point at :8765/mcp and there's no caller value in
+// duplicating the agent endpoint on :9766.
 package web
 
 import (
@@ -26,13 +27,28 @@ import (
 //go:embed all:ui/dashboard-v2/dist
 var dashboardV2FS embed.FS
 
-// HandlerV2 returns the HTTP handler for Portal V2. Static-only for the
-// chunk-1 plumbing milestone — no API surface yet. Future chunks add the
-// shared API + MCP + WebSocket mux once the React app starts making real
-// requests.
-func HandlerV2() http.Handler {
+// HandlerV2 returns the HTTP handler for Portal V2 on :9766. Same
+// backend services as Handler() (the Portal A handler), routed onto a
+// fresh mux so the React frontend at `/` doesn't fight the legacy
+// vanilla-JS dashboard mounted at `/` on Portal A.
+func HandlerV2(deps ServerDeps) http.Handler {
 	r := mux.NewRouter()
 
+	// /api/* — same routes as Portal A, same handlers, same data. The
+	// React shell on :9766 fetches /api/* against its own port (no
+	// CORS, no proxy) so requests resolve in-process via the same
+	// handler chain that serves :8765/api/*.
+	api := r.PathPrefix("/api").Subrouter()
+	mountAPI(api, deps)
+
+	// /ws — broadcast hub. Subscriptions opened from the React shell
+	// land in the same hub Portal A subscribers use, so events emit
+	// to both UIs simultaneously.
+	mountWS(r, deps)
+
+	// React shell — Vite build output. Hashed assets (assets/*) and
+	// images (images/*) under their own paths; everything else falls
+	// back to index.html so the TanStack hash router can take over.
 	v2Content, err := fs.Sub(dashboardV2FS, "ui/dashboard-v2/dist")
 	if err != nil {
 		// Embed directive is statically validated, so this is unreachable.
@@ -41,16 +57,13 @@ func HandlerV2() http.Handler {
 		panic(fmt.Sprintf("dashboard-v2 embed sub: %v", err))
 	}
 
-	// SPA fallback: any path that doesn't resolve to a static file falls
-	// back to index.html so HashRouter deep-links (#overview, #active,
-	// etc.) reload cleanly. The hash never reaches the server, so this is
-	// belt-and-suspenders for chunk 1; the real router lands later.
 	fileServer := http.FileServer(http.FS(v2Content))
 	r.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		// no-store on the entrypoint so updates land on hard-reload
 		// without operators having to bust cache manually. Hashed asset
-		// chunks (when Vite ships real ones) get long-cache headers via
-		// Vite's default fingerprint contract — they don't need this.
+		// chunks (Vite default fingerprint contract) need long-cache
+		// headers eventually but for now the FileServer's defaults are
+		// fine while we iterate.
 		if req.URL.Path == "/" || req.URL.Path == "/index.html" {
 			w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 		}

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -29,20 +29,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- Primary Meta Tags -->
-    <title>Shadcn Admin</title>
-    <meta name="title" content="Shadcn Admin" />
+    <title>OpenPraxis Portal V2</title>
+    <meta name="title" content="OpenPraxis Portal V2" />
     <meta
       name="description"
-      content="Admin Dashboard UI built with Shadcn and Vite."
+      content="OpenPraxis Portal V2"
     />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://shadcn-admin.netlify.app" />
-    <meta property="og:title" content="Shadcn Admin" />
+    <meta property="og:title" content="OpenPraxis Portal V2" />
     <meta
       property="og:description"
-      content="Admin Dashboard UI built with Shadcn and Vite."
+      content="OpenPraxis Portal V2"
     />
     <meta
       property="og:image"
@@ -52,10 +52,10 @@
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:url" content="https://shadcn-admin.netlify.app" />
-    <meta property="twitter:title" content="Shadcn Admin" />
+    <meta property="twitter:title" content="OpenPraxis Portal V2" />
     <meta
       property="twitter:description"
-      content="Admin Dashboard UI built with Shadcn and Vite."
+      content="OpenPraxis Portal V2"
     />
     <meta
       property="twitter:image"
@@ -71,9 +71,9 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-nFBoW7ZD.js"></script>
+    <script type="module" crossorigin src="/assets/index-B-gBqghv.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/button-CRnsSOkM.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-BJddwif1.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-BNVamtWB.css">
   </head>
 
   <body>

--- a/internal/web/ui/dashboard-v2/src/features/overview/api-health-check.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/overview/api-health-check.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+
+// Three-way wiring proof for chunk 3:
+//   1. GET  /api/status   — proves same-origin GET works on :9766
+//   2. GET  /api/tasks    — proves list endpoints return same shape as :8765
+//   3. WSS  /ws           — proves WebSocket upgrade works on the V2 port
+//
+// Renders inline on the Overview placeholder. Replaces with real
+// content once the Overview tab proper is built (chunk 4+).
+export function ApiHealthCheck() {
+  const status = useQuery({
+    queryKey: ['health', 'status'],
+    queryFn: async () => {
+      const res = await fetch('/api/status')
+      if (!res.ok) throw new Error(`status ${res.status}`)
+      return res.json() as Promise<Record<string, unknown>>
+    },
+    staleTime: 30 * 1000,
+  })
+
+  const tasks = useQuery({
+    queryKey: ['health', 'tasks-sample'],
+    queryFn: async () => {
+      const res = await fetch('/api/tasks?limit=3')
+      if (!res.ok) throw new Error(`tasks ${res.status}`)
+      return res.json() as Promise<Array<{ id: string; title?: string; status?: string }>>
+    },
+    staleTime: 30 * 1000,
+  })
+
+  // Open one WebSocket connection on mount. Don't subscribe to any
+  // event types — we just want to prove the upgrade succeeds. Close
+  // on unmount so dev-mode HMR doesn't leak handles.
+  const [wsState, setWsState] = useState<'connecting' | 'open' | 'error' | 'closed'>('connecting')
+  useEffect(() => {
+    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const ws = new WebSocket(`${proto}//${window.location.host}/ws`)
+    ws.addEventListener('open', () => setWsState('open'))
+    ws.addEventListener('error', () => setWsState('error'))
+    ws.addEventListener('close', () => setWsState((s) => (s === 'open' ? 'closed' : s)))
+    return () => ws.close()
+  }, [])
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className='text-base'>Backend wiring (chunk 3 health check)</CardTitle>
+      </CardHeader>
+      <CardContent className='space-y-2 text-sm'>
+        <Row
+          label='GET /api/status'
+          state={
+            status.isLoading
+              ? 'pending'
+              : status.isError
+                ? 'fail'
+                : 'ok'
+          }
+          detail={
+            status.isError
+              ? String(status.error)
+              : status.data
+                ? `${Object.keys(status.data).length} keys`
+                : '—'
+          }
+        />
+        <Row
+          label='GET /api/tasks?limit=3'
+          state={
+            tasks.isLoading
+              ? 'pending'
+              : tasks.isError
+                ? 'fail'
+                : 'ok'
+          }
+          detail={
+            tasks.isError
+              ? String(tasks.error)
+              : tasks.data
+                ? `${tasks.data.length} tasks`
+                : '—'
+          }
+        />
+        <Row
+          label='WS /ws'
+          state={
+            wsState === 'connecting'
+              ? 'pending'
+              : wsState === 'open' || wsState === 'closed'
+                ? 'ok'
+                : 'fail'
+          }
+          detail={wsState}
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+function Row({
+  label,
+  state,
+  detail,
+}: {
+  label: string
+  state: 'pending' | 'ok' | 'fail'
+  detail: string
+}) {
+  const color =
+    state === 'ok'
+      ? 'bg-emerald-500/15 text-emerald-500'
+      : state === 'fail'
+        ? 'bg-rose-500/15 text-rose-500'
+        : 'bg-amber-500/15 text-amber-500'
+  return (
+    <div className='flex items-center justify-between gap-3'>
+      <code className='font-mono text-xs'>{label}</code>
+      <div className='flex items-center gap-2'>
+        <span className='text-muted-foreground text-xs'>{detail}</span>
+        <Badge className={color} variant='secondary'>
+          {state}
+        </Badge>
+      </div>
+    </div>
+  )
+}

--- a/internal/web/ui/dashboard-v2/src/features/overview/index.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/overview/index.tsx
@@ -1,0 +1,40 @@
+import { Header } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ApiHealthCheck } from './api-health-check'
+
+// Overview tab — morning landing for the operator. Currently shows the
+// placeholder + the chunk-3 backend wiring health check. Real content
+// (alerts, ship feed, budget gauge, productivity strip, message of the
+// day) lands in chunk 4 once the spec is locked.
+export function Overview() {
+  return (
+    <>
+      <Header />
+      <Main>
+        <div className='mb-2 flex items-center justify-between space-y-2'>
+          <h1 className='text-2xl font-bold tracking-tight'>Overview</h1>
+        </div>
+        <div className='grid grid-cols-1 gap-4 lg:grid-cols-2'>
+          <Card>
+            <CardHeader>
+              <CardTitle>Pending</CardTitle>
+            </CardHeader>
+            <CardContent className='text-muted-foreground space-y-3 text-sm'>
+              <p>
+                Morning landing — alerts, where I left off, overnight ship
+                feed, budget gauge, productivity strip, message of the day.
+              </p>
+              <p>
+                Real content ships in chunk 4. The wiring health check on
+                the right proves the React shell on :9766 talks to the same
+                backend Portal A on :8765 talks to.
+              </p>
+            </CardContent>
+          </Card>
+          <ApiHealthCheck />
+        </div>
+      </Main>
+    </>
+  )
+}

--- a/internal/web/ui/dashboard-v2/src/routes/_authenticated/index.tsx
+++ b/internal/web/ui/dashboard-v2/src/routes/_authenticated/index.tsx
@@ -1,11 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { TabPlaceholder } from '@/features/_placeholder'
+import { Overview } from '@/features/overview'
 
 export const Route = createFileRoute('/_authenticated/')({
-  component: () => (
-    <TabPlaceholder
-      name='Overview'
-      description='Morning landing — alerts, where I left off, overnight ship feed, budget gauge, message of the day.'
-    />
-  ),
+  component: Overview,
 })

--- a/internal/web/ui/dashboard-v2/vite.config.ts
+++ b/internal/web/ui/dashboard-v2/vite.config.ts
@@ -28,4 +28,24 @@ export default defineConfig({
     outDir: 'dist',
     emptyOutDir: true,
   },
+  server: {
+    // Dev-mode proxy. `npm run dev` hosts the React app on :5173 with
+    // HMR; production-mode `npm run build` ships dist/ which the Go
+    // binary serves on :9766 alongside /api + /ws (HandlerV2). To keep
+    // dev-mode parity, route /api + /ws through the same backend so
+    // fetch('/api/...') and new WebSocket('/ws') work identically in
+    // both modes. ws:true flips the proxy to handle WebSocket upgrade
+    // frames (otherwise /ws would return 404 in dev).
+    proxy: {
+      '/api': {
+        target: 'http://localhost:9766',
+        changeOrigin: true,
+      },
+      '/ws': {
+        target: 'ws://localhost:9766',
+        ws: true,
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary

Three commits, each independently revertable:

**Commit A** — refactor(web): extract `ServerDeps` + `mountAPI` / `mountWS` / `mountMCP`. No behavior change. Pure structural prep. Verified via route-count parity (142 `api.HandleFunc` lines, 4 `registerXxx` calls — both match `github/main`).

**Commit B** — feat(portal-v2): mount shared API + WebSocket on :9766. `HandlerV2(deps)` now calls the same `mountAPI` + `mountWS` Portal A uses. Same Node, same DB, same hub. `/mcp` deliberately NOT on :9766 (agent configs point at :8765 — duplicating adds surface no caller uses).

**Commit C** — Vite dev proxy + Overview wires three end-to-end probes. The Overview tab on :9766 shows a live "Backend wiring" card with three status rows:
- `GET /api/status` — same-origin GET parity
- `GET /api/tasks?limit=3` — list endpoint shape parity
- `WS /ws` — WebSocket upgrade succeeds on V2 port

Vite `server.proxy` routes `/api` + `/ws` to :9766 so `npm run dev` HMR mode behaves identically to production-built dist/.

## Test plan

After merge + restart serve:

- [ ] `curl -sI http://127.0.0.1:8765/api/status` → 200 (Portal A unchanged)
- [ ] `curl -sI http://127.0.0.1:9766/api/status` → 200 (V2 same shape)
- [ ] `curl -sI http://127.0.0.1:9766/api/tasks?limit=3` → 200, JSON array
- [ ] `curl -sI http://127.0.0.1:9766/mcp` → 404 (correctly absent)
- [ ] Browser to `http://localhost:9766/` → Overview shows three "ok" badges on the wiring card
- [ ] `npm run dev` from `dashboard-v2/` → HMR on :5173 shows the same three "ok" badges via the proxy

Refs #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)