### PR TITLE
feat(execution): EL/M2-T2 — capture TTFB from stream parser

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -430,6 +430,12 @@ func (n *Node) InitRunner(onEvent func(string, map[string]string)) *task.Runner 
 	if n.TemplatesResolv != nil {
 		n.runner.SetTemplateResolver(n.TemplatesResolv)
 	}
+	// EL/M2-T1: hand the unified execution_log store to the runner so
+	// every run start writes a row. Nil is safe — the runner's helper
+	// is a no-op when the store is not wired.
+	if n.ExecutionLog != nil {
+		n.runner.SetExecutionLog(n.ExecutionLog)
+	}
 	// Host-metrics sampler: polls the serve process's CPU/RSS every
 	// `host_sampler_tick_seconds` (system scope, catalog default 5s) and
 	// attributes each sample to every currently-running task. Data lands

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -12,7 +12,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/k8nstantin/OpenPraxis/internal/action"
+	executionlog "github.com/k8nstantin/OpenPraxis/internal/execution"
 	"github.com/k8nstantin/OpenPraxis/internal/settings"
 	"github.com/k8nstantin/OpenPraxis/internal/templates"
 )
@@ -40,6 +43,11 @@ type RunningTask struct {
 	// Model is the model id reported by the first assistant event — used to
 	// pick a pricing table and for calibration after the run.
 	Model string `json:"model"`
+	// ExecLogID is the execution_log row id minted at run start (EL/M2-T1).
+	// Empty when the runner was constructed without an execution_log store
+	// wired via SetExecutionLog. Subsequent updates (TTFB, completion,
+	// cancellation) target this id.
+	ExecLogID string `json:"exec_log_id,omitempty"`
 	// usageByMessage tracks the last-seen usage per message id so we can
 	// dedupe the repeated assistant events Claude Code emits while a single
 	// logical message streams. Not serialized; live-estimate only.
@@ -99,6 +107,54 @@ type Runner struct {
 	// are skipped (tests + pre-wire code paths). Wired via
 	// SetHostSampler from cmd/serve.go at boot.
 	hostSampler *HostSampler
+
+	// execLog is the unified-run-history store (EL/M2). Wired via
+	// SetExecutionLog. Nil → the runner skips the execution_log writes
+	// entirely, preserving pre-EL/M2 behavior for tests + harnesses
+	// that don't open a sqlite-backed store.
+	execLog *executionlog.Store
+}
+
+// SetExecutionLog wires the execution_log store onto the runner. The runner
+// inserts a row at run start (status=running) and updates it at completion.
+// Nil disables the feature — existing test harnesses that build a Runner
+// without a sqlite-backed store continue to work.
+func (r *Runner) SetExecutionLog(s *executionlog.Store) { r.execLog = s }
+
+// recordExecLogStart inserts the at-start execution_log row for a freshly
+// spawned task and stamps the new id onto rt.ExecLogID. The function is the
+// single write point for the run-start path so the test harness can exercise
+// it without spawning a subprocess. Errors are logged and swallowed — a
+// failure to write history must not abort a live run.
+func (r *Runner) recordExecLogStart(ctx context.Context, rt *RunningTask, t *Task, workDir string) {
+	if r == nil || r.execLog == nil || rt == nil || t == nil {
+		return
+	}
+	info := executionlog.LookupModel(rt.Model)
+	r.mu.RLock()
+	parallelCount := len(r.running)
+	r.mu.RUnlock()
+	row := executionlog.Row{
+		ID:               uuid.New().String(),
+		EntityKind:       executionlog.KindTask,
+		EntityID:         t.ID,
+		Trigger:          t.Schedule,
+		NodeID:           r.sourceNode,
+		Status:           "running",
+		StartedAt:        rt.StartedAt.UnixMilli(),
+		Model:            rt.Model,
+		Provider:         info.Provider,
+		ModelContextSize: info.ContextWindowSize,
+		AgentRuntime:     t.Agent,
+		ParallelTasks:    parallelCount,
+		WorktreePath:     workDir,
+	}
+	if err := r.execLog.Insert(ctx, row); err != nil {
+		slog.Warn("execution_log: insert run-start row failed",
+			"component", "runner", "task_id", t.ID, "error", err)
+		return
+	}
+	rt.ExecLogID = row.ID
 }
 
 // SetHostSampler wires a started HostSampler onto the runner. Attach is
@@ -862,6 +918,9 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 	if err := r.store.SaveRuntimeState(t.ID, t.Title, manifestTitle, t.Agent, cmd.Process.Pid, false, 0, 0, "", rt.StartedAt); err != nil {
 		slog.Error("save runtime state failed", "component", "runner", "task_id", t.ID, "error", err)
 	}
+
+	// EL/M2-T1: record the run-start row in execution_log. Nil store → no-op.
+	r.recordExecLogStart(ctx, rt, t, workDir)
 
 	if r.onEvent != nil {
 		r.onEvent("task_started", map[string]string{

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -48,6 +48,10 @@ type RunningTask struct {
 	// wired via SetExecutionLog. Subsequent updates (TTFB, completion,
 	// cancellation) target this id.
 	ExecLogID string `json:"exec_log_id,omitempty"`
+	// ttfbOnce guards the TTFB stamp so it lands on the very first
+	// type=assistant event of the run and never re-fires on subsequent
+	// assistant events (Claude Code emits many per logical message).
+	ttfbOnce sync.Once
 	// usageByMessage tracks the last-seen usage per message id so we can
 	// dedupe the repeated assistant events Claude Code emits while a single
 	// logical message streams. Not serialized; live-estimate only.
@@ -155,6 +159,22 @@ func (r *Runner) recordExecLogStart(ctx context.Context, rt *RunningTask, t *Tas
 		return
 	}
 	rt.ExecLogID = row.ID
+}
+
+// recordExecLogTTFB stamps `ttfb_ms` on the execution_log row at the moment
+// the first assistant event lands in the stream-reader goroutine. Single
+// write-point so the test exercises the helper directly without spawning a
+// subprocess. Errors are logged + swallowed — a failure to record TTFB must
+// not abort the live run.
+func (r *Runner) recordExecLogTTFB(ctx context.Context, rt *RunningTask) {
+	if r == nil || r.execLog == nil || rt == nil || rt.ExecLogID == "" {
+		return
+	}
+	ttfbMS := time.Since(rt.StartedAt).Milliseconds()
+	if err := r.execLog.UpdateCompletion(ctx, rt.ExecLogID, map[string]any{"ttfb_ms": ttfbMS}); err != nil {
+		slog.Warn("execution_log: update ttfb failed",
+			"component", "runner", "exec_log_id", rt.ExecLogID, "error", err)
+	}
 }
 
 // SetHostSampler wires a started HostSampler onto the runner. Attach is
@@ -993,6 +1013,14 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 				eventType, _ := event["type"].(string)
 
 				if eventType == "assistant" {
+					// EL/M2-T2: stamp TTFB on the first assistant event of
+					// the run. sync.Once guarantees one-shot semantics —
+					// Claude Code re-emits assistant events for every chunk
+					// of a streaming message, so the unguarded path would
+					// thrash UpdateCompletion.
+					rt.ttfbOnce.Do(func() {
+						r.recordExecLogTTFB(ctx, rt)
+					})
 					// Extract tool_use blocks from assistant message
 					if msg, ok := event["message"].(map[string]any); ok {
 						if content, ok := msg["content"].([]any); ok {

--- a/internal/task/runner_exec_log_test.go
+++ b/internal/task/runner_exec_log_test.go
@@ -111,3 +111,105 @@ func TestRunStart_no_store_is_noop(t *testing.T) {
 		t.Fatalf("ExecLogID = %q, want empty (no store wired)", rt.ExecLogID)
 	}
 }
+
+// TestTTFB_nonzero — EL/M2-T2 acceptance: after a run-start row is in place
+// and the first assistant-event handler fires recordExecLogTTFB, the row
+// should carry a positive ttfb_ms and remain in status=running (TTFB does
+// not flip terminal state).
+func TestTTFB_nonzero(t *testing.T) {
+	r, _, _, _ := newRunnerHarness(t)
+
+	dbPath := filepath.Join(t.TempDir(), "execlog.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := executionlog.InitSchema(db); err != nil {
+		t.Fatalf("execution.InitSchema: %v", err)
+	}
+	store := executionlog.NewStore(db)
+	r.SetExecutionLog(store)
+	r.SetSourceNode("node-test")
+
+	taskID := "t-ttfb"
+	tk := &Task{ID: taskID, Title: "ttfb", Agent: "claude-code", Schedule: "once"}
+	rt := &RunningTask{
+		TaskID:    taskID,
+		Title:     tk.Title,
+		Agent:     tk.Agent,
+		StartedAt: time.Now(),
+		Model:     "claude-opus-4-7",
+	}
+	r.recordExecLogStart(context.Background(), rt, tk, "/tmp/wt-ttfb")
+	if rt.ExecLogID == "" {
+		t.Fatalf("recordExecLogStart did not stamp ExecLogID")
+	}
+
+	// Simulate first-assistant-event arrival after a measurable delay so
+	// time.Since(rt.StartedAt) is guaranteed positive on every platform.
+	time.Sleep(2 * time.Millisecond)
+	rt.ttfbOnce.Do(func() {
+		r.recordExecLogTTFB(context.Background(), rt)
+	})
+
+	got, err := store.Get(context.Background(), rt.ExecLogID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got.TTFBMS <= 0 {
+		t.Fatalf("ttfb_ms = %d, want > 0", got.TTFBMS)
+	}
+	if got.Status != "running" {
+		t.Fatalf("status = %q after ttfb stamp, want %q (TTFB must not flip terminal state)", got.Status, "running")
+	}
+
+	// Re-firing the once-guard must be a no-op — TTFB stays as the first-event
+	// measurement. We capture the value before re-firing and assert it is
+	// unchanged afterwards.
+	first := got.TTFBMS
+	time.Sleep(5 * time.Millisecond)
+	rt.ttfbOnce.Do(func() {
+		r.recordExecLogTTFB(context.Background(), rt)
+	})
+	got2, err := store.Get(context.Background(), rt.ExecLogID)
+	if err != nil {
+		t.Fatalf("store.Get (second): %v", err)
+	}
+	if got2.TTFBMS != first {
+		t.Fatalf("ttfb_ms re-fired: was %d, now %d — sync.Once is supposed to gate this", first, got2.TTFBMS)
+	}
+}
+
+// TestTTFB_no_execlog_id_is_noop — when the runner was constructed without an
+// execution_log store wired (so rt.ExecLogID stays empty), recordExecLogTTFB
+// must return silently and write nothing.
+func TestTTFB_no_execlog_id_is_noop(t *testing.T) {
+	r, _, _, _ := newRunnerHarness(t)
+
+	dbPath := filepath.Join(t.TempDir(), "execlog.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := executionlog.InitSchema(db); err != nil {
+		t.Fatalf("execution.InitSchema: %v", err)
+	}
+	store := executionlog.NewStore(db)
+	// Wire the store so we can verify no rows land for the unstamped task.
+	r.SetExecutionLog(store)
+
+	rt := &RunningTask{TaskID: "t-ttfb-noop", StartedAt: time.Now()}
+	// Deliberately leave rt.ExecLogID == "" — recordExecLogStart was not
+	// called, so the helper should bail before issuing any UPDATE.
+	r.recordExecLogTTFB(context.Background(), rt)
+
+	rows, err := store.ListByEntity(context.Background(), executionlog.KindTask, "t-ttfb-noop", 10)
+	if err != nil {
+		t.Fatalf("ListByEntity: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("ListByEntity rows = %d, want 0 (nothing should have landed)", len(rows))
+	}
+}

--- a/internal/task/runner_exec_log_test.go
+++ b/internal/task/runner_exec_log_test.go
@@ -1,0 +1,113 @@
+package task
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	executionlog "github.com/k8nstantin/OpenPraxis/internal/execution"
+)
+
+// TestRunStart_writes_exec_log — EL/M2-T1 acceptance: when the runner has an
+// execution_log store wired and the run-start helper fires, exactly one row
+// lands in execution_log for the task with status=running and the identity +
+// agent + worktree fields the rest of M2 will update on completion.
+func TestRunStart_writes_exec_log(t *testing.T) {
+	r, _, _, _ := newRunnerHarness(t)
+
+	// Open a separate sqlite for the execution_log store so this test stays
+	// independent of the harness's schema.
+	dbPath := filepath.Join(t.TempDir(), "execlog.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := executionlog.InitSchema(db); err != nil {
+		t.Fatalf("execution.InitSchema: %v", err)
+	}
+	store := executionlog.NewStore(db)
+	r.SetExecutionLog(store)
+	r.SetSourceNode("node-test")
+
+	taskID := "t-exec-start"
+	tk := &Task{ID: taskID, Title: "exec start", Agent: "claude-code", Schedule: "once"}
+	rt := &RunningTask{
+		TaskID:    taskID,
+		Title:     tk.Title,
+		Agent:     tk.Agent,
+		StartedAt: time.Now(),
+		Model:     "claude-opus-4-7",
+	}
+	workDir := "/tmp/wt-exec-start"
+
+	r.recordExecLogStart(context.Background(), rt, tk, workDir)
+
+	if rt.ExecLogID == "" {
+		t.Fatalf("recordExecLogStart did not stamp ExecLogID on RunningTask")
+	}
+
+	rows, err := store.ListByEntity(context.Background(), executionlog.KindTask, taskID, 10)
+	if err != nil {
+		t.Fatalf("ListByEntity: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("ListByEntity rows = %d, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.ID != rt.ExecLogID {
+		t.Fatalf("row id = %q, want %q (rt.ExecLogID)", got.ID, rt.ExecLogID)
+	}
+	if got.Status != "running" {
+		t.Fatalf("row status = %q, want %q", got.Status, "running")
+	}
+	if got.EntityKind != executionlog.KindTask {
+		t.Fatalf("entity_kind = %q, want %q", got.EntityKind, executionlog.KindTask)
+	}
+	if got.EntityID != taskID {
+		t.Fatalf("entity_id = %q, want %q", got.EntityID, taskID)
+	}
+	if got.AgentRuntime != "claude-code" {
+		t.Fatalf("agent_runtime = %q, want %q", got.AgentRuntime, "claude-code")
+	}
+	if got.WorktreePath != workDir {
+		t.Fatalf("worktree_path = %q, want %q", got.WorktreePath, workDir)
+	}
+	if got.NodeID != "node-test" {
+		t.Fatalf("node_id = %q, want %q", got.NodeID, "node-test")
+	}
+	if got.Model != "claude-opus-4-7" {
+		t.Fatalf("model = %q, want %q", got.Model, "claude-opus-4-7")
+	}
+	if got.Provider != "anthropic" {
+		t.Fatalf("provider = %q, want %q (LookupModel should have filled this)", got.Provider, "anthropic")
+	}
+	if got.ModelContextSize != 1_000_000 {
+		t.Fatalf("model_context_size = %d, want %d", got.ModelContextSize, 1_000_000)
+	}
+	if got.Trigger != "once" {
+		t.Fatalf("trigger = %q, want %q", got.Trigger, "once")
+	}
+	if got.StartedAt == 0 {
+		t.Fatalf("started_at = 0, want non-zero (rt.StartedAt.UnixMilli)")
+	}
+}
+
+// TestRunStart_no_store_is_noop — when no execution_log store is wired, the
+// helper must be a no-op and must not stamp ExecLogID.
+func TestRunStart_no_store_is_noop(t *testing.T) {
+	r, _, _, _ := newRunnerHarness(t)
+	// Deliberately do NOT call SetExecutionLog.
+
+	rt := &RunningTask{TaskID: "t-noop", StartedAt: time.Now()}
+	tk := &Task{ID: "t-noop", Agent: "claude-code"}
+	r.recordExecLogStart(context.Background(), rt, tk, "/tmp/wt-noop")
+
+	if rt.ExecLogID != "" {
+		t.Fatalf("ExecLogID = %q, want empty (no store wired)", rt.ExecLogID)
+	}
+}


### PR DESCRIPTION
## Summary

- Stamps `ttfb_ms` on the `execution_log` row the moment the first `type=assistant` event lands in the stream-reader goroutine.
- New `RunningTask.ttfbOnce sync.Once` + `Runner.recordExecLogTTFB(ctx, rt)` helper as a single write-point.
- Hook site: inside the `eventType == \"assistant\"` branch of the stream reader, wrapped in `rt.ttfbOnce.Do(...)` so it fires exactly once per run despite Claude Code re-emitting assistant events for every streaming chunk.

## Why

Part of the Execution Log product (`019de575`), milestone EL/M2 (write path: runner emits execution_log rows). T2 is the TTFB slice — the first user-visible signal that the agent is actually responding, distinct from the run-start row T1 inserts and the completion update T3 will write.

## Branch deviation

Branched off `openpraxis/el-m2-t1-run-start` (PR #321 — still open at the time of this run) instead of `main` because the `RunningTask.ExecLogID` field + `Runner.execLog` store this task targets only exist on T1's branch. Branching off `main` would have made the diff uncompilable. Once T1 lands, this PR will rebase cleanly onto `main` and the diff will be just the TTFB delta.

## Test plan

- [x] `go build ./...` clean (only pre-existing cgo warnings from go-m1cpu / sqlite-vec).
- [x] `go test ./internal/task/... ./internal/execution/...` passes (5.4s + 0.4s).
- [x] New `TestTTFB_nonzero` — exercises `recordExecLogStart` → 2ms sleep → `recordExecLogTTFB`; asserts reloaded `Get` row has `TTFBMS > 0` + `Status==\"running\"` (TTFB does not flip terminal state). Then re-fires the once-guard and asserts TTFB unchanged — validates `sync.Once` semantics.
- [x] New `TestTTFB_no_execlog_id_is_noop` — calls helper with `ExecLogID==\"\"`; asserts no rows land. Validates the empty-id guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)