### PR TITLE
fix(portal-v2/products): resizable-panels v2 + grabbable handle

### DIFF
--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -71,9 +71,9 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-ChouqcHl.js"></script>
+    <script type="module" crossorigin src="/assets/index-C18FO6Z4.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/button-DHIYrovv.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-D7meo7UX.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-DuPhu48T.css">
   </head>
 
   <body>

--- a/internal/web/ui/dashboard-v2/package-lock.json
+++ b/internal/web/ui/dashboard-v2/package-lock.json
@@ -45,7 +45,7 @@
         "react-day-picker": "9.14.0",
         "react-dom": "^19.2.5",
         "react-hook-form": "^7.72.1",
-        "react-resizable-panels": "^4.10.0",
+        "react-resizable-panels": "^2.1.9",
         "recharts": "^3.8.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
@@ -4135,13 +4135,13 @@
       }
     },
     "node_modules/react-resizable-panels": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.10.0.tgz",
-      "integrity": "sha512-frjewRQt7TCv/vCH1pJfjZ7RxAhr5pKuqVQtVgzFq/vherxBFOWyC3xMbryx5Ti2wylViGUFc93Etg4rB3E0UA==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-2.1.9.tgz",
+      "integrity": "sha512-z77+X08YDIrgAes4jl8xhnUu1LNIRp4+E7cv4xHmLOxxUPO/ML7PSrE813b90vj7xvQ1lcf7g2uA9GeMZonjhQ==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/react-style-singleton": {

--- a/internal/web/ui/dashboard-v2/package.json
+++ b/internal/web/ui/dashboard-v2/package.json
@@ -47,7 +47,7 @@
     "react-day-picker": "9.14.0",
     "react-dom": "^19.2.5",
     "react-hook-form": "^7.72.1",
-    "react-resizable-panels": "^4.10.0",
+    "react-resizable-panels": "^2.1.9",
     "recharts": "^3.8.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",

--- a/internal/web/ui/dashboard-v2/src/features/products/index.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/products/index.tsx
@@ -1,13 +1,8 @@
 import { useEffect } from 'react'
 import { useNavigate, useSearch } from '@tanstack/react-router'
-// react-resizable-panels v3 renamed exports: Group / Panel / Separator
-// (was PanelGroup / Panel / PanelResizeHandle in v2 docs). Alias on
-// import so JSX call sites read the same as v2 docs.
-import {
-  Group as PanelGroup,
-  Panel,
-  Separator as PanelResizeHandle,
-} from 'react-resizable-panels'
+// react-resizable-panels v2 — stable, well-documented API. v4 is a
+// breaking rewrite with renamed primitives + altered drag semantics.
+import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels'
 import { Header } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProductsListPane } from './list-pane'
@@ -90,7 +85,17 @@ export function ProductsPage() {
                 onSelect={setSelected}
               />
             </Panel>
-            <PanelResizeHandle className='bg-border hover:bg-primary/50 data-[resize-handle-active=true]:bg-primary w-px transition-colors' />
+            <PanelResizeHandle className='group bg-border hover:bg-primary/40 data-[resize-handle-state=drag]:bg-primary relative w-1 cursor-col-resize transition-colors'>
+              {/* Grip indicator — three dots vertically centered. Shows
+                  the divider is interactive, follows VS Code / Linear
+                  pattern. Only visible on hover so the resting state
+                  stays clean. */}
+              <div className='absolute top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col gap-0.5 opacity-0 transition-opacity group-hover:opacity-100'>
+                <span className='block h-0.5 w-0.5 rounded-full bg-foreground/60' />
+                <span className='block h-0.5 w-0.5 rounded-full bg-foreground/60' />
+                <span className='block h-0.5 w-0.5 rounded-full bg-foreground/60' />
+              </div>
+            </PanelResizeHandle>
             <Panel defaultSize={78} minSize={40}>
               <ProductDetailPane
                 productId={selectedId}


### PR DESCRIPTION
v4 was a breaking rewrite. Pin to v2.1.7 (documented stable API). Beef up handle width 1px → 4px with hover grip indicator. Refs #256.