### PR TITLE
feat(portal-v2/comments): description-as-comment compose + visual treatment

### DIFF
--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/comments.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/comments.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   useCreateEntityComment,
   useEntityComments,
+  useUpdateEntity,
   type EntityKind,
 } from '@/lib/queries/entity'
 import type { Comment } from '@/lib/types'
@@ -27,7 +28,7 @@ import { claimAttachment } from '@/lib/queries/attachments'
 
 const TYPE_LABEL: Record<string, string> = {
   execution_review: 'Execution Review',
-  description_revision: 'Description Revision',
+  description_revision: 'Description',
   agent_note: 'Agent Note',
   user_note: 'Note',
   watcher_finding: 'Watcher Finding',
@@ -35,8 +36,13 @@ const TYPE_LABEL: Record<string, string> = {
   link: 'Link',
 }
 
+// Compose-time picker. `description_revision` posts an audit row AND
+// PATCHes the entity's stored description / content (legacy field stays
+// the source of truth — see post() below). Order: Note first so the
+// dropdown's default option is the most common case.
 const COMPOSE_TYPES: Array<keyof typeof TYPE_LABEL> = [
   'user_note',
+  'description_revision',
   'decision',
   'agent_note',
 ]
@@ -100,6 +106,7 @@ export function CommentsTab({
 }) {
   const comments = useEntityComments(kind, entityId)
   const create = useCreateEntityComment(kind, entityId)
+  const update = useUpdateEntity(kind, entityId)
   const [filter, setFilter] = useState<string>('all')
   const [composeType, setComposeType] =
     useState<keyof typeof TYPE_LABEL>('user_note')
@@ -158,6 +165,20 @@ export function CommentsTab({
             })
           )
         )
+      }
+      // Description-as-comment: keep the entity's stored description /
+      // content field as the source of truth. Post the comment row as a
+      // versioned audit trail, then PATCH the canonical field so the
+      // Main tab's DescriptionView reflects the new body. Manifests use
+      // `content` for the spec body; products + tasks use `description`.
+      if (composeType === 'description_revision' && body) {
+        const patch =
+          kind === 'manifest' ? { content: body } : { description: body }
+        try {
+          await update.mutateAsync(patch)
+        } catch (err) {
+          console.error('description PATCH after comment post failed', err)
+        }
       }
       close()
     } catch (e) {
@@ -231,7 +252,11 @@ export function CommentsTab({
               ref={composerRef}
               onSave={post}
               onCancel={close}
-              placeholder='Add a comment… drop files, paste images, type / for blocks (Cmd-Enter to post)'
+              placeholder={
+                composeType === 'description_revision'
+                  ? 'Write the description-of-record… drop files, paste images, type / for blocks (Cmd-Enter to post)'
+                  : 'Add a comment… drop files, paste images, type / for blocks (Cmd-Enter to post)'
+              }
             />
             <div className='flex items-center justify-end gap-2'>
               {create.isError ? (
@@ -271,7 +296,13 @@ export function CommentsTab({
                 onClick={post}
                 disabled={posting}
               >
-                {posting ? 'Posting…' : 'Post'}
+                {posting
+                  ? composeType === 'description_revision'
+                    ? 'Saving…'
+                    : 'Posting…'
+                  : composeType === 'description_revision'
+                    ? 'Post as Description'
+                    : 'Post'}
               </Button>
             </div>
           </CardContent>
@@ -296,13 +327,27 @@ export function CommentsTab({
           ) : (
             <div className='divide-y'>
               {visible.map((c) => (
-                <div key={c.id} className='space-y-1 p-3 text-sm'>
+                <div
+                  key={c.id}
+                  className={
+                    c.type === 'description_revision'
+                      ? 'space-y-1 border-l-2 border-emerald-500/60 bg-emerald-500/5 p-3 text-sm'
+                      : 'space-y-1 p-3 text-sm'
+                  }
+                >
                   <div className='flex items-center justify-between gap-2'>
                     <div className='flex items-center gap-2'>
                       <code className='font-mono text-[11px]'>
                         {c.author.slice(0, 16)}
                       </code>
-                      <Badge variant='outline' className='text-[10px]'>
+                      <Badge
+                        variant={
+                          c.type === 'description_revision'
+                            ? 'secondary'
+                            : 'outline'
+                        }
+                        className='text-[10px]'
+                      >
                         {TYPE_LABEL[c.type] ?? c.type}
                       </Badge>
                     </div>


### PR DESCRIPTION
## Summary

Closes **block D** of manifest M1 (file attachments + description-as-comment, `019de31f-9ac3-72ee-aea5-3b8cd1205684`). Blocks R / B / F shipped previously via PRs #306–#309 + the attachments-backend commit (`94c5835`); this PR adds the missing description-of-record compose path on the Comments tab.

- Comments tab compose dropdown now offers **Description** (`description_revision`) alongside Note / Decision / Agent Note. Same BlockNote editor, same attachment hooks (drop, paste, thumbnail, inline render) — inherited from F.
- Posting a description dual-writes: append-only audit row in `comments` **plus** a PATCH on the entity's canonical field (`content` for manifests, `description` for products + tasks). Legacy field stays the source of truth so the Main tab's edit / DescriptionView flow is unchanged.
- Description rows render with an emerald left border + tinted background + secondary badge so the description-of-record stands out in the thread.
- Post button relabels to "Post as Description" and the placeholder hints at the dual-write while the description type is selected.

## Source-of-truth decision

Per the manifest's "pick one and document" prompt: **the entity's stored \`description\` / \`content\` field remains canonical.** Posting a description_revision comment writes the audit row and then PATCHes the entity field with the same body. Rationale: the Main tab's existing edit + DescriptionView path keeps working without rewiring; the comment row is a versioned trail that complements (not replaces) the canonical field. Switching to "latest comment is the truth" is a follow-up if needed.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean
- [ ] Manual smoke on a product detail page → Comments tab → pick "Description" → enter body + drop image → click "Post as Description" → row appears with badge + emerald rail; Main tab DescriptionView reflects the new content; image renders inline via the attachments backend
- [ ] Same on a manifest detail page (writes \`content\`)
- [ ] Same on a task detail page (writes \`description\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)