### PR TITLE
feat(portal-v2/products): full UUIDs everywhere — drop marker

### DIFF
--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -71,7 +71,7 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-C-BF2_AE.js"></script>
+    <script type="module" crossorigin src="/assets/index-CvwDp8po.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/button-DHIYrovv.js">
     <link rel="stylesheet" crossorigin href="/assets/index-C1A8NRIH.css">
   </head>

--- a/internal/web/ui/dashboard-v2/src/features/products/dep-picker.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/products/dep-picker.tsx
@@ -106,8 +106,8 @@ export function DepPicker({
                 >
                   <div className='min-w-0'>
                     <div className='truncate font-medium'>{r.title}</div>
-                    <code className='text-muted-foreground font-mono text-[11px]'>
-                      {r.marker}
+                    <code className='text-muted-foreground font-mono text-[11px] block truncate'>
+                      {r.id}
                     </code>
                   </div>
                   <Badge

--- a/internal/web/ui/dashboard-v2/src/features/products/detail-pane.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/products/detail-pane.tsx
@@ -84,7 +84,7 @@ export function ProductDetailPane({
                     {product.data.title}
                   </h1>
                   <code className='text-muted-foreground font-mono text-xs'>
-                    {product.data.marker}
+                    {product.data.id}
                   </code>
                 </div>
                 <ProductStatusControl

--- a/internal/web/ui/dashboard-v2/src/features/products/list-pane.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/products/list-pane.tsx
@@ -128,7 +128,7 @@ export function ProductsListPane({
               <TreeRow
                 key={p.id}
                 id={p.id}
-                marker={p.marker}
+                marker={p.id}
                 title={p.title}
                 status={p.status}
                 depth={0}
@@ -231,8 +231,8 @@ function TreeRow({
         >
           <div className='min-w-0'>
             <div className='truncate font-medium'>{title}</div>
-            <code className='text-muted-foreground font-mono text-[11px]'>
-              {marker}
+            <code className='text-muted-foreground font-mono text-[11px] block truncate'>
+              {id}
             </code>
           </div>
           <Badge

--- a/internal/web/ui/dashboard-v2/src/features/products/tabs/dependencies.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/products/tabs/dependencies.tsx
@@ -440,15 +440,15 @@ function DepSection({
                     className='min-w-0 flex-1'
                   >
                     <div className='truncate font-medium'>{r.title}</div>
-                    <code className='text-muted-foreground font-mono text-[11px]'>
-                      {r.marker}
+                    <code className='text-muted-foreground font-mono text-[11px] block truncate'>
+                      {r.id}
                     </code>
                   </Link>
                 ) : (
                   <div className='min-w-0 flex-1'>
                     <div className='truncate font-medium'>{r.title}</div>
-                    <code className='text-muted-foreground font-mono text-[11px]'>
-                      {r.marker}
+                    <code className='text-muted-foreground font-mono text-[11px] block truncate'>
+                      {r.id}
                     </code>
                   </div>
                 )}


### PR DESCRIPTION
Operator-requested. Show full UUID id instead of 12-char marker on every row. Search still matches both. Refs #256.