### PR TITLE
fix(portal-v2/products): pagination observer must use ScrollArea viewport

### DIFF
--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -71,7 +71,7 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-BsfO1-Kk.js"></script>
+    <script type="module" crossorigin src="/assets/index-3f4xLq6R.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/button-DHIYrovv.js">
     <link rel="stylesheet" crossorigin href="/assets/index-BYNosV7G.css">
   </head>

--- a/internal/web/ui/dashboard-v2/src/features/products/list-pane.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/products/list-pane.tsx
@@ -62,18 +62,23 @@ export function ProductsListPane({
     if (!hasMore) return
     const el = sentinelRef.current
     if (!el) return
+    // The list scrolls inside Radix's ScrollArea viewport, NOT the
+    // document viewport. IntersectionObserver's default root would
+    // never see the sentinel intersect because Radix translates the
+    // inner content with CSS transforms — the sentinel's screen
+    // position relative to the page doesn't change when the list
+    // scrolls. Walk up to find the [data-radix-scroll-area-viewport]
+    // ancestor and use IT as the observer's root.
+    const root = el.closest<HTMLElement>(
+      '[data-radix-scroll-area-viewport]'
+    )
     const io = new IntersectionObserver(
       (entries) => {
         if (entries.some((e) => e.isIntersecting)) {
           setVisibleCount((n) => Math.min(n + PAGE_SIZE, filtered.length))
         }
       },
-      // root: null defaults to viewport, but inside ScrollArea the
-      // useful root is the Radix viewport — leaving null still works
-      // because the sentinel becomes visible when content scrolls
-      // into the page viewport. rootMargin pre-loads slightly before
-      // the sentinel is fully on screen.
-      { rootMargin: '120px 0px' }
+      { root, rootMargin: '120px 0px' }
     )
     io.observe(el)
     return () => io.disconnect()


### PR DESCRIPTION
Pagination silently failed because IntersectionObserver root was the document viewport, not the actual scrolling container. Use closest('[data-radix-scroll-area-viewport]'). Refs #256.