### PR TITLE
feat(relationships): PR/M3 — single-write + drop legacy ownership columns

### DIFF
--- a/internal/manifest/m3_single_write_test.go
+++ b/internal/manifest/m3_single_write_test.go
@@ -1,0 +1,97 @@
+package manifest
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/k8nstantin/OpenPraxis/internal/relationships"
+)
+
+// openM3TestStore opens a fresh DB + manifest store + relationships
+// backend wired together. Mirrors the production wiring in
+// internal/node/node.go but stripped to the bits this regression test
+// needs.
+func openM3TestStore(t *testing.T) (*Store, *relationships.Store, *sql.DB) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "m3.db") + "?_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	rels, err := relationships.New(db)
+	if err != nil {
+		t.Fatalf("relationships.New: %v", err)
+	}
+	s, err := NewStore(db)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	s.SetRelationshipsBackend(rels)
+	return s, rels, db
+}
+
+// TestManifestCreate_WritesEdgeOwnsOnly — creating a manifest under a
+// product writes (a) one EdgeOwns row in `relationships` and (b) leaves
+// no `project_id` column on the manifests table. Single-write
+// regression for PR/M3.
+func TestManifestCreate_WritesEdgeOwnsOnly(t *testing.T) {
+	s, rels, db := openM3TestStore(t)
+	productID := "prod-m3-create"
+
+	m, err := s.Create("M3 manifest", "d", "c", "open", "test", "src", productID, "", nil, nil)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// (a) One EdgeOwns row pointing product → manifest.
+	edges, err := rels.ListIncoming(context.Background(), m.ID, relationships.EdgeOwns)
+	if err != nil {
+		t.Fatalf("ListIncoming: %v", err)
+	}
+	found := false
+	for _, e := range edges {
+		if e.SrcID == productID && e.SrcKind == relationships.KindProduct && e.DstID == m.ID && e.Kind == relationships.EdgeOwns {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("no EdgeOwns(product=%s → manifest=%s) row", productID, m.ID)
+	}
+
+	// (b) PRAGMA table_info(manifests) does NOT list project_id.
+	rows, err := db.Query(`PRAGMA table_info(manifests)`)
+	if err != nil {
+		t.Fatalf("pragma: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid          int
+			name, ctype  string
+			notnull, pk  int
+			defaultVal   sql.NullString
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &defaultVal, &pk); err != nil {
+			t.Fatalf("scan pragma: %v", err)
+		}
+		if strings.EqualFold(name, "project_id") {
+			t.Errorf("manifests still has project_id column post-PR/M3")
+		}
+	}
+
+	// Read-back: Get populates ProjectID through the rels lookup.
+	got, err := s.Get(m.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got == nil || got.ProjectID != productID {
+		t.Errorf("Get.ProjectID = %v, want %s", got, productID)
+	}
+}

--- a/internal/manifest/store.go
+++ b/internal/manifest/store.go
@@ -129,6 +129,10 @@ func NewStore(db *sql.DB) (*Store, error) {
 }
 
 func (s *Store) init() error {
+	// Schema after PR/M3: ownership lives in `relationships` (EdgeOwns
+	// product → manifest). The legacy `project_id` column is no longer
+	// part of CREATE TABLE; existing DBs get it dropped by
+	// relationships.DropOwnershipColumns at boot.
 	_, err := s.db.Exec(`CREATE TABLE IF NOT EXISTS manifests (
 		id TEXT PRIMARY KEY,
 		title TEXT NOT NULL,
@@ -155,28 +159,24 @@ func (s *Store) init() error {
 	if err != nil {
 		return err
 	}
+	// Legacy ALTERs kept for upgrade path on DBs that pre-date these
+	// columns. project_id is intentionally absent — relationships.
+	// DropOwnershipColumns is responsible for removing it from any DB
+	// that still has it.
 	s.db.Exec(`ALTER TABLE manifests ADD COLUMN source_node TEXT NOT NULL DEFAULT ''`)
 	s.db.Exec(`ALTER TABLE manifests ADD COLUMN deleted_at TEXT NOT NULL DEFAULT ''`)
-	s.db.Exec(`ALTER TABLE manifests ADD COLUMN project_id TEXT NOT NULL DEFAULT ''`)
-	s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_manifests_project ON manifests(project_id)`)
 	s.db.Exec(`ALTER TABLE manifests ADD COLUMN depends_on TEXT NOT NULL DEFAULT ''`)
 	return nil
 }
 
 // Create stores a new manifest.
 //
-// Ownership wiring: when projectID is non-empty, also writes the
-// canonical `EdgeOwns(product → manifest)` row into the relationships
-// SCD-2 table at the same instant. The DAG endpoint reads from
-// relationships only, so this is what makes the manifest appear under
-// its product in the dashboard graph.
-//
-// We continue to populate the legacy `manifests.project_id` column
-// alongside the relationships row for backward compatibility with the
-// handful of readers still hitting the column directly (handlers_stats
-// JOIN, settings_adapter, list responses). Those readers will migrate
-// to relationships.ListIncoming in a follow-up; column drop happens
-// after that lands.
+// Ownership wiring (PR/M3): when projectID is non-empty, opens an
+// `EdgeOwns(product → manifest)` row in the relationships SCD-2 table.
+// That edge IS the canonical ownership record — the legacy
+// `manifests.project_id` column was dropped in this PR. Every read
+// path (DAG endpoint, hierarchy walkers, settings resolver,
+// ListByProject) consults relationships.
 func (s *Store) Create(title, description, content, status, author, sourceNode, projectID, dependsOn string, jiraRefs, tags []string) (*Manifest, error) {
 	if status == "" {
 		status = "draft"
@@ -193,9 +193,9 @@ func (s *Store) Create(title, description, content, status, author, sourceNode, 
 	jiraJSON, _ := json.Marshal(jiraRefs)
 	tagsJSON, _ := json.Marshal(tags)
 
-	_, err := s.db.Exec(`INSERT INTO manifests (id, title, description, content, status, jira_refs, tags, author, source_node, project_id, depends_on, version, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)`,
-		id, title, description, content, status, string(jiraJSON), string(tagsJSON), author, sourceNode, projectID, dependsOn,
+	_, err := s.db.Exec(`INSERT INTO manifests (id, title, description, content, status, jira_refs, tags, author, source_node, depends_on, version, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)`,
+		id, title, description, content, status, string(jiraJSON), string(tagsJSON), author, sourceNode, dependsOn,
 		now.Format(time.RFC3339), now.Format(time.RFC3339))
 	if err != nil {
 		return nil, err
@@ -211,10 +211,6 @@ func (s *Store) Create(title, description, content, status, author, sourceNode, 
 			CreatedBy: author,
 			Reason:    "manifest created under product",
 		}); err != nil {
-			// Don't fail the create — the manifest row landed and the
-			// project_id column carries the ownership. A follow-up sweep
-			// can backfill missing rels rows. But surface the error to
-			// the caller's logs so we don't silently drift again.
 			return nil, fmt.Errorf("manifest created but relationships row failed: %w", err)
 		}
 	}
@@ -232,6 +228,13 @@ func (s *Store) Create(title, description, content, status, author, sourceNode, 
 // from a non-terminal value (draft/open) to a terminal one
 // (closed/archive). The handler propagates the close into downstream
 // waiting tasks — see SetTerminalTransitionHandler.
+//
+// Ownership re-parenting (projectID changing): post-PR/M3 the legacy
+// `manifests.project_id` column is gone, so the parent product is no
+// longer a column on the row. If projectID differs from the manifest's
+// current parent (resolved via the relationships store), we close the
+// prior EdgeOwns edge and open a new one. Empty projectID = "no
+// parent"; the prior edge (if any) is closed without replacement.
 func (s *Store) Update(id, title, description, content, status, projectID, dependsOn string, jiraRefs, tags []string) error {
 	// Read prior status so we can detect the non-terminal → terminal
 	// edge. An error here (e.g. row doesn't exist) falls through and
@@ -244,12 +247,39 @@ func (s *Store) Update(id, title, description, content, status, projectID, depen
 	jiraJSON, _ := json.Marshal(jiraRefs)
 	tagsJSON, _ := json.Marshal(tags)
 
-	_, err := s.db.Exec(`UPDATE manifests SET title=?, description=?, content=?, status=?, project_id=?, depends_on=?, jira_refs=?, tags=?,
+	_, err := s.db.Exec(`UPDATE manifests SET title=?, description=?, content=?, status=?, depends_on=?, jira_refs=?, tags=?,
 		version=version+1, updated_at=? WHERE id=?`,
-		title, description, content, status, projectID, dependsOn, string(jiraJSON), string(tagsJSON),
+		title, description, content, status, dependsOn, string(jiraJSON), string(tagsJSON),
 		now.Format(time.RFC3339), id)
 	if err != nil {
 		return err
+	}
+
+	// Reconcile ownership edge if the caller's projectID differs from
+	// what relationships currently records. No-op when both are equal,
+	// including when both are empty.
+	if s.rels != nil {
+		ctx := context.Background()
+		priorProjectID := s.lookupOwner(ctx, id)
+		if priorProjectID != projectID {
+			if priorProjectID != "" {
+				_ = s.rels.Remove(ctx, priorProjectID, id, relationships.EdgeOwns,
+					"manifest.Store.Update", "manifest reparented")
+			}
+			if projectID != "" {
+				if err := s.rels.Create(ctx, relationships.Edge{
+					SrcKind:   relationships.KindProduct,
+					SrcID:     projectID,
+					DstKind:   relationships.KindManifest,
+					DstID:     id,
+					Kind:      relationships.EdgeOwns,
+					CreatedBy: "manifest.Store.Update",
+					Reason:    "manifest reparented",
+				}); err != nil {
+					return fmt.Errorf("update manifest ownership: %w", err)
+				}
+			}
+		}
 	}
 
 	// Fire propagation ONLY on the non-terminal → terminal edge.
@@ -258,81 +288,119 @@ func (s *Store) Update(id, title, description, content, status, projectID, depen
 	// idempotent on its own but we save the work.
 	if s.onTerminalTransition != nil &&
 		!IsTerminalStatus(priorStatus) && IsTerminalStatus(status) {
-		// Fire in-process. If the handler blocks, the Update returns
-		// only after propagation completes — intentional, so the
-		// operator sees "close + downstream activated" as one atomic
-		// unit from their UI's POV. Handlers that want async behavior
-		// should spawn internally.
 		s.onTerminalTransition(context.Background(), id)
 	}
 	return nil
 }
 
-// Get retrieves a manifest by full UUID.
+// lookupOwner returns the current product owner of a manifest from the
+// relationships store, or "" if no current EdgeOwns row points at it.
+// Used by Update to detect re-parenting and by the post-scan ownership
+// populator to fill Manifest.ProjectID.
+func (s *Store) lookupOwner(ctx context.Context, manifestID string) string {
+	if s.rels == nil {
+		return ""
+	}
+	edges, err := s.rels.ListIncoming(ctx, manifestID, relationships.EdgeOwns)
+	if err != nil {
+		return ""
+	}
+	for _, e := range edges {
+		if e.SrcKind == relationships.KindProduct {
+			return e.SrcID
+		}
+	}
+	return ""
+}
+
+// populateOwnership fills ProjectID on a slice of manifests by issuing
+// a single batched ListIncomingForMany lookup against the relationships
+// store. Empty input is a no-op. Used by every read path (Get / List /
+// ListByProject / Search / ListDeleted) so consumers continue to see
+// `manifest.ProjectID` populated even though the column is gone.
+func (s *Store) populateOwnership(manifests []*Manifest) {
+	if s.rels == nil || len(manifests) == 0 {
+		return
+	}
+	ctx := context.Background()
+	ids := make([]string, 0, len(manifests))
+	mapByID := make(map[string]*Manifest, len(manifests))
+	for _, m := range manifests {
+		if m == nil {
+			continue
+		}
+		ids = append(ids, m.ID)
+		mapByID[m.ID] = m
+	}
+	if len(ids) == 0 {
+		return
+	}
+	byDst, err := s.rels.ListIncomingForMany(ctx, ids, relationships.EdgeOwns)
+	if err != nil {
+		return
+	}
+	for mid, edges := range byDst {
+		m, ok := mapByID[mid]
+		if !ok {
+			continue
+		}
+		for _, e := range edges {
+			if e.SrcKind == relationships.KindProduct {
+				m.ProjectID = e.SrcID
+				break
+			}
+		}
+	}
+}
+
+// Get retrieves a manifest by full UUID. ProjectID is populated post-
+// scan from the relationships store (the legacy column was dropped in
+// PR/M3).
 func (s *Store) Get(id string) (*Manifest, error) {
-	row := s.db.QueryRow(`SELECT id, title, description, content, status, jira_refs, tags, author, source_node, project_id, depends_on, version, created_at, updated_at
+	row := s.db.QueryRow(`SELECT `+manifestColumns+`
 		FROM manifests WHERE id = ? AND deleted_at = ''`, id)
 	m, err := scanManifest(row)
 	if err == nil && m != nil {
+		s.populateOwnership([]*Manifest{m})
 		s.EnrichWithCosts([]*Manifest{m})
 	}
 	return m, err
 }
 
-// ListByProject returns manifests belonging to a project. Reads
-// canonical ownership from the relationships SCD-2 store via
-// `EdgeOwns(product → manifest)`. Falls back to the legacy
-// `manifests.project_id` column when the relationships backend isn't
-// wired (test fixtures + boot path before SetRelationshipsBackend).
+// ListByProject returns manifests belonging to a project, reading
+// ownership from the relationships SCD-2 store via
+// `EdgeOwns(product → manifest)`. Post-PR/M3 there is no legacy column
+// fallback — the column is gone.
 func (s *Store) ListByProject(projectID string, limit int) ([]*Manifest, error) {
 	if limit <= 0 {
 		limit = 50
 	}
-	if s.rels != nil {
-		ctx := context.Background()
-		edges, err := s.rels.ListOutgoing(ctx, projectID, relationships.EdgeOwns)
-		if err != nil {
-			return nil, err
-		}
-		ids := make([]string, 0, len(edges))
-		for _, e := range edges {
-			if e.DstKind == relationships.KindManifest {
-				ids = append(ids, e.DstID)
-			}
-		}
-		if len(ids) == 0 {
-			// Fall through to legacy JOIN — could be a test fixture
-			// that writes only to manifests.project_id without the
-			// EdgeOwns row. Production has both populated post-backfill,
-			// so legacy returns identical 0-row result there.
-			goto legacyFallback
-		}
-		placeholders := strings.Repeat("?,", len(ids))
-		placeholders = placeholders[:len(placeholders)-1]
-		args := make([]any, 0, len(ids)+1)
-		for _, id := range ids {
-			args = append(args, id)
-		}
-		args = append(args, limit)
-		rows, err := s.db.Query(`SELECT id, title, description, content, status, jira_refs, tags, author, source_node, project_id, depends_on, version, created_at, updated_at
-			FROM manifests WHERE id IN (`+placeholders+`) AND deleted_at = '' ORDER BY CASE status WHEN 'draft' THEN 0 WHEN 'open' THEN 1 WHEN 'closed' THEN 2 WHEN 'archive' THEN 3 ELSE 4 END, updated_at DESC LIMIT ?`, args...)
-		if err != nil {
-			return nil, err
-		}
-		defer rows.Close()
-		var results []*Manifest
-		for rows.Next() {
-			m, err := scanManifestRows(rows)
-			if err != nil {
-				return nil, err
-			}
-			results = append(results, m)
-		}
-		return results, rows.Err()
+	if s.rels == nil {
+		return nil, fmt.Errorf("manifest.ListByProject: relationships backend not wired")
 	}
-legacyFallback:
-	rows, err := s.db.Query(`SELECT id, title, description, content, status, jira_refs, tags, author, source_node, project_id, depends_on, version, created_at, updated_at
-		FROM manifests WHERE project_id = ? AND deleted_at = '' ORDER BY CASE status WHEN 'draft' THEN 0 WHEN 'open' THEN 1 WHEN 'closed' THEN 2 WHEN 'archive' THEN 3 ELSE 4 END, updated_at DESC LIMIT ?`, projectID, limit)
+	ctx := context.Background()
+	edges, err := s.rels.ListOutgoing(ctx, projectID, relationships.EdgeOwns)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(edges))
+	for _, e := range edges {
+		if e.DstKind == relationships.KindManifest {
+			ids = append(ids, e.DstID)
+		}
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	placeholders := strings.Repeat("?,", len(ids))
+	placeholders = placeholders[:len(placeholders)-1]
+	args := make([]any, 0, len(ids)+1)
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	args = append(args, limit)
+	rows, err := s.db.Query(`SELECT `+manifestColumns+`
+		FROM manifests WHERE id IN (`+placeholders+`) AND deleted_at = '' ORDER BY CASE status WHEN 'draft' THEN 0 WHEN 'open' THEN 1 WHEN 'closed' THEN 2 WHEN 'archive' THEN 3 ELSE 4 END, updated_at DESC LIMIT ?`, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -343,9 +411,15 @@ legacyFallback:
 		if err != nil {
 			return nil, err
 		}
+		// Caller already knows the projectID — short-circuit the
+		// rels lookup for this hot path.
+		m.ProjectID = projectID
 		results = append(results, m)
 	}
-	return results, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return results, nil
 }
 
 // List returns manifests sorted by updated_at.
@@ -367,7 +441,7 @@ func (s *Store) List(status string, limit int) ([]*Manifest, error) {
 		limit = 50 // defensive — negative is ambiguous, fall back to a sane cap
 	}
 
-	query := `SELECT id, title, description, content, status, jira_refs, tags, author, source_node, project_id, depends_on, version, created_at, updated_at FROM manifests WHERE deleted_at = ''`
+	query := `SELECT ` + manifestColumns + ` FROM manifests WHERE deleted_at = ''`
 	var args []any
 
 	if status != "" {
@@ -397,8 +471,12 @@ func (s *Store) List(status string, limit int) ([]*Manifest, error) {
 		}
 		results = append(results, m)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	s.populateOwnership(results)
 	s.EnrichWithCosts(results)
-	return results, rows.Err()
+	return results, nil
 }
 
 // Search finds manifests matching a query. Supports id-substring and
@@ -412,7 +490,7 @@ func (s *Store) Search(query string, limit int) ([]*Manifest, error) {
 		return nil, nil
 	}
 	pattern := "%" + q + "%"
-	rows, err := s.db.Query(`SELECT id, title, description, content, status, jira_refs, tags, author, source_node, project_id, depends_on, version, created_at, updated_at
+	rows, err := s.db.Query(`SELECT `+manifestColumns+`
 		FROM manifests WHERE deleted_at = '' AND (id LIKE ? OR title LIKE ? OR description LIKE ? OR content LIKE ? OR jira_refs LIKE ? OR tags LIKE ?)
 		ORDER BY CASE status WHEN 'draft' THEN 0 WHEN 'open' THEN 1 WHEN 'closed' THEN 2 WHEN 'archive' THEN 3 ELSE 4 END, updated_at DESC LIMIT ?`, pattern, pattern, pattern, pattern, pattern, pattern, limit)
 	if err != nil {
@@ -428,8 +506,12 @@ func (s *Store) Search(query string, limit int) ([]*Manifest, error) {
 		}
 		results = append(results, m)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	s.populateOwnership(results)
 	s.EnrichWithCosts(results)
-	return results, rows.Err()
+	return results, nil
 }
 
 // EnrichWithCosts populates TotalTasks, TotalTurns, and TotalCost from task_runs for each manifest.
@@ -444,91 +526,69 @@ func (s *Store) EnrichWithCosts(manifests []*Manifest) {
 		ids = append(ids, m.ID)
 	}
 
-	// Resolve task ownership via the unified relationships store. Falls
-	// back to the legacy tasks.manifest_id JOIN when the relationships
-	// backend isn't wired (test bootstrap path).
-	if s.rels != nil {
-		ctx := context.Background()
-		ownsByMan, err := s.rels.ListOutgoingForMany(ctx, ids, relationships.EdgeOwns)
-		if err != nil {
-			return
-		}
-		// Flatten to (taskID → manifestID) so a single SQL aggregate over
-		// task_runs yields the per-manifest totals without N+1.
-		taskToMan := make(map[string]string)
-		allTaskIDs := []string{}
-		for mID, edges := range ownsByMan {
-			for _, e := range edges {
-				if e.DstKind != relationships.KindTask {
-					continue
-				}
-				taskToMan[e.DstID] = mID
-				allTaskIDs = append(allTaskIDs, e.DstID)
-			}
-		}
-		if len(allTaskIDs) == 0 {
-			return
-		}
-		placeholders := strings.Repeat("?,", len(allTaskIDs))
-		placeholders = placeholders[:len(placeholders)-1]
-		args := make([]any, len(allTaskIDs))
-		for i, id := range allTaskIDs {
-			args[i] = id
-		}
-		rows, err := s.db.Query(`SELECT t.id, COALESCE(SUM(tr.turns),0), COALESCE(SUM(tr.cost_usd),0)
-			FROM tasks t LEFT JOIN task_runs tr ON t.id = tr.task_id
-			WHERE t.id IN (`+placeholders+`) AND t.deleted_at = ''
-			GROUP BY t.id`, args...)
-		if err != nil {
-			return
-		}
-		defer rows.Close()
-		// Initialise per-manifest task counts from the ownership graph;
-		// tasks with no runs still count toward TotalTasks.
-		for mID := range mMap {
-			edges := ownsByMan[mID]
-			n := 0
-			for _, e := range edges {
-				if e.DstKind == relationships.KindTask {
-					n++
-				}
-			}
-			mMap[mID].TotalTasks = n
-		}
-		for rows.Next() {
-			var tID string
-			var turns int
-			var cost float64
-			if err := rows.Scan(&tID, &turns, &cost); err == nil {
-				if mID, ok := taskToMan[tID]; ok {
-					if m, ok := mMap[mID]; ok {
-						m.TotalTurns += turns
-						m.TotalCost += cost
-					}
-				}
-			}
-		}
+	// Resolve task ownership via the unified relationships store. The
+	// legacy tasks.manifest_id JOIN was retired in PR/M3 — this path
+	// is the sole source of truth.
+	if s.rels == nil {
 		return
 	}
-
-	// Legacy fallback — only reached when rels backend isn't wired.
-	rows, err := s.db.Query(`SELECT t.manifest_id, COUNT(DISTINCT t.id), COALESCE(SUM(tr.turns),0), COALESCE(SUM(tr.cost_usd),0)
+	ctx := context.Background()
+	ownsByMan, err := s.rels.ListOutgoingForMany(ctx, ids, relationships.EdgeOwns)
+	if err != nil {
+		return
+	}
+	// Flatten to (taskID → manifestID) so a single SQL aggregate over
+	// task_runs yields the per-manifest totals without N+1.
+	taskToMan := make(map[string]string)
+	allTaskIDs := []string{}
+	for mID, edges := range ownsByMan {
+		for _, e := range edges {
+			if e.DstKind != relationships.KindTask {
+				continue
+			}
+			taskToMan[e.DstID] = mID
+			allTaskIDs = append(allTaskIDs, e.DstID)
+		}
+	}
+	// Initialise per-manifest task counts from the ownership graph;
+	// tasks with no runs still count toward TotalTasks.
+	for mID := range mMap {
+		edges := ownsByMan[mID]
+		n := 0
+		for _, e := range edges {
+			if e.DstKind == relationships.KindTask {
+				n++
+			}
+		}
+		mMap[mID].TotalTasks = n
+	}
+	if len(allTaskIDs) == 0 {
+		return
+	}
+	placeholders := strings.Repeat("?,", len(allTaskIDs))
+	placeholders = placeholders[:len(placeholders)-1]
+	args := make([]any, len(allTaskIDs))
+	for i, id := range allTaskIDs {
+		args[i] = id
+	}
+	rows, err := s.db.Query(`SELECT t.id, COALESCE(SUM(tr.turns),0), COALESCE(SUM(tr.cost_usd),0)
 		FROM tasks t LEFT JOIN task_runs tr ON t.id = tr.task_id
-		WHERE t.manifest_id != '' AND t.deleted_at = ''
-		GROUP BY t.manifest_id`)
+		WHERE t.id IN (`+placeholders+`) AND t.deleted_at = ''
+		GROUP BY t.id`, args...)
 	if err != nil {
 		return
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var mid string
-		var tasks, turns int
+		var tID string
+		var turns int
 		var cost float64
-		if err := rows.Scan(&mid, &tasks, &turns, &cost); err == nil {
-			if m, ok := mMap[mid]; ok {
-				m.TotalTasks = tasks
-				m.TotalTurns = turns
-				m.TotalCost = cost
+		if err := rows.Scan(&tID, &turns, &cost); err == nil {
+			if mID, ok := taskToMan[tID]; ok {
+				if m, ok := mMap[mID]; ok {
+					m.TotalTurns += turns
+					m.TotalCost += cost
+				}
 			}
 		}
 	}
@@ -546,58 +606,36 @@ func (s *Store) EnrichRecursiveCosts(m *Manifest) {
 		return
 	}
 	// Resolve owned task IDs through the relationships store; aggregate
-	// task_runs WHERE task_id IN (...). Falls back to the legacy
-	// tasks.manifest_id JOIN when rels isn't wired.
-	if s.rels != nil {
-		ctx := context.Background()
-		edges, err := s.rels.ListOutgoing(ctx, m.ID, relationships.EdgeOwns)
-		if err != nil {
-			return
-		}
-		taskIDs := make([]string, 0, len(edges))
-		for _, e := range edges {
-			if e.DstKind == relationships.KindTask {
-				taskIDs = append(taskIDs, e.DstID)
-			}
-		}
-		if len(taskIDs) == 0 {
-			m.TotalTasks = 0
-			m.TotalTurns = 0
-			m.TotalCost = 0
-			m.TotalActions = 0
-			m.TotalTokens = 0
-			return
-		}
-		placeholders := strings.Repeat("?,", len(taskIDs))
-		placeholders = placeholders[:len(placeholders)-1]
-		args := make([]any, len(taskIDs))
-		for i, id := range taskIDs {
-			args[i] = id
-		}
-		row := s.db.QueryRow(`
-			SELECT
-				COUNT(DISTINCT t.id),
-				COALESCE(SUM(tr.turns), 0),
-				COALESCE(SUM(tr.cost_usd), 0),
-				COALESCE(SUM(tr.actions), 0),
-				COALESCE(SUM(tr.input_tokens + tr.output_tokens + tr.cache_read_tokens + tr.cache_create_tokens), 0)
-			FROM tasks t
-			LEFT JOIN task_runs tr ON tr.task_id = t.id
-			WHERE t.id IN (`+placeholders+`) AND t.deleted_at = ''`,
-			args...,
-		)
-		var tasks, turns, actions, tokens int
-		var cost float64
-		if err := row.Scan(&tasks, &turns, &cost, &actions, &tokens); err == nil {
-			m.TotalTasks = tasks
-			m.TotalTurns = turns
-			m.TotalCost = cost
-			m.TotalActions = actions
-			m.TotalTokens = tokens
-		}
+	// task_runs WHERE task_id IN (...). The legacy tasks.manifest_id
+	// JOIN was retired in PR/M3.
+	if s.rels == nil {
 		return
 	}
-	// Legacy fallback.
+	ctx := context.Background()
+	edges, err := s.rels.ListOutgoing(ctx, m.ID, relationships.EdgeOwns)
+	if err != nil {
+		return
+	}
+	taskIDs := make([]string, 0, len(edges))
+	for _, e := range edges {
+		if e.DstKind == relationships.KindTask {
+			taskIDs = append(taskIDs, e.DstID)
+		}
+	}
+	if len(taskIDs) == 0 {
+		m.TotalTasks = 0
+		m.TotalTurns = 0
+		m.TotalCost = 0
+		m.TotalActions = 0
+		m.TotalTokens = 0
+		return
+	}
+	placeholders := strings.Repeat("?,", len(taskIDs))
+	placeholders = placeholders[:len(placeholders)-1]
+	args := make([]any, len(taskIDs))
+	for i, id := range taskIDs {
+		args[i] = id
+	}
 	row := s.db.QueryRow(`
 		SELECT
 			COUNT(DISTINCT t.id),
@@ -607,8 +645,8 @@ func (s *Store) EnrichRecursiveCosts(m *Manifest) {
 			COALESCE(SUM(tr.input_tokens + tr.output_tokens + tr.cache_read_tokens + tr.cache_create_tokens), 0)
 		FROM tasks t
 		LEFT JOIN task_runs tr ON tr.task_id = t.id
-		WHERE t.manifest_id = ? AND t.deleted_at = ''`,
-		m.ID,
+		WHERE t.id IN (`+placeholders+`) AND t.deleted_at = ''`,
+		args...,
 	)
 	var tasks, turns, actions, tokens int
 	var cost float64
@@ -633,7 +671,7 @@ func (s *Store) ListDeleted(limit int) ([]*Manifest, error) {
 	if limit <= 0 {
 		limit = 50
 	}
-	rows, err := s.db.Query(`SELECT id, title, description, content, status, jira_refs, tags, author, source_node, project_id, depends_on, version, created_at, updated_at
+	rows, err := s.db.Query(`SELECT `+manifestColumns+`
 		FROM manifests WHERE deleted_at != '' ORDER BY deleted_at DESC LIMIT ?`, limit)
 	if err != nil {
 		return nil, err
@@ -647,7 +685,11 @@ func (s *Store) ListDeleted(limit int) ([]*Manifest, error) {
 		}
 		results = append(results, m)
 	}
-	return results, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	s.populateOwnership(results)
+	return results, nil
 }
 
 // Restore un-deletes a soft-deleted manifest.
@@ -689,12 +731,18 @@ func (m *Manifest) HasDependency(manifestID string) bool {
 	return false
 }
 
+// manifestColumns is the canonical SELECT projection for manifests.
+// Mirrors scanManifest / scanManifestRows; PR/M3 dropped project_id
+// from this list along with the underlying column. Manifest.ProjectID
+// is now populated post-scan via populateOwnership / explicit assignment.
+const manifestColumns = `id, title, description, content, status, jira_refs, tags, author, source_node, depends_on, version, created_at, updated_at`
+
 func scanManifest(row *sql.Row) (*Manifest, error) {
 	var m Manifest
 	var jiraStr, tagsStr, createdStr, updatedStr string
 
 	err := row.Scan(&m.ID, &m.Title, &m.Description, &m.Content, &m.Status,
-		&jiraStr, &tagsStr, &m.Author, &m.SourceNode, &m.ProjectID, &m.DependsOn, &m.Version, &createdStr, &updatedStr)
+		&jiraStr, &tagsStr, &m.Author, &m.SourceNode, &m.DependsOn, &m.Version, &createdStr, &updatedStr)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -719,7 +767,7 @@ func scanManifestRows(rows *sql.Rows) (*Manifest, error) {
 	var jiraStr, tagsStr, createdStr, updatedStr string
 
 	err := rows.Scan(&m.ID, &m.Title, &m.Description, &m.Content, &m.Status,
-		&jiraStr, &tagsStr, &m.Author, &m.SourceNode, &m.ProjectID, &m.DependsOn, &m.Version, &createdStr, &updatedStr)
+		&jiraStr, &tagsStr, &m.Author, &m.SourceNode, &m.DependsOn, &m.Version, &createdStr, &updatedStr)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -276,13 +276,20 @@ func New(cfg *config.Config) (*Node, error) {
 	}
 	// PR/M2 + PR/M3 — copy every row out of the three legacy dependency
 	// tables (product_dependencies / manifest_dependencies /
-	// task_dependency) into the unified relationships SCD-2 table.
-	// Idempotent — re-running on a migrated DB inserts zero rows. The
-	// legacy tables are NOT dropped; they sit dormant as historical
-	// safety. All read + write paths in product / manifest / task have
-	// been cut over to read from relationships.
+	// task_dependency) PLUS the legacy ownership FK columns
+	// (manifests.project_id / tasks.manifest_id) into the unified
+	// relationships SCD-2 table. Idempotent — re-running inserts zero
+	// rows.
 	if _, err := relationshipsStore.MigrateLegacyDeps(context.Background()); err != nil {
 		return nil, fmt.Errorf("migrate legacy deps to relationships: %w", err)
+	}
+	// PR/M3 — drop the legacy ownership columns now that every row is
+	// represented in `relationships` as an EdgeOwns edge. The migration
+	// is a SQLite-portable rename-table swap inside a single
+	// transaction; idempotent (a second boot finds the column already
+	// gone and is a no-op).
+	if err := relationships.DropOwnershipColumns(context.Background(), index.DB()); err != nil {
+		return nil, fmt.Errorf("drop legacy ownership columns: %w", err)
 	}
 	// Wire the relationships store into the legacy dep stores so their
 	// Add/Remove/List methods read + write the unified table while

--- a/internal/product/store.go
+++ b/internal/product/store.go
@@ -388,132 +388,95 @@ func (s *Store) EnrichWithCosts(products []*Product) {
 		ids[i] = p.ID
 	}
 
-	if s.rels != nil {
-		ctx := context.Background()
-		ownsByProduct, err := s.rels.ListOutgoingForMany(ctx, ids, relationships.EdgeOwns)
-		if err == nil {
-			// (manifestID → productID) so a single SQL aggregate over
-			// task_runs joined via tasks.manifest_id rolls up by product
-			// without N+1.
-			manifestToProduct := make(map[string]string)
-			perProductManifestCount := make(map[string]int)
-			allManifestIDs := []string{}
-			for pid, edges := range ownsByProduct {
-				for _, e := range edges {
-					if e.DstKind != relationships.KindManifest {
-						continue
-					}
-					manifestToProduct[e.DstID] = pid
-					perProductManifestCount[pid]++
-					allManifestIDs = append(allManifestIDs, e.DstID)
-				}
+	// Resolve manifest + task ownership through the relationships store.
+	// PR/M3 dropped the legacy m.project_id / t.manifest_id JOIN; rels
+	// is now the sole source of truth.
+	if s.rels == nil {
+		return
+	}
+	ctx := context.Background()
+	ownsByProduct, err := s.rels.ListOutgoingForMany(ctx, ids, relationships.EdgeOwns)
+	if err != nil {
+		return
+	}
+	// (manifestID → productID) so a single SQL aggregate over task_runs
+	// rolls up by product without N+1.
+	manifestToProduct := make(map[string]string)
+	perProductManifestCount := make(map[string]int)
+	allManifestIDs := []string{}
+	for pid, edges := range ownsByProduct {
+		for _, e := range edges {
+			if e.DstKind != relationships.KindManifest {
+				continue
 			}
-			for pid, n := range perProductManifestCount {
-				if p, ok := pMap[pid]; ok {
-					p.TotalManifests = n
-				}
-			}
-			if len(allManifestIDs) == 0 {
-				return
-			}
-			// Owns(manifest→task) for the manifests we found.
-			taskEdgesByManifest, err := s.rels.ListOutgoingForMany(ctx, allManifestIDs, relationships.EdgeOwns)
-			if err != nil {
-				return
-			}
-			taskToProduct := make(map[string]string)
-			perProductTaskCount := make(map[string]int)
-			allTaskIDs := []string{}
-			for mID, edges := range taskEdgesByManifest {
-				pid, ok := manifestToProduct[mID]
-				if !ok {
-					continue
-				}
-				for _, e := range edges {
-					if e.DstKind != relationships.KindTask {
-						continue
-					}
-					taskToProduct[e.DstID] = pid
-					perProductTaskCount[pid]++
-					allTaskIDs = append(allTaskIDs, e.DstID)
-				}
-			}
-			for pid, n := range perProductTaskCount {
-				if p, ok := pMap[pid]; ok {
-					p.TotalTasks = n
-				}
-			}
-			if len(allTaskIDs) == 0 {
-				return
-			}
-			ph := strings.Repeat("?,", len(allTaskIDs))
-			ph = ph[:len(ph)-1]
-			tArgs := make([]any, len(allTaskIDs))
-			for i, id := range allTaskIDs {
-				tArgs[i] = id
-			}
-			rows, err := s.db.Query(`SELECT t.id,
-				COALESCE(SUM(tr.turns), 0),
-				COALESCE(SUM(tr.cost_usd), 0)
-				FROM tasks t LEFT JOIN task_runs tr ON tr.task_id = t.id
-				WHERE t.id IN (`+ph+`) AND t.deleted_at = ''
-				GROUP BY t.id`, tArgs...)
-			if err != nil {
-				return
-			}
-			defer rows.Close()
-			for rows.Next() {
-				var tid string
-				var turns int
-				var cost float64
-				if err := rows.Scan(&tid, &turns, &cost); err == nil {
-					if pid, ok := taskToProduct[tid]; ok {
-						if p, ok := pMap[pid]; ok {
-							p.TotalTurns += turns
-							p.TotalCost += cost
-						}
-					}
-				}
-			}
-			return
+			manifestToProduct[e.DstID] = pid
+			perProductManifestCount[pid]++
+			allManifestIDs = append(allManifestIDs, e.DstID)
 		}
 	}
-
-	// Legacy fallback path.
-	placeholders := strings.Repeat("?,", len(ids))
-	placeholders = placeholders[:len(placeholders)-1]
-	args := make([]any, len(ids))
-	for i, id := range ids {
-		args[i] = id
+	for pid, n := range perProductManifestCount {
+		if p, ok := pMap[pid]; ok {
+			p.TotalManifests = n
+		}
 	}
-
-	rows, err := s.db.Query(
-		fmt.Sprintf(`SELECT m.project_id,
-			COUNT(DISTINCT m.id),
-			COUNT(DISTINCT t.id),
-			COALESCE(SUM(tr.turns), 0),
-			COALESCE(SUM(tr.cost_usd), 0)
-		FROM manifests m
-		LEFT JOIN tasks t ON t.manifest_id = m.id AND t.deleted_at = ''
-		LEFT JOIN task_runs tr ON tr.task_id = t.id
-		WHERE m.project_id IN (%s) AND m.deleted_at = ''
-		GROUP BY m.project_id`, placeholders),
-		args...,
-	)
+	if len(allManifestIDs) == 0 {
+		return
+	}
+	taskEdgesByManifest, err := s.rels.ListOutgoingForMany(ctx, allManifestIDs, relationships.EdgeOwns)
+	if err != nil {
+		return
+	}
+	taskToProduct := make(map[string]string)
+	perProductTaskCount := make(map[string]int)
+	allTaskIDs := []string{}
+	for mID, edges := range taskEdgesByManifest {
+		pid, ok := manifestToProduct[mID]
+		if !ok {
+			continue
+		}
+		for _, e := range edges {
+			if e.DstKind != relationships.KindTask {
+				continue
+			}
+			taskToProduct[e.DstID] = pid
+			perProductTaskCount[pid]++
+			allTaskIDs = append(allTaskIDs, e.DstID)
+		}
+	}
+	for pid, n := range perProductTaskCount {
+		if p, ok := pMap[pid]; ok {
+			p.TotalTasks = n
+		}
+	}
+	if len(allTaskIDs) == 0 {
+		return
+	}
+	ph := strings.Repeat("?,", len(allTaskIDs))
+	ph = ph[:len(ph)-1]
+	tArgs := make([]any, len(allTaskIDs))
+	for i, id := range allTaskIDs {
+		tArgs[i] = id
+	}
+	rows, err := s.db.Query(`SELECT t.id,
+		COALESCE(SUM(tr.turns), 0),
+		COALESCE(SUM(tr.cost_usd), 0)
+		FROM tasks t LEFT JOIN task_runs tr ON tr.task_id = t.id
+		WHERE t.id IN (`+ph+`) AND t.deleted_at = ''
+		GROUP BY t.id`, tArgs...)
 	if err != nil {
 		return
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var pid string
-		var manifests, tasks, turns int
+		var tid string
+		var turns int
 		var cost float64
-		if err := rows.Scan(&pid, &manifests, &tasks, &turns, &cost); err == nil {
-			if p, ok := pMap[pid]; ok {
-				p.TotalManifests = manifests
-				p.TotalTasks = tasks
-				p.TotalTurns = turns
-				p.TotalCost = cost
+		if err := rows.Scan(&tid, &turns, &cost); err == nil {
+			if pid, ok := taskToProduct[tid]; ok {
+				if p, ok := pMap[pid]; ok {
+					p.TotalTurns += turns
+					p.TotalCost += cost
+				}
 			}
 		}
 	}

--- a/internal/relationships/drop_ownership_columns.go
+++ b/internal/relationships/drop_ownership_columns.go
@@ -1,0 +1,242 @@
+package relationships
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// DropOwnershipColumns is the M3 schema migration that removes the
+// legacy ownership FKs `manifests.project_id` and `tasks.manifest_id`
+// from the schema. After M3 the canonical source of truth for ownership
+// is the relationships SCD-2 table — every read path consults
+// `EdgeOwns(product → manifest)` and `EdgeOwns(manifest → task)` rows.
+//
+// Run AFTER MigrateLegacyDeps so any rows whose ownership lived only in
+// the legacy column have been swept into relationships first. Idempotent:
+// if the columns are already gone (post-M3 fresh DBs or a prior boot
+// already dropped them) the function is a no-op.
+//
+// The migration uses the SQLite-portable rename-table pattern instead of
+// ALTER TABLE DROP COLUMN: CREATE TABLE *_new without the column, INSERT
+// FROM old, DROP old, RENAME new → original. This works on every SQLite
+// version we ship against (3.30+) including ones predating the native
+// DROP COLUMN support added in 3.35.
+//
+// Wraps the whole sequence in a single transaction so a failure leaves
+// the legacy schema intact rather than half-converted. Indexes that
+// existed on the old table are recreated on the renamed one.
+func DropOwnershipColumns(ctx context.Context, db *sql.DB) error {
+	if db == nil {
+		return fmt.Errorf("relationships: nil db handle")
+	}
+	if err := dropManifestProjectIDColumn(ctx, db); err != nil {
+		return fmt.Errorf("drop manifests.project_id: %w", err)
+	}
+	if err := dropTaskManifestIDColumn(ctx, db); err != nil {
+		return fmt.Errorf("drop tasks.manifest_id: %w", err)
+	}
+	return nil
+}
+
+// hasColumn reports whether `table` currently has a column named `col`.
+// Uses PRAGMA table_info (SQLite-only). Returns (false, nil) when the
+// table doesn't exist — both the "no project_id column" and "no
+// manifests table" cases collapse to the same "nothing to drop"
+// outcome, which is what the caller wants.
+func hasColumn(ctx context.Context, db *sql.DB, table, col string) (bool, error) {
+	rows, err := db.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid          int
+			name, ctype  string
+			notnull, pk  int
+			defaultVal   sql.NullString
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &defaultVal, &pk); err != nil {
+			return false, err
+		}
+		if strings.EqualFold(name, col) {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+func dropManifestProjectIDColumn(ctx context.Context, db *sql.DB) error {
+	has, err := hasColumn(ctx, db, "manifests", "project_id")
+	if err != nil {
+		return err
+	}
+	if !has {
+		return nil
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Schema mirrors manifest.Store.init() current shape minus project_id.
+	// The init() ALTER TABLE chain adds source_node, deleted_at, depends_on
+	// on legacy DBs; we declare the union here so post-migration the table
+	// has exactly the columns the rest of the code reads.
+	if _, err := tx.ExecContext(ctx, `CREATE TABLE manifests_new (
+		id TEXT PRIMARY KEY,
+		title TEXT NOT NULL,
+		description TEXT NOT NULL DEFAULT '',
+		content TEXT NOT NULL DEFAULT '',
+		status TEXT NOT NULL DEFAULT 'draft',
+		jira_refs TEXT NOT NULL DEFAULT '[]',
+		tags TEXT NOT NULL DEFAULT '[]',
+		author TEXT NOT NULL DEFAULT '',
+		source_node TEXT NOT NULL DEFAULT '',
+		depends_on TEXT NOT NULL DEFAULT '',
+		version INTEGER NOT NULL DEFAULT 1,
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL,
+		deleted_at TEXT NOT NULL DEFAULT ''
+	)`); err != nil {
+		return fmt.Errorf("create manifests_new: %w", err)
+	}
+
+	// Pull every column except project_id. COALESCE'd defaults match the
+	// init()-time ALTER ADD COLUMN defaults so legacy rows that never had
+	// these columns landed empty rather than NULL.
+	if _, err := tx.ExecContext(ctx, `INSERT INTO manifests_new
+		(id, title, description, content, status, jira_refs, tags, author,
+		 source_node, depends_on, version, created_at, updated_at, deleted_at)
+		SELECT id, title, description, content, status, jira_refs, tags, author,
+		       COALESCE(source_node, ''), COALESCE(depends_on, ''),
+		       COALESCE(version, 1), created_at, updated_at,
+		       COALESCE(deleted_at, '')
+		  FROM manifests`); err != nil {
+		return fmt.Errorf("copy rows to manifests_new: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `DROP TABLE manifests`); err != nil {
+		return fmt.Errorf("drop legacy manifests: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `ALTER TABLE manifests_new RENAME TO manifests`); err != nil {
+		return fmt.Errorf("rename manifests_new: %w", err)
+	}
+
+	// Recreate the indexes the original table had. idx_manifests_project
+	// is intentionally NOT recreated — it pointed at the column we just
+	// dropped.
+	if _, err := tx.ExecContext(ctx,
+		`CREATE INDEX IF NOT EXISTS idx_manifests_status ON manifests(status)`); err != nil {
+		return fmt.Errorf("recreate idx_manifests_status: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`CREATE INDEX IF NOT EXISTS idx_manifests_updated ON manifests(updated_at DESC)`); err != nil {
+		return fmt.Errorf("recreate idx_manifests_updated: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	committed = true
+	slog.Info("relationships: dropped legacy manifests.project_id column")
+	return nil
+}
+
+func dropTaskManifestIDColumn(ctx context.Context, db *sql.DB) error {
+	has, err := hasColumn(ctx, db, "tasks", "manifest_id")
+	if err != nil {
+		return err
+	}
+	if !has {
+		return nil
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Schema mirrors task.Store.init() current shape minus manifest_id.
+	// max_turns was retired in M4-T14 (DropMaxTurnsColumn) so it isn't
+	// on the new schema either.
+	if _, err := tx.ExecContext(ctx, `CREATE TABLE tasks_new (
+		id TEXT PRIMARY KEY,
+		title TEXT NOT NULL,
+		description TEXT NOT NULL DEFAULT '',
+		schedule TEXT NOT NULL DEFAULT 'once',
+		status TEXT NOT NULL DEFAULT 'pending',
+		agent TEXT NOT NULL DEFAULT 'claude-code',
+		source_node TEXT NOT NULL DEFAULT '',
+		created_by TEXT NOT NULL DEFAULT '',
+		run_count INTEGER NOT NULL DEFAULT 0,
+		last_run_at TEXT NOT NULL DEFAULT '',
+		next_run_at TEXT NOT NULL DEFAULT '',
+		last_output TEXT NOT NULL DEFAULT '',
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL,
+		deleted_at TEXT NOT NULL DEFAULT '',
+		depends_on TEXT NOT NULL DEFAULT '',
+		block_reason TEXT NOT NULL DEFAULT '',
+		action_request TEXT NOT NULL DEFAULT ''
+	)`); err != nil {
+		return fmt.Errorf("create tasks_new: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `INSERT INTO tasks_new
+		(id, title, description, schedule, status, agent, source_node,
+		 created_by, run_count, last_run_at, next_run_at, last_output,
+		 created_at, updated_at, deleted_at, depends_on, block_reason,
+		 action_request)
+		SELECT id, title, description, schedule, status, agent,
+		       COALESCE(source_node, ''), COALESCE(created_by, ''),
+		       COALESCE(run_count, 0), COALESCE(last_run_at, ''),
+		       COALESCE(next_run_at, ''), COALESCE(last_output, ''),
+		       created_at, updated_at, COALESCE(deleted_at, ''),
+		       COALESCE(depends_on, ''), COALESCE(block_reason, ''),
+		       COALESCE(action_request, '')
+		  FROM tasks`); err != nil {
+		return fmt.Errorf("copy rows to tasks_new: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `DROP TABLE tasks`); err != nil {
+		return fmt.Errorf("drop legacy tasks: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `ALTER TABLE tasks_new RENAME TO tasks`); err != nil {
+		return fmt.Errorf("rename tasks_new: %w", err)
+	}
+
+	// Recreate non-manifest_id indexes. idx_tasks_manifest pointed at the
+	// dropped column and is gone for good.
+	if _, err := tx.ExecContext(ctx,
+		`CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)`); err != nil {
+		return fmt.Errorf("recreate idx_tasks_status: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`CREATE INDEX IF NOT EXISTS idx_tasks_next_run ON tasks(next_run_at)`); err != nil {
+		return fmt.Errorf("recreate idx_tasks_next_run: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	committed = true
+	slog.Info("relationships: dropped legacy tasks.manifest_id column")
+	return nil
+}

--- a/internal/relationships/m3_single_write_test.go
+++ b/internal/relationships/m3_single_write_test.go
@@ -1,0 +1,225 @@
+package relationships
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// openTestDB opens an in-memory SQLite handle in WAL mode + busy_timeout
+// so concurrent writes during these tests don't deadlock.
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:?_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// columnExists is the test-side mirror of the package-private hasColumn
+// helper. We can't import the unexported one, but PRAGMA is a one-liner.
+func columnExists(t *testing.T, db *sql.DB, table, col string) bool {
+	t.Helper()
+	rows, err := db.Query("PRAGMA table_info(" + table + ")")
+	if err != nil {
+		return false
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid          int
+			name, ctype  string
+			notnull, pk  int
+			defaultVal   sql.NullString
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &defaultVal, &pk); err != nil {
+			return false
+		}
+		if strings.EqualFold(name, col) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDropOwnershipColumns_DropsManifestProjectID — given a legacy DB
+// with manifests.project_id present, the migration moves rows into a
+// new schema without the column and preserves all other data.
+func TestDropOwnershipColumns_DropsManifestProjectID(t *testing.T) {
+	db := openTestDB(t)
+
+	// Recreate the legacy schema. Mirrors what manifest.Store.init()
+	// produced before PR/M3 cut the project_id column out.
+	if _, err := db.Exec(`CREATE TABLE manifests (
+		id TEXT PRIMARY KEY,
+		title TEXT NOT NULL,
+		description TEXT NOT NULL DEFAULT '',
+		content TEXT NOT NULL DEFAULT '',
+		status TEXT NOT NULL DEFAULT 'draft',
+		jira_refs TEXT NOT NULL DEFAULT '[]',
+		tags TEXT NOT NULL DEFAULT '[]',
+		author TEXT NOT NULL DEFAULT '',
+		source_node TEXT NOT NULL DEFAULT '',
+		project_id TEXT NOT NULL DEFAULT '',
+		depends_on TEXT NOT NULL DEFAULT '',
+		version INTEGER NOT NULL DEFAULT 1,
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL,
+		deleted_at TEXT NOT NULL DEFAULT ''
+	)`); err != nil {
+		t.Fatalf("create legacy manifests: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO manifests
+		(id, title, description, content, status, jira_refs, tags, author, source_node, project_id, depends_on, version, created_at, updated_at, deleted_at)
+		VALUES ('m1', 'M1', 'd1', 'c1', 'open', '[]', '[]', 'me', 'src', 'prod-A', '', 2, '2026-01-01T00:00:00Z', '2026-01-02T00:00:00Z', '')`); err != nil {
+		t.Fatalf("seed manifests row: %v", err)
+	}
+
+	if err := DropOwnershipColumns(context.Background(), db); err != nil {
+		t.Fatalf("DropOwnershipColumns: %v", err)
+	}
+	if columnExists(t, db, "manifests", "project_id") {
+		t.Errorf("manifests.project_id still present after migration")
+	}
+
+	// Row data preserved.
+	var id, title, status, srcNode, dependsOn string
+	var version int
+	row := db.QueryRow(`SELECT id, title, status, source_node, depends_on, version FROM manifests WHERE id = 'm1'`)
+	if err := row.Scan(&id, &title, &status, &srcNode, &dependsOn, &version); err != nil {
+		t.Fatalf("scan migrated row: %v", err)
+	}
+	if id != "m1" || title != "M1" || status != "open" || srcNode != "src" || version != 2 {
+		t.Errorf("data lost in migration: id=%q title=%q status=%q src=%q version=%d", id, title, status, srcNode, version)
+	}
+}
+
+// TestDropOwnershipColumns_DropsTaskManifestID — same shape for tasks.
+func TestDropOwnershipColumns_DropsTaskManifestID(t *testing.T) {
+	db := openTestDB(t)
+
+	if _, err := db.Exec(`CREATE TABLE tasks (
+		id TEXT PRIMARY KEY,
+		manifest_id TEXT NOT NULL DEFAULT '',
+		title TEXT NOT NULL,
+		description TEXT NOT NULL DEFAULT '',
+		schedule TEXT NOT NULL DEFAULT 'once',
+		status TEXT NOT NULL DEFAULT 'pending',
+		agent TEXT NOT NULL DEFAULT 'claude-code',
+		source_node TEXT NOT NULL DEFAULT '',
+		created_by TEXT NOT NULL DEFAULT '',
+		run_count INTEGER NOT NULL DEFAULT 0,
+		last_run_at TEXT NOT NULL DEFAULT '',
+		next_run_at TEXT NOT NULL DEFAULT '',
+		last_output TEXT NOT NULL DEFAULT '',
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL,
+		deleted_at TEXT NOT NULL DEFAULT '',
+		depends_on TEXT NOT NULL DEFAULT '',
+		block_reason TEXT NOT NULL DEFAULT '',
+		action_request TEXT NOT NULL DEFAULT ''
+	)`); err != nil {
+		t.Fatalf("create legacy tasks: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO tasks (id, manifest_id, title, status, created_at, updated_at)
+		VALUES ('t1', 'm-legacy', 'T1', 'pending', '2026-01-01T00:00:00Z', '2026-01-02T00:00:00Z')`); err != nil {
+		t.Fatalf("seed tasks row: %v", err)
+	}
+
+	if err := DropOwnershipColumns(context.Background(), db); err != nil {
+		t.Fatalf("DropOwnershipColumns: %v", err)
+	}
+	if columnExists(t, db, "tasks", "manifest_id") {
+		t.Errorf("tasks.manifest_id still present after migration")
+	}
+
+	var id, title, status string
+	row := db.QueryRow(`SELECT id, title, status FROM tasks WHERE id = 't1'`)
+	if err := row.Scan(&id, &title, &status); err != nil {
+		t.Fatalf("scan migrated row: %v", err)
+	}
+	if id != "t1" || title != "T1" || status != "pending" {
+		t.Errorf("data lost: id=%q title=%q status=%q", id, title, status)
+	}
+}
+
+// TestDropOwnershipColumns_Idempotent — running the migration twice is
+// a no-op the second time. Guards against accidental re-runs corrupting
+// data on subsequent boots.
+func TestDropOwnershipColumns_Idempotent(t *testing.T) {
+	db := openTestDB(t)
+
+	// Fresh schema (post-M3 shape).
+	if _, err := db.Exec(`CREATE TABLE manifests (
+		id TEXT PRIMARY KEY, title TEXT NOT NULL,
+		created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+	)`); err != nil {
+		t.Fatalf("create fresh manifests: %v", err)
+	}
+	if _, err := db.Exec(`CREATE TABLE tasks (
+		id TEXT PRIMARY KEY, title TEXT NOT NULL,
+		created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+	)`); err != nil {
+		t.Fatalf("create fresh tasks: %v", err)
+	}
+
+	if err := DropOwnershipColumns(context.Background(), db); err != nil {
+		t.Fatalf("DropOwnershipColumns first call: %v", err)
+	}
+	if err := DropOwnershipColumns(context.Background(), db); err != nil {
+		t.Fatalf("DropOwnershipColumns second call: %v", err)
+	}
+}
+
+// TestBackfillOwnershipEdges_Idempotent — given seeded legacy ownership
+// rows, MigrateLegacyDeps inserts EdgeOwns rows once; a second call
+// against the same DB inserts zero new rows.
+func TestBackfillOwnershipEdges_Idempotent(t *testing.T) {
+	db := openTestDB(t)
+
+	// Seed legacy schemas + a row each.
+	if _, err := db.Exec(`CREATE TABLE manifests (
+		id TEXT PRIMARY KEY, project_id TEXT NOT NULL DEFAULT '',
+		created_at TEXT NOT NULL DEFAULT '', deleted_at TEXT NOT NULL DEFAULT ''
+	)`); err != nil {
+		t.Fatalf("create manifests: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO manifests (id, project_id, created_at) VALUES ('m1', 'p1', '2026-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("seed manifests: %v", err)
+	}
+	if _, err := db.Exec(`CREATE TABLE tasks (
+		id TEXT PRIMARY KEY, manifest_id TEXT NOT NULL DEFAULT '',
+		created_at TEXT NOT NULL DEFAULT '', deleted_at TEXT NOT NULL DEFAULT ''
+	)`); err != nil {
+		t.Fatalf("create tasks: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO tasks (id, manifest_id, created_at) VALUES ('t1', 'm1', '2026-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("seed tasks: %v", err)
+	}
+
+	store, err := New(db)
+	if err != nil {
+		t.Fatalf("relationships.New: %v", err)
+	}
+
+	first, err := store.MigrateLegacyDeps(context.Background())
+	if err != nil {
+		t.Fatalf("first MigrateLegacyDeps: %v", err)
+	}
+	if first < 2 {
+		t.Errorf("first migrate inserted %d rows; want >= 2 (1 manifest-owns + 1 task-owns)", first)
+	}
+
+	second, err := store.MigrateLegacyDeps(context.Background())
+	if err != nil {
+		t.Fatalf("second MigrateLegacyDeps: %v", err)
+	}
+	if second != 0 {
+		t.Errorf("second migrate inserted %d rows; want 0 (idempotency)", second)
+	}
+}

--- a/internal/relationships/migrate_legacy.go
+++ b/internal/relationships/migrate_legacy.go
@@ -100,7 +100,10 @@ func (s *Store) migrateManifestOwnership(ctx context.Context) (int, error) {
 		 WHERE project_id IS NOT NULL AND project_id != ''
 		   AND deleted_at = ''`)
 	if err != nil {
-		if isNoSuchTable(err) {
+		// Fresh DBs (post-M3) no longer have the project_id column at
+		// all — the read fails with "no such column", which means
+		// "nothing to backfill" and is the expected steady state.
+		if isNoSuchTable(err) || isNoSuchColumn(err) {
 			return 0, nil
 		}
 		return 0, err
@@ -164,7 +167,8 @@ func (s *Store) migrateTaskOwnership(ctx context.Context) (int, error) {
 		 WHERE manifest_id IS NOT NULL AND manifest_id != ''
 		   AND deleted_at = ''`)
 	if err != nil {
-		if isNoSuchTable(err) {
+		// Post-M3 fresh DBs lack the manifest_id column entirely.
+		if isNoSuchTable(err) || isNoSuchColumn(err) {
 			return 0, nil
 		}
 		return 0, err
@@ -433,6 +437,16 @@ func firstNonEmpty(vals ...string) string {
 		}
 	}
 	return ""
+}
+
+// isNoSuchColumn returns true when err is SQLite's missing-column
+// error. Used by the ownership backfills which read legacy columns
+// that no longer exist on M3+ fresh DBs.
+func isNoSuchColumn(err error) bool {
+	if err == nil || err == sql.ErrNoRows {
+		return false
+	}
+	return contains(err.Error(), "no such column")
 }
 
 // isNoSuchTable returns true when err is SQLite's missing-table error.

--- a/internal/task/m3_single_write_test.go
+++ b/internal/task/m3_single_write_test.go
@@ -1,0 +1,82 @@
+package task
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/k8nstantin/OpenPraxis/internal/relationships"
+)
+
+// TestTaskCreate_WritesEdgeOwnsOnly — creating a task under a manifest
+// writes (a) one EdgeOwns(manifest → task) row in `relationships` and
+// (b) leaves no `manifest_id` column on the tasks table.
+func TestTaskCreate_WritesEdgeOwnsOnly(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "m3-task.db") + "?_journal_mode=WAL&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	s, err := NewStore(db)
+	if err != nil {
+		t.Fatalf("task.NewStore: %v", err)
+	}
+	rels := s.rels // task.NewStore auto-wires a backend
+
+	manifestID := "m-m3"
+	tk, err := s.Create(manifestID, "T", "", "once", "claude-code", "node", "test", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// (a) EdgeOwns row from manifest → task.
+	edges, err := rels.ListIncoming(context.Background(), tk.ID, relationships.EdgeOwns)
+	if err != nil {
+		t.Fatalf("ListIncoming: %v", err)
+	}
+	found := false
+	for _, e := range edges {
+		if e.SrcID == manifestID && e.SrcKind == relationships.KindManifest && e.Kind == relationships.EdgeOwns {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("no EdgeOwns(manifest=%s → task=%s) row", manifestID, tk.ID)
+	}
+
+	// (b) PRAGMA table_info(tasks) does NOT list manifest_id.
+	rows, err := db.Query(`PRAGMA table_info(tasks)`)
+	if err != nil {
+		t.Fatalf("pragma: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid          int
+			name, ctype  string
+			notnull, pk  int
+			defaultVal   sql.NullString
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &defaultVal, &pk); err != nil {
+			t.Fatalf("scan pragma: %v", err)
+		}
+		if strings.EqualFold(name, "manifest_id") {
+			t.Errorf("tasks still has manifest_id column post-PR/M3")
+		}
+	}
+
+	// Read-back: Get populates ManifestID through the rels lookup.
+	got, err := s.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got == nil || got.ManifestID != manifestID {
+		t.Errorf("Get.ManifestID = %v, want %s", got, manifestID)
+	}
+}

--- a/internal/task/manifest_activation.go
+++ b/internal/task/manifest_activation.go
@@ -5,7 +5,10 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
+
+	"github.com/k8nstantin/OpenPraxis/internal/relationships"
 )
 
 // manifestBlockPrefix is the canonical prefix both Store.Create and
@@ -75,14 +78,39 @@ func (s *Store) FlipManifestBlockedTasks(ctx context.Context, manifestID string,
 	if newStatus == StatusScheduled {
 		nextRunAt = now
 	}
+	// Resolve owned task IDs via relationships (the legacy
+	// tasks.manifest_id column was dropped in PR/M3).
+	if s.rels == nil {
+		return 0, fmt.Errorf("FlipManifestBlockedTasks: relationships backend not wired")
+	}
+	edges, err := s.rels.ListOutgoing(ctx, manifestID, relationships.EdgeOwns)
+	if err != nil {
+		return 0, fmt.Errorf("flip manifest-blocked tasks: list owned tasks: %w", err)
+	}
+	taskIDs := make([]string, 0, len(edges))
+	for _, e := range edges {
+		if e.DstKind == relationships.KindTask {
+			taskIDs = append(taskIDs, e.DstID)
+		}
+	}
+	if len(taskIDs) == 0 {
+		return 0, nil
+	}
+	ph := strings.Repeat("?,", len(taskIDs))
+	ph = ph[:len(ph)-1]
+	args := make([]any, 0, len(taskIDs)+5)
+	args = append(args, string(newStatus), nextRunAt, now)
+	for _, id := range taskIDs {
+		args = append(args, id)
+	}
+	args = append(args, manifestBlockPrefix+"%", legacyManifestBlockPrefix+"%")
 	res, err := s.db.ExecContext(ctx,
 		`UPDATE tasks
 		 SET status = ?, block_reason = '', next_run_at = ?, updated_at = ?
-		 WHERE manifest_id = ? AND status = 'waiting'
+		 WHERE id IN (`+ph+`) AND status = 'waiting'
 		   AND (block_reason LIKE ? OR block_reason LIKE ?)
 		   AND deleted_at = ''`,
-		string(newStatus), nextRunAt, now, manifestID,
-		manifestBlockPrefix+"%", legacyManifestBlockPrefix+"%")
+		args...)
 	if err != nil {
 		return 0, fmt.Errorf("flip manifest-blocked tasks: %w", err)
 	}
@@ -173,14 +201,36 @@ func (s *Store) PropagateManifestClosed(
 }
 
 // CountManifestBlockedTasks returns how many tasks in manifestID are
-// currently 'waiting' with a manifest-level block_reason. Useful for
-// tests + dashboards that want to show "N blocked" without a separate
-// query path.
+// currently 'waiting' with a manifest-level block_reason. Resolves
+// task IDs via the relationships store (PR/M3).
 func (s *Store) CountManifestBlockedTasks(ctx context.Context, manifestID string) (int, error) {
+	if s.rels == nil {
+		return 0, fmt.Errorf("CountManifestBlockedTasks: relationships backend not wired")
+	}
+	edges, err := s.rels.ListOutgoing(ctx, manifestID, relationships.EdgeOwns)
+	if err != nil {
+		return 0, err
+	}
+	taskIDs := make([]string, 0, len(edges))
+	for _, e := range edges {
+		if e.DstKind == relationships.KindTask {
+			taskIDs = append(taskIDs, e.DstID)
+		}
+	}
+	if len(taskIDs) == 0 {
+		return 0, nil
+	}
+	ph := strings.Repeat("?,", len(taskIDs))
+	ph = ph[:len(ph)-1]
+	args := make([]any, 0, len(taskIDs)+1)
+	for _, id := range taskIDs {
+		args = append(args, id)
+	}
+	args = append(args, manifestBlockPrefix+"%")
 	var n int
-	err := s.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM tasks WHERE manifest_id = ? AND status = 'waiting' AND block_reason LIKE ? AND deleted_at = ''`,
-		manifestID, manifestBlockPrefix+"%").Scan(&n)
+	err = s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM tasks WHERE id IN (`+ph+`) AND status = 'waiting' AND block_reason LIKE ? AND deleted_at = ''`,
+		args...).Scan(&n)
 	if err == sql.ErrNoRows {
 		return 0, nil
 	}

--- a/internal/task/metrics.go
+++ b/internal/task/metrics.go
@@ -149,8 +149,10 @@ func (s *Store) CostByPeriod(period string, days int, agent string) ([]CostAggre
 }
 
 // CostDrillDown returns individual task runs for a specific date.
+// ManifestID is resolved via the relationships store after the SELECT
+// (PR/M3 dropped tasks.manifest_id from the schema).
 func (s *Store) CostDrillDown(date string, agent string) ([]CostDrillDownEntry, error) {
-	query := `SELECT r.id, r.task_id, t.title, t.manifest_id, t.agent, r.run_number, r.status, r.actions, r.cost_usd, r.turns, r.started_at, r.completed_at
+	query := `SELECT r.id, r.task_id, t.title, t.agent, r.run_number, r.status, r.actions, r.cost_usd, r.turns, r.started_at, r.completed_at
 		FROM task_runs r LEFT JOIN tasks t ON r.task_id = t.id
 		WHERE strftime('%Y-%m-%d', r.started_at) = ?`
 	args := []any{date}
@@ -166,18 +168,17 @@ func (s *Store) CostDrillDown(date string, agent string) ([]CostDrillDownEntry, 
 	defer rows.Close()
 
 	var results []CostDrillDownEntry
+	taskIDs := []string{}
+	idxByTaskID := map[string][]int{}
 	for rows.Next() {
 		var e CostDrillDownEntry
-		var title, manifestID, agentStr sql.NullString
+		var title, agentStr sql.NullString
 		var startedStr, completedStr string
-		if err := rows.Scan(&e.RunID, &e.TaskID, &title, &manifestID, &agentStr, &e.RunNumber, &e.Status, &e.Actions, &e.CostUSD, &e.Turns, &startedStr, &completedStr); err != nil {
+		if err := rows.Scan(&e.RunID, &e.TaskID, &title, &agentStr, &e.RunNumber, &e.Status, &e.Actions, &e.CostUSD, &e.Turns, &startedStr, &completedStr); err != nil {
 			return nil, err
 		}
 		if title.Valid {
 			e.TaskTitle = title.String
-		}
-		if manifestID.Valid {
-			e.ManifestID = manifestID.String
 		}
 		if agentStr.Valid {
 			e.Agent = agentStr.String
@@ -191,9 +192,31 @@ func (s *Store) CostDrillDown(date string, agent string) ([]CostDrillDownEntry, 
 				e.Duration = int(ct.Sub(st).Seconds())
 			}
 		}
+		idxByTaskID[e.TaskID] = append(idxByTaskID[e.TaskID], len(results))
+		taskIDs = append(taskIDs, e.TaskID)
 		results = append(results, e)
 	}
-	return results, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// Resolve owning manifest per task via relationships.
+	if s.rels != nil && len(taskIDs) > 0 {
+		ctx := context.Background()
+		byTask, err := s.rels.ListIncomingForMany(ctx, taskIDs, relationships.EdgeOwns)
+		if err == nil {
+			for tID, edges := range byTask {
+				for _, e := range edges {
+					if e.SrcKind == relationships.KindManifest {
+						for _, idx := range idxByTaskID[tID] {
+							results[idx].ManifestID = e.SrcID
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+	return results, nil
 }
 
 // DistinctAgents returns the list of distinct agent names that have task runs.
@@ -265,83 +288,64 @@ func (s *Store) GetCostTrendSummary(agent string) (*CostTrendSummary, error) {
 	return &ts, nil
 }
 
-// SumCostSince returns the total cost_usd spent across task_runs whose tasks
-// belong to the given product (via tasks.manifest_id → manifests.project_id)
-// since the supplied timestamp. Used by the runner's daily-budget pre-spawn
-// check: the runtime sums all runs on/after start-of-day UTC and refuses to
-// spawn another when a per-product daily cap has already been hit.
+// SumCostSince returns the total cost_usd spent across task_runs whose
+// tasks belong to the given product since the supplied timestamp.
+// Used by the runner's daily-budget pre-spawn check: the runtime sums
+// all runs on/after start-of-day UTC and refuses to spawn another when
+// a per-product daily cap has already been hit.
 //
-// An empty productID returns 0 — standalone tasks (no manifest/product) have
-// no product-level budget to enforce. This is a feature: the daily-budget
-// knob is defined at product scope and nowhere else in the catalog.
+// Empty productID returns 0 — standalone tasks (no manifest/product)
+// have no product-level budget to enforce. The daily-budget knob is
+// defined at product scope and nowhere else in the catalog.
+//
+// Resolves manifest → task chain via the relationships store. The
+// legacy m.project_id / t.manifest_id JOIN was retired in PR/M3.
 func (s *Store) SumCostSince(productID string, since time.Time) (float64, error) {
 	if productID == "" {
 		return 0, nil
 	}
-	// Resolve manifest → task chain via the relationships store.
-	// Falls back to the legacy m.project_id / t.manifest_id JOINs when
-	// rels backend isn't wired OR when rels has no rows for this
-	// product (test bootstrap path that writes only to legacy
-	// columns).
-	if s.rels != nil {
-		ctx := context.Background()
-		manifestEdges, err := s.rels.ListOutgoing(ctx, productID, relationships.EdgeOwns)
-		if err != nil {
-			return 0, err
-		}
-		manifestIDs := make([]string, 0, len(manifestEdges))
-		for _, e := range manifestEdges {
-			if e.DstKind == relationships.KindManifest {
-				manifestIDs = append(manifestIDs, e.DstID)
-			}
-		}
-		if len(manifestIDs) == 0 {
-			// Empty result — could be (a) genuinely no manifests under
-			// this product, or (b) test fixture that wrote only to
-			// manifests.project_id without the EdgeOwns row. Fall
-			// through to legacy JOIN to disambiguate; legacy returns 0
-			// in case (a) too, so behaviour is identical.
-			goto legacyFallback
-		}
-		taskEdgesByManifest, err := s.rels.ListOutgoingForMany(ctx, manifestIDs, relationships.EdgeOwns)
-		if err != nil {
-			return 0, err
-		}
-		taskIDs := []string{}
-		for _, edges := range taskEdgesByManifest {
-			for _, e := range edges {
-				if e.DstKind == relationships.KindTask {
-					taskIDs = append(taskIDs, e.DstID)
-				}
-			}
-		}
-		if len(taskIDs) == 0 {
-			return 0, nil
-		}
-		ph := strings.Repeat("?,", len(taskIDs))
-		ph = ph[:len(ph)-1]
-		args := make([]any, 0, len(taskIDs)+1)
-		for _, id := range taskIDs {
-			args = append(args, id)
-		}
-		args = append(args, since.UTC().Format(time.RFC3339))
-		var total float64
-		err = s.db.QueryRow(`SELECT COALESCE(SUM(cost_usd), 0)
-			FROM task_runs WHERE task_id IN (`+ph+`) AND started_at >= ?`, args...).Scan(&total)
-		if err != nil {
-			return 0, fmt.Errorf("sum cost since: %w", err)
-		}
-		return total, nil
+	if s.rels == nil {
+		return 0, fmt.Errorf("SumCostSince: relationships backend not wired")
 	}
-legacyFallback:
-	// Legacy fallback.
+	ctx := context.Background()
+	manifestEdges, err := s.rels.ListOutgoing(ctx, productID, relationships.EdgeOwns)
+	if err != nil {
+		return 0, err
+	}
+	manifestIDs := make([]string, 0, len(manifestEdges))
+	for _, e := range manifestEdges {
+		if e.DstKind == relationships.KindManifest {
+			manifestIDs = append(manifestIDs, e.DstID)
+		}
+	}
+	if len(manifestIDs) == 0 {
+		return 0, nil
+	}
+	taskEdgesByManifest, err := s.rels.ListOutgoingForMany(ctx, manifestIDs, relationships.EdgeOwns)
+	if err != nil {
+		return 0, err
+	}
+	taskIDs := []string{}
+	for _, edges := range taskEdgesByManifest {
+		for _, e := range edges {
+			if e.DstKind == relationships.KindTask {
+				taskIDs = append(taskIDs, e.DstID)
+			}
+		}
+	}
+	if len(taskIDs) == 0 {
+		return 0, nil
+	}
+	ph := strings.Repeat("?,", len(taskIDs))
+	ph = ph[:len(ph)-1]
+	args := make([]any, 0, len(taskIDs)+1)
+	for _, id := range taskIDs {
+		args = append(args, id)
+	}
+	args = append(args, since.UTC().Format(time.RFC3339))
 	var total float64
-	err := s.db.QueryRow(`SELECT COALESCE(SUM(tr.cost_usd), 0)
-		FROM task_runs tr
-		JOIN tasks t ON tr.task_id = t.id
-		JOIN manifests m ON t.manifest_id = m.id
-		WHERE m.project_id = ? AND tr.started_at >= ?`,
-		productID, since.UTC().Format(time.RFC3339)).Scan(&total)
+	err = s.db.QueryRow(`SELECT COALESCE(SUM(cost_usd), 0)
+		FROM task_runs WHERE task_id IN (`+ph+`) AND started_at >= ?`, args...).Scan(&total)
 	if err != nil {
 		return 0, fmt.Errorf("sum cost since: %w", err)
 	}

--- a/internal/task/product_activation.go
+++ b/internal/task/product_activation.go
@@ -63,81 +63,56 @@ func (s *Store) FlipProductBlockedTasks(ctx context.Context, productID string, n
 	if newStatus == StatusScheduled {
 		nextRunAt = now
 	}
-	// Resolve manifest → task chain via the relationships store. Falls
-	// back to the legacy m.project_id / t.manifest_id JOIN when rels
-	// isn't wired OR when rels is empty for this product (test
-	// bootstrap path that writes only to legacy columns).
-	if s.rels != nil {
-		manifestEdges, err := s.rels.ListOutgoing(ctx, productID, relationships.EdgeOwns)
-		if err != nil {
-			return 0, fmt.Errorf("flip product-blocked tasks: list manifests: %w", err)
-		}
-		manifestIDs := make([]string, 0, len(manifestEdges))
-		for _, e := range manifestEdges {
-			if e.DstKind == relationships.KindManifest {
-				manifestIDs = append(manifestIDs, e.DstID)
-			}
-		}
-		if len(manifestIDs) == 0 {
-			goto legacyFallback
-		}
-		taskEdgesByManifest, err := s.rels.ListOutgoingForMany(ctx, manifestIDs, relationships.EdgeOwns)
-		if err != nil {
-			return 0, fmt.Errorf("flip product-blocked tasks: list tasks: %w", err)
-		}
-		taskIDs := []string{}
-		for _, edges := range taskEdgesByManifest {
-			for _, e := range edges {
-				if e.DstKind == relationships.KindTask {
-					taskIDs = append(taskIDs, e.DstID)
-				}
-			}
-		}
-		if len(taskIDs) == 0 {
-			goto legacyFallback
-		}
-		ph := strings.Repeat("?,", len(taskIDs))
-		ph = ph[:len(ph)-1]
-		args := make([]any, 0, len(taskIDs)+4)
-		args = append(args, string(newStatus), nextRunAt, now)
-		for _, id := range taskIDs {
-			args = append(args, id)
-		}
-		args = append(args, productBlockPrefix+"%")
-		res, err := s.db.ExecContext(ctx,
-			`UPDATE tasks
-			 SET status = ?, block_reason = '', next_run_at = ?, updated_at = ?
-			 WHERE id IN (`+ph+`)
-			   AND status = 'waiting'
-			   AND block_reason LIKE ?
-			   AND deleted_at = ''`,
-			args...)
-		if err != nil {
-			return 0, fmt.Errorf("flip product-blocked tasks: %w", err)
-		}
-		n, _ := res.RowsAffected()
-		if n > 0 {
-			slog.Info("flipped product-blocked tasks",
-				"component", "task", "product_id", productID,
-				"new_status", newStatus, "count", n)
-		}
-		return int(n), nil
+	// Resolve manifest → task chain via the relationships store. PR/M3
+	// dropped the legacy m.project_id / t.manifest_id JOIN — the
+	// relationships table is now the sole source of truth.
+	if s.rels == nil {
+		return 0, fmt.Errorf("FlipProductBlockedTasks: relationships backend not wired")
 	}
-legacyFallback:
-	// Legacy fallback path.
+	manifestEdges, err := s.rels.ListOutgoing(ctx, productID, relationships.EdgeOwns)
+	if err != nil {
+		return 0, fmt.Errorf("flip product-blocked tasks: list manifests: %w", err)
+	}
+	manifestIDs := make([]string, 0, len(manifestEdges))
+	for _, e := range manifestEdges {
+		if e.DstKind == relationships.KindManifest {
+			manifestIDs = append(manifestIDs, e.DstID)
+		}
+	}
+	if len(manifestIDs) == 0 {
+		return 0, nil
+	}
+	taskEdgesByManifest, err := s.rels.ListOutgoingForMany(ctx, manifestIDs, relationships.EdgeOwns)
+	if err != nil {
+		return 0, fmt.Errorf("flip product-blocked tasks: list tasks: %w", err)
+	}
+	taskIDs := []string{}
+	for _, edges := range taskEdgesByManifest {
+		for _, e := range edges {
+			if e.DstKind == relationships.KindTask {
+				taskIDs = append(taskIDs, e.DstID)
+			}
+		}
+	}
+	if len(taskIDs) == 0 {
+		return 0, nil
+	}
+	ph := strings.Repeat("?,", len(taskIDs))
+	ph = ph[:len(ph)-1]
+	args := make([]any, 0, len(taskIDs)+4)
+	args = append(args, string(newStatus), nextRunAt, now)
+	for _, id := range taskIDs {
+		args = append(args, id)
+	}
+	args = append(args, productBlockPrefix+"%")
 	res, err := s.db.ExecContext(ctx,
 		`UPDATE tasks
 		 SET status = ?, block_reason = '', next_run_at = ?, updated_at = ?
-		 WHERE id IN (
-		   SELECT t.id FROM tasks t
-		   JOIN manifests m ON m.id = t.manifest_id
-		   WHERE m.project_id = ?
-		     AND t.status = 'waiting'
-		     AND t.block_reason LIKE ?
-		     AND t.deleted_at = ''
-		     AND m.deleted_at = ''
-		 )`,
-		string(newStatus), nextRunAt, now, productID, productBlockPrefix+"%")
+		 WHERE id IN (`+ph+`)
+		   AND status = 'waiting'
+		   AND block_reason LIKE ?
+		   AND deleted_at = ''`,
+		args...)
 	if err != nil {
 		return 0, fmt.Errorf("flip product-blocked tasks: %w", err)
 	}

--- a/internal/task/product_activation_test.go
+++ b/internal/task/product_activation_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/k8nstantin/OpenPraxis/internal/relationships"
 )
 
 type fakeProductChecker struct {
@@ -28,25 +30,35 @@ func (f *fakeProductChecker) IsSatisfied(_ context.Context, productID string) (b
 	return true, nil, nil
 }
 
-// seedManifestForProduct inserts a minimal manifest row. task.Create's
-// product lookup joins manifests.project_id; internal/manifest import
-// from tests here would produce a cycle, so raw SQL it is.
+// seedManifestForProduct creates a minimal manifests row + the
+// EdgeOwns(product → manifest) edge in the relationships store.
+// PR/M3 dropped the legacy manifests.project_id column; ownership now
+// lives exclusively in `relationships`.
 func seedManifestForProduct(t *testing.T, s *Store, manifestID, productID string) {
 	t.Helper()
 	if _, err := s.db.Exec(`CREATE TABLE IF NOT EXISTS manifests (
 		id TEXT PRIMARY KEY, title TEXT, description TEXT, content TEXT,
 		status TEXT, jira_refs TEXT, tags TEXT, author TEXT, source_node TEXT,
-		project_id TEXT, depends_on TEXT, version INT, created_at TEXT,
+		depends_on TEXT, version INT, created_at TEXT,
 		updated_at TEXT, deleted_at TEXT DEFAULT ''
 	)`); err != nil {
 		t.Fatalf("create manifests fixture: %v", err)
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
 	if _, err := s.db.Exec(`INSERT OR REPLACE INTO manifests
-		(id, title, description, content, status, jira_refs, tags, author, source_node, project_id, depends_on, version, created_at, updated_at, deleted_at)
-		VALUES (?, 'm', '', '', 'open', '[]', '[]', 't', '', ?, '', 1, ?, ?, '')`,
-		manifestID, productID, now, now); err != nil {
+		(id, title, description, content, status, jira_refs, tags, author, source_node, depends_on, version, created_at, updated_at, deleted_at)
+		VALUES (?, 'm', '', '', 'open', '[]', '[]', 't', '', '', 1, ?, ?, '')`,
+		manifestID, now, now); err != nil {
 		t.Fatalf("seed manifest row: %v", err)
+	}
+	if s.rels != nil {
+		if err := s.rels.Create(context.Background(), relationships.Edge{
+			SrcKind: relationships.KindProduct, SrcID: productID,
+			DstKind: relationships.KindManifest, DstID: manifestID,
+			Kind: relationships.EdgeOwns, CreatedBy: "test", Reason: "test fixture",
+		}); err != nil {
+			t.Fatalf("seed owns edge: %v", err)
+		}
 	}
 }
 

--- a/internal/task/rc_m5_test.go
+++ b/internal/task/rc_m5_test.go
@@ -13,12 +13,14 @@ import (
 
 // insertRunningTask seeds a task row directly in the running status so
 // RecoverInFlight has something to classify. Bypasses Store.Create
-// because that path forces status='pending'.
+// because that path forces status='pending'. PR/M3 dropped the legacy
+// manifest_id column from tasks; ownership wiring lives in the
+// relationships store now.
 func insertRunningTask(t *testing.T, db *sql.DB, taskID string) {
 	t.Helper()
 	now := time.Now().UTC().Format(time.RFC3339)
-	_, err := db.Exec(`INSERT INTO tasks (id, manifest_id, title, description, schedule, status, agent, source_node, created_by, created_at, updated_at)
-		VALUES (?, '', 'orphan', '', 'once', 'running', 'claude-code', '', 'test', ?, ?)`,
+	_, err := db.Exec(`INSERT INTO tasks (id, title, description, schedule, status, agent, source_node, created_by, created_at, updated_at)
+		VALUES (?, 'orphan', '', 'once', 'running', 'claude-code', '', 'test', ?, ?)`,
 		taskID, now, now)
 	if err != nil {
 		t.Fatalf("insert running task: %v", err)

--- a/internal/task/repository.go
+++ b/internal/task/repository.go
@@ -102,13 +102,20 @@ func (s *Store) Create(manifestID, title, description, schedule, agent, sourceNo
 	// innermost blocker is named in block_reason; outer checks re-run
 	// at activation time as inner blockers clear.
 	//
-	// productID is derived from manifests.project_id. Kept as a local
-	// SELECT rather than a dedicated cross-package store method so the
-	// task package doesn't need to import product.
-	if initialStatus == StatusPending && manifestID != "" && s.productChecker != nil {
+	// productID is resolved through the relationships store. The
+	// legacy `manifests.project_id` column was dropped in PR/M3 — we
+	// look up the manifest's parent product via ListIncoming(EdgeOwns)
+	// instead.
+	if initialStatus == StatusPending && manifestID != "" && s.productChecker != nil && s.rels != nil {
 		var productID string
-		_ = s.db.QueryRow(`SELECT project_id FROM manifests WHERE id = ? AND deleted_at = ''`,
-			manifestID).Scan(&productID)
+		if edges, err := s.rels.ListIncoming(context.Background(), manifestID, relationships.EdgeOwns); err == nil {
+			for _, e := range edges {
+				if e.SrcKind == relationships.KindProduct {
+					productID = e.SrcID
+					break
+				}
+			}
+		}
 		if productID != "" {
 			ok, unsatisfied, err := s.productChecker.IsSatisfied(context.Background(), productID)
 			if err == nil && !ok {
@@ -119,20 +126,18 @@ func (s *Store) Create(manifestID, title, description, schedule, agent, sourceNo
 		}
 	}
 
-	_, err := s.db.Exec(`INSERT INTO tasks (id, manifest_id, title, description, schedule, status, agent, source_node, created_by, depends_on, block_reason, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		id, manifestID, title, description, schedule, string(initialStatus), agent, sourceNode, createdBy, dependsOn, blockReason,
+	_, err := s.db.Exec(`INSERT INTO tasks (id, title, description, schedule, status, agent, source_node, created_by, depends_on, block_reason, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, title, description, schedule, string(initialStatus), agent, sourceNode, createdBy, dependsOn, blockReason,
 		now.Format(time.RFC3339), now.Format(time.RFC3339))
 	if err != nil {
 		return nil, err
 	}
 
-	// Ownership wiring: write the canonical EdgeOwns(manifest → task)
-	// row into the relationships SCD-2 table. The DAG endpoint walks
-	// relationships only — without this row the new task is invisible
-	// in the manifest's graph view. The legacy manifest_id column is
-	// also populated (above) for the readers still hitting it; column
-	// drop is a follow-up.
+	// Ownership wiring (PR/M3): the EdgeOwns(manifest → task) row IS
+	// the canonical ownership record. The legacy manifest_id column
+	// was dropped in this PR — every reader that needs the parent
+	// looks it up via relationships.ListIncoming.
 	if manifestID != "" && s.rels != nil {
 		if err := s.rels.Create(context.Background(), relationships.Edge{
 			SrcKind:   relationships.KindManifest,
@@ -189,26 +194,61 @@ func (s *Store) Get(id string) (*Task, error) {
 	row := s.db.QueryRow(`SELECT `+taskColumns+` FROM tasks WHERE id = ? AND deleted_at = ''`, id)
 	t, err := scanTask(row)
 	if err == nil && t != nil {
+		s.populateOwnership([]*Task{t})
 		s.enrichWithCosts([]*Task{t})
 	}
 	return t, err
 }
 
-// ListByManifest returns tasks for a manifest.
+// ListByManifest returns tasks owned by a manifest. Reads ownership
+// from the relationships store (legacy tasks.manifest_id column was
+// dropped in PR/M3).
 func (s *Store) ListByManifest(manifestID string, limit int) ([]*Task, error) {
 	if limit <= 0 {
 		limit = 50
 	}
-	rows, err := s.db.Query(`SELECT `+taskColumns+` FROM tasks WHERE manifest_id = ? AND deleted_at = '' ORDER BY created_at DESC LIMIT ?`, manifestID, limit)
+	if s.rels == nil {
+		return nil, fmt.Errorf("task.ListByManifest: relationships backend not wired")
+	}
+	ctx := context.Background()
+	edges, err := s.rels.ListOutgoing(ctx, manifestID, relationships.EdgeOwns)
+	if err != nil {
+		return nil, err
+	}
+	taskIDs := make([]string, 0, len(edges))
+	for _, e := range edges {
+		if e.DstKind == relationships.KindTask {
+			taskIDs = append(taskIDs, e.DstID)
+		}
+	}
+	if len(taskIDs) == 0 {
+		return nil, nil
+	}
+	placeholders := strings.Repeat("?,", len(taskIDs))
+	placeholders = placeholders[:len(placeholders)-1]
+	args := make([]any, 0, len(taskIDs)+1)
+	for _, id := range taskIDs {
+		args = append(args, id)
+	}
+	args = append(args, limit)
+	rows, err := s.db.Query(`SELECT `+taskColumns+`
+		FROM tasks WHERE id IN (`+placeholders+`) AND deleted_at = ''
+		ORDER BY created_at DESC LIMIT ?`, args...)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 	tasks, err := scanTasks(rows)
-	if err == nil {
-		s.enrichWithCosts(tasks)
+	if err != nil {
+		return nil, err
 	}
-	return tasks, err
+	// Caller already knows the manifest — short-circuit the rels
+	// lookup that populateOwnership would otherwise do.
+	for _, t := range tasks {
+		t.ManifestID = manifestID
+	}
+	s.enrichWithCosts(tasks)
+	return tasks, nil
 }
 
 // List returns all tasks.
@@ -247,6 +287,7 @@ func (s *Store) List(status string, limit int) ([]*Task, error) {
 	defer rows.Close()
 	tasks, err := scanTasks(rows)
 	if err == nil {
+		s.populateOwnership(tasks)
 		s.enrichWithCosts(tasks)
 	}
 	return tasks, err
@@ -285,17 +326,48 @@ func (s *Store) Update(id string, title, description *string) (*Task, error) {
 	return s.Get(id)
 }
 
-// SetManifest swaps a task's primary manifest_id. Used to re-home a task
+// SetManifest swaps a task's primary manifest. Used to re-home a task
 // when an operator splits / restructures manifests after the task was
-// originally created. Returns the task as it stands after the update.
+// originally created. Post-PR/M3 the canonical manifest pointer is the
+// EdgeOwns(manifest → task) row in the relationships store; this
+// closes the prior edge (if any) and opens a new one.
+//
+// Returns the task as it stands after the update.
 func (s *Store) SetManifest(taskID, manifestID string) (*Task, error) {
+	if s.rels == nil {
+		return nil, fmt.Errorf("set manifest: relationships backend not wired")
+	}
+	ctx := context.Background()
+	prior := s.lookupOwner(ctx, taskID)
+	if prior != manifestID {
+		if prior != "" {
+			if err := s.rels.Remove(ctx, prior, taskID, relationships.EdgeOwns,
+				"task.Store.SetManifest", "task reparented"); err != nil {
+				return nil, fmt.Errorf("set manifest: close prior owner: %w", err)
+			}
+		}
+		if manifestID != "" {
+			if err := s.rels.Create(ctx, relationships.Edge{
+				SrcKind:   relationships.KindManifest,
+				SrcID:     manifestID,
+				DstKind:   relationships.KindTask,
+				DstID:     taskID,
+				Kind:      relationships.EdgeOwns,
+				CreatedBy: "task.Store.SetManifest",
+				Reason:    "task reparented",
+			}); err != nil {
+				return nil, fmt.Errorf("set manifest: open new owner: %w", err)
+			}
+		}
+	}
+	// Bump updated_at so list sorts move the task to the top after a
+	// re-home, mirroring pre-M3 behaviour.
 	now := time.Now().UTC().Format(time.RFC3339)
-	_, err := s.db.Exec(
-		"UPDATE tasks SET manifest_id = ?, updated_at = ? WHERE id = ? AND deleted_at = ''",
-		manifestID, now, taskID,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("set manifest: %w", err)
+	if _, err := s.db.Exec(
+		"UPDATE tasks SET updated_at = ? WHERE id = ? AND deleted_at = ''",
+		now, taskID,
+	); err != nil {
+		return nil, fmt.Errorf("set manifest: bump updated_at: %w", err)
 	}
 	return s.Get(taskID)
 }
@@ -339,7 +411,12 @@ func (s *Store) ListDeleted(limit int) ([]*Task, error) {
 		return nil, err
 	}
 	defer rows.Close()
-	return scanTasks(rows)
+	tasks, err := scanTasks(rows)
+	if err != nil {
+		return nil, err
+	}
+	s.populateOwnership(tasks)
+	return tasks, nil
 }
 
 // Restore un-deletes a soft-deleted task.
@@ -1009,7 +1086,7 @@ func (s *Store) ListTasksByLinkedManifest(manifestID string, limit int) ([]*Task
 	if limit <= 0 {
 		limit = 50
 	}
-	rows, err := s.db.Query(`SELECT t.id, t.manifest_id, t.title, t.description, t.schedule, t.status, t.agent, t.source_node, t.created_by, t.depends_on, t.block_reason, t.run_count, t.last_run_at, t.next_run_at, t.last_output, t.created_at, t.updated_at
+	rows, err := s.db.Query(`SELECT t.id, t.title, t.description, t.schedule, t.status, t.agent, t.source_node, t.created_by, t.depends_on, t.block_reason, t.run_count, t.last_run_at, t.next_run_at, t.last_output, t.created_at, t.updated_at
 		FROM tasks t JOIN task_manifests tm ON t.id = tm.task_id
 		WHERE tm.manifest_id = ? AND t.deleted_at = '' ORDER BY t.created_at DESC LIMIT ?`, manifestID, limit)
 	if err != nil {
@@ -1018,6 +1095,7 @@ func (s *Store) ListTasksByLinkedManifest(manifestID string, limit int) ([]*Task
 	defer rows.Close()
 	tasks, err := scanTasks(rows)
 	if err == nil {
+		s.populateOwnership(tasks)
 		s.enrichWithCosts(tasks)
 	}
 	return tasks, err

--- a/internal/task/runner_test.go
+++ b/internal/task/runner_test.go
@@ -12,6 +12,7 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 
+	"github.com/k8nstantin/OpenPraxis/internal/relationships"
 	"github.com/k8nstantin/OpenPraxis/internal/settings"
 )
 
@@ -273,37 +274,50 @@ func recordPastRun(t *testing.T, db *sql.DB, taskID string, costUSD float64, sta
 	}
 }
 
-// insertTaskRow creates a real tasks row so the manifest join in SumCostSince
-// returns the product_id. The fake task/manifest lookups used for the
-// resolver cannot satisfy the SQL join — we need actual DB state here.
+// insertTaskRow creates a real tasks row + the EdgeOwns(manifest →
+// task) row that ownership-aware queries (SumCostSince, etc.) join
+// against. PR/M3 dropped the legacy tasks.manifest_id column; tests
+// must wire ownership through the relationships store now.
 func insertTaskRow(t *testing.T, db *sql.DB, taskID, manifestID string) {
 	t.Helper()
 	now := time.Now().UTC().Format(time.RFC3339)
-	_, err := db.Exec(`INSERT INTO tasks (id, manifest_id, title, description, schedule, status, agent, source_node, created_by, created_at, updated_at)
-		VALUES (?, ?, 'test task', '', 'once', 'pending', 'claude-code', '', 'test', ?, ?)`,
-		taskID, manifestID, now, now)
+	_, err := db.Exec(`INSERT INTO tasks (id, title, description, schedule, status, agent, source_node, created_by, created_at, updated_at)
+		VALUES (?, 'test task', '', 'once', 'pending', 'claude-code', '', 'test', ?, ?)`,
+		taskID, now, now)
 	if err != nil {
 		t.Fatalf("insert task: %v", err)
 	}
+	if manifestID != "" {
+		rels, err := relationships.New(db)
+		if err != nil {
+			t.Fatalf("init rels for owns edge: %v", err)
+		}
+		if err := rels.Create(context.Background(), relationships.Edge{
+			SrcKind: relationships.KindManifest, SrcID: manifestID,
+			DstKind: relationships.KindTask, DstID: taskID,
+			Kind: relationships.EdgeOwns, CreatedBy: "test", Reason: "test fixture",
+		}); err != nil {
+			t.Fatalf("write owns edge: %v", err)
+		}
+	}
 }
 
-// insertManifestRow creates a real manifests row tying manifest_id to
-// project_id (the settings package calls this ProductID). Required for the
-// daily-budget JOIN in SumCostSince.
+// insertManifestRow creates an EdgeOwns(product → manifest) row in the
+// relationships store. The legacy manifests.project_id column was
+// dropped in PR/M3; ownership-aware joins (SumCostSince, etc.) read
+// from relationships.
 func insertManifestRow(t *testing.T, db *sql.DB, manifestID, productID string) {
 	t.Helper()
-	// The manifests table is created by manifest.NewStore; the runner test
-	// DB does not wire that up. Create the minimal shape SumCostSince needs.
-	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS manifests (
-		id TEXT PRIMARY KEY,
-		project_id TEXT NOT NULL DEFAULT ''
-	)`)
+	rels, err := relationships.New(db)
 	if err != nil {
-		t.Fatalf("create manifests table: %v", err)
+		t.Fatalf("init rels: %v", err)
 	}
-	_, err = db.Exec(`INSERT OR REPLACE INTO manifests (id, project_id) VALUES (?, ?)`, manifestID, productID)
-	if err != nil {
-		t.Fatalf("insert manifest: %v", err)
+	if err := rels.Create(context.Background(), relationships.Edge{
+		SrcKind: relationships.KindProduct, SrcID: productID,
+		DstKind: relationships.KindManifest, DstID: manifestID,
+		Kind: relationships.EdgeOwns, CreatedBy: "test", Reason: "test fixture",
+	}); err != nil {
+		t.Fatalf("write owns edge: %v", err)
 	}
 }
 

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"time"
@@ -144,9 +145,12 @@ func NewStore(db *sql.DB) (*Store, error) {
 func (s *Store) DB() *sql.DB { return s.db }
 
 func (s *Store) init() error {
+	// Schema after PR/M3: ownership lives in `relationships` (EdgeOwns
+	// manifest → task). The legacy `manifest_id` column is no longer
+	// part of CREATE TABLE; existing DBs get it dropped by
+	// relationships.DropOwnershipColumns at boot.
 	_, err := s.db.Exec(`CREATE TABLE IF NOT EXISTS tasks (
 		id TEXT PRIMARY KEY,
-		manifest_id TEXT NOT NULL DEFAULT '',
 		title TEXT NOT NULL,
 		description TEXT NOT NULL DEFAULT '',
 		schedule TEXT NOT NULL DEFAULT 'once',
@@ -164,11 +168,6 @@ func (s *Store) init() error {
 	)`)
 	if err != nil {
 		return fmt.Errorf("create tasks table: %w", err)
-	}
-
-	_, err = s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_tasks_manifest ON tasks(manifest_id)`)
-	if err != nil {
-		return fmt.Errorf("create tasks manifest index: %w", err)
 	}
 
 	_, err = s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)`)
@@ -425,12 +424,14 @@ func (s *Store) init() error {
 }
 
 // taskColumns is the standard column list for task SELECT queries.
-const taskColumns = `id, manifest_id, title, description, schedule, status, agent, source_node, created_by, depends_on, block_reason, run_count, last_run_at, next_run_at, last_output, created_at, updated_at`
+// PR/M3 dropped manifest_id; Task.ManifestID is now populated post-scan
+// via populateOwnership using the relationships store.
+const taskColumns = `id, title, description, schedule, status, agent, source_node, created_by, depends_on, block_reason, run_count, last_run_at, next_run_at, last_output, created_at, updated_at`
 
 func scanTask(row *sql.Row) (*Task, error) {
 	var t Task
 	var createdStr, updatedStr string
-	err := row.Scan(&t.ID, &t.ManifestID, &t.Title, &t.Description, &t.Schedule, &t.Status, &t.Agent, &t.SourceNode, &t.CreatedBy,
+	err := row.Scan(&t.ID, &t.Title, &t.Description, &t.Schedule, &t.Status, &t.Agent, &t.SourceNode, &t.CreatedBy,
 		&t.DependsOn, &t.BlockReason, &t.RunCount, &t.LastRunAt, &t.NextRunAt, &t.LastOutput, &createdStr, &updatedStr)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -448,7 +449,7 @@ func scanTasks(rows *sql.Rows) ([]*Task, error) {
 	for rows.Next() {
 		var t Task
 		var createdStr, updatedStr string
-		err := rows.Scan(&t.ID, &t.ManifestID, &t.Title, &t.Description, &t.Schedule, &t.Status, &t.Agent, &t.SourceNode, &t.CreatedBy,
+		err := rows.Scan(&t.ID, &t.Title, &t.Description, &t.Schedule, &t.Status, &t.Agent, &t.SourceNode, &t.CreatedBy,
 			&t.DependsOn, &t.BlockReason, &t.RunCount, &t.LastRunAt, &t.NextRunAt, &t.LastOutput, &createdStr, &updatedStr)
 		if err != nil {
 			return nil, err
@@ -458,6 +459,62 @@ func scanTasks(rows *sql.Rows) ([]*Task, error) {
 		tasks = append(tasks, &t)
 	}
 	return tasks, rows.Err()
+}
+
+// populateOwnership fills Task.ManifestID via the relationships store
+// using a single batched ListIncomingForMany call. Used by every read
+// path so Task consumers continue to see ManifestID populated even
+// though the column was dropped in PR/M3.
+func (s *Store) populateOwnership(tasks []*Task) {
+	if s.rels == nil || len(tasks) == 0 {
+		return
+	}
+	ctx := context.Background()
+	ids := make([]string, 0, len(tasks))
+	mapByID := make(map[string]*Task, len(tasks))
+	for _, t := range tasks {
+		if t == nil {
+			continue
+		}
+		ids = append(ids, t.ID)
+		mapByID[t.ID] = t
+	}
+	if len(ids) == 0 {
+		return
+	}
+	byDst, err := s.rels.ListIncomingForMany(ctx, ids, relationships.EdgeOwns)
+	if err != nil {
+		return
+	}
+	for tid, edges := range byDst {
+		t, ok := mapByID[tid]
+		if !ok {
+			continue
+		}
+		for _, e := range edges {
+			if e.SrcKind == relationships.KindManifest {
+				t.ManifestID = e.SrcID
+				break
+			}
+		}
+	}
+}
+
+// lookupOwner returns the current manifest owner of a task (or "").
+func (s *Store) lookupOwner(ctx context.Context, taskID string) string {
+	if s.rels == nil {
+		return ""
+	}
+	edges, err := s.rels.ListIncoming(ctx, taskID, relationships.EdgeOwns)
+	if err != nil {
+		return ""
+	}
+	for _, e := range edges {
+		if e.SrcKind == relationships.KindManifest {
+			return e.SrcID
+		}
+	}
+	return ""
 }
 
 // taskRunsColumns is the canonical column list for task_runs SELECTs.

--- a/internal/web/handlers_stats.go
+++ b/internal/web/handlers_stats.go
@@ -1,14 +1,87 @@
 package web
 
 import (
+	"context"
 	"database/sql"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/k8nstantin/OpenPraxis/internal/node"
+	"github.com/k8nstantin/OpenPraxis/internal/relationships"
 	"github.com/k8nstantin/OpenPraxis/internal/task"
 )
+
+// taskIDsForManifest returns every task owned by manifestID, sourced
+// from the relationships SCD-2 store.
+func taskIDsForManifest(n *node.Node, manifestID string) ([]string, error) {
+	if n == nil || n.Relationships == nil {
+		return nil, nil
+	}
+	edges, err := n.Relationships.ListOutgoing(context.Background(), manifestID, relationships.EdgeOwns)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(edges))
+	for _, e := range edges {
+		if e.DstKind == relationships.KindTask {
+			ids = append(ids, e.DstID)
+		}
+	}
+	return ids, nil
+}
+
+// taskIDsForProduct walks the product DAG (umbrella + sub-products via
+// EdgeDependsOn) then gathers every owned manifest + every owned task
+// purely through the relationships store.
+func taskIDsForProduct(n *node.Node, productID string) ([]string, error) {
+	if n == nil || n.Relationships == nil {
+		return nil, nil
+	}
+	ctx := context.Background()
+	walkRows, err := n.Relationships.Walk(ctx, productID, relationships.KindProduct,
+		[]string{relationships.EdgeDependsOn}, relationships.MaxWalkDepth)
+	if err != nil {
+		return nil, err
+	}
+	productIDs := make([]string, 0, len(walkRows))
+	for _, r := range walkRows {
+		if r.Kind == relationships.KindProduct {
+			productIDs = append(productIDs, r.ID)
+		}
+	}
+	if len(productIDs) == 0 {
+		return nil, nil
+	}
+	manifestEdges, err := n.Relationships.ListOutgoingForMany(ctx, productIDs, relationships.EdgeOwns)
+	if err != nil {
+		return nil, err
+	}
+	manifestIDs := make([]string, 0, 16)
+	for _, edges := range manifestEdges {
+		for _, e := range edges {
+			if e.DstKind == relationships.KindManifest {
+				manifestIDs = append(manifestIDs, e.DstID)
+			}
+		}
+	}
+	if len(manifestIDs) == 0 {
+		return nil, nil
+	}
+	taskEdges, err := n.Relationships.ListOutgoingForMany(ctx, manifestIDs, relationships.EdgeOwns)
+	if err != nil {
+		return nil, err
+	}
+	taskIDs := make([]string, 0, 16)
+	for _, edges := range taskEdges {
+		for _, e := range edges {
+			if e.DstKind == relationships.KindTask {
+				taskIDs = append(taskIDs, e.DstID)
+			}
+		}
+	}
+	return taskIDs, nil
+}
 
 // GET /api/run-stats?entity_kind=...&entity_id=...&as_of=<rfc3339>
 //
@@ -51,7 +124,8 @@ func apiRunStats(n *node.Node) http.HandlerFunc {
 		}
 
 		db := n.Tasks.DB()
-		runs, err := selectRunsForEntity(db, kind, entityID, asOfClause, asOfStr, args)
+		_ = args // kept for future extension; unused after PR/M3 cleanup
+		runs, err := selectRunsForEntity(n, db, kind, entityID, asOfClause, asOfStr)
 		if err != nil {
 			writeError(w, err.Error(), 500)
 			return
@@ -76,60 +150,65 @@ func apiRunStats(n *node.Node) http.HandlerFunc {
 	}
 }
 
-// selectRunsForEntity returns task_runs scoped to the entity. Walks the
-// product DAG when kind=product so a parent product's stats include all
-// descendants — mirrors the existing EnrichRecursiveCosts walk.
-func selectRunsForEntity(db *sql.DB, kind, entityID, asOfClause, asOfStr string, _ []any) ([]task.TaskRun, error) {
+// selectRunsForEntity returns task_runs scoped to the entity. Resolves
+// the manifest/product cases through the relationships store (PR/M3
+// dropped tasks.manifest_id and manifests.project_id from the schema).
+func selectRunsForEntity(n *node.Node, db *sql.DB, kind, entityID, asOfClause, asOfStr string) ([]task.TaskRun, error) {
 	cols := taskRunColumnsForSelect("tr")
 
-	var (
-		query string
-		args  []any
-	)
 	switch kind {
 	case "task":
-		query = `SELECT ` + cols + ` FROM task_runs tr WHERE tr.task_id = ?` + asOfClause + ` ORDER BY tr.started_at DESC LIMIT 500`
-		args = append(args, entityID)
+		query := `SELECT ` + cols + ` FROM task_runs tr WHERE tr.task_id = ?` + asOfClause + ` ORDER BY tr.started_at DESC LIMIT 500`
+		args := []any{entityID}
 		if asOfStr != "" {
 			args = append(args, asOfStr)
 		}
+		rows, err := db.Query(query, args...)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		return scanTaskRunsRows(rows)
 	case "manifest":
-		query = `SELECT ` + cols + ` FROM task_runs tr
-			INNER JOIN tasks t ON t.id = tr.task_id AND t.deleted_at = ''
-			WHERE t.manifest_id = ?` + asOfClause + ` ORDER BY tr.started_at DESC LIMIT 500`
-		args = append(args, entityID)
-		if asOfStr != "" {
-			args = append(args, asOfStr)
+		taskIDs, err := taskIDsForManifest(n, entityID)
+		if err != nil || len(taskIDs) == 0 {
+			return []task.TaskRun{}, err
 		}
+		return runsByTaskIDs(db, cols, taskIDs, asOfClause, asOfStr)
 	case "product":
-		// Mirror product.Store.EnrichRecursiveCosts — recursive descend
-		// into descendant products via product_dependencies, then sum
-		// task_runs under any descendant's manifests.
-		query = `WITH RECURSIVE descendants(id) AS (
-				SELECT ?
-				UNION ALL
-				SELECT pd.depends_on_product_id FROM product_dependencies pd
-				INNER JOIN descendants d ON pd.product_id = d.id
-			)
-			SELECT ` + cols + ` FROM task_runs tr
-			INNER JOIN tasks t ON t.id = tr.task_id AND t.deleted_at = ''
-			INNER JOIN manifests m ON m.id = t.manifest_id AND m.deleted_at = ''
-			INNER JOIN descendants d ON d.id = m.project_id
-			WHERE 1=1` + asOfClause + ` ORDER BY tr.started_at DESC LIMIT 500`
-		args = append(args, entityID)
-		if asOfStr != "" {
-			args = append(args, asOfStr)
+		// Walk the product DAG (umbrella → sub-products) via
+		// EdgeDependsOn and gather every owned manifest, then every
+		// owned task, then run the same task_runs aggregate as the
+		// task case.
+		taskIDs, err := taskIDsForProduct(n, entityID)
+		if err != nil || len(taskIDs) == 0 {
+			return []task.TaskRun{}, err
 		}
+		return runsByTaskIDs(db, cols, taskIDs, asOfClause, asOfStr)
 	default:
 		return nil, errBadKind(kind)
 	}
+}
 
-	rows, err := db.Query(query, args...)
+func runsByTaskIDs(db *sql.DB, cols string, taskIDs []string, asOfClause, asOfStr string) ([]task.TaskRun, error) {
+	if len(taskIDs) == 0 {
+		return []task.TaskRun{}, nil
+	}
+	ph := strings.Repeat("?,", len(taskIDs))
+	ph = ph[:len(ph)-1]
+	args := make([]any, 0, len(taskIDs)+1)
+	for _, id := range taskIDs {
+		args = append(args, id)
+	}
+	if asOfStr != "" {
+		args = append(args, asOfStr)
+	}
+	q := `SELECT ` + cols + ` FROM task_runs tr WHERE tr.task_id IN (` + ph + `)` + asOfClause + ` ORDER BY tr.started_at DESC LIMIT 500`
+	rows, err := db.Query(q, args...)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-
 	return scanTaskRunsRows(rows)
 }
 

--- a/internal/web/handlers_task.go
+++ b/internal/web/handlers_task.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/k8nstantin/OpenPraxis/internal/comments"
 	"github.com/k8nstantin/OpenPraxis/internal/node"
+	"github.com/k8nstantin/OpenPraxis/internal/relationships"
 	"github.com/k8nstantin/OpenPraxis/internal/task"
 
 	"github.com/gorilla/mux"
@@ -585,8 +587,16 @@ func apiRunningTasksLive(n *node.Node) http.HandlerFunc {
 				lt.StartedAt = r.startedAt.UTC().Format(time.RFC3339)
 				lt.ElapsedSec = int(now.Sub(r.startedAt).Seconds())
 			}
-			if lt.ManifestID == "" {
-				_ = db.QueryRow(`SELECT manifest_id FROM tasks WHERE id = ?`, r.id).Scan(&lt.ManifestID)
+			if lt.ManifestID == "" && n.Relationships != nil {
+				edges, err := n.Relationships.ListIncoming(context.Background(), r.id, relationships.EdgeOwns)
+				if err == nil {
+					for _, e := range edges {
+						if e.SrcKind == relationships.KindManifest {
+							lt.ManifestID = e.SrcID
+							break
+						}
+					}
+				}
 			}
 
 			// task_runs row for the live run (one is created at run start


### PR DESCRIPTION
## Summary
- Closes the M2 dual-write loop: `relationships` is now the sole source of truth for `EdgeOwns(product → manifest)` and `EdgeOwns(manifest → task)`.
- Drops legacy ownership columns `manifests.project_id` and `tasks.manifest_id` via SQLite-portable rename-table migration.
- Removes every `legacyFallback` read branch across manifest, product, task, and web handlers.

## Verification

`go build ./...` — exits 0.

`go test ./...` — all packages `ok`:
```
ok  internal/action       internal/comments    internal/idea
ok  internal/manifest     internal/mcp         internal/memory
ok  internal/node         internal/product     internal/relationships
ok  internal/render       internal/settings    internal/task
ok  internal/templates    internal/watcher     internal/web
```

`git grep -nE 'manifests\.project_id|tasks\.manifest_id' -- internal/**/*.go` — only comments + migration string literals remain (zero code references).

`git grep -nE 'legacyFallback|legacy fallback|goto legacyFallback' -- internal/**/*.go` — zero hits.

Schema check via `TestDropOwnershipColumns_*` confirms `PRAGMA table_info(manifests)` no longer lists `project_id` and `PRAGMA table_info(tasks)` no longer lists `manifest_id` after the boot migration.

## Test plan
- [x] Unit + integration suite green (`go test ./...`)
- [x] New regression tests:
  - [x] `relationships.TestDropOwnershipColumns_DropsManifestProjectID`
  - [x] `relationships.TestDropOwnershipColumns_DropsTaskManifestID`
  - [x] `relationships.TestDropOwnershipColumns_Idempotent`
  - [x] `relationships.TestBackfillOwnershipEdges_Idempotent`
  - [x] `manifest.TestManifestCreate_WritesEdgeOwnsOnly`
  - [x] `task.TestTaskCreate_WritesEdgeOwnsOnly`
- [ ] **Operator action required before merge:** back up `~/openloom-serve/memories.db` once. The migration is wrapped in a transaction (rollback-safe) but it is the first time it runs on real data — see "Migration unverified" in the task's execution_review comment.
- [ ] Post-merge: rebuild + restart serve from `~/openloom-serve` per visceral rule 15. The migration is idempotent; subsequent boots are no-ops.

## Self-summary
The full self_summary block lives on the final commit (`5749345`) and on the task's execution_review comment. Highlights:

1. Backfill counts on dev DB: zero pre-existing orphans (CI uses ephemeral SQLite). The idempotent test seeds 1 manifest + 1 task, confirms first call inserts ≥ 2 EdgeOwns rows, second call inserts 0.
2. Surprises: `task.Store.SetManifest` now serialises through the relationships writer mutex — was a single SQL UPDATE before. `selectRunsForEntity(kind=product)` swapped the legacy recursive CTE for a `relationships.Walk(EdgeDependsOn)` + batched `ListOutgoingForMany`.
3. Translated test fixtures: `runner_test.insertManifestRow`/`insertTaskRow`, `rc_m5_test.insertRunningTask`, `product_activation_test.seedManifestForProduct`. None resisted translation.
4. Migration unverified end-to-end on real production data — only ephemeral SQLite under `go test`. Operator boot is the first prod exercise.
5. Row-count diff in `relationships`: starts at 0 in CI, +N after backfill where N = test-seeded rows. Idempotency proven by second-call delta = 0.
6. Out of scope (deliberate): `tasks.depends_on` cache column, legacy dep tables (`product_dependencies` etc.), frontend / Portal V2 changes, `idea.project_id` (separate concept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)