### PR TITLE
fix(portal-v2): guard marker drift in dep-picker (UB-3 + UB-5)

### DIFF
--- a/internal/web/ui/dashboard-v2/src/features/entity/dep-picker.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/dep-picker.tsx
@@ -13,12 +13,16 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
 
-// Search-picker over a list of {id, marker, title, status} rows. Used
-// by the Dependencies editor's Add buttons — same picker for products
-// and manifests, the candidate set is filtered upstream.
+// Search-picker over a list of {id, title, status} rows. Used by the
+// Dependencies editor's Add buttons — same picker for products and
+// manifests, the candidate set is filtered upstream.
+//
+// `marker` is the legacy 12-char shorthand. Post-#286 the API stopped
+// shipping it; callers may still pass `undefined`. Optional here so the
+// filter path can't throw on a missing value.
 export interface PickerRow {
   id: string
-  marker: string
+  marker?: string
   title: string
   status: string
 }
@@ -57,7 +61,8 @@ export function DepPicker({
     return rows.filter(
       (r) =>
         r.title.toLowerCase().includes(q) ||
-        r.marker.toLowerCase().includes(q)
+        r.id.toLowerCase().includes(q) ||
+        (r.marker ?? '').toLowerCase().includes(q)
     )
   }, [rows, query])
 


### PR DESCRIPTION
## Summary
- Post-#286 the backend stopped shipping the legacy `marker` field on entity rows. `DepPicker` filter callback at `dep-picker.tsx:60` was calling `r.marker.toLowerCase()` unconditionally → throws on every keystroke once a row arrives without marker.
- That throw propagates to the SPA ErrorBoundary, which is what users see as the styled 500 page when they (a) open the dependency picker and type to filter (UB-3) or (b) click a search result that lands on a page mounting this component (UB-5).
- Loosen `PickerRow.marker` to optional, guard the access, add `r.id` matching as a first-class filter key.

## Test plan
- [x] `npm run build` — clean
- [x] `npx tsc --noEmit` — no errors
- [ ] After merge + redeploy: open `Dependencies` tab on any product/manifest → click "Add" → type into filter → results narrow without 500