### PR TITLE
feat(execution): EL/M1-T2 — model registry LookupModel(modelID) → provider + context_window

### DIFF
--- a/internal/execution/model_registry.go
+++ b/internal/execution/model_registry.go
@@ -1,0 +1,43 @@
+package execution
+
+// ModelInfo describes a model's provider and maximum context window.
+type ModelInfo struct {
+	Provider          string
+	ContextWindowSize int
+}
+
+// modelRegistry maps known model IDs to their provider and context window.
+// Seeded from the default_model catalog values plus common Anthropic/Google/OpenAI entries.
+var modelRegistry = map[string]ModelInfo{
+	// Anthropic
+	"claude-opus-4-7":         {Provider: "anthropic", ContextWindowSize: 1_000_000},
+	"claude-sonnet-4-6":       {Provider: "anthropic", ContextWindowSize: 200_000},
+	"claude-haiku-4-5":        {Provider: "anthropic", ContextWindowSize: 200_000},
+	"claude-haiku-4-5-20251001": {Provider: "anthropic", ContextWindowSize: 200_000},
+
+	// Google — Gemini 3 series (in catalog)
+	"gemini-3-pro":   {Provider: "google", ContextWindowSize: 2_097_152},
+	"gemini-3-flash": {Provider: "google", ContextWindowSize: 1_048_576},
+	"gemini-3-ultra": {Provider: "google", ContextWindowSize: 2_097_152},
+
+	// Google — Gemini 2.5 series
+	"gemini-2.5-pro":   {Provider: "google", ContextWindowSize: 2_097_152},
+	"gemini-2.5-flash": {Provider: "google", ContextWindowSize: 1_048_576},
+
+	// Google — Gemini 2.0 series
+	"gemini-2.0-flash":          {Provider: "google", ContextWindowSize: 1_048_576},
+	"gemini-2.0-flash-exp":      {Provider: "google", ContextWindowSize: 1_048_576},
+	"gemini-2.0-pro-exp-02-05":  {Provider: "google", ContextWindowSize: 1_048_576},
+
+	// OpenAI
+	"gpt-4o": {Provider: "openai", ContextWindowSize: 128_000},
+}
+
+// LookupModel returns the ModelInfo for a given model ID.
+// Returns {Provider:"unknown", ContextWindowSize:200_000} for unrecognised models.
+func LookupModel(modelID string) ModelInfo {
+	if info, ok := modelRegistry[modelID]; ok {
+		return info
+	}
+	return ModelInfo{Provider: "unknown", ContextWindowSize: 200_000}
+}

--- a/internal/execution/store_test.go
+++ b/internal/execution/store_test.go
@@ -165,6 +165,26 @@ func TestListByEntity_order(t *testing.T) {
 	}
 }
 
+func TestLookupModel_known(t *testing.T) {
+	info := LookupModel("claude-opus-4-7")
+	if info.Provider != "anthropic" {
+		t.Errorf("Provider: got %q want %q", info.Provider, "anthropic")
+	}
+	if info.ContextWindowSize != 1_000_000 {
+		t.Errorf("ContextWindowSize: got %d want %d", info.ContextWindowSize, 1_000_000)
+	}
+}
+
+func TestLookupModel_unknown(t *testing.T) {
+	info := LookupModel("some-future-model-xyz")
+	if info.Provider != "unknown" {
+		t.Errorf("Provider: got %q want %q", info.Provider, "unknown")
+	}
+	if info.ContextWindowSize != 200_000 {
+		t.Errorf("ContextWindowSize: got %d want %d", info.ContextWindowSize, 200_000)
+	}
+}
+
 func TestInsertSample_and_list(t *testing.T) {
 	db := openTestDB(t)
 	if err := InitSchema(db); err != nil {


### PR DESCRIPTION
Re-opened after stacked base (#313) was merged and deleted.

Adds `internal/execution/model_registry.go` — `ModelInfo{Provider, ContextWindowSize}` + `LookupModel(modelID string) ModelInfo` seeded with all known Anthropic / Google / OpenAI model strings. Used by the write path (EL/M2) to populate `provider` and `context_window_pct` in `execution_log` at run start.

Part of [Execution Log product 019de575](http://localhost:8765/#/products?id=019de575-7c07-7196-89c4-2f690db1da87).