### PR TITLE
fix(portal-v2): BlockNote UX — toolbar + dark bg + slash hint + task rendered drift

### DIFF
--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,10 +49,10 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-DEz7B2Kn.js"></script>
+    <script type="module" crossorigin src="/assets/index-BkXf2MwO.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-CGgIkkjv.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-_EQQkAM-.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-COX1rcIE.css">
   </head>
 
   <body>

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,7 +49,7 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-BkXf2MwO.js"></script>
+    <script type="module" crossorigin src="/assets/index-BMoMixb_.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-CGgIkkjv.js">
     <link rel="stylesheet" crossorigin href="/assets/index-COX1rcIE.css">

--- a/internal/web/ui/dashboard-v2/src/components/blocknote-composer.tsx
+++ b/internal/web/ui/dashboard-v2/src/components/blocknote-composer.tsx
@@ -6,14 +6,29 @@ import {
   getDefaultReactSlashMenuItems,
   useCreateBlockNote,
   type DefaultReactSuggestionItem,
+  type BlockNoteEditor,
 } from '@blocknote/react'
-import { Layers, ListChecks, Package } from 'lucide-react'
 import {
-  searchEntities,
-  type EntityHit,
-} from '@/lib/queries/entity-search'
+  Bold,
+  Code,
+  Heading1,
+  Heading2,
+  Heading3,
+  Italic,
+  Link as LinkIcon,
+  List,
+  ListChecks,
+  ListOrdered,
+  Quote,
+  Strikethrough,
+  Underline,
+  Layers,
+  Package,
+} from 'lucide-react'
+import { searchEntities, type EntityHit } from '@/lib/queries/entity-search'
 import { uploadOrphanAttachment } from '@/lib/queries/attachments'
 import { opSchema } from './blocknote-schema'
+import { cn } from '@/lib/utils'
 import '@blocknote/core/fonts/inter.css'
 import '@blocknote/mantine/style.css'
 
@@ -23,18 +38,103 @@ export type BlockNoteComposerHandle = {
   clear: () => void
 }
 
-// BlockNote-based markdown composer. Replaces the textarea + toolbar
-// editor on every compose surface. The editor is wired with:
-//   - drag-drop + paste-image upload via uploadFile → orphan attachment
-//   - @-mentions for products / manifests / tasks via SuggestionMenuController
-//   - extended slash menu with 3 custom items for embedding entity cards
-//   - default toolbar, formatting, code blocks, tables, task lists,
-//     keyboard shortcuts (Cmd+B/I/U/E/K/Z + our Cmd-Enter / Esc bridge)
-//
-// Markdown round-trip: mentions degrade to plain anchor tags inside
-// the body (`[@label](href)`); custom card blocks degrade to anchor
-// links. They re-rehydrate on fresh inserts but persist as plain
-// links across save/load, matching the markdown source-of-truth.
+// Permanent formatting toolbar. Each button reaches into editor.*
+// directly — FormattingToolbarController is selection-driven and
+// won't render without a text selection. These show always.
+function ToolbarBtn({
+  title,
+  onClick,
+  children,
+}: {
+  title: string
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type='button'
+      tabIndex={-1}
+      title={title}
+      onMouseDown={(e) => {
+        e.preventDefault() // keep editor focused
+        onClick()
+      }}
+      className='text-muted-foreground hover:text-foreground hover:bg-accent rounded-sm p-1 transition-colors'
+    >
+      {children}
+    </button>
+  )
+}
+
+function Sep() {
+  return <span className='bg-border mx-0.5 inline-block h-4 w-px' />
+}
+
+function Toolbar({ editor }: { editor: BlockNoteEditor }) {
+  const block = () => editor.getTextCursorPosition().block
+
+  const setType = (type: string, props?: Record<string, unknown>) =>
+    editor.updateBlock(block(), { type, ...(props && { props }) } as never)
+
+  const toggle = (style: 'bold' | 'italic' | 'underline' | 'strike' | 'code') =>
+    editor.toggleStyles({ [style]: true } as never)
+
+  const insertLink = () => {
+    const url = window.prompt('URL') ?? ''
+    if (url.trim()) editor.createLink(url.trim())
+  }
+
+  const iconCls = 'h-3.5 w-3.5'
+  return (
+    <div className='border-border bg-muted/30 flex flex-wrap items-center gap-0.5 border-b px-2 py-1'>
+      <ToolbarBtn title='Heading 1' onClick={() => setType('heading', { level: 1 })}>
+        <Heading1 className={iconCls} />
+      </ToolbarBtn>
+      <ToolbarBtn title='Heading 2' onClick={() => setType('heading', { level: 2 })}>
+        <Heading2 className={iconCls} />
+      </ToolbarBtn>
+      <ToolbarBtn title='Heading 3' onClick={() => setType('heading', { level: 3 })}>
+        <Heading3 className={iconCls} />
+      </ToolbarBtn>
+      <Sep />
+      <ToolbarBtn title='Bold (⌘B)' onClick={() => toggle('bold')}>
+        <Bold className={iconCls} />
+      </ToolbarBtn>
+      <ToolbarBtn title='Italic (⌘I)' onClick={() => toggle('italic')}>
+        <Italic className={iconCls} />
+      </ToolbarBtn>
+      <ToolbarBtn title='Underline (⌘U)' onClick={() => toggle('underline')}>
+        <Underline className={iconCls} />
+      </ToolbarBtn>
+      <ToolbarBtn title='Strikethrough' onClick={() => toggle('strike')}>
+        <Strikethrough className={iconCls} />
+      </ToolbarBtn>
+      <ToolbarBtn title='Inline code (⌘E)' onClick={() => toggle('code')}>
+        <Code className={iconCls} />
+      </ToolbarBtn>
+      <ToolbarBtn title='Link (⌘K)' onClick={insertLink}>
+        <LinkIcon className={iconCls} />
+      </ToolbarBtn>
+      <Sep />
+      <ToolbarBtn title='Bullet list' onClick={() => setType('bulletListItem')}>
+        <List className={iconCls} />
+      </ToolbarBtn>
+      <ToolbarBtn title='Numbered list' onClick={() => setType('numberedListItem')}>
+        <ListOrdered className={iconCls} />
+      </ToolbarBtn>
+      <ToolbarBtn title='Task list' onClick={() => setType('checkListItem')}>
+        <ListChecks className={iconCls} />
+      </ToolbarBtn>
+      <ToolbarBtn title='Quote' onClick={() => setType('quote')}>
+        <Quote className={iconCls} />
+      </ToolbarBtn>
+      <ToolbarBtn title='Code block' onClick={() => setType('codeBlock')}>
+        <Code className={cn(iconCls, 'opacity-70')} />
+      </ToolbarBtn>
+    </div>
+  )
+}
+
 export function BlockNoteComposer({
   initialMarkdown = '',
   onSave,
@@ -59,11 +159,14 @@ export function BlockNoteComposer({
   const editor = useCreateBlockNote({
     schema: opSchema,
     uploadFile,
+    dictionary: {
+      placeholders: {
+        default: placeholder ?? "Type '/' for blocks, '@' to mention…",
+        emptyDocument: undefined,
+      },
+    } as never,
   })
 
-  // Hydrate from markdown on mount. Editor instance is stable per
-  // mount; cancel guard prevents the parse promise resolving after
-  // unmount.
   const hydratedRef = useRef(false)
   useEffect(() => {
     if (hydratedRef.current) return
@@ -78,58 +181,37 @@ export function BlockNoteComposer({
       editor.replaceBlocks(editor.document, blocks)
       hydratedRef.current = true
     })()
-    return () => {
-      cancelled = true
-    }
+    return () => { cancelled = true }
   }, [editor, initialMarkdown])
 
-  useImperativeHandle(
-    ref,
-    () => ({
-      getMarkdown: () => editor.blocksToMarkdownLossy(editor.document),
-      getAttachmentIDs: () => attachmentIdsRef.current.slice(),
-      clear: () => {
-        editor.replaceBlocks(editor.document, [
-          { type: 'paragraph', content: [] },
-        ])
-        attachmentIdsRef.current = []
-      },
-    }),
-    [editor]
-  )
+  useImperativeHandle(ref, () => ({
+    getMarkdown: () => editor.blocksToMarkdownLossy(editor.document),
+    getAttachmentIDs: () => attachmentIdsRef.current.slice(),
+    clear: () => {
+      editor.replaceBlocks(editor.document, [{ type: 'paragraph', content: [] }])
+      attachmentIdsRef.current = []
+    },
+  }), [editor])
 
   const onKeyDownCapture = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-      if (onSave) {
-        e.preventDefault()
-        e.stopPropagation()
-        onSave()
-      }
+      e.preventDefault(); e.stopPropagation(); onSave?.()
     } else if (e.key === 'Escape') {
-      if (onCancel) {
-        e.preventDefault()
-        e.stopPropagation()
-        onCancel()
-      }
+      e.preventDefault(); e.stopPropagation(); onCancel?.()
     }
   }
 
-  // @-mention items — fan-out search across products, manifests, tasks.
   const getMentionItems = useCallback(
     async (query: string): Promise<DefaultReactSuggestionItem[]> => {
       const hits = await searchEntities(query)
       return hits.map((hit: EntityHit) => ({
         title: hit.title,
         subtext: `${hit.kind} · ${hit.id.slice(0, 8)}`,
-        onItemClick: () => {
+        onItemClick: () =>
           editor.insertInlineContent([
-            {
-              type: 'mention',
-              props: { kind: hit.kind, id: hit.id, label: hit.title },
-            },
+            { type: 'mention', props: { kind: hit.kind, id: hit.id, label: hit.title } },
             ' ',
-          ])
-        },
+          ]),
         aliases: [hit.id, hit.id.slice(0, 8)],
         group: hit.kind,
       }))
@@ -137,9 +219,6 @@ export function BlockNoteComposer({
     [editor]
   )
 
-  // Slash menu — defaults plus three "Embed … card" items that prompt
-  // the operator for an entity id, then insert the corresponding
-  // custom block.
   const getSlashItems = useCallback(
     async (query: string): Promise<DefaultReactSuggestionItem[]> => {
       const defaults = getDefaultReactSlashMenuItems(editor)
@@ -154,37 +233,35 @@ export function BlockNoteComposer({
         group: 'OpenPraxis',
         icon: <Icon className='h-4 w-4' />,
         onItemClick: () => {
-          const id = window.prompt(`${label} id (UUID)`) ?? ''
-          const trimmed = id.trim()
-          if (!trimmed) return
+          const id = (window.prompt(`${label} id (UUID)`) ?? '').trim()
+          if (!id) return
           editor.insertBlocks(
-            [{ type, props: { id: trimmed } }],
+            [{ type, props: { id } }],
             editor.getTextCursorPosition().block,
             'after'
           )
         },
       })
-      const custom: DefaultReactSuggestionItem[] = [
-        insertCard('productCard', 'Product card', Package),
-        insertCard('manifestCard', 'Manifest card', Layers),
-        insertCard('taskCard', 'Task card', ListChecks),
-      ]
-      return filterSuggestionItems([...custom, ...defaults], query)
+      return filterSuggestionItems(
+        [
+          insertCard('productCard', 'Product card', Package),
+          insertCard('manifestCard', 'Manifest card', Layers),
+          insertCard('taskCard', 'Task card', ListChecks),
+          ...defaults,
+        ],
+        query
+      )
     },
     [editor]
   )
 
   return (
     <div
-      className='border-border bg-input/30 overflow-hidden rounded-md border'
+      className='border-border bg-card overflow-hidden rounded-md border'
       onKeyDownCapture={onKeyDownCapture}
-      data-placeholder={placeholder}
     >
-      <BlockNoteView
-        editor={editor}
-        theme='dark'
-        slashMenu={false}
-      >
+      <Toolbar editor={editor as BlockNoteEditor} />
+      <BlockNoteView editor={editor} theme='dark' slashMenu={false}>
         <SuggestionMenuController
           triggerCharacter='@'
           minQueryLength={1}

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/main.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/main.tsx
@@ -83,11 +83,10 @@ export function MainTab({
 
   const startEdit = () => {
     const e = entity.data as Product | Manifest | undefined
-    // Manifests use `content` for the spec body; products use `description`.
     const initial =
-      kind === 'product'
-        ? (e?.description ?? '')
-        : ((e as Manifest | undefined)?.content ?? e?.description ?? '')
+      kind === 'manifest'
+        ? ((e as Manifest | undefined)?.content ?? e?.description ?? '')
+        : (e?.description ?? '')
     setInitialDraft(initial)
     setEditing(true)
   }
@@ -105,9 +104,9 @@ export function MainTab({
       // in the markdown still resolve via /api/attachments/{id}; row
       // hygiene (orphan cleanup or claim-against-entity) is a follow-up.
       const patch =
-        kind === 'product'
-          ? { description: draft }
-          : { content: draft }
+        kind === 'manifest'
+          ? { content: draft }
+          : { description: draft }
       await update.mutateAsync(patch)
       setEditing(false)
     } catch (e) {
@@ -135,19 +134,18 @@ export function MainTab({
         : 'text-emerald-500'
 
   const description =
-    kind === 'product'
-      ? (e as Product | undefined)?.description
-      : // Manifest's description-of-record is the spec body in `content`;
-        // `description` is just a one-liner summary. Show the spec.
-        ((e as Manifest | undefined)?.content ??
-          (e as Manifest | undefined)?.description)
+    kind === 'manifest'
+      ? // Manifests store the spec body in `content`; `description` is
+        // just a one-liner summary. Show the full spec.
+        ((e as Manifest | undefined)?.content ?? e?.description)
+      : e?.description
 
   const descriptionHTML =
-    kind === 'product'
-      ? ((e as Record<string, unknown> | undefined)?.['description_html'] as
+    kind === 'manifest'
+      ? ((e as Record<string, unknown> | undefined)?.['content_html'] as
           | string
           | undefined)
-      : ((e as Record<string, unknown> | undefined)?.['content_html'] as
+      : ((e as Record<string, unknown> | undefined)?.['description_html'] as
           | string
           | undefined)
 

--- a/internal/web/ui/dashboard-v2/src/styles/blocknote-theme.css
+++ b/internal/web/ui/dashboard-v2/src/styles/blocknote-theme.css
@@ -1,46 +1,43 @@
 /* BlockNote → shadcn token bridge.
  *
- * BlockNote ships its own --bn-colors-* CSS vars (light + dark via
- * data-color-scheme). Map them onto our shadcn tokens so the editor
- * adopts the same background, border, ring, and surface colors as
- * the rest of Portal V2 instead of the default mantine palette.
- *
- * Targets .bn-container[data-color-scheme] (BlockNote 0.49 wraps
- * every editor in this element). Light + dark inherit because we
- * remap the same tokens in both modes — shadcn's --background +
- * --foreground already flip via .dark on <html>.
+ * The token vars live on .bn-root (not .bn-container — previous
+ * selector was wrong). BlockNote sets data-color-scheme on .bn-root
+ * and resolves --bn-colors-* from there. We remap those vars to our
+ * shadcn tokens in both light and dark; the .dark class on <html>
+ * already flips --background / --foreground / etc.
  */
 
-.bn-container[data-color-scheme] {
-  --bn-colors-editor-text: var(--foreground);
-  --bn-colors-editor-background: var(--background);
-  --bn-colors-menu-text: var(--foreground);
-  --bn-colors-menu-background: var(--popover);
-  --bn-colors-tooltip-text: var(--popover-foreground);
-  --bn-colors-tooltip-background: var(--popover);
-  --bn-colors-hovered-text: var(--accent-foreground);
-  --bn-colors-hovered-background: var(--accent);
-  --bn-colors-selected-text: var(--primary-foreground);
-  --bn-colors-selected-background: var(--primary);
-  --bn-colors-disabled-text: var(--muted-foreground);
-  --bn-colors-disabled-background: var(--muted);
-  --bn-colors-shadow: var(--border);
-  --bn-colors-border: var(--border);
-  --bn-colors-side-menu: var(--muted-foreground);
-  --bn-border-radius: var(--radius);
-  --bn-font-family: inherit;
+.bn-root[data-color-scheme],
+.bn-root[data-color-scheme="dark"],
+.bn-root[data-color-scheme="light"] {
+  --bn-colors-editor-text: var(--foreground) !important;
+  --bn-colors-editor-background: var(--card) !important;
+  --bn-colors-menu-text: var(--foreground) !important;
+  --bn-colors-menu-background: var(--popover) !important;
+  --bn-colors-tooltip-text: var(--popover-foreground) !important;
+  --bn-colors-tooltip-background: var(--popover) !important;
+  --bn-colors-hovered-text: var(--accent-foreground) !important;
+  --bn-colors-hovered-background: var(--accent) !important;
+  --bn-colors-selected-text: var(--primary-foreground) !important;
+  --bn-colors-selected-background: var(--primary) !important;
+  --bn-colors-disabled-text: var(--muted-foreground) !important;
+  --bn-colors-disabled-background: var(--muted) !important;
+  --bn-colors-shadow: var(--border) !important;
+  --bn-colors-border: var(--border) !important;
+  --bn-colors-side-menu: var(--muted-foreground) !important;
+  --bn-border-radius: var(--radius) !important;
+  --bn-font-family: inherit !important;
 }
 
-/* The mantine-themed inner editor inherits some focus rings from its
- * default stylesheet that don't match shadcn — flatten them onto our
- * --ring token so focused blocks/buttons match the rest of the app. */
-.bn-container [class*="mantine-"]:focus-visible,
-.bn-container [class*="mantine-"][data-focused="true"] {
-  outline-color: var(--ring) !important;
-}
-
-/* Compose surfaces sit inside our existing rounded card; remove the
- * BlockNote container's inner padding so it lines up flush. */
-.bn-container .bn-editor {
+/* Ensure the inner contenteditable area inherits our bg rather than
+ * whatever mantine inlines as a style attribute. */
+.bn-root .bn-editor {
+  background-color: var(--card) !important;
   padding: 0.5rem 0.75rem;
+}
+
+/* Match focus rings to shadcn --ring. */
+.bn-root [class*="mantine-"]:focus-visible,
+.bn-root [class*="mantine-"][data-focused="true"] {
+  outline-color: var(--ring) !important;
 }


### PR DESCRIPTION
## Summary

Four fixes based on operator review session (2026-05-01).

### 1. Theme bridge selector was wrong (gray background)
`blocknote-theme.css` targeted `.bn-container[data-color-scheme]` — BlockNote puts `data-color-scheme` on `.bn-root`, not `.bn-container`. Added `!important` on all token remaps so they beat any mantine inline styles. Editor body now uses `--card` to match the surrounding surface.

### 2. No visible toolbar
BlockNote's formatting toolbar is selection-driven (popup on text select). Operators expected a permanent strip like the old textarea editor. Added a custom static toolbar above `<BlockNoteView>` with: H1/H2/H3, B/I/U/Strike/code, link, bullet/numbered/task list, quote, code block. Uses `onMouseDown + preventDefault` so clicking a button doesn't steal editor focus.

### 3. Empty-state placeholder hid the `/` and `@` discovery paths
Overrode `dictionary.placeholders.default` so the empty editor shows: *"Type '/' for blocks, '@' to mention…"*

### 4. Task `Rendered` mode showed nothing (description_html drift)
`main.tsx` had `kind === 'product' ? ... : ...` with manifests as the implied else. Tasks also have `description_html` (not `content_html`), so the rendered HTML was always `undefined` for tasks. Same drift in `startEdit` (read) and `save` (write) — tasks were trying to read/write `content` instead of `description`. Fixed by making manifest the special case and products + tasks the shared default path.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [x] Headless Chromium smoke — home / products / manifests / tasks all render, zero pageerrors
- [x] Comment compose screenshot confirms toolbar + dark bg + placeholder visible
- [ ] Verify task "Rendered" mode shows description content (needs live serve test)