### PR TITLE
feat(schedule): consumer goroutine — drive entity firings off the schedules table

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -17,6 +17,7 @@ import (
 	mcpserver "github.com/k8nstantin/OpenPraxis/internal/mcp"
 	"github.com/k8nstantin/OpenPraxis/internal/node"
 	"github.com/k8nstantin/OpenPraxis/internal/peer"
+	"github.com/k8nstantin/OpenPraxis/internal/schedule"
 	"github.com/k8nstantin/OpenPraxis/internal/setup"
 	"github.com/k8nstantin/OpenPraxis/internal/task"
 	"github.com/k8nstantin/OpenPraxis/internal/web"
@@ -297,6 +298,23 @@ var serveCmd = &cobra.Command{
 		scheduler.SetResolver(n.SettingsResolver)
 		scheduler.Start()
 		defer scheduler.Stop()
+
+		// Schedules consumer — registers every current+enabled row in
+		// the schedules table against an in-memory robfig/cron/v3 ticker.
+		// Dispatches by entity_kind: today only `task`; product/manifest
+		// dispatchers slot in here when their fire semantics are defined.
+		// HTTP handlers in handlers_schedule.go call ScheduleRunner.Reload
+		// after every Create/Close so the in-memory cron stays in sync.
+		scheduleRunner := schedule.NewRunner(n.Schedules, map[string]schedule.DispatchFunc{
+			"task": func(ctx context.Context, entityID string, scheduleID int64) error {
+				now := time.Now().UTC().Format(time.RFC3339)
+				return n.Tasks.UpdateSchedule(entityID, "once", now)
+			},
+		})
+		n.ScheduleRunner = scheduleRunner
+		if err := scheduleRunner.Start(ctx); err != nil {
+			slog.Error("schedule runner start failed", "error", err)
+		}
 
 		// Cross-process action watcher — applies pause/resume/cancel signals
 		// written by other binaries (MCP) to tasks this runner owns.

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/miekg/dns v1.1.27 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/shirou/gopsutil/v3 v3.24.5 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -53,6 +53,12 @@ type Node struct {
 	// fields off the task row; a follow-up cuts it over to read here.
 	// This PR persists schedules so the dashboard surfaces them.
 	Schedules        *schedule.Store
+	// ScheduleRunner consumes the schedules table — registers each
+	// current+enabled row against an in-memory robfig/cron/v3 ticker
+	// and dispatches by entity_kind on fire. Wired in cmd/serve.go
+	// after the node is built so the dispatcher map can capture
+	// references to n.Tasks etc.
+	ScheduleRunner   *schedule.Runner
 	runner           *task.Runner
 	hostSampler      *task.HostSampler
 	Embedder         *embedding.Engine

--- a/internal/schedule/runner.go
+++ b/internal/schedule/runner.go
@@ -1,0 +1,280 @@
+// Runner registers every current+enabled row in the schedules table
+// against an in-memory robfig/cron/v3 ticker. The library owns the
+// next-fire computation (cron parser handles cron_expr; a one-shot
+// adapter handles cron_expr=''); we own the SQLite-side persistence
+// (rows live in `schedules`, MarkFired increments runs_so_far + flips
+// enabled when max_runs is reached).
+//
+// Reload is the synchronisation seam: every HTTP/MCP path that mutates
+// the schedules table should call Runner.Reload so the in-memory cron
+// stays in sync. Reload is cheap (one indexed query + a Stop/Start
+// inside the cron lib); calling it on every write is well within
+// budget for OpenPraxis-scale workloads.
+
+package schedule
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+// DispatchFunc fires the given entity. Receives the same context the
+// runner was started with, the entity_id, and the schedule row id (so
+// the dispatcher can correlate with audit trails). Returns an error if
+// the entity could not be enqueued / fired; on error the runner SKIPS
+// MarkFired so the row remains pending for the next tick.
+type DispatchFunc func(ctx context.Context, entityID string, scheduleID int64) error
+
+// Runner owns a singleton cron.Cron instance and keeps it in sync with
+// the schedules table.
+type Runner struct {
+	store       *Store
+	dispatchers map[string]DispatchFunc
+
+	cron *cron.Cron
+	// entries maps schedule.id → cron.EntryID so Reload can Remove
+	// entries that no longer have a current+enabled row.
+	mu      sync.Mutex
+	entries map[int64]cron.EntryID
+
+	// ctx is captured at Start; jobs use it so a cancellation propagates
+	// to in-flight dispatches (best-effort — a long-running dispatcher
+	// must respect ctx itself).
+	ctx context.Context
+}
+
+// NewRunner builds a runner with the given dispatcher map. The map is
+// keyed on entity_kind ("task", "manifest", "product", …); a row whose
+// kind has no dispatcher registered is logged + skipped at fire time.
+func NewRunner(store *Store, dispatchers map[string]DispatchFunc) *Runner {
+	if dispatchers == nil {
+		dispatchers = map[string]DispatchFunc{}
+	}
+	// SkipIfStillRunning prevents a slow dispatcher from stacking up if
+	// it takes longer than the cron interval. Logger forwards lib
+	// internals to slog at INFO so we see "skipped because previous
+	// instance still running" + parse errors in the operator log.
+	c := cron.New(
+		cron.WithChain(cron.SkipIfStillRunning(cron.DefaultLogger)),
+		cron.WithLogger(cron.PrintfLogger(slogPrintfer{})),
+	)
+	return &Runner{
+		store:       store,
+		dispatchers: dispatchers,
+		cron:        c,
+		entries:     map[int64]cron.EntryID{},
+	}
+}
+
+// Start kicks the cron ticker. Call once at server boot; the goroutine
+// the lib spawns lives until ctx cancellation. Reload is invoked once
+// synchronously before the ticker spins so the registered set matches
+// the DB on first tick.
+func (r *Runner) Start(ctx context.Context) error {
+	r.ctx = ctx
+	if err := r.Reload(ctx); err != nil {
+		return fmt.Errorf("schedule.Runner: initial reload: %w", err)
+	}
+	r.cron.Start()
+	go func() {
+		<-ctx.Done()
+		// cron.Stop returns a context that closes when in-flight jobs
+		// drain; we don't block boot/shutdown on that here.
+		_ = r.cron.Stop()
+	}()
+	return nil
+}
+
+// Reload re-syncs the in-memory cron set with the schedules table.
+// Diff-based: rows that no longer exist (enabled=0 / closed / max_runs
+// reached) get cron.Remove'd; new rows get registered; rows that are
+// still present + unchanged keep their existing entry.
+//
+// Idempotent + safe to call on every schedule mutation. Cost on a
+// tens-of-rows table: ~1 indexed query + a few map lookups, well under
+// 1ms.
+func (r *Runner) Reload(ctx context.Context) error {
+	rows, err := r.store.ListAllCurrent(ctx)
+	if err != nil {
+		return fmt.Errorf("list all current: %w", err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Build the set of ids that should be present after this Reload.
+	want := make(map[int64]*Schedule, len(rows))
+	for _, row := range rows {
+		want[row.ID] = row
+	}
+
+	// Remove entries whose row is no longer in the wanted set.
+	for id, entryID := range r.entries {
+		if _, ok := want[id]; !ok {
+			r.cron.Remove(entryID)
+			delete(r.entries, id)
+		}
+	}
+
+	// Add entries that don't yet exist in-memory.
+	for id, row := range want {
+		if _, ok := r.entries[id]; ok {
+			// Already registered. Skip; we don't restart entries on
+			// no-op reloads to avoid resetting next-fire timing.
+			continue
+		}
+		entryID, err := r.register(row)
+		if err != nil {
+			slog.Warn("schedule.Runner: register failed",
+				"schedule_id", row.ID,
+				"entity_kind", row.EntityKind,
+				"entity_id", row.EntityID,
+				"cron_expr", row.CronExpr,
+				"run_at", row.RunAt,
+				"error", err)
+			continue
+		}
+		r.entries[id] = entryID
+	}
+	return nil
+}
+
+// register builds the cron.Schedule for one row and adds it to the
+// cron with a closure that dispatches + marks fired.
+func (r *Runner) register(row *Schedule) (cron.EntryID, error) {
+	sched, err := buildSchedule(row)
+	if err != nil {
+		return 0, err
+	}
+	job := r.makeJob(row.ID, row.EntityKind, row.EntityID)
+	return r.cron.Schedule(sched, cron.FuncJob(job)), nil
+}
+
+// makeJob is the per-row dispatch closure. Captured fields stay valid
+// across Reload because cron's entry table holds the FuncJob; closing
+// over only the immutable triple (id, kind, entityID) keeps the job
+// serializable across schedule mutations.
+func (r *Runner) makeJob(id int64, kind, entityID string) func() {
+	return func() {
+		ctx := r.ctx
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		dispatch, ok := r.dispatchers[kind]
+		if !ok {
+			slog.Warn("schedule.Runner: no dispatcher for kind",
+				"schedule_id", id, "entity_kind", kind, "entity_id", entityID)
+			return
+		}
+		if err := dispatch(ctx, entityID, id); err != nil {
+			// Don't MarkFired on dispatch failure — leave the row to
+			// retry on the next tick. The cron lib will fire us again
+			// at the next scheduled time without our intervention.
+			slog.Error("schedule.Runner: dispatch failed",
+				"schedule_id", id, "entity_kind", kind, "entity_id", entityID,
+				"error", err)
+			return
+		}
+		if err := r.store.MarkFired(ctx, id); err != nil {
+			slog.Warn("schedule.Runner: MarkFired failed (dispatched anyway)",
+				"schedule_id", id, "entity_kind", kind, "entity_id", entityID,
+				"error", err)
+		}
+		slog.Info("schedule.Runner: fired",
+			"schedule_id", id, "entity_kind", kind, "entity_id", entityID)
+
+		// One-shot semantics: if the row is now disabled (max_runs hit),
+		// remove it from the in-memory cron immediately so a stuck
+		// future tick can't re-fire before the next Reload. Cron's own
+		// one-shot Schedule returns zero time on subsequent Next() calls,
+		// which would also handle this — belt-and-braces here.
+		r.mu.Lock()
+		if entryID, ok := r.entries[id]; ok {
+			r.cron.Remove(entryID)
+			delete(r.entries, id)
+		}
+		r.mu.Unlock()
+	}
+}
+
+// buildSchedule chooses the cron.Schedule implementation for a row.
+// Non-empty cron_expr → standard cron parser. Empty → one-shot adapter
+// firing at run_at exactly once.
+func buildSchedule(row *Schedule) (cron.Schedule, error) {
+	if row.CronExpr != "" {
+		// Use the standard 5-field cron parser (minute hour dom month dow).
+		// Robfig defaults to a 6-field parser with seconds; standard is
+		// what the schema implies and what UIs typically show.
+		parser := cron.NewParser(
+			cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow,
+		)
+		s, err := parser.Parse(row.CronExpr)
+		if err != nil {
+			return nil, fmt.Errorf("parse cron_expr %q: %w", row.CronExpr, err)
+		}
+		return s, nil
+	}
+	// One-shot.
+	if row.RunAt == "" {
+		return nil, errors.New("buildSchedule: empty cron_expr requires run_at")
+	}
+	t, err := parseRunAt(row.RunAt)
+	if err != nil {
+		return nil, fmt.Errorf("parse run_at %q: %w", row.RunAt, err)
+	}
+	return &oneShot{runAt: t}, nil
+}
+
+// parseRunAt accepts either RFC3339Nano (UTC TEXT, what the store
+// emits) or RFC3339 (older rows pre-nano). Falls back to the
+// SQLite-default "2006-01-02 15:04:05" if both fail.
+func parseRunAt(s string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t.UTC(), nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC(), nil
+	}
+	if t, err := time.Parse("2006-01-02 15:04:05", s); err == nil {
+		return t.UTC(), nil
+	}
+	return time.Time{}, fmt.Errorf("unrecognised run_at format: %q", s)
+}
+
+// oneShot is a cron.Schedule that fires exactly once at runAt. After
+// the first Next() that returns a non-zero time, subsequent calls
+// return zero — cron interprets that as "deregister this entry."
+type oneShot struct {
+	mu    sync.Mutex
+	runAt time.Time
+	fired bool
+}
+
+func (s *oneShot) Next(now time.Time) time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.fired {
+		return time.Time{}
+	}
+	s.fired = true
+	// If runAt is in the past at registration time (e.g. we restarted
+	// after a missed fire), still return runAt — cron will fire
+	// immediately on the next tick.
+	return s.runAt
+}
+
+// slogPrintfer adapts cron's Printfer interface to slog. cron uses this
+// for Info-level lifecycle messages ("scheduling next run", "skip due
+// to still-running"); we forward at slog.Info so they land in the
+// operator log alongside everything else.
+type slogPrintfer struct{}
+
+func (slogPrintfer) Printf(format string, args ...any) {
+	slog.Info(fmt.Sprintf("cron: "+format, args...))
+}

--- a/internal/schedule/store.go
+++ b/internal/schedule/store.go
@@ -495,3 +495,65 @@ func timed(label string, body func() error) error {
 }
 
 var _ = timed // suppress unused warning until the runner picks it up
+
+// ListAllCurrent returns every CURRENT, ENABLED schedule across all
+// entities whose RunsSoFar has not yet hit MaxRuns. Drives the
+// in-memory cron registration on Runner.Reload.
+//
+// Hot path: filtered by the partial index `idx_sched_due_current` so
+// the scan is bounded to current+enabled rows. No tick-time row filter
+// — the cron library owns the "is this fire-due" decision in memory
+// against each row's parsed cron expr / one-shot run_at.
+func (s *Store) ListAllCurrent(ctx context.Context) ([]*Schedule, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+rowColumns+` FROM schedules
+		 WHERE valid_to = ''
+		   AND enabled = 1
+		   AND (max_runs = 0 OR runs_so_far < max_runs)
+		 ORDER BY id ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("list all current: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]*Schedule, 0, 16)
+	for rows.Next() {
+		row, err := scanSchedule(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan current: %w", err)
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+// MarkFired increments runs_so_far for the given schedule id. If
+// max_runs > 0 and the new runs_so_far reaches max_runs, also flips
+// enabled to 0 so the next Reload skips it.
+//
+// One-shot schedules (cron_expr='') typically have max_runs=1 and
+// self-disable on the first MarkFired. Recurring (cron_expr non-empty)
+// schedules with max_runs=0 fire indefinitely.
+func (s *Store) MarkFired(ctx context.Context, id int64) error {
+	if id <= 0 {
+		return fmt.Errorf("schedule: MarkFired requires positive id, got %d", id)
+	}
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE schedules
+		 SET runs_so_far = runs_so_far + 1,
+		     enabled = CASE
+		         WHEN max_runs > 0 AND runs_so_far + 1 >= max_runs THEN 0
+		         ELSE enabled
+		     END
+		 WHERE id = ? AND valid_to = ''`,
+		id)
+	if err != nil {
+		return fmt.Errorf("mark fired: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		// Already closed or id invalid — surface as a soft warning so
+		// the consumer can ignore it without bubbling.
+		slog.Debug("schedule MarkFired: zero rows affected", "id", id)
+	}
+	return nil
+}

--- a/internal/web/handlers_schedule.go
+++ b/internal/web/handlers_schedule.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -224,6 +225,15 @@ func apiSchedulesCreate(n *node.Node) http.HandlerFunc {
 			writeScheduleError(w, code, err.Error(), status)
 			return
 		}
+		// Sync the in-memory cron with the DB so the new row fires on
+		// the next tick. Best-effort: log + continue if the runner is
+		// not yet wired (test harness path).
+		if n.ScheduleRunner != nil {
+			if rerr := n.ScheduleRunner.Reload(r.Context()); rerr != nil {
+				slog.Warn("schedule.Runner: reload after create failed",
+					"schedule_id", row.ID, "error", rerr)
+			}
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(row)
@@ -252,6 +262,12 @@ func apiScheduleClose(n *node.Node) http.HandlerFunc {
 		if err := n.Schedules.Close(r.Context(), id, reason, by); err != nil {
 			writeScheduleError(w, "internal", err.Error(), http.StatusInternalServerError)
 			return
+		}
+		if n.ScheduleRunner != nil {
+			if rerr := n.ScheduleRunner.Reload(r.Context()); rerr != nil {
+				slog.Warn("schedule.Runner: reload after close failed",
+					"schedule_id", id, "error", rerr)
+			}
 		}
 		writeJSON(w, map[string]any{"ok": true, "id": id})
 	}


### PR DESCRIPTION
## Summary
The schedules table has been written to by the new entity Schedule UI since PR/M-Schedule/M1 but **no goroutine consumed it** — schedules with run_at in the past never fired because the existing task scheduler only watches \`tasks.next_run_at\`, not this table.

This PR adds the consumer.

## Architecture
- **\`robfig/cron/v3\`** (~3KB, MIT) for cron parsing + the in-memory ticker. Library owns the next-fire math; SQLite owns the persistence.
- **\`internal/schedule/runner.go\`** (NEW): \`Runner\` registers every current+enabled row against a singleton \`cron.Cron\` via a kind-keyed dispatcher map. One-shot rows (\`cron_expr=''\`) get a \`cron.Schedule\` adapter that fires once then returns zero time so cron auto-deregisters.
- **\`internal/schedule/store.go\`**: \`ListAllCurrent\` (Reload) + \`MarkFired\` (runs_so_far + auto-disable on max_runs hit).
- **HTTP handlers** for \`POST /api/schedules\` and \`DELETE /api/schedules/{id}\` call \`ScheduleRunner.Reload\` after the DB write so the in-memory cron stays in sync.
- **\`cmd/serve.go\`** wires the runner with one dispatcher today: \`task\` → \`Tasks.UpdateSchedule(entityID, "once", now)\`. Product / manifest dispatchers slot in here when their fire semantics are defined.
- **\`node.Node.ScheduleRunner\`** field so handlers can reach it via the existing \`*node.Node\` argument.

## Behaviour matrix
| Schedule kind | Behaviour |
|---|---|
| One-shot (\`cron_expr=''\`, \`max_runs=1\`) | Fires once at \`run_at\`. \`MarkFired\` flips \`enabled=0\`. Next Reload removes it. |
| Cron (\`cron_expr\` non-empty) | Cron lib advances next-fire in memory. \`MarkFired\` increments \`runs_so_far\` each tick. \`max_runs=0\` = unbounded. |
| max_runs cap reached | \`MarkFired\` auto-disables; next Reload deregisters. |
| Operator mutation (POST/DELETE) | Handler calls \`Reload\` after DB write; cron picks up the change on the next tick. |
| Process restart | \`Reload\` re-registers everything at boot. No schedule is lost. |
| Dispatch error | Log + leave row pending; cron retries on next tick. |
| Parse error on \`cron_expr\` | Log + skip the row; doesn't poison Reload. |
| Slow dispatch + tick collision | \`SkipIfStillRunning\` middleware skips the next tick (logged). |

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./internal/web/... ./internal/node/...\` green
- [ ] After merge + redeploy: a schedule row with \`run_at\` in the past + \`enabled=1\` + \`runs_so_far<max_runs\` fires within 60s
- [ ] Operator-created schedule for a future \`run_at\` fires at the scheduled time (±10s tick lag)
- [ ] \`runs_so_far\` increments + \`enabled\` flips when \`max_runs\` is reached

## Out of scope
- Manifest / product dispatchers — wire when their fire semantics are defined
- Cutover of the existing task scheduler (\`tasks.next_run_at\`) to write through the schedules table — separate PR