### PR TITLE
fix(portal-v2): default render mode to 'rendered' (UB-6)

### DIFF
--- a/internal/web/ui/dashboard-v2/src/components/description-view.tsx
+++ b/internal/web/ui/dashboard-v2/src/components/description-view.tsx
@@ -7,11 +7,15 @@ const STORAGE_KEY = 'descMode'
 type Mode = 'markup' | 'rendered'
 
 function readMode(): Mode {
+  // Default to 'rendered' so markdown content (description, comment
+  // bodies, watcher findings) renders out of the box. Operator can
+  // toggle to 'markup' for raw-source view; the choice persists in
+  // localStorage and broadcasts via `desc-mode-change`.
   try {
     const v = localStorage.getItem(STORAGE_KEY)
-    return v === 'rendered' ? 'rendered' : 'markup'
+    return v === 'markup' ? 'markup' : 'rendered'
   } catch {
-    return 'markup'
+    return 'rendered'
   }
 }
 function writeMode(m: Mode): void {

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/comments.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/comments.tsx
@@ -43,11 +43,15 @@ function fmtTime(ts: number | string): string {
 
 type Mode = 'markup' | 'rendered'
 function readMode(): Mode {
+  // Default to 'rendered' — comment bodies are markdown that should
+  // render by default. Operator can opt into 'markup' (raw source)
+  // via the toggle; localStorage + the desc-mode-change event keep
+  // this in sync with description-view.tsx.
   try {
     const v = localStorage.getItem('descMode')
-    return v === 'rendered' ? 'rendered' : 'markup'
+    return v === 'markup' ? 'markup' : 'rendered'
   } catch {
-    return 'markup'
+    return 'rendered'
   }
 }
 function useDescMode(): [Mode, (m: Mode) => void] {


### PR DESCRIPTION
## Summary
- Comments + descriptions were showing as raw markdown source everywhere — users reported the bug as "comments + descriptions stopped rendering everywhere" (UB-6 / P0).
- Root cause: \`readMode()\` in both \`components/description-view.tsx\` and \`features/entity/tabs/comments.tsx\` defaulted to \`'markup'\` when localStorage had no \`descMode\` entry. Fresh sessions never opted in → markdown never rendered.
- Flip the default: localStorage unset → \`'rendered'\`. Markup mode is the explicit opt-in.

## Test plan
- [x] \`npm run build\` clean
- [x] \`npx tsc --noEmit\` no errors
- [ ] After redeploy, hard-refresh dashboard → descriptions + comments render markdown by default; toggle to Markup still works; choice persists across reloads