### PR TITLE
fix(web/tasks): deterministic order on /api/tasks/running/live (P3)

### DIFF
--- a/internal/web/handlers_task.go
+++ b/internal/web/handlers_task.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"math"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -665,6 +666,18 @@ func apiRunningTasksLive(n *node.Node) http.HandlerFunc {
 
 			out = append(out, lt)
 		}
+
+		// Stable order: oldest-running first. The map-based runner state
+		// returns tasks in non-deterministic order, which made per-tile
+		// sparklines appear to "reset" each poll because React kept the
+		// component instance (stable key=task_id) but ECharts re-rasterized
+		// when its DOM node moved between grid cells.
+		sort.Slice(out, func(i, j int) bool {
+			if out[i].StartedAt == out[j].StartedAt {
+				return out[i].TaskID < out[j].TaskID
+			}
+			return out[i].StartedAt < out[j].StartedAt
+		})
 
 		writeJSON(w, out)
 	}


### PR DESCRIPTION
## Summary
- Sort the `/api/tasks/running/live` response by `started_at` ASC (oldest first), tiebreak on `task_id`, before `writeJSON`.
- Reliability Recovery **P3** (live-tile flicker / sparkline reset on the Tasks panel).

## Why
The runner's `ListRunning()` is map-backed, so iteration order changed every poll (1.5s). React keeps each tile's component instance via stable `key={task_id}`, but the DOM node moves between grid cells when the list reorders, forcing ECharts' canvas to re-rasterize. The user-visible effect was sparklines that appeared to "reset" on every refresh.

## Test plan
- [ ] `go build ./...` clean (verified locally — only third-party cgo warnings).
- [ ] After merge: load `/` with three tasks running and confirm tile positions are stable across 30 consecutive polls.
- [ ] Older started_at always ranks first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)