### PR TITLE
ci: build + tsc-check dashboard-v2 (P6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,21 +28,23 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      # Node toolchain for the React v2 dashboard. The Go binary embeds
-      # internal/web/ui/dashboard/dist via go:embed, so the frontend MUST
-      # build before `go build` — otherwise CI ships the committed stub
-      # index.html instead of real React assets.
+      # Node toolchain for the React dashboards. Both dist trees are
+      # embedded via go:embed (handler.go: ui/dashboard/dist,
+      # handler_v2.go: ui/dashboard-v2/dist) — both MUST build before
+      # `go build` or CI ships stale assets.
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: internal/web/ui/dashboard/package-lock.json
+          cache-dependency-path: |
+            internal/web/ui/dashboard/package-lock.json
+            internal/web/ui/dashboard-v2/package-lock.json
 
       - name: npm ci (dashboard)
         working-directory: internal/web/ui/dashboard
         run: npm ci
 
-      - name: tsc --noEmit (strict TS gate)
+      - name: tsc --noEmit (dashboard, strict TS gate)
         working-directory: internal/web/ui/dashboard
         run: npm run check
 
@@ -52,6 +54,22 @@ jobs:
 
       - name: npm run build (dashboard)
         working-directory: internal/web/ui/dashboard
+        run: npm run build
+
+      # Portal V2 (dashboard-v2). PR #286 shipped a TS regression in
+      # dependencies.tsx / dep-picker.tsx that the Go pipeline missed
+      # entirely because the only frontend gate ran against the legacy
+      # dashboard. Adding tsc --noEmit + vite build here closes that hole.
+      - name: npm ci (dashboard-v2)
+        working-directory: internal/web/ui/dashboard-v2
+        run: npm ci
+
+      - name: tsc --noEmit (dashboard-v2, strict TS gate)
+        working-directory: internal/web/ui/dashboard-v2
+        run: npm run check
+
+      - name: npm run build (dashboard-v2)
+        working-directory: internal/web/ui/dashboard-v2
         run: npm run build
 
       - name: go build


### PR DESCRIPTION
## Summary
- Adds three CI steps for \`internal/web/ui/dashboard-v2\`: npm ci, npm run check (tsc --noEmit), npm run build (vite).
- Widens setup-node cache to include both lockfiles.
- Closes the gap that let the marker-elim rebase regression in PR #286 ship without CI flagging it.
- Reliability Recovery **P6**.

## Merge order
This PR will fail CI until P1 (PR #290 or successor) lands. Merge order: **P1 first, then P6**.

Verified locally on main: tsc --noEmit passes; vite build fails with \`UNLOADABLE_DEPENDENCY: src/lib/queries/products\` from \`features/entity/tabs/dependencies.tsx\` — exactly the regression P1 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)