### PR TITLE
chore(claude.md): rip out visceral / Total Recall priming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,19 +4,6 @@
 
 → **Full design doc:** [`docs/workflow-engine.md`](docs/workflow-engine.md) — states, deps, activation model, review loop, SCD principle, and the roadmap. Every PR touching those primitives must check itself against that doc.
 
-## Session Init — Total Recall Protocol
-
-**Every session MUST execute this before any work:**
-
-1. Call `visceral_rules` — load mandatory operating rules
-2. Call `visceral_confirm` with the rule count — acknowledge rules
-3. Call `memory_search` with current project/task context — load relevant prior knowledge
-4. Call `manifest_list` — know what active specs exist
-
-Or call `totalrecall` which does all of the above in one shot.
-
-**These are not optional.** Skipping them results in amnesia flagging on the dashboard.
-
 ## Task System
 
 OpenPraxis has a task entity. **Never use CronCreate or external schedulers.**
@@ -43,17 +30,17 @@ The binary is also used as an MCP server via `./openpraxis mcp` (stdio transport
 ```
 cmd/                    CLI commands (cobra): serve, mcp, version
 internal/
-  action/               Action recording + visceral/delusion compliance checks
+  action/               Action recording
   config/               YAML config loader + platform detection
   conversation/         Conversation storage (SQLite)
   embedding/            Ollama embedding client (nomic-embed-text)
   idea/                 Ideas store (many-to-many manifest linking)
-  manifest/             Manifest CRUD + marker tracking
-  marker/               Flag/notification system between peers
+  manifest/             Manifest CRUD
   mcp/                  MCP server (stdio + streamable HTTP), all tool handlers
   memory/               Memory store + SQLite-vec semantic search
   node/                 Node orchestrator (wires all stores together)
   peer/                 mDNS peer discovery + Automerge sync
+  schedule/             SCD-2 schedules table + cron-driven consumer
   setup/                Agent detection + auto-configuration (Claude Code, Cursor, etc.)
   task/                 Task runner + scheduler + prompt builder
   web/                  HTTP dashboard + WebSocket + hook handler
@@ -65,10 +52,10 @@ tools/                  Python utility scripts
 ## Key Files
 
 - `internal/mcp/server.go` — MCP server init, tool registration, session tracking, instructions
-- `internal/mcp/tools.go` — All MCP tool handlers (memory, conversation, marker, totalrecall)
-- `internal/mcp/visceral.go` — Visceral rule tools + manifest/idea/link tools
+- `internal/mcp/tools.go` — All MCP tool handlers (memory, conversation, totalrecall)
 - `internal/web/handler.go` — HTTP API routes, hook handler, dashboard data
 - `internal/task/runner.go` — Task scheduler, runner, prompt context builder
+- `internal/schedule/runner.go` — Cron-driven schedules consumer
 - `internal/node/node.go` — Node init, wires stores + DB
 - `internal/setup/agents.go` — Agent detection + MCP config writer + hooks setup
 - `cmd/serve.go` — Server startup, scheduler callbacks, peer registry
@@ -77,20 +64,17 @@ tools/                  Python utility scripts
 
 OpenPraxis registers Claude Code hooks in `~/.claude/settings.json`:
 
-- **PostToolUse** (`*`): Records every tool call as an action, checks visceral compliance + manifest delusion
-- **PreToolUse** (`mcp__openpraxis__*`): Enforces visceral rules are loaded before any OpenPraxis MCP tool call
+- **PostToolUse** (`*`): Records every tool call as an action
 - **UserPromptSubmit**: Tracks session activity
-- **Stop**: Checks visceral compliance, flags amnesia if rules weren't confirmed, saves conversation
+- **Stop**: Saves conversation from transcript
 - **SessionEnd**: Saves conversation from transcript
 
 All hooks hit `http://127.0.0.1:8765/api/hook`.
 
-## MCP Tools (48)
+## MCP Tools
 
 Memory: `memory_store`, `memory_search`, `memory_recall`, `memory_list`, `memory_forget`, `memory_status`, `memory_peers`
 Conversations: `conversation_save`, `conversation_search`, `conversation_list`, `conversation_get`
-Markers: `marker_flag`, `marker_list`, `marker_done`
-Visceral: `visceral_rules`, `visceral_confirm`, `visceral_set`, `visceral_remove`
 Products: `product_create`, `product_get`, `product_list`, `product_update`, `product_delete`, `product_dep_add`, `product_dep_remove`, `product_dep_list`
 Manifests: `manifest_create`, `manifest_get`, `manifest_list`, `manifest_update`, `manifest_delete`, `manifest_search`, `manifest_dep_add`, `manifest_dep_remove`, `manifest_dep_list`
 Tasks: `task_create`, `task_list`, `task_get`, `task_start`, `task_cancel`, `task_link_manifest`, `task_unlink_manifest`
@@ -115,4 +99,6 @@ embedding:
 
 ## Dashboard
 
-`http://localhost:8765` — Activity feed, memories, manifests, tasks, sessions, visceral compliance, amnesia flags.
+`http://localhost:8765` — Activity feed, memories, manifests, tasks, sessions.
+
+`http://localhost:9766` — Portal V2 (React + TanStack Router).


### PR DESCRIPTION
## Summary
- Stops priming fresh agent worktrees to call `/api/visceral/rules` — the visceral subsystem was deleted weeks ago
- Drops references to removed `marker/` package
- Adds `internal/schedule/` to the architecture map

## Why
The running attachments task (019de321) was spinning in early-init lookups against endpoints that no longer exist because every fresh worktree clones a CLAUDE.md still telling agents:

> **Every session MUST execute this before any work:** Call `visceral_rules`...

That priming has to die at the source.

## Test plan
- [ ] CI green
- [ ] After merge: redeploy serve, fire a fresh task, confirm zero `/api/visceral/*` curls in its action log