### PR TITLE
fix(web/run-stats): 404 when entity_id does not exist (P10)

### DIFF
--- a/internal/web/handlers_stats.go
+++ b/internal/web/handlers_stats.go
@@ -113,6 +113,45 @@ func apiRunStats(n *node.Node) http.HandlerFunc {
 			return
 		}
 
+		// Reliability Recovery P10 — distinguish "no runs yet" (empty 200)
+		// from "entity does not exist" (404). Without this the Stats tab
+		// silently renders an empty chart for typo'd UUIDs.
+		switch kind {
+		case "task":
+			t, err := n.Tasks.Get(entityID)
+			if err != nil {
+				writeError(w, err.Error(), 500)
+				return
+			}
+			if t == nil {
+				writeError(w, "task not found", 404)
+				return
+			}
+		case "manifest":
+			m, err := n.Manifests.Get(entityID)
+			if err != nil {
+				writeError(w, err.Error(), 500)
+				return
+			}
+			if m == nil {
+				writeError(w, "manifest not found", 404)
+				return
+			}
+		case "product":
+			p, err := n.Products.Get(entityID)
+			if err != nil {
+				writeError(w, err.Error(), 500)
+				return
+			}
+			if p == nil {
+				writeError(w, "product not found", 404)
+				return
+			}
+		default:
+			writeError(w, "entity_kind must be task|manifest|product", 400)
+			return
+		}
+
 		asOfClause := ""
 		var args []any
 		if asOfStr != "" {


### PR DESCRIPTION
## Summary
- /api/run-stats now returns 404 when entity_id is unknown (verified via Tasks.Get / Manifests.Get / Products.Get).
- Empty 200 was indistinguishable from "no runs yet" — Reliability Recovery **P10**.
- Default kind case now returns 400 with a clear message instead of falling through.

## Test plan
- [ ] curl /api/run-stats?entity_kind=task&entity_id=does-not-exist → 404.
- [ ] curl /api/run-stats?entity_kind=task&entity_id=<real-task-no-runs> → 200 {runs:[], samples_by_run:{}}.
- [ ] curl /api/run-stats?entity_kind=widget&entity_id=x → 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)