### PR TITLE
feat(execution): EL/M1-T3 — BackfillFromTaskRuns + ComputeDerived

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/k8nstantin/OpenPraxis/internal/chat"
 	"github.com/k8nstantin/OpenPraxis/internal/config"
+	executionlog "github.com/k8nstantin/OpenPraxis/internal/execution"
 	mcpserver "github.com/k8nstantin/OpenPraxis/internal/mcp"
 	"github.com/k8nstantin/OpenPraxis/internal/node"
 	"github.com/k8nstantin/OpenPraxis/internal/peer"
@@ -216,6 +217,13 @@ var serveCmd = &cobra.Command{
 		// Backfill cost_usd for existing runs that have output but no cost recorded
 		if backfilled, err := n.Tasks.BackfillCosts(); err == nil && backfilled > 0 {
 			slog.Info("backfilled cost data", "runs", backfilled)
+		}
+
+		// Backfill execution_log from task_runs (one-shot, idempotent).
+		if migrated, err := executionlog.BackfillFromTaskRuns(ctx, n.Index.DB()); err != nil {
+			slog.Warn("execution_log backfill failed", "error", err)
+		} else if migrated > 0 {
+			slog.Info("execution_log: backfilled rows from task_runs", "count", migrated)
 		}
 
 		// Post-task subsystem torn out per operator request 2026-04-30.

--- a/internal/execution/migration.go
+++ b/internal/execution/migration.go
@@ -1,0 +1,241 @@
+package execution
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// BackfillFromTaskRuns copies all existing task_runs rows into execution_log.
+// Idempotent: returns 0 immediately if any task-kind rows already exist.
+func BackfillFromTaskRuns(ctx context.Context, db *sql.DB) (int, error) {
+	var existing int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM execution_log WHERE entity_kind='task' AND run_number > 0`,
+	).Scan(&existing); err != nil {
+		return 0, fmt.Errorf("backfill: check existing: %w", err)
+	}
+	if existing > 0 {
+		return 0, nil
+	}
+
+	rows, err := db.QueryContext(ctx, `SELECT
+		task_id, run_number, output, status, actions, lines,
+		cost_usd, turns, started_at, completed_at,
+		input_tokens, output_tokens, cache_read_tokens, cache_create_tokens,
+		model, pricing_version, duration_ms, agent_runtime, agent_version,
+		peak_cpu_pct, avg_cpu_pct, peak_rss_mb, avg_rss_mb,
+		errors, compactions, files_changed, lines_added, lines_removed,
+		exit_code, cancelled_at, cancelled_by,
+		branch, commit_sha, commits, pr_number, worktree_path
+	FROM task_runs`)
+	if err != nil {
+		return 0, fmt.Errorf("backfill: query task_runs: %w", err)
+	}
+	defer rows.Close()
+
+	type taskRunRow struct {
+		taskID, output, status, model, pricingVersion   string
+		agentRuntime, agentVersion                      string
+		startedAt, completedAt, cancelledAt, cancelledBy string
+		branch, commitSHA, worktreePath                  string
+		runNumber, actions, lines, turns                 int
+		inputTokens, outputTokens                        int
+		cacheReadTokens, cacheCreateTokens               int
+		errors, compactions, filesChanged                int
+		linesAdded, linesRemoved, exitCode, commits      int
+		prNumber                                         int
+		costUSD                                          float64
+		durationMS                                       int64
+		peakCPUPct, avgCPUPct, peakRSSMB, avgRSSMB      float64
+	}
+
+	var batch []taskRunRow
+	for rows.Next() {
+		var r taskRunRow
+		if err := rows.Scan(
+			&r.taskID, &r.runNumber, &r.output, &r.status, &r.actions, &r.lines,
+			&r.costUSD, &r.turns, &r.startedAt, &r.completedAt,
+			&r.inputTokens, &r.outputTokens, &r.cacheReadTokens, &r.cacheCreateTokens,
+			&r.model, &r.pricingVersion, &r.durationMS, &r.agentRuntime, &r.agentVersion,
+			&r.peakCPUPct, &r.avgCPUPct, &r.peakRSSMB, &r.avgRSSMB,
+			&r.errors, &r.compactions, &r.filesChanged, &r.linesAdded, &r.linesRemoved,
+			&r.exitCode, &r.cancelledAt, &r.cancelledBy,
+			&r.branch, &r.commitSHA, &r.commits, &r.prNumber, &r.worktreePath,
+		); err != nil {
+			return 0, fmt.Errorf("backfill: scan row: %w", err)
+		}
+		batch = append(batch, r)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("backfill: iterate rows: %w", err)
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("backfill: begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	inserted := 0
+	for _, tr := range batch {
+		id, _ := uuid.NewV7()
+
+		startedAtMS := parseTimeMS(tr.startedAt)
+		completedAtMS := parseTimeMS(tr.completedAt)
+		cancelledAtMS := parseTimeMS(tr.cancelledAt)
+
+		info := LookupModel(tr.model)
+
+		exitCode := tr.exitCode
+		var prNumber *int
+		if tr.prNumber != 0 {
+			n := tr.prNumber
+			prNumber = &n
+		}
+
+		r := Row{
+			ID:                id.String(),
+			EntityKind:        KindTask,
+			EntityID:          tr.taskID,
+			RunNumber:         tr.runNumber,
+			Status:            tr.status,
+			TerminalReason:    terminalReason(tr.status),
+			StartedAt:         startedAtMS,
+			CompletedAt:       completedAtMS,
+			DurationMS:        tr.durationMS,
+			ExitCode:          &exitCode,
+			CancelledAt:       cancelledAtMS,
+			CancelledBy:       tr.cancelledBy,
+			Provider:          info.Provider,
+			Model:             tr.model,
+			ModelContextSize:  info.ContextWindowSize,
+			AgentRuntime:      tr.agentRuntime,
+			AgentVersion:      tr.agentVersion,
+			PricingVersion:    tr.pricingVersion,
+			InputTokens:       tr.inputTokens,
+			OutputTokens:      tr.outputTokens,
+			CacheReadTokens:   tr.cacheReadTokens,
+			CacheCreateTokens: tr.cacheCreateTokens,
+			CostUSD:           tr.costUSD,
+			Turns:             tr.turns,
+			Actions:           tr.actions,
+			Errors:            tr.errors,
+			Compactions:       tr.compactions,
+			FilesChanged:      tr.filesChanged,
+			LinesAdded:        tr.linesAdded,
+			LinesRemoved:      tr.linesRemoved,
+			Commits:           tr.commits,
+			PRNumber:          prNumber,
+			Branch:            tr.branch,
+			CommitSHA:         tr.commitSHA,
+			WorktreePath:      tr.worktreePath,
+			PeakCPUPct:        tr.peakCPUPct,
+			AvgCPUPct:         tr.avgCPUPct,
+			PeakRSSMB:         tr.peakRSSMB,
+			AvgRSSMB:          tr.avgRSSMB,
+			ToolCallsJSON:     "{}",
+			LastOutput:        tr.output,
+		}
+		ComputeDerived(&r)
+
+		_, err := tx.ExecContext(ctx, `INSERT INTO execution_log (
+			id, entity_kind, entity_id, run_number, trigger, node_id, status,
+			terminal_reason, started_at, completed_at, duration_ms, ttfb_ms,
+			exit_code, error, cancelled_at, cancelled_by, provider, model,
+			model_context_size, agent_runtime, agent_version, pricing_version,
+			input_tokens, output_tokens, cache_read_tokens, cache_create_tokens,
+			reasoning_tokens, tool_use_tokens, cost_usd, estimated_cost_usd,
+			cache_savings_usd, cache_hit_rate_pct, context_window_pct,
+			cost_per_turn, cost_per_action, tokens_per_turn, turns, actions,
+			errors, compactions, parallel_tasks, tool_calls_json,
+			lines_added, lines_removed, files_changed, commits, pr_number,
+			branch, commit_sha, worktree_path,
+			peak_cpu_pct, avg_cpu_pct, peak_rss_mb, avg_rss_mb, disk_used_gb,
+			last_output
+		) VALUES (
+			?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?
+		)`,
+			r.ID, r.EntityKind, r.EntityID, r.RunNumber, r.Trigger, r.NodeID, r.Status,
+			r.TerminalReason, r.StartedAt, r.CompletedAt, r.DurationMS, r.TTFBMS,
+			r.ExitCode, r.Error, r.CancelledAt, r.CancelledBy, r.Provider, r.Model,
+			r.ModelContextSize, r.AgentRuntime, r.AgentVersion, r.PricingVersion,
+			r.InputTokens, r.OutputTokens, r.CacheReadTokens, r.CacheCreateTokens,
+			r.ReasoningTokens, r.ToolUseTokens, r.CostUSD, r.EstimatedCostUSD,
+			r.CacheSavingsUSD, r.CacheHitRatePct, r.ContextWindowPct,
+			r.CostPerTurn, r.CostPerAction, r.TokensPerTurn, r.Turns, r.Actions,
+			r.Errors, r.Compactions, r.ParallelTasks, r.ToolCallsJSON,
+			r.LinesAdded, r.LinesRemoved, r.FilesChanged, r.Commits, r.PRNumber,
+			r.Branch, r.CommitSHA, r.WorktreePath,
+			r.PeakCPUPct, r.AvgCPUPct, r.PeakRSSMB, r.AvgRSSMB, r.DiskUsedGB,
+			r.LastOutput,
+		)
+		if err != nil {
+			return 0, fmt.Errorf("backfill: insert row: %w", err)
+		}
+		inserted++
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("backfill: commit: %w", err)
+	}
+
+	slog.Info("backfill: migrated N rows from task_runs", "count", inserted)
+	return inserted, nil
+}
+
+// ComputeDerived fills in ratio/derived fields on r from its raw counters.
+func ComputeDerived(r *Row) {
+	if r.DurationMS == 0 && r.CompletedAt > r.StartedAt {
+		r.DurationMS = r.CompletedAt - r.StartedAt
+	}
+
+	totalInput := r.InputTokens + r.CacheReadTokens
+	if totalInput > 0 {
+		r.CacheHitRatePct = float64(r.CacheReadTokens) / float64(totalInput) * 100
+	}
+
+	if r.ModelContextSize > 0 {
+		total := r.InputTokens + r.OutputTokens + r.CacheReadTokens + r.CacheCreateTokens
+		r.ContextWindowPct = float64(total) / float64(r.ModelContextSize) * 100
+	}
+
+	if r.Turns > 0 {
+		r.CostPerTurn = r.CostUSD / float64(r.Turns)
+		r.TokensPerTurn = float64(r.InputTokens+r.OutputTokens) / float64(r.Turns)
+	}
+
+	if r.Actions > 0 {
+		r.CostPerAction = r.CostUSD / float64(r.Actions)
+	}
+}
+
+func terminalReason(status string) string {
+	switch status {
+	case "completed":
+		return "success"
+	case "failed":
+		return "error"
+	case "cancelled":
+		return "cancelled"
+	default:
+		return status
+	}
+}
+
+// parseTimeMS parses an RFC3339 string and returns unix milliseconds.
+// Returns 0 for empty or unparseable strings.
+func parseTimeMS(s string) int64 {
+	if s == "" {
+		return 0
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return 0
+	}
+	return t.UnixMilli()
+}

--- a/internal/execution/store_test.go
+++ b/internal/execution/store_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -213,5 +214,192 @@ func TestInsertSample_and_list(t *testing.T) {
 	}
 	if samples[0].CPUPct != 30 {
 		t.Errorf("CPUPct: got %v want 30", samples[0].CPUPct)
+	}
+}
+
+// seedTaskRuns creates the task_runs table and inserts rows for backfill tests.
+func seedTaskRuns(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS task_runs (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		task_id TEXT NOT NULL,
+		run_number INTEGER NOT NULL DEFAULT 0,
+		output TEXT NOT NULL DEFAULT '',
+		status TEXT NOT NULL DEFAULT '',
+		actions INTEGER NOT NULL DEFAULT 0,
+		lines INTEGER NOT NULL DEFAULT 0,
+		cost_usd REAL NOT NULL DEFAULT 0,
+		turns INTEGER NOT NULL DEFAULT 0,
+		started_at TEXT NOT NULL DEFAULT '',
+		completed_at TEXT NOT NULL DEFAULT '',
+		input_tokens INTEGER NOT NULL DEFAULT 0,
+		output_tokens INTEGER NOT NULL DEFAULT 0,
+		cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+		cache_create_tokens INTEGER NOT NULL DEFAULT 0,
+		model TEXT NOT NULL DEFAULT '',
+		pricing_version TEXT NOT NULL DEFAULT '',
+		duration_ms INTEGER NOT NULL DEFAULT 0,
+		agent_runtime TEXT NOT NULL DEFAULT '',
+		agent_version TEXT NOT NULL DEFAULT '',
+		peak_cpu_pct REAL NOT NULL DEFAULT 0,
+		avg_cpu_pct REAL NOT NULL DEFAULT 0,
+		peak_rss_mb REAL NOT NULL DEFAULT 0,
+		avg_rss_mb REAL NOT NULL DEFAULT 0,
+		errors INTEGER NOT NULL DEFAULT 0,
+		compactions INTEGER NOT NULL DEFAULT 0,
+		files_changed INTEGER NOT NULL DEFAULT 0,
+		lines_added INTEGER NOT NULL DEFAULT 0,
+		lines_removed INTEGER NOT NULL DEFAULT 0,
+		exit_code INTEGER NOT NULL DEFAULT 0,
+		cancelled_at TEXT NOT NULL DEFAULT '',
+		cancelled_by TEXT NOT NULL DEFAULT '',
+		branch TEXT NOT NULL DEFAULT '',
+		commit_sha TEXT NOT NULL DEFAULT '',
+		commits INTEGER NOT NULL DEFAULT 0,
+		pr_number INTEGER NOT NULL DEFAULT 0,
+		worktree_path TEXT NOT NULL DEFAULT ''
+	)`)
+	if err != nil {
+		t.Fatalf("seedTaskRuns: create table: %v", err)
+	}
+}
+
+func insertTaskRun(t *testing.T, db *sql.DB, taskID string, runNum int, status string, startedAt time.Time, cost float64, turns, actions int) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO task_runs
+		(task_id, run_number, output, status, actions, lines, cost_usd, turns,
+		 started_at, completed_at, input_tokens, output_tokens,
+		 cache_read_tokens, cache_create_tokens, model, pricing_version,
+		 duration_ms, agent_runtime, agent_version,
+		 peak_cpu_pct, avg_cpu_pct, peak_rss_mb, avg_rss_mb,
+		 errors, compactions, files_changed, lines_added, lines_removed,
+		 exit_code, cancelled_at, cancelled_by,
+		 branch, commit_sha, commits, pr_number, worktree_path)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		taskID, runNum, "done", status, actions, 0, cost, turns,
+		startedAt.UTC().Format(time.RFC3339),
+		startedAt.Add(10*time.Second).UTC().Format(time.RFC3339),
+		100, 50, 20, 10, "claude-sonnet-4-6", "v1-2026-04",
+		10000, "claude-code", "",
+		70.0, 40.0, 256.0, 200.0,
+		0, 0, 2, 5, 1,
+		0, "", "",
+		"feat/x", "abc123", 1, 0, "/tmp/wt",
+	)
+	if err != nil {
+		t.Fatalf("insertTaskRun: %v", err)
+	}
+}
+
+func TestBackfill_idempotent(t *testing.T) {
+	db := openTestDB(t)
+	if err := InitSchema(db); err != nil {
+		t.Fatal(err)
+	}
+	seedTaskRuns(t, db)
+	ctx := context.Background()
+	started := time.Now().UTC().Truncate(time.Second)
+	insertTaskRun(t, db, "task-001", 1, "completed", started, 0.01, 3, 5)
+	insertTaskRun(t, db, "task-001", 2, "failed", started.Add(time.Minute), 0.005, 1, 2)
+
+	n1, err := BackfillFromTaskRuns(ctx, db)
+	if err != nil {
+		t.Fatalf("first backfill: %v", err)
+	}
+	if n1 != 2 {
+		t.Errorf("first backfill: expected 2 rows, got %d", n1)
+	}
+
+	n2, err := BackfillFromTaskRuns(ctx, db)
+	if err != nil {
+		t.Fatalf("second backfill: %v", err)
+	}
+	if n2 != 0 {
+		t.Errorf("second backfill should be no-op, got %d", n2)
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM execution_log`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Errorf("row count after double backfill: got %d want 2", count)
+	}
+}
+
+func TestBackfill_field_mapping(t *testing.T) {
+	db := openTestDB(t)
+	if err := InitSchema(db); err != nil {
+		t.Fatal(err)
+	}
+	seedTaskRuns(t, db)
+	ctx := context.Background()
+
+	started := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	insertTaskRun(t, db, "task-xyz", 3, "completed", started, 0.025, 5, 10)
+
+	if _, err := BackfillFromTaskRuns(ctx, db); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	s := NewStore(db)
+	rows, err := s.ListByEntity(ctx, KindTask, "task-xyz", 10)
+	if err != nil {
+		t.Fatalf("ListByEntity: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	r := rows[0]
+
+	if r.EntityKind != KindTask {
+		t.Errorf("EntityKind: got %q want %q", r.EntityKind, KindTask)
+	}
+	if r.EntityID != "task-xyz" {
+		t.Errorf("EntityID: got %q want task-xyz", r.EntityID)
+	}
+	if r.RunNumber != 3 {
+		t.Errorf("RunNumber: got %d want 3", r.RunNumber)
+	}
+	if r.Status != "completed" {
+		t.Errorf("Status: got %q want completed", r.Status)
+	}
+	if r.TerminalReason != "success" {
+		t.Errorf("TerminalReason: got %q want success", r.TerminalReason)
+	}
+	if r.CostUSD != 0.025 {
+		t.Errorf("CostUSD: got %v want 0.025", r.CostUSD)
+	}
+	if r.Turns != 5 {
+		t.Errorf("Turns: got %d want 5", r.Turns)
+	}
+	if r.Actions != 10 {
+		t.Errorf("Actions: got %d want 10", r.Actions)
+	}
+	wantStartedAt := started.UnixMilli()
+	if r.StartedAt != wantStartedAt {
+		t.Errorf("StartedAt: got %d want %d", r.StartedAt, wantStartedAt)
+	}
+	if r.Provider != "anthropic" {
+		t.Errorf("Provider: got %q want anthropic", r.Provider)
+	}
+	if r.Model != "claude-sonnet-4-6" {
+		t.Errorf("Model: got %q want claude-sonnet-4-6", r.Model)
+	}
+	if r.ModelContextSize != 200_000 {
+		t.Errorf("ModelContextSize: got %d want 200000", r.ModelContextSize)
+	}
+	// Derived: CacheHitRatePct = 20/(100+20)*100 ≈ 16.666...
+	if r.CacheHitRatePct <= 0 {
+		t.Errorf("CacheHitRatePct: got %v want > 0", r.CacheHitRatePct)
+	}
+	if r.CostPerTurn <= 0 {
+		t.Errorf("CostPerTurn: got %v want > 0", r.CostPerTurn)
+	}
+	if r.Branch != "feat/x" {
+		t.Errorf("Branch: got %q want feat/x", r.Branch)
+	}
+	if r.CommitSHA != "abc123" {
+		t.Errorf("CommitSHA: got %q want abc123", r.CommitSHA)
 	}
 }


### PR DESCRIPTION
## Summary

- Creates `internal/execution/migration.go` with `BackfillFromTaskRuns(ctx, db)` — one-shot idempotent migration from `task_runs` → `execution_log`
- Adds `ComputeDerived(*Row)` — fills cache hit rate, context window %, cost/turn, tokens/turn ratios from raw counters
- Wires `BackfillFromTaskRuns` call in `cmd/serve.go` after `BackfillCosts`, before server starts
- Adds `TestBackfill_idempotent` and `TestBackfill_field_mapping` to the execution package test suite

## Test plan

- [ ] `go build ./...` — passes (only third-party deprecation warnings)
- [ ] `go test ./internal/execution/...` — 8/8 PASS including both new backfill tests
- [ ] Idempotency verified: second call returns 0 rows without doubling

🤖 Generated with [Claude Code](https://claude.ai/claude-code)