### PR TITLE
feat(execution): EL/M2-T1 — INSERT execution_log row at run start

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -430,6 +430,12 @@ func (n *Node) InitRunner(onEvent func(string, map[string]string)) *task.Runner 
 	if n.TemplatesResolv != nil {
 		n.runner.SetTemplateResolver(n.TemplatesResolv)
 	}
+	// EL/M2-T1: hand the unified execution_log store to the runner so
+	// every run start writes a row. Nil is safe — the runner's helper
+	// is a no-op when the store is not wired.
+	if n.ExecutionLog != nil {
+		n.runner.SetExecutionLog(n.ExecutionLog)
+	}
 	// Host-metrics sampler: polls the serve process's CPU/RSS every
 	// `host_sampler_tick_seconds` (system scope, catalog default 5s) and
 	// attributes each sample to every currently-running task. Data lands

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -12,7 +12,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/k8nstantin/OpenPraxis/internal/action"
+	executionlog "github.com/k8nstantin/OpenPraxis/internal/execution"
 	"github.com/k8nstantin/OpenPraxis/internal/settings"
 	"github.com/k8nstantin/OpenPraxis/internal/templates"
 )
@@ -40,6 +43,11 @@ type RunningTask struct {
 	// Model is the model id reported by the first assistant event — used to
 	// pick a pricing table and for calibration after the run.
 	Model string `json:"model"`
+	// ExecLogID is the execution_log row id minted at run start (EL/M2-T1).
+	// Empty when the runner was constructed without an execution_log store
+	// wired via SetExecutionLog. Subsequent updates (TTFB, completion,
+	// cancellation) target this id.
+	ExecLogID string `json:"exec_log_id,omitempty"`
 	// usageByMessage tracks the last-seen usage per message id so we can
 	// dedupe the repeated assistant events Claude Code emits while a single
 	// logical message streams. Not serialized; live-estimate only.
@@ -99,6 +107,54 @@ type Runner struct {
 	// are skipped (tests + pre-wire code paths). Wired via
 	// SetHostSampler from cmd/serve.go at boot.
 	hostSampler *HostSampler
+
+	// execLog is the unified-run-history store (EL/M2). Wired via
+	// SetExecutionLog. Nil → the runner skips the execution_log writes
+	// entirely, preserving pre-EL/M2 behavior for tests + harnesses
+	// that don't open a sqlite-backed store.
+	execLog *executionlog.Store
+}
+
+// SetExecutionLog wires the execution_log store onto the runner. The runner
+// inserts a row at run start (status=running) and updates it at completion.
+// Nil disables the feature — existing test harnesses that build a Runner
+// without a sqlite-backed store continue to work.
+func (r *Runner) SetExecutionLog(s *executionlog.Store) { r.execLog = s }
+
+// recordExecLogStart inserts the at-start execution_log row for a freshly
+// spawned task and stamps the new id onto rt.ExecLogID. The function is the
+// single write point for the run-start path so the test harness can exercise
+// it without spawning a subprocess. Errors are logged and swallowed — a
+// failure to write history must not abort a live run.
+func (r *Runner) recordExecLogStart(ctx context.Context, rt *RunningTask, t *Task, workDir string) {
+	if r == nil || r.execLog == nil || rt == nil || t == nil {
+		return
+	}
+	info := executionlog.LookupModel(rt.Model)
+	r.mu.RLock()
+	parallelCount := len(r.running)
+	r.mu.RUnlock()
+	row := executionlog.Row{
+		ID:               uuid.New().String(),
+		EntityKind:       executionlog.KindTask,
+		EntityID:         t.ID,
+		Trigger:          t.Schedule,
+		NodeID:           r.sourceNode,
+		Status:           "running",
+		StartedAt:        rt.StartedAt.UnixMilli(),
+		Model:            rt.Model,
+		Provider:         info.Provider,
+		ModelContextSize: info.ContextWindowSize,
+		AgentRuntime:     t.Agent,
+		ParallelTasks:    parallelCount,
+		WorktreePath:     workDir,
+	}
+	if err := r.execLog.Insert(ctx, row); err != nil {
+		slog.Warn("execution_log: insert run-start row failed",
+			"component", "runner", "task_id", t.ID, "error", err)
+		return
+	}
+	rt.ExecLogID = row.ID
 }
 
 // SetHostSampler wires a started HostSampler onto the runner. Attach is
@@ -862,6 +918,9 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 	if err := r.store.SaveRuntimeState(t.ID, t.Title, manifestTitle, t.Agent, cmd.Process.Pid, false, 0, 0, "", rt.StartedAt); err != nil {
 		slog.Error("save runtime state failed", "component", "runner", "task_id", t.ID, "error", err)
 	}
+
+	// EL/M2-T1: record the run-start row in execution_log. Nil store → no-op.
+	r.recordExecLogStart(ctx, rt, t, workDir)
 
 	if r.onEvent != nil {
 		r.onEvent("task_started", map[string]string{

--- a/internal/task/runner_exec_log_test.go
+++ b/internal/task/runner_exec_log_test.go
@@ -1,0 +1,113 @@
+package task
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	executionlog "github.com/k8nstantin/OpenPraxis/internal/execution"
+)
+
+// TestRunStart_writes_exec_log — EL/M2-T1 acceptance: when the runner has an
+// execution_log store wired and the run-start helper fires, exactly one row
+// lands in execution_log for the task with status=running and the identity +
+// agent + worktree fields the rest of M2 will update on completion.
+func TestRunStart_writes_exec_log(t *testing.T) {
+	r, _, _, _ := newRunnerHarness(t)
+
+	// Open a separate sqlite for the execution_log store so this test stays
+	// independent of the harness's schema.
+	dbPath := filepath.Join(t.TempDir(), "execlog.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := executionlog.InitSchema(db); err != nil {
+		t.Fatalf("execution.InitSchema: %v", err)
+	}
+	store := executionlog.NewStore(db)
+	r.SetExecutionLog(store)
+	r.SetSourceNode("node-test")
+
+	taskID := "t-exec-start"
+	tk := &Task{ID: taskID, Title: "exec start", Agent: "claude-code", Schedule: "once"}
+	rt := &RunningTask{
+		TaskID:    taskID,
+		Title:     tk.Title,
+		Agent:     tk.Agent,
+		StartedAt: time.Now(),
+		Model:     "claude-opus-4-7",
+	}
+	workDir := "/tmp/wt-exec-start"
+
+	r.recordExecLogStart(context.Background(), rt, tk, workDir)
+
+	if rt.ExecLogID == "" {
+		t.Fatalf("recordExecLogStart did not stamp ExecLogID on RunningTask")
+	}
+
+	rows, err := store.ListByEntity(context.Background(), executionlog.KindTask, taskID, 10)
+	if err != nil {
+		t.Fatalf("ListByEntity: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("ListByEntity rows = %d, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.ID != rt.ExecLogID {
+		t.Fatalf("row id = %q, want %q (rt.ExecLogID)", got.ID, rt.ExecLogID)
+	}
+	if got.Status != "running" {
+		t.Fatalf("row status = %q, want %q", got.Status, "running")
+	}
+	if got.EntityKind != executionlog.KindTask {
+		t.Fatalf("entity_kind = %q, want %q", got.EntityKind, executionlog.KindTask)
+	}
+	if got.EntityID != taskID {
+		t.Fatalf("entity_id = %q, want %q", got.EntityID, taskID)
+	}
+	if got.AgentRuntime != "claude-code" {
+		t.Fatalf("agent_runtime = %q, want %q", got.AgentRuntime, "claude-code")
+	}
+	if got.WorktreePath != workDir {
+		t.Fatalf("worktree_path = %q, want %q", got.WorktreePath, workDir)
+	}
+	if got.NodeID != "node-test" {
+		t.Fatalf("node_id = %q, want %q", got.NodeID, "node-test")
+	}
+	if got.Model != "claude-opus-4-7" {
+		t.Fatalf("model = %q, want %q", got.Model, "claude-opus-4-7")
+	}
+	if got.Provider != "anthropic" {
+		t.Fatalf("provider = %q, want %q (LookupModel should have filled this)", got.Provider, "anthropic")
+	}
+	if got.ModelContextSize != 1_000_000 {
+		t.Fatalf("model_context_size = %d, want %d", got.ModelContextSize, 1_000_000)
+	}
+	if got.Trigger != "once" {
+		t.Fatalf("trigger = %q, want %q", got.Trigger, "once")
+	}
+	if got.StartedAt == 0 {
+		t.Fatalf("started_at = 0, want non-zero (rt.StartedAt.UnixMilli)")
+	}
+}
+
+// TestRunStart_no_store_is_noop — when no execution_log store is wired, the
+// helper must be a no-op and must not stamp ExecLogID.
+func TestRunStart_no_store_is_noop(t *testing.T) {
+	r, _, _, _ := newRunnerHarness(t)
+	// Deliberately do NOT call SetExecutionLog.
+
+	rt := &RunningTask{TaskID: "t-noop", StartedAt: time.Now()}
+	tk := &Task{ID: "t-noop", Agent: "claude-code"}
+	r.recordExecLogStart(context.Background(), rt, tk, "/tmp/wt-noop")
+
+	if rt.ExecLogID != "" {
+		t.Fatalf("ExecLogID = %q, want empty (no store wired)", rt.ExecLogID)
+	}
+}


### PR DESCRIPTION
## Summary

- Runner inserts a `status=running` row into `execution_log` at run start, immediately after `SaveRuntimeState`. UUIDv4 id is stamped on `RunningTask.ExecLogID` so EL/M2-T2/T3/T4 have a stable handle for UPDATE.
- `Runner` gets a `*execution.Store` field + `SetExecutionLog` setter, wired in `node.InitRunner`. Followed the existing `SetExecutionReviewChecker` pattern instead of a `*node.Node` field to avoid a task → node import cycle.
- Insert errors are logged + swallowed; nil store is a no-op (preserves existing test harnesses).

Row populated at start: `entity_kind=task`, `entity_id=t.ID`, `trigger=t.Schedule`, `node_id=r.sourceNode`, `status=running`, `started_at=rt.StartedAt.UnixMilli()`, `model=rt.Model`, `provider`+`model_context_size` from `LookupModel`, `agent_runtime=t.Agent`, `parallel_tasks=len(r.running)`, `worktree_path=workDir`. Token / cost / derived columns stay zero — those are for the completion UPDATE in T3.

## Files

- `internal/task/runner.go` — `RunningTask.ExecLogID`, `Runner.execLog`, `SetExecutionLog`, `recordExecLogStart`; called from `Execute` after `SaveRuntimeState`.
- `internal/node/node.go` — `InitRunner` calls `n.runner.SetExecutionLog(n.ExecutionLog)`.
- `internal/task/runner_exec_log_test.go` (new) — `TestRunStart_writes_exec_log` + `TestRunStart_no_store_is_noop`.

## Spec note

The manifest spec called for a `node *node.Node` field on `Runner`. That would create an import cycle (node already imports task). Used a direct `*execution.Store` field instead — same outcome, follows the precedent set by `SetExecutionReviewChecker` / `SetTemplateResolver` / `SetHostSampler`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/task/... ./internal/execution/...`
- [ ] Operator: spin up serve, fire a task, check `sqlite3 ~/.openpraxis/memories.db "SELECT id,entity_id,status FROM execution_log ORDER BY started_at DESC LIMIT 5"` — should show one row per task spawn with `status=running` until EL/M2-T3 lands the completion UPDATE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)