### PR TITLE
fix(task/list): never-run tasks must sort above completed ones

### DIFF
--- a/internal/task/repository.go
+++ b/internal/task/repository.go
@@ -269,12 +269,12 @@ func (s *Store) List(status string, limit int) ([]*Task, error) {
 		query += ` AND status = ?`
 		args = append(args, status)
 	}
-	// Sort: most-recently-executed first, tiebreak by created_at DESC.
-	// Running tasks naturally bubble to the top because their last_run_at
-	// is the most recent (set when the task fired). Never-run tasks have
-	// last_run_at='' which sorts last under DESC, then their created_at
-	// DESC ranks newest creations above older ones.
-	query += ` ORDER BY last_run_at DESC, created_at DESC`
+	// Sort: most-recent activity first. For never-run tasks, "activity"
+	// is the create event — collapse to created_at via COALESCE/NULLIF
+	// so a freshly-created task sorts above completed tasks that finished
+	// hours ago. Tiebreak on created_at DESC for two rows with identical
+	// last_run_at (rare but possible with sub-second creates).
+	query += ` ORDER BY COALESCE(NULLIF(last_run_at,''), created_at) DESC, created_at DESC`
 	if limit > 0 {
 		query += ` LIMIT ?`
 		args = append(args, limit)


### PR DESCRIPTION
## Summary
- Newly-created tasks were sorting below 524 completed rows because the previous `ORDER BY last_run_at DESC, created_at DESC` ranked empty `last_run_at` last under DESC.
- Switch to `ORDER BY COALESCE(NULLIF(last_run_at,''), created_at) DESC, created_at DESC` so never-run rows collapse onto their `created_at` and bubble to the top alongside running tasks.

## Test plan
- [x] `go build ./internal/task/...`
- [x] `go test ./internal/task/...` — green
- [ ] Reload Portal Tasks tab — newly-created tasks appear at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)