### PR TITLE
feat(execution): EL/M2-T3 — wire execution_log_samples into HostSampler

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -430,6 +430,12 @@ func (n *Node) InitRunner(onEvent func(string, map[string]string)) *task.Runner 
 	if n.TemplatesResolv != nil {
 		n.runner.SetTemplateResolver(n.TemplatesResolv)
 	}
+	// EL/M2-T1: hand the unified execution_log store to the runner so
+	// every run start writes a row. Nil is safe — the runner's helper
+	// is a no-op when the store is not wired.
+	if n.ExecutionLog != nil {
+		n.runner.SetExecutionLog(n.ExecutionLog)
+	}
 	// Host-metrics sampler: polls the serve process's CPU/RSS every
 	// `host_sampler_tick_seconds` (system scope, catalog default 5s) and
 	// attributes each sample to every currently-running task. Data lands

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -446,6 +446,13 @@ func (n *Node) InitRunner(onEvent func(string, map[string]string)) *task.Runner 
 	n.hostSampler = task.NewHostSampler(tick)
 	n.hostSampler.Start(context.Background())
 	n.runner.SetHostSampler(n.hostSampler)
+	// EL/M2-T3: hand the same execution_log store to the sampler so the
+	// per-tick fanout also writes rows into execution_log_samples for
+	// every attached task whose run was registered via the runner's
+	// post-Attach RegisterExecLogRun call.
+	if n.ExecutionLog != nil {
+		n.hostSampler.SetExecLogStore(n.ExecutionLog)
+	}
 	return n.runner
 }
 

--- a/internal/task/host_metrics.go
+++ b/internal/task/host_metrics.go
@@ -17,6 +17,8 @@ import (
 	gpload "github.com/shirou/gopsutil/v3/load"
 	gpmem "github.com/shirou/gopsutil/v3/mem"
 	gpnet "github.com/shirou/gopsutil/v3/net"
+
+	executionlog "github.com/k8nstantin/OpenPraxis/internal/execution"
 )
 
 // HostMetricsSample is one CPU/RSS reading of the serve process. The
@@ -76,6 +78,13 @@ type HostSampler struct {
 	pid      int
 	stopCh   chan struct{}
 	started  bool
+
+	// EL/M2-T3: per-tick fan-out also writes a row into
+	// execution_log_samples for any attached task that has been
+	// registered with an execution_log run id. Both fields are nil/empty
+	// pre-wire and the per-tick path no-ops on them.
+	execStore  *executionlog.Store
+	execRunIDs map[string]string
 }
 
 // NewHostSampler returns a sampler that polls every interval. interval
@@ -85,11 +94,38 @@ func NewHostSampler(interval time.Duration) *HostSampler {
 		interval = 5 * time.Second
 	}
 	return &HostSampler{
-		attached: make(map[string]*attachedTask),
-		interval: interval,
-		pid:      os.Getpid(),
-		stopCh:   make(chan struct{}),
+		attached:   make(map[string]*attachedTask),
+		interval:   interval,
+		pid:        os.Getpid(),
+		stopCh:     make(chan struct{}),
+		execRunIDs: make(map[string]string),
 	}
+}
+
+// SetExecLogStore wires the unified execution_log store onto the sampler so
+// the per-tick fanout can also append a row to execution_log_samples for
+// every attached task that has been registered via RegisterExecLogRun.
+// Nil is safe — the fanout simply skips the execution_log write.
+func (s *HostSampler) SetExecLogStore(store *executionlog.Store) {
+	s.mu.Lock()
+	s.execStore = store
+	s.mu.Unlock()
+}
+
+// RegisterExecLogRun associates an attached task with the execution_log
+// row id minted at run start (EL/M2-T1). Only attached tasks with a
+// registered run id participate in the per-tick execution_log_samples
+// write. Re-registering the same taskID overwrites the prior id.
+func (s *HostSampler) RegisterExecLogRun(taskID, execLogID string) {
+	if taskID == "" || execLogID == "" {
+		return
+	}
+	s.mu.Lock()
+	if s.execRunIDs == nil {
+		s.execRunIDs = make(map[string]string)
+	}
+	s.execRunIDs[taskID] = execLogID
+	s.mu.Unlock()
 }
 
 // Start launches the poll loop. Idempotent — the second call is a no-op.
@@ -144,15 +180,55 @@ func (s *HostSampler) loop(ctx context.Context) {
 // fanout snaps host CPU/RSS into each attached task's sample buffer,
 // enriching per-task fields from the Attach-time callback. Host values
 // are identical across all attached tasks in one tick.
+//
+// EL/M2-T3: in the same pass, append a row to execution_log_samples for
+// every attached task that has been registered via RegisterExecLogRun.
+// The execution_log write is best-effort — failures are logged at warn
+// and never block the in-memory buffer that backs the legacy
+// task_run_host_samples flush on Detach.
 func (s *HostSampler) fanout(hostOnly HostMetricsSample) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	for _, at := range s.attached {
+	store := s.execStore
+	type pendingExecSample struct {
+		runID string
+		smp   executionlog.Sample
+	}
+	var pending []pendingExecSample
+	for taskID, at := range s.attached {
 		sample := hostOnly
 		if at.statFn != nil {
 			sample.CostUSD, sample.Turns, sample.Actions = at.statFn()
 		}
 		at.samples = append(at.samples, sample)
+		if store != nil {
+			if runID, ok := s.execRunIDs[taskID]; ok && runID != "" {
+				pending = append(pending, pendingExecSample{
+					runID: runID,
+					smp: executionlog.Sample{
+						RunID:      runID,
+						TS:         sample.TS.UnixMilli(),
+						CPUPct:     sample.CPUPct,
+						RSSMB:      sample.RSSMB,
+						DiskUsedGB: sample.DiskUsedGB,
+						CostUSD:    sample.CostUSD,
+						Turns:      sample.Turns,
+						Actions:    sample.Actions,
+					},
+				})
+			}
+		}
+	}
+	s.mu.Unlock()
+
+	if store == nil || len(pending) == 0 {
+		return
+	}
+	ctx := context.Background()
+	for _, p := range pending {
+		if err := store.InsertSample(ctx, p.smp); err != nil {
+			slog.Warn("execution_log_samples insert failed",
+				"component", "host_sampler", "run_id", p.runID, "error", err)
+		}
 	}
 }
 
@@ -176,6 +252,7 @@ func (s *HostSampler) Detach(taskID string) ([]HostMetricsSample, HostMetrics) {
 	s.mu.Lock()
 	at := s.attached[taskID]
 	delete(s.attached, taskID)
+	delete(s.execRunIDs, taskID)
 	s.mu.Unlock()
 	if at == nil {
 		return nil, HostMetrics{}

--- a/internal/task/host_metrics_exec_log_test.go
+++ b/internal/task/host_metrics_exec_log_test.go
@@ -1,0 +1,122 @@
+package task
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	executionlog "github.com/k8nstantin/OpenPraxis/internal/execution"
+)
+
+// TestHostSampler_fanout_writes_execution_log_samples — EL/M2-T3 acceptance:
+// after two fanout() ticks, execution_log_samples has 2 rows for the
+// registered runID and 0 rows for an attached-but-unregistered task.
+func TestHostSampler_fanout_writes_execution_log_samples(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "execlog.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := executionlog.InitSchema(db); err != nil {
+		t.Fatalf("execution.InitSchema: %v", err)
+	}
+	store := executionlog.NewStore(db)
+
+	hs := NewHostSampler(time.Second)
+	hs.SetExecLogStore(store)
+
+	// Two attached tasks: one is registered with an execution_log run id,
+	// the other is intentionally left unregistered to assert the fanout
+	// only writes for tasks the runner explicitly enrolled.
+	registeredTask := "t-registered"
+	unregisteredTask := "t-no-run"
+	runID := "run-registered"
+
+	hs.Attach(registeredTask, func() (float64, int, int) { return 1.25, 7, 13 })
+	hs.Attach(unregisteredTask, func() (float64, int, int) { return 9.0, 99, 99 })
+	hs.RegisterExecLogRun(registeredTask, runID)
+
+	// Two synthetic ticks. We hand-call fanout instead of letting the
+	// real loop fire so the test is deterministic and doesn't depend on
+	// `ps` shell-out timing.
+	for i := 0; i < 2; i++ {
+		hs.fanout(HostMetricsSample{
+			TS:         time.Now().UTC(),
+			CPUPct:     12.5 + float64(i),
+			RSSMB:      256.0 + float64(i),
+			DiskUsedGB: 10.0,
+		})
+	}
+
+	got, err := store.ListSamples(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("ListSamples: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("registered run sample count = %d, want 2", len(got))
+	}
+	for i, s := range got {
+		if s.RunID != runID {
+			t.Fatalf("sample[%d].RunID = %q, want %q", i, s.RunID, runID)
+		}
+		if s.CostUSD != 1.25 {
+			t.Fatalf("sample[%d].CostUSD = %v, want 1.25 (statFn output)", i, s.CostUSD)
+		}
+		if s.Turns != 7 || s.Actions != 13 {
+			t.Fatalf("sample[%d] turns/actions = %d/%d, want 7/13", i, s.Turns, s.Actions)
+		}
+		if s.RSSMB == 0 || s.CPUPct == 0 {
+			t.Fatalf("sample[%d] CPU/RSS empty: %+v", i, s)
+		}
+		if s.DiskUsedGB != 10.0 {
+			t.Fatalf("sample[%d].DiskUsedGB = %v, want 10.0", i, s.DiskUsedGB)
+		}
+		if s.TS == 0 {
+			t.Fatalf("sample[%d].TS = 0, want unix-ms timestamp", i)
+		}
+	}
+
+	// Unregistered task must not have any rows in execution_log_samples
+	// (its samples still live in the in-memory buffer that backs the
+	// existing task_run_host_samples flush on Detach).
+	stray, err := store.ListSamples(context.Background(), "run-not-registered")
+	if err != nil {
+		t.Fatalf("ListSamples (stray): %v", err)
+	}
+	if len(stray) != 0 {
+		t.Fatalf("unregistered run sample count = %d, want 0", len(stray))
+	}
+
+	// Detach must drop the execRunIDs entry so a subsequent fanout
+	// triggered before the goroutine fully exits doesn't double-write.
+	if _, _ = hs.Detach(registeredTask); len(hs.execRunIDs) != 0 {
+		t.Fatalf("execRunIDs after Detach = %v, want empty map", hs.execRunIDs)
+	}
+}
+
+// TestHostSampler_fanout_no_exec_store_is_noop — when no execution_log
+// store is wired, fanout must still buffer per-task samples for the
+// legacy task_run_host_samples flush, but write nothing to execution_log_samples.
+func TestHostSampler_fanout_no_exec_store_is_noop(t *testing.T) {
+	hs := NewHostSampler(time.Second)
+	// Deliberately do NOT call SetExecLogStore.
+	taskID := "t-no-store"
+	hs.Attach(taskID, func() (float64, int, int) { return 0, 0, 0 })
+	// RegisterExecLogRun on a sampler with no store must also be a no-op
+	// — the fanout's own `store == nil` guard short-circuits before
+	// reading execRunIDs, so this just exercises the registration path.
+	hs.RegisterExecLogRun(taskID, "run-orphan")
+
+	hs.fanout(HostMetricsSample{TS: time.Now().UTC(), CPUPct: 1, RSSMB: 1})
+
+	// The per-task buffer should still have grown — Detach returns it.
+	samples, _ := hs.Detach(taskID)
+	if len(samples) != 1 {
+		t.Fatalf("in-memory buffer len = %d, want 1 (legacy task_run_host_samples flow must be untouched)", len(samples))
+	}
+}

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -12,7 +12,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/k8nstantin/OpenPraxis/internal/action"
+	executionlog "github.com/k8nstantin/OpenPraxis/internal/execution"
 	"github.com/k8nstantin/OpenPraxis/internal/settings"
 	"github.com/k8nstantin/OpenPraxis/internal/templates"
 )
@@ -40,6 +43,11 @@ type RunningTask struct {
 	// Model is the model id reported by the first assistant event — used to
 	// pick a pricing table and for calibration after the run.
 	Model string `json:"model"`
+	// ExecLogID is the execution_log row id minted at run start (EL/M2-T1).
+	// Empty when the runner was constructed without an execution_log store
+	// wired via SetExecutionLog. Subsequent updates (TTFB, completion,
+	// cancellation) target this id.
+	ExecLogID string `json:"exec_log_id,omitempty"`
 	// usageByMessage tracks the last-seen usage per message id so we can
 	// dedupe the repeated assistant events Claude Code emits while a single
 	// logical message streams. Not serialized; live-estimate only.
@@ -99,6 +107,54 @@ type Runner struct {
 	// are skipped (tests + pre-wire code paths). Wired via
 	// SetHostSampler from cmd/serve.go at boot.
 	hostSampler *HostSampler
+
+	// execLog is the unified-run-history store (EL/M2). Wired via
+	// SetExecutionLog. Nil → the runner skips the execution_log writes
+	// entirely, preserving pre-EL/M2 behavior for tests + harnesses
+	// that don't open a sqlite-backed store.
+	execLog *executionlog.Store
+}
+
+// SetExecutionLog wires the execution_log store onto the runner. The runner
+// inserts a row at run start (status=running) and updates it at completion.
+// Nil disables the feature — existing test harnesses that build a Runner
+// without a sqlite-backed store continue to work.
+func (r *Runner) SetExecutionLog(s *executionlog.Store) { r.execLog = s }
+
+// recordExecLogStart inserts the at-start execution_log row for a freshly
+// spawned task and stamps the new id onto rt.ExecLogID. The function is the
+// single write point for the run-start path so the test harness can exercise
+// it without spawning a subprocess. Errors are logged and swallowed — a
+// failure to write history must not abort a live run.
+func (r *Runner) recordExecLogStart(ctx context.Context, rt *RunningTask, t *Task, workDir string) {
+	if r == nil || r.execLog == nil || rt == nil || t == nil {
+		return
+	}
+	info := executionlog.LookupModel(rt.Model)
+	r.mu.RLock()
+	parallelCount := len(r.running)
+	r.mu.RUnlock()
+	row := executionlog.Row{
+		ID:               uuid.New().String(),
+		EntityKind:       executionlog.KindTask,
+		EntityID:         t.ID,
+		Trigger:          t.Schedule,
+		NodeID:           r.sourceNode,
+		Status:           "running",
+		StartedAt:        rt.StartedAt.UnixMilli(),
+		Model:            rt.Model,
+		Provider:         info.Provider,
+		ModelContextSize: info.ContextWindowSize,
+		AgentRuntime:     t.Agent,
+		ParallelTasks:    parallelCount,
+		WorktreePath:     workDir,
+	}
+	if err := r.execLog.Insert(ctx, row); err != nil {
+		slog.Warn("execution_log: insert run-start row failed",
+			"component", "runner", "task_id", t.ID, "error", err)
+		return
+	}
+	rt.ExecLogID = row.ID
 }
 
 // SetHostSampler wires a started HostSampler onto the runner. Attach is
@@ -862,6 +918,9 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 	if err := r.store.SaveRuntimeState(t.ID, t.Title, manifestTitle, t.Agent, cmd.Process.Pid, false, 0, 0, "", rt.StartedAt); err != nil {
 		slog.Error("save runtime state failed", "component", "runner", "task_id", t.ID, "error", err)
 	}
+
+	// EL/M2-T1: record the run-start row in execution_log. Nil store → no-op.
+	r.recordExecLogStart(ctx, rt, t, workDir)
 
 	if r.onEvent != nil {
 		r.onEvent("task_started", map[string]string{

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -942,6 +942,14 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 		r.hostSampler.Attach(t.ID, func() (float64, int, int) {
 			return rtRef.CumulativeCostUSD, len(rtRef.usageByMessage), rtRef.Actions
 		})
+		// EL/M2-T3: associate the attached task with the execution_log
+		// run id minted by recordExecLogStart so the per-tick fanout
+		// also writes a row into execution_log_samples. Empty
+		// ExecLogID (no exec store wired, or the start-row insert
+		// failed) is a deliberate no-op on the sampler side.
+		if rt.ExecLogID != "" {
+			r.hostSampler.RegisterExecLogRun(t.ID, rt.ExecLogID)
+		}
 	}
 
 	// Read output in background

--- a/internal/task/runner_exec_log_test.go
+++ b/internal/task/runner_exec_log_test.go
@@ -1,0 +1,113 @@
+package task
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	executionlog "github.com/k8nstantin/OpenPraxis/internal/execution"
+)
+
+// TestRunStart_writes_exec_log — EL/M2-T1 acceptance: when the runner has an
+// execution_log store wired and the run-start helper fires, exactly one row
+// lands in execution_log for the task with status=running and the identity +
+// agent + worktree fields the rest of M2 will update on completion.
+func TestRunStart_writes_exec_log(t *testing.T) {
+	r, _, _, _ := newRunnerHarness(t)
+
+	// Open a separate sqlite for the execution_log store so this test stays
+	// independent of the harness's schema.
+	dbPath := filepath.Join(t.TempDir(), "execlog.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := executionlog.InitSchema(db); err != nil {
+		t.Fatalf("execution.InitSchema: %v", err)
+	}
+	store := executionlog.NewStore(db)
+	r.SetExecutionLog(store)
+	r.SetSourceNode("node-test")
+
+	taskID := "t-exec-start"
+	tk := &Task{ID: taskID, Title: "exec start", Agent: "claude-code", Schedule: "once"}
+	rt := &RunningTask{
+		TaskID:    taskID,
+		Title:     tk.Title,
+		Agent:     tk.Agent,
+		StartedAt: time.Now(),
+		Model:     "claude-opus-4-7",
+	}
+	workDir := "/tmp/wt-exec-start"
+
+	r.recordExecLogStart(context.Background(), rt, tk, workDir)
+
+	if rt.ExecLogID == "" {
+		t.Fatalf("recordExecLogStart did not stamp ExecLogID on RunningTask")
+	}
+
+	rows, err := store.ListByEntity(context.Background(), executionlog.KindTask, taskID, 10)
+	if err != nil {
+		t.Fatalf("ListByEntity: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("ListByEntity rows = %d, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.ID != rt.ExecLogID {
+		t.Fatalf("row id = %q, want %q (rt.ExecLogID)", got.ID, rt.ExecLogID)
+	}
+	if got.Status != "running" {
+		t.Fatalf("row status = %q, want %q", got.Status, "running")
+	}
+	if got.EntityKind != executionlog.KindTask {
+		t.Fatalf("entity_kind = %q, want %q", got.EntityKind, executionlog.KindTask)
+	}
+	if got.EntityID != taskID {
+		t.Fatalf("entity_id = %q, want %q", got.EntityID, taskID)
+	}
+	if got.AgentRuntime != "claude-code" {
+		t.Fatalf("agent_runtime = %q, want %q", got.AgentRuntime, "claude-code")
+	}
+	if got.WorktreePath != workDir {
+		t.Fatalf("worktree_path = %q, want %q", got.WorktreePath, workDir)
+	}
+	if got.NodeID != "node-test" {
+		t.Fatalf("node_id = %q, want %q", got.NodeID, "node-test")
+	}
+	if got.Model != "claude-opus-4-7" {
+		t.Fatalf("model = %q, want %q", got.Model, "claude-opus-4-7")
+	}
+	if got.Provider != "anthropic" {
+		t.Fatalf("provider = %q, want %q (LookupModel should have filled this)", got.Provider, "anthropic")
+	}
+	if got.ModelContextSize != 1_000_000 {
+		t.Fatalf("model_context_size = %d, want %d", got.ModelContextSize, 1_000_000)
+	}
+	if got.Trigger != "once" {
+		t.Fatalf("trigger = %q, want %q", got.Trigger, "once")
+	}
+	if got.StartedAt == 0 {
+		t.Fatalf("started_at = 0, want non-zero (rt.StartedAt.UnixMilli)")
+	}
+}
+
+// TestRunStart_no_store_is_noop — when no execution_log store is wired, the
+// helper must be a no-op and must not stamp ExecLogID.
+func TestRunStart_no_store_is_noop(t *testing.T) {
+	r, _, _, _ := newRunnerHarness(t)
+	// Deliberately do NOT call SetExecutionLog.
+
+	rt := &RunningTask{TaskID: "t-noop", StartedAt: time.Now()}
+	tk := &Task{ID: "t-noop", Agent: "claude-code"}
+	r.recordExecLogStart(context.Background(), rt, tk, "/tmp/wt-noop")
+
+	if rt.ExecLogID != "" {
+		t.Fatalf("ExecLogID = %q, want empty (no store wired)", rt.ExecLogID)
+	}
+}


### PR DESCRIPTION
## Summary
- Per-tick fanout in `HostSampler` now also writes a row into `execution_log_samples` for every attached task whose run id has been registered, in addition to the existing in-memory buffer that flushes to `task_run_host_samples` on `Detach` (dual-write per the EL/M2 manifest).
- Adds `HostSampler.SetExecLogStore(store)` (boot-time wiring in `node.InitRunner`) and `HostSampler.RegisterExecLogRun(taskID, execLogID)`, called from `runner.Execute` directly after `hostSampler.Attach` using the id minted by `recordExecLogStart`.
- `Detach` also drops the `execRunIDs` entry to avoid a stale fanout double-write.

## Files
- `internal/task/host_metrics.go` — struct fields + setters + extended `fanout` + `Detach` cleanup
- `internal/task/runner.go` — `RegisterExecLogRun` call after `Attach`
- `internal/node/node.go` — boot-time `SetExecLogStore` wire
- `internal/task/host_metrics_exec_log_test.go` — new

## Stacking
Built on `openpraxis/el-m2-t1-run-start` (PR pending merge) — the dependency stamps `rt.ExecLogID` that this task hands the sampler. Once T1 is merged, this PR's diff against `main` reduces to the host-sampler delta only.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/task/... ./internal/execution/...`
- [x] New tests: `TestHostSampler_fanout_writes_execution_log_samples` (2 fanout calls → 2 rows for registered run, 0 for unregistered) and `TestHostSampler_fanout_no_exec_store_is_noop` (nil exec store still buffers locally for the legacy flush path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)