### PR TITLE
fix(portal-v2/products): detail pane height + grid column

### DIFF
--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -71,9 +71,9 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-DgSdIGgH.js"></script>
+    <script type="module" crossorigin src="/assets/index-CjsWfU04.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/button-CRnsSOkM.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-CyRj_INI.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-BOzoo5pQ.css">
   </head>
 
   <body>

--- a/internal/web/ui/dashboard-v2/src/features/products/detail-pane.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/products/detail-pane.tsx
@@ -56,7 +56,8 @@ export function ProductDetailPane({
   }
 
   return (
-    <ScrollArea className='h-full'>
+    <div className='flex h-full flex-col'>
+      <ScrollArea className='flex-1'>
       <div className='space-y-4 p-4'>
         <ProductsBreadcrumb
           productId={productId}
@@ -124,6 +125,7 @@ export function ProductDetailPane({
           </TabsContent>
         </Tabs>
       </div>
-    </ScrollArea>
+      </ScrollArea>
+    </div>
   )
 }

--- a/internal/web/ui/dashboard-v2/src/features/products/index.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/products/index.tsx
@@ -80,14 +80,14 @@ export function ProductsPage() {
         <div className='mb-3 flex items-center justify-between'>
           <h1 className='text-2xl font-bold tracking-tight'>Products</h1>
         </div>
-        <div className='bg-card grid h-[calc(100vh-10rem)] grid-cols-1 overflow-hidden rounded-lg border lg:grid-cols-[320px_1fr]'>
-          <div className='border-b lg:border-r lg:border-b-0'>
+        <div className='bg-card grid h-[calc(100vh-10rem)] grid-cols-1 overflow-hidden rounded-lg border lg:grid-cols-[320px_minmax(0,1fr)]'>
+          <div className='h-full min-h-0 overflow-hidden border-b lg:border-r lg:border-b-0'>
             <ProductsListPane
               selectedId={selectedId}
               onSelect={setSelected}
             />
           </div>
-          <div className='min-h-0'>
+          <div className='h-full min-h-0 overflow-hidden'>
             <ProductDetailPane
               productId={selectedId}
               tab={tab}


### PR DESCRIPTION
Refs #256, follows #263. Click on a product wasn't rendering tabs because detail pane collapsed to zero height. Wraps detail-pane in flex column with ScrollArea flex-1 (mirroring list-pane), and tightens the grid template to `minmax(0,1fr)` so the second column doesn't get pushed by intrinsic content width.