### PR TITLE
fix(web/websocket): per-connection mutex to stop concurrent-write panic

### DIFF
--- a/internal/web/websocket.go
+++ b/internal/web/websocket.go
@@ -15,10 +15,23 @@ type Event struct {
 	Data any    `json:"data"`
 }
 
+// wsClient wraps a connection with a per-connection write mutex.
+//
+// gorilla/websocket explicitly forbids concurrent calls to WriteMessage /
+// WriteJSON / NextWriter on the same connection — it panics when it
+// detects them. Hub.Broadcast is invoked from many goroutines (scheduler
+// fires, peer events, runner stream events) so writes must be serialized
+// per connection. Mutex is per-client (not Hub-wide) so a slow reader on
+// one socket can't block broadcasts to the others.
+type wsClient struct {
+	conn  *websocket.Conn
+	write sync.Mutex
+}
+
 // Hub manages WebSocket connections and broadcasts events.
 type Hub struct {
 	mu      sync.RWMutex
-	clients map[*websocket.Conn]bool
+	clients map[*wsClient]bool
 }
 
 var upgrader = websocket.Upgrader{
@@ -28,7 +41,7 @@ var upgrader = websocket.Upgrader{
 // NewHub creates a WebSocket hub.
 func NewHub() *Hub {
 	return &Hub{
-		clients: make(map[*websocket.Conn]bool),
+		clients: make(map[*wsClient]bool),
 	}
 }
 
@@ -40,15 +53,16 @@ func (h *Hub) HandleWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	c := &wsClient{conn: conn}
 	h.mu.Lock()
-	h.clients[conn] = true
+	h.clients[c] = true
 	h.mu.Unlock()
 
 	// Read loop (discard incoming messages, detect disconnect)
 	go func() {
 		defer func() {
 			h.mu.Lock()
-			delete(h.clients, conn)
+			delete(h.clients, c)
 			h.mu.Unlock()
 			conn.Close()
 		}()
@@ -67,17 +81,25 @@ func (h *Hub) Broadcast(event Event) {
 		return
 	}
 
+	// Snapshot the client set under the read lock, then release it
+	// before any I/O. Keeps registration + disconnect paths from
+	// waiting on a slow socket.
 	h.mu.RLock()
-	defer h.mu.RUnlock()
+	clients := make([]*wsClient, 0, len(h.clients))
+	for c := range h.clients {
+		clients = append(clients, c)
+	}
+	h.mu.RUnlock()
 
-	for conn := range h.clients {
-		if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
-			conn.Close()
-			go func(c *websocket.Conn) {
-				h.mu.Lock()
-				delete(h.clients, c)
-				h.mu.Unlock()
-			}(conn)
+	for _, c := range clients {
+		c.write.Lock()
+		err := c.conn.WriteMessage(websocket.TextMessage, data)
+		c.write.Unlock()
+		if err != nil {
+			c.conn.Close()
+			h.mu.Lock()
+			delete(h.clients, c)
+			h.mu.Unlock()
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Three PCR tasks fired on the same scheduler tick at 03:00:08 UTC. Each handler called `Hub.Broadcast`, which iterates every connected client and calls `conn.WriteMessage(...)`. With three goroutines doing that concurrently, gorilla/websocket's built-in concurrent-write detector panicked → whole serve process died.
- Per the [gorilla/websocket docs](https://pkg.go.dev/github.com/gorilla/websocket): *"Connections support one concurrent reader and one concurrent writer. Applications are responsible for ensuring that no more than one goroutine calls the write methods … concurrently."* Documented behaviour, not a library bug.
- Wrap each `*websocket.Conn` in a `wsClient` carrying its own write mutex. Snapshot the client list under the existing `RWMutex`, release it before any I/O, take the per-client mutex around `WriteMessage`. Slow socket on one tab no longer blocks broadcasts to the others.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/web/...`
- [x] `go test -race ./internal/web/...` — clean
- [ ] Live smoke: start serve, fire three tasks simultaneously (e.g. PCR product), confirm no panic, dashboard updates for all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)