### PR TITLE
fix(portal-v2/products): click → 404 — Links use new route shape

### DIFF
--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -71,7 +71,7 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-CjsWfU04.js"></script>
+    <script type="module" crossorigin src="/assets/index-CSEDoTkJ.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/button-CRnsSOkM.js">
     <link rel="stylesheet" crossorigin href="/assets/index-BOzoo5pQ.css">
   </head>

--- a/internal/web/ui/dashboard-v2/src/features/products/breadcrumb.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/products/breadcrumb.tsx
@@ -58,9 +58,8 @@ export function ProductsBreadcrumb({
               <span className='text-foreground font-medium'>{node.title}</span>
             ) : (
               <Link
-                to='/products/$productId'
-                params={{ productId: node.id }}
-                search={{ tab: 'main' }}
+                to='/products'
+                search={{ id: node.id, tab: 'main' }}
                 className='hover:text-foreground'
               >
                 {node.title}

--- a/internal/web/ui/dashboard-v2/src/features/products/index.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/products/index.tsx
@@ -51,7 +51,7 @@ export function ProductsPage() {
     if (!selectedId) {
       const last = readLastViewedProductId()
       if (last) {
-        navigate({ search: { id: last, tab: 'main' } })
+        navigate({ to: '/products', search: { id: last, tab: 'main' } })
       }
     }
     // we only want this on mount + when selectedId changes from undefined
@@ -67,10 +67,10 @@ export function ProductsPage() {
   }, [selectedId])
 
   const setSelected = (id: string) => {
-    navigate({ search: { id, tab: 'main' } })
+    navigate({ to: '/products', search: { id, tab: 'main' } })
   }
   const setTab = (next: ProductsTab) => {
-    navigate({ search: { id: selectedId, tab: next } })
+    navigate({ to: '/products', search: { id: selectedId, tab: next } })
   }
 
   return (

--- a/internal/web/ui/dashboard-v2/src/features/products/tabs/dependencies.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/products/tabs/dependencies.tsx
@@ -56,9 +56,8 @@ export function DependenciesTab({ productId }: { productId: string }) {
               {upstream.data.map((d) => (
                 <Link
                   key={d.id}
-                  to='/products/$productId'
-                  params={{ productId: d.id }}
-                  search={{ tab: 'main' }}
+                  to='/products'
+                  search={{ id: d.id, tab: 'main' }}
                   className='hover:bg-accent flex items-center justify-between gap-2 rounded-md px-3 py-2'
                 >
                   <div className='min-w-0'>

--- a/internal/web/ui/dashboard-v2/src/features/products/tabs/main.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/products/tabs/main.tsx
@@ -88,9 +88,8 @@ function SubProductsCard({
             {items.map((sp) => (
               <Link
                 key={sp.id}
-                to='/products/$productId'
-                params={{ productId: sp.id }}
-                search={{ tab: 'main' }}
+                to='/products'
+                search={{ id: sp.id, tab: 'main' }}
                 className='hover:border-primary/50 group flex items-center justify-between gap-2 rounded-md border p-3 text-sm transition-colors'
               >
                 <div className='min-w-0'>


### PR DESCRIPTION
Refs #256, follows #263 + #264. After PR #263 deleted the `/products/$productId` route, four call sites still pointed at it (breadcrumb, main tab sub-product cards, dependencies tab, navigate calls in index.tsx). Updated to use `to='/products' search={{ id, tab }}` everywhere. routeTree regenerates cleanly.