### PR TITLE
feat(portal-v2/products): DAG designer — visual link / create / unlink

### DIFF
--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -71,9 +71,9 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-0YzuO2Vn.js"></script>
+    <script type="module" crossorigin src="/assets/index-RCNwYjRZ.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/button-DHIYrovv.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-DqEd1Rko.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-BfGmypuf.css">
   </head>
 
   <body>

--- a/internal/web/ui/dashboard-v2/src/features/products/link-or-create-modal.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/products/link-or-create-modal.tsx
@@ -1,0 +1,195 @@
+import { useState } from 'react'
+import { Search } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Input } from '@/components/ui/input'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import type { PickerRow } from './dep-picker'
+
+const STATUS_COLOR: Record<string, string> = {
+  open: 'bg-emerald-500/15 text-emerald-500',
+  in_progress: 'bg-sky-500/15 text-sky-500',
+  draft: 'bg-amber-500/15 text-amber-500',
+  closed: 'bg-zinc-500/15 text-zinc-400',
+  archived: 'bg-zinc-500/10 text-zinc-500',
+}
+
+// Two-tab modal used by the DAG designer's add-buttons. "Link
+// existing" reuses the same picker the textual Dependencies editor
+// uses; "Create new" takes a title and fires the create-and-link
+// mutation. Operators see one consistent flow whether they're
+// pulling existing entities into the structure or starting fresh.
+export function LinkOrCreateModal({
+  open,
+  onOpenChange,
+  title,
+  description,
+  candidates,
+  loading,
+  emptyLabel,
+  onLinkExisting,
+  onCreateNew,
+  createLabel = 'Create',
+}: {
+  open: boolean
+  onOpenChange: (next: boolean) => void
+  title: string
+  description: string
+  candidates: PickerRow[]
+  loading?: boolean
+  emptyLabel?: string
+  onLinkExisting: (row: PickerRow) => void | Promise<void>
+  onCreateNew: (title: string) => void | Promise<void>
+  createLabel?: string
+}) {
+  const [tab, setTab] = useState<'link' | 'create'>('link')
+  const [query, setQuery] = useState('')
+  const [newTitle, setNewTitle] = useState('')
+
+  const filtered = candidates.filter((r) => {
+    const q = query.trim().toLowerCase()
+    if (!q) return true
+    return r.title.toLowerCase().includes(q) || r.id.toLowerCase().includes(q)
+  })
+
+  const reset = () => {
+    setQuery('')
+    setNewTitle('')
+    setTab('link')
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) reset()
+        onOpenChange(next)
+      }}
+    >
+      <DialogContent className='max-w-lg'>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <Tabs
+          value={tab}
+          onValueChange={(v) => setTab(v as 'link' | 'create')}
+          className='space-y-3'
+        >
+          <TabsList className='grid w-full grid-cols-2'>
+            <TabsTrigger value='link'>Link existing</TabsTrigger>
+            <TabsTrigger value='create'>Create new</TabsTrigger>
+          </TabsList>
+          <TabsContent value='link' className='space-y-2'>
+            <div className='relative'>
+              <Search className='text-muted-foreground absolute top-1/2 left-2 h-4 w-4 -translate-y-1/2' />
+              <Input
+                autoFocus
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder='Filter…'
+                className='pl-8'
+              />
+            </div>
+            <ScrollArea className='max-h-72'>
+              <div className='py-1'>
+                {loading ? (
+                  <div className='space-y-1.5 p-1'>
+                    {Array.from({ length: 5 }).map((_, i) => (
+                      <Skeleton key={i} className='h-10 w-full' />
+                    ))}
+                  </div>
+                ) : filtered.length === 0 ? (
+                  <div className='text-muted-foreground p-3 text-xs'>
+                    {query
+                      ? 'No matches.'
+                      : (emptyLabel ?? 'Nothing to link.')}
+                  </div>
+                ) : (
+                  filtered.map((r) => (
+                    <button
+                      key={r.id}
+                      type='button'
+                      onClick={async () => {
+                        await onLinkExisting(r)
+                        onOpenChange(false)
+                        reset()
+                      }}
+                      className='hover:bg-accent flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-sm'
+                    >
+                      <div className='min-w-0'>
+                        <div className='truncate font-medium'>{r.title}</div>
+                        <code className='text-muted-foreground block truncate font-mono text-[11px]'>
+                          {r.id}
+                        </code>
+                      </div>
+                      <Badge
+                        variant='secondary'
+                        className={cn(
+                          'shrink-0 text-[10px] uppercase',
+                          STATUS_COLOR[r.status] ?? 'bg-zinc-500/15'
+                        )}
+                      >
+                        {r.status}
+                      </Badge>
+                    </button>
+                  ))
+                )}
+              </div>
+            </ScrollArea>
+          </TabsContent>
+          <TabsContent value='create' className='space-y-3'>
+            <div className='space-y-1.5'>
+              <label className='text-muted-foreground text-xs uppercase tracking-wider'>
+                Title
+              </label>
+              <Input
+                autoFocus
+                value={newTitle}
+                onChange={(e) => setNewTitle(e.target.value)}
+                placeholder='New entity title…'
+              />
+              <p className='text-muted-foreground text-xs'>
+                The new entity will be created in <em>draft</em> status
+                and linked to the current parent. You can change its
+                status from its detail page.
+              </p>
+            </div>
+            <DialogFooter>
+              <Button
+                variant='ghost'
+                onClick={() => {
+                  onOpenChange(false)
+                  reset()
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                disabled={!newTitle.trim()}
+                onClick={async () => {
+                  await onCreateNew(newTitle.trim())
+                  onOpenChange(false)
+                  reset()
+                }}
+              >
+                {createLabel}
+              </Button>
+            </DialogFooter>
+          </TabsContent>
+        </Tabs>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/internal/web/ui/dashboard-v2/src/features/products/tabs/dag.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/products/tabs/dag.tsx
@@ -1,17 +1,39 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import cytoscape from 'cytoscape'
 // @ts-expect-error — cytoscape-dagre ships without bundled types
 import dagre from 'cytoscape-dagre'
-import { useProductHierarchy } from '@/lib/queries/products'
+import { Pencil, Plus, Unlink, X } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+  useAddDownstreamProductDep,
+  useAllManifests,
+  useCreateAndLinkManifest,
+  useCreateAndLinkSubProduct,
+  useLinkManifest,
+  useProductDependencies,
+  useProductHierarchy,
+  useProductManifests,
+  useProducts,
+  useRemoveDownstreamProductDep,
+  useUnlinkManifest,
+} from '@/lib/queries/products'
 import type { HierarchyNode } from '@/lib/types'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
-
-// Same library Portal A uses (cytoscape + cytoscape-dagre, vendor-
-// pinned). React mount via useEffect, layout via dagre, tap-to-navigate
-// for sub-products. No new mental model — operators see the same graph
-// shape they're used to.
+import { LinkOrCreateModal } from '../link-or-create-modal'
+import type { PickerRow } from '../dep-picker'
 
 let DAGRE_REGISTERED = false
 function ensureDagre() {
@@ -30,7 +52,15 @@ const STATUS_BORDER: Record<string, string> = {
 }
 
 type CyEl =
-  | { data: { id: string; label: string; status: string; type: string } }
+  | {
+      data: {
+        id: string
+        label: string
+        status: string
+        type: string
+        parent_id?: string
+      }
+    }
   | { data: { id: string; source: string; target: string } }
 
 function toElements(root: HierarchyNode | undefined): CyEl[] {
@@ -43,6 +73,7 @@ function toElements(root: HierarchyNode | undefined): CyEl[] {
         label: n.title,
         status: n.status,
         type: n.type,
+        parent_id: parentId,
       },
     })
     if (parentId) {
@@ -59,11 +90,73 @@ function toElements(root: HierarchyNode | undefined): CyEl[] {
 
 export function DAGTab({ productId }: { productId: string }) {
   const hierarchy = useProductHierarchy(productId)
+  const subs = useProductDependencies(productId)
+  const manifests = useProductManifests(productId)
+  const allProducts = useProducts()
+  const allManifests = useAllManifests()
+
   const containerRef = useRef<HTMLDivElement>(null)
   const cyRef = useRef<cytoscape.Core | null>(null)
   const navigate = useNavigate()
 
+  const [editing, setEditing] = useState(false)
+  const [modal, setModal] = useState<null | 'subproduct' | 'manifest'>(null)
+  const [unlinkConfirm, setUnlinkConfirm] = useState<null | {
+    nodeId: string
+    nodeTitle: string
+    parentId: string
+    isManifest: boolean
+  }>(null)
+
+  const addSub = useAddDownstreamProductDep(productId)
+  const remSub = useRemoveDownstreamProductDep(productId)
+  const linkM = useLinkManifest(productId)
+  const unlinkM = useUnlinkManifest(productId)
+  const createSub = useCreateAndLinkSubProduct(productId)
+  const createM = useCreateAndLinkManifest(productId)
+
   const elements = useMemo(() => toElements(hierarchy.data), [hierarchy.data])
+
+  const snapshot = useMemo(
+    () => ({
+      upstream: [],
+      downstream: (subs.data ?? []).map((d) => d.id),
+      manifests: (manifests.data ?? []).map((m) => m.id),
+    }),
+    [subs.data, manifests.data]
+  )
+
+  const subProductCandidates = useMemo<PickerRow[]>(() => {
+    const exclude = new Set([productId, ...(subs.data ?? []).map((d) => d.id)])
+    return (allProducts.data ?? [])
+      .filter((p) => !exclude.has(p.id))
+      .map((p) => ({
+        id: p.id,
+        marker: p.marker,
+        title: p.title,
+        status: p.status,
+      }))
+  }, [allProducts.data, subs.data, productId])
+
+  const manifestCandidates = useMemo<PickerRow[]>(() => {
+    const exclude = new Set((manifests.data ?? []).map((m) => m.id))
+    return (allManifests.data ?? [])
+      .filter((m) => !exclude.has(m.id))
+      .map((m) => ({
+        id: m.id,
+        marker: m.marker,
+        title: m.title,
+        status: m.status,
+      }))
+  }, [allManifests.data, manifests.data])
+
+  // Stash editing in a ref so cytoscape event handlers (closed over
+  // initial editing value at registration) read live state without
+  // forcing a canvas re-init on every toggle.
+  const editingRef = useRef(editing)
+  useEffect(() => {
+    editingRef.current = editing
+  }, [editing])
 
   useEffect(() => {
     if (!containerRef.current) return
@@ -135,7 +228,28 @@ export function DAGTab({ productId }: { productId: string }) {
     cy.on('tap', 'node', (e) => {
       const id = e.target.id() as string
       if (id === productId) return
+      if (editingRef.current) return
       navigate({ to: '/products', search: { id, tab: 'dag' } })
+    })
+
+    cy.on('cxttap', 'node', (e) => {
+      if (!editingRef.current) return
+      const node = e.target as cytoscape.NodeSingular
+      const id = node.id()
+      if (id === productId) return
+      const parentId = node.data('parent_id') as string | undefined
+      const type = node.data('type') as string
+      if (!parentId) return
+      if (parentId !== productId) {
+        toast.message('Drill into the parent to edit its children.')
+        return
+      }
+      setUnlinkConfirm({
+        nodeId: id,
+        nodeTitle: node.data('label') as string,
+        parentId,
+        isManifest: type === 'manifest',
+      })
     })
 
     cyRef.current = cy
@@ -144,6 +258,27 @@ export function DAGTab({ productId }: { productId: string }) {
       cyRef.current = null
     }
   }, [elements, productId, navigate])
+
+  const onUnlinkConfirmed = async () => {
+    if (!unlinkConfirm) return
+    try {
+      const target = {
+        id: unlinkConfirm.nodeId,
+        marker: unlinkConfirm.nodeId.slice(0, 12),
+        title: unlinkConfirm.nodeTitle,
+      }
+      if (unlinkConfirm.isManifest) {
+        await unlinkM.mutateAsync({ target, snapshot })
+        toast.success(`Unlinked manifest "${unlinkConfirm.nodeTitle}"`)
+      } else {
+        await remSub.mutateAsync({ target, snapshot })
+        toast.success(`Unlinked sub-product "${unlinkConfirm.nodeTitle}"`)
+      }
+    } catch (e) {
+      toast.error(`Failed: ${String(e)}`)
+    }
+    setUnlinkConfirm(null)
+  }
 
   if (hierarchy.isLoading) {
     return (
@@ -161,33 +296,162 @@ export function DAGTab({ productId }: { productId: string }) {
       </div>
     )
   }
-  if (elements.length === 0) {
-    return (
-      <Card>
-        <CardContent className='text-muted-foreground p-6 text-sm'>
-          No graph — this product has no sub-products yet.
-        </CardContent>
-      </Card>
-    )
-  }
 
   return (
     <Card>
       <CardContent className='relative p-0'>
-        <div
-          ref={containerRef}
-          className='bg-background h-[calc(100vh-22rem)] min-h-96 w-full rounded-md'
+        {elements.length === 0 ? (
+          <div className='text-muted-foreground p-6 text-sm'>
+            No graph yet — this product has no sub-products. Click{' '}
+            <Pencil className='inline h-3 w-3' /> Edit to add children.
+          </div>
+        ) : (
+          <div
+            ref={containerRef}
+            className='bg-background h-[calc(100vh-22rem)] min-h-96 w-full rounded-md'
+          />
+        )}
+
+        <div className='absolute top-2 right-2 flex items-center gap-1.5'>
+          {editing ? (
+            <>
+              <Button
+                variant='outline'
+                size='sm'
+                className='h-7 px-2 text-xs'
+                onClick={() => setModal('subproduct')}
+              >
+                <Plus className='mr-1 h-3 w-3' />
+                Sub-product
+              </Button>
+              <Button
+                variant='outline'
+                size='sm'
+                className='h-7 px-2 text-xs'
+                onClick={() => setModal('manifest')}
+              >
+                <Plus className='mr-1 h-3 w-3' />
+                Manifest
+              </Button>
+              <Button
+                variant='secondary'
+                size='sm'
+                className='h-7 px-2 text-xs'
+                onClick={() => setEditing(false)}
+              >
+                <X className='mr-1 h-3 w-3' />
+                Done
+              </Button>
+            </>
+          ) : (
+            <Button
+              variant='outline'
+              size='sm'
+              className='h-7 px-2 text-xs'
+              onClick={() => setEditing(true)}
+            >
+              <Pencil className='mr-1 h-3 w-3' />
+              Edit
+            </Button>
+          )}
+          <Button
+            variant='outline'
+            size='sm'
+            className='h-7 px-2 text-xs'
+            onClick={() => cyRef.current?.fit(undefined, 32)}
+            disabled={elements.length === 0}
+          >
+            Fit
+          </Button>
+        </div>
+
+        {editing ? (
+          <div className='bg-card/90 absolute bottom-2 left-2 rounded-md border px-3 py-1.5 text-xs backdrop-blur'>
+            Right-click a child node to unlink. Tasks deferred — coming
+            with the Tasks top-level menu.
+          </div>
+        ) : null}
+
+        <LinkOrCreateModal
+          open={modal === 'subproduct'}
+          onOpenChange={(open) => setModal(open ? 'subproduct' : null)}
+          title='Sub-product'
+          description='Pull an existing product in as a sub-product, or create a new one and link it.'
+          candidates={subProductCandidates}
+          loading={allProducts.isLoading}
+          createLabel='Create + link'
+          onLinkExisting={async (row) => {
+            try {
+              await addSub.mutateAsync({ target: row, snapshot })
+              toast.success(`Linked "${row.title}" as sub-product`)
+            } catch (e) {
+              toast.error(`Failed: ${String(e)}`)
+            }
+          }}
+          onCreateNew={async (title) => {
+            try {
+              const c = await createSub.mutateAsync({ title, snapshot })
+              toast.success(`Created + linked "${c.title}"`)
+            } catch (e) {
+              toast.error(`Failed: ${String(e)}`)
+            }
+          }}
         />
-        {/* Fit-to-view affordance — operator-clickable rescue when
-            the dagre layout sprawls past the panel and even maxed-out
-            wheel zoom-out doesn't reveal the whole graph. */}
-        <button
-          type='button'
-          onClick={() => cyRef.current?.fit(undefined, 32)}
-          className='bg-card hover:bg-accent absolute top-2 right-2 rounded-md border px-2 py-1 text-xs shadow-sm'
+
+        <LinkOrCreateModal
+          open={modal === 'manifest'}
+          onOpenChange={(open) => setModal(open ? 'manifest' : null)}
+          title='Manifest'
+          description='Pull an existing manifest under this product, or create a new one.'
+          candidates={manifestCandidates}
+          loading={allManifests.isLoading}
+          createLabel='Create + link'
+          onLinkExisting={async (row) => {
+            try {
+              await linkM.mutateAsync({ target: row, snapshot })
+              toast.success(`Linked manifest "${row.title}"`)
+            } catch (e) {
+              toast.error(`Failed: ${String(e)}`)
+            }
+          }}
+          onCreateNew={async (title) => {
+            try {
+              const c = await createM.mutateAsync({ title, snapshot })
+              toast.success(`Created + linked "${c.title}"`)
+            } catch (e) {
+              toast.error(`Failed: ${String(e)}`)
+            }
+          }}
+        />
+
+        <AlertDialog
+          open={unlinkConfirm !== null}
+          onOpenChange={(open) => !open && setUnlinkConfirm(null)}
         >
-          Fit
-        </button>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                Unlink {unlinkConfirm?.isManifest ? 'manifest' : 'sub-product'}
+                ?
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                Sever the link from this product to{' '}
+                <span className='font-medium'>
+                  {unlinkConfirm?.nodeTitle}
+                </span>
+                . The entity stays alive as standalone — you can re-link
+                it later. Action is logged in revision history.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={onUnlinkConfirmed}>
+                <Unlink className='mr-1 h-3 w-3' />
+                Unlink
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </CardContent>
     </Card>
   )

--- a/internal/web/ui/dashboard-v2/src/lib/queries/products.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/queries/products.ts
@@ -548,3 +548,138 @@ export function useRestoreDependencySnapshot(
 export function useChangeProductStatus(productId: string | undefined) {
   return useUpdateProduct(productId)
 }
+
+// ── Create-new-and-link mutations ────────────────────────────────────
+//
+// The DAG designer's "Create new" flow needs to create the entity AND
+// link it to the current parent in one operator action. Each helper
+// composes two API calls + a dependency_revision log so the audit
+// trail matches the textual editor.
+
+// Create a new product, then link it as a sub-product of `productId`.
+export function useCreateAndLinkSubProduct(productId: string | undefined) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: {
+      title: string
+      snapshot: { upstream: string[]; downstream: string[]; manifests: string[] }
+    }) => {
+      // 1. POST /api/products to create the new product (status defaults to draft)
+      const createRes = await fetch('/api/products', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: input.title, status: 'draft' }),
+      })
+      if (!createRes.ok)
+        throw new Error(`create product → ${createRes.status}`)
+      const created = (await createRes.json()) as Product
+
+      // 2. POST link new->this as a downstream dep (new depends on this)
+      const linkRes = await fetch(
+        `/api/products/${created.id}/dependencies/${productId}`,
+        { method: 'POST' }
+      )
+      if (!linkRes.ok && linkRes.status !== 409)
+        throw new Error(`link sub → ${linkRes.status}`)
+
+      // 3. Log dependency_revision capturing the new state
+      if (productId) {
+        const newSnapshot = {
+          ...input.snapshot,
+          downstream: [...input.snapshot.downstream, created.id],
+        }
+        await fetch(`/api/products/${productId}/comments`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            author: 'operator',
+            type: 'agent_note',
+            body:
+              '<dependency_revision>\n' +
+              JSON.stringify(
+                {
+                  op: 'add',
+                  kind: 'product_downstream',
+                  target: {
+                    id: created.id,
+                    marker: created.marker,
+                    title: created.title,
+                  },
+                  snapshot: newSnapshot,
+                },
+                null,
+                2
+              ) +
+              '\n</dependency_revision>',
+          }),
+        })
+      }
+
+      return created
+    },
+    onSuccess: () => {
+      if (productId) invalidateDepCaches(qc, productId)
+      qc.invalidateQueries({ queryKey: productKeys.list() })
+    },
+  })
+}
+
+// Create a new manifest with project_id = this product, in one shot.
+export function useCreateAndLinkManifest(productId: string | undefined) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: {
+      title: string
+      snapshot: { upstream: string[]; downstream: string[]; manifests: string[] }
+    }) => {
+      const res = await fetch('/api/manifests', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: input.title,
+          project_id: productId,
+          status: 'draft',
+        }),
+      })
+      if (!res.ok) throw new Error(`create manifest → ${res.status}`)
+      const created = (await res.json()) as Manifest
+
+      if (productId) {
+        const newSnapshot = {
+          ...input.snapshot,
+          manifests: [...input.snapshot.manifests, created.id],
+        }
+        await fetch(`/api/products/${productId}/comments`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            author: 'operator',
+            type: 'agent_note',
+            body:
+              '<dependency_revision>\n' +
+              JSON.stringify(
+                {
+                  op: 'add',
+                  kind: 'manifest',
+                  target: {
+                    id: created.id,
+                    marker: created.marker,
+                    title: created.title,
+                  },
+                  snapshot: newSnapshot,
+                },
+                null,
+                2
+              ) +
+              '\n</dependency_revision>',
+          }),
+        })
+      }
+
+      return created
+    },
+    onSuccess: () => {
+      if (productId) invalidateDepCaches(qc, productId)
+    },
+  })
+}


### PR DESCRIPTION
Edit toggle on DAG tab. Visual create-and-link for sub-products + manifests with two-tab modal (link existing / create new). Right-click to unlink. Tasks deferred. Refs #256.