### PR TITLE
fix(portal-v2/products): DAG fits any size — minZoom 0.05 + Fit button

### DIFF
--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -71,9 +71,9 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-CvwDp8po.js"></script>
+    <script type="module" crossorigin src="/assets/index-0YzuO2Vn.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/button-DHIYrovv.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-C1A8NRIH.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-DqEd1Rko.css">
   </head>
 
   <body>

--- a/internal/web/ui/dashboard-v2/src/features/products/tabs/dag.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/products/tabs/dag.tsx
@@ -127,7 +127,7 @@ export function DAGTab({ productId }: { productId: string }) {
           },
         },
       ],
-      minZoom: 0.3,
+      minZoom: 0.05,
       maxZoom: 2.5,
       wheelSensitivity: 0.2,
     })
@@ -173,11 +173,21 @@ export function DAGTab({ productId }: { productId: string }) {
 
   return (
     <Card>
-      <CardContent className='p-0'>
+      <CardContent className='relative p-0'>
         <div
           ref={containerRef}
           className='bg-background h-[calc(100vh-22rem)] min-h-96 w-full rounded-md'
         />
+        {/* Fit-to-view affordance — operator-clickable rescue when
+            the dagre layout sprawls past the panel and even maxed-out
+            wheel zoom-out doesn't reveal the whole graph. */}
+        <button
+          type='button'
+          onClick={() => cyRef.current?.fit(undefined, 32)}
+          className='bg-card hover:bg-accent absolute top-2 right-2 rounded-md border px-2 py-1 text-xs shadow-sm'
+        >
+          Fit
+        </button>
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
minZoom 0.3 → 0.05 + overlay Fit button. Designer mode comes in follow-up PR. Refs #256.