### PR TITLE
fix(portal-v2/blocknote): properly instantiate React block specs

### DIFF
--- a/internal/web/ui/dashboard-v2/src/components/blocknote-schema.tsx
+++ b/internal/web/ui/dashboard-v2/src/components/blocknote-schema.tsx
@@ -164,9 +164,9 @@ export const ProductCard = makeCardSpec('product')
 export const opSchema = BlockNoteSchema.create({
   blockSpecs: {
     ...defaultBlockSpecs,
-    taskCard: TaskCard,
-    manifestCard: ManifestCard,
-    productCard: ProductCard,
+    taskCard: TaskCard(),
+    manifestCard: ManifestCard(),
+    productCard: ProductCard(),
   },
   inlineContentSpecs: {
     ...defaultInlineContentSpecs,


### PR DESCRIPTION
This PR fixes a critical 500 error in the Portal V2 React UI where the BlockNote editor would crash on the Products, Manifests, and Tasks tabs. 

**Root Cause:**
`@blocknote/react` v0.49+ requires custom block spec constructors (e.g., `TaskCard`, `ManifestCard`, `ProductCard`) to be invoked as factory functions when passed to `BlockNoteSchema.create()`. The schema previously passed raw function references, causing an internal `TypeError: Cannot read properties of undefined (reading 'node')` during editor instantiation.

**Fix:**
Invoked the specs in `src/components/blocknote-schema.tsx` (e.g., `TaskCard()`).