### PR TITLE
fix(portal-v2/products): detail pane scrolls — min-h-0 on flex chain

### DIFF
--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -71,7 +71,7 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-C18FO6Z4.js"></script>
+    <script type="module" crossorigin src="/assets/index-B8-0kFSB.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/button-DHIYrovv.js">
     <link rel="stylesheet" crossorigin href="/assets/index-DuPhu48T.css">
   </head>

--- a/internal/web/ui/dashboard-v2/src/features/products/detail-pane.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/products/detail-pane.tsx
@@ -61,8 +61,8 @@ export function ProductDetailPane({
   }
 
   return (
-    <div className='flex h-full flex-col'>
-      <ScrollArea className='flex-1'>
+    <div className='flex h-full min-h-0 flex-col'>
+      <ScrollArea className='min-h-0 flex-1'>
         <div className='space-y-4 p-4'>
           <ProductsBreadcrumb
             productId={productId}


### PR DESCRIPTION
Detail pane wasn't scrolling — ScrollArea flex-1 needed min-h-0 to constrain against parent's height. Mirror the list-pane pattern. Refs #256.