### PR TITLE
feat(execution): EL/M2-T4 — UPDATE execution_log at run completion

### DIFF
--- a/internal/execution/derived.go
+++ b/internal/execution/derived.go
@@ -1,0 +1,86 @@
+package execution
+
+import "strings"
+
+// DerivedInput is the raw run-counter shape ComputeDerived needs to compute
+// the per-run ratio fields stored on execution_log.
+type DerivedInput struct {
+	InputTokens       int
+	OutputTokens      int
+	CacheReadTokens   int
+	CacheCreateTokens int
+	CostUSD           float64
+	Turns             int
+	Actions           int
+	Model             string
+}
+
+// DerivedOutput is the set of computed fields ComputeDerived returns. The
+// runner UPDATEs each one onto the execution_log row at completion.
+type DerivedOutput struct {
+	CacheHitRatePct  float64
+	ContextWindowPct float64
+	CostPerTurn      float64
+	CostPerAction    float64
+	TokensPerTurn    float64
+	CacheSavingsUSD  float64
+}
+
+// ComputeDerived computes ratio fields from raw counters. Zero-input safe:
+// all outputs default to 0 when the relevant denominator is zero. Pure
+// function — no I/O, no logging — so it is trivial to test exhaustively
+// (TestComputeDerived_values).
+func ComputeDerived(in DerivedInput) DerivedOutput {
+	var out DerivedOutput
+
+	totalInput := in.InputTokens + in.CacheReadTokens
+	if totalInput > 0 {
+		out.CacheHitRatePct = float64(in.CacheReadTokens) / float64(totalInput) * 100
+	}
+
+	if ctxSize := LookupModel(in.Model).ContextWindowSize; ctxSize > 0 {
+		total := in.InputTokens + in.OutputTokens + in.CacheReadTokens + in.CacheCreateTokens
+		out.ContextWindowPct = float64(total) / float64(ctxSize) * 100
+	}
+
+	if in.Turns > 0 {
+		out.CostPerTurn = in.CostUSD / float64(in.Turns)
+		out.TokensPerTurn = float64(in.InputTokens+in.OutputTokens) / float64(in.Turns)
+	}
+
+	if in.Actions > 0 {
+		out.CostPerAction = in.CostUSD / float64(in.Actions)
+	}
+
+	rates := defaultRates(in.Model)
+	out.CacheSavingsUSD = float64(in.CacheReadTokens) *
+		(rates.InputPerMTok - rates.CacheReadPerMTok) / 1_000_000
+
+	return out
+}
+
+// modelRates is a private mirror of internal/task.ModelRates. Replicated
+// here (instead of imported) to avoid an import cycle: internal/task already
+// depends on internal/execution, so the dependency cannot run the other way.
+type modelRates struct {
+	InputPerMTok      float64
+	CacheReadPerMTok  float64
+	OutputPerMTok     float64
+	CacheWritePerMTok float64
+}
+
+// defaultRates returns the list-price rates for the given model id. Substring
+// match on the model family — same algorithm as task.DefaultRates so that
+// dual-write rows round-trip consistent cache_savings_usd values.
+func defaultRates(model string) modelRates {
+	m := strings.ToLower(model)
+	switch {
+	case strings.Contains(m, "opus"):
+		return modelRates{InputPerMTok: 15, CacheReadPerMTok: 1.5, OutputPerMTok: 75, CacheWritePerMTok: 18.75}
+	case strings.Contains(m, "sonnet"):
+		return modelRates{InputPerMTok: 3, CacheReadPerMTok: 0.3, OutputPerMTok: 15, CacheWritePerMTok: 3.75}
+	case strings.Contains(m, "haiku"):
+		return modelRates{InputPerMTok: 1, CacheReadPerMTok: 0.1, OutputPerMTok: 5, CacheWritePerMTok: 1.25}
+	}
+	return modelRates{InputPerMTok: 15, CacheReadPerMTok: 1.5, OutputPerMTok: 75, CacheWritePerMTok: 18.75}
+}

--- a/internal/execution/derived_test.go
+++ b/internal/execution/derived_test.go
@@ -1,0 +1,84 @@
+package execution
+
+import (
+	"math"
+	"testing"
+)
+
+// TestComputeDerived_values exercises every ratio formula with realistic
+// Sonnet-shaped inputs. Hand-computed expected values keep the test
+// independent of the implementation under review.
+func TestComputeDerived_values(t *testing.T) {
+	in := DerivedInput{
+		InputTokens:       2_000,
+		OutputTokens:      1_000,
+		CacheReadTokens:   8_000,
+		CacheCreateTokens: 500,
+		CostUSD:           0.05,
+		Turns:             4,
+		Actions:           20,
+		Model:             "claude-sonnet-4-6", // 200_000 ctx, sonnet rates
+	}
+	got := ComputeDerived(in)
+
+	// CacheHitRate = 8000 / (2000 + 8000) * 100 = 80
+	if !approx(got.CacheHitRatePct, 80) {
+		t.Errorf("CacheHitRatePct = %v, want 80", got.CacheHitRatePct)
+	}
+	// ContextWindowPct = (2000 + 1000 + 8000 + 500) / 200000 * 100 = 5.75
+	if !approx(got.ContextWindowPct, 5.75) {
+		t.Errorf("ContextWindowPct = %v, want 5.75", got.ContextWindowPct)
+	}
+	// CostPerTurn = 0.05 / 4 = 0.0125
+	if !approx(got.CostPerTurn, 0.0125) {
+		t.Errorf("CostPerTurn = %v, want 0.0125", got.CostPerTurn)
+	}
+	// CostPerAction = 0.05 / 20 = 0.0025
+	if !approx(got.CostPerAction, 0.0025) {
+		t.Errorf("CostPerAction = %v, want 0.0025", got.CostPerAction)
+	}
+	// TokensPerTurn = (2000 + 1000) / 4 = 750
+	if !approx(got.TokensPerTurn, 750) {
+		t.Errorf("TokensPerTurn = %v, want 750", got.TokensPerTurn)
+	}
+	// CacheSavings = 8000 * (3 - 0.3) / 1_000_000 = 0.0216
+	if !approx(got.CacheSavingsUSD, 0.0216) {
+		t.Errorf("CacheSavingsUSD = %v, want 0.0216", got.CacheSavingsUSD)
+	}
+}
+
+// TestComputeDerived_zero — every denominator is zero; no NaN, no Inf.
+func TestComputeDerived_zero(t *testing.T) {
+	got := ComputeDerived(DerivedInput{})
+	for _, f := range []float64{
+		got.CacheHitRatePct, got.ContextWindowPct,
+		got.CostPerTurn, got.CostPerAction, got.TokensPerTurn,
+		got.CacheSavingsUSD,
+	} {
+		if math.IsNaN(f) || math.IsInf(f, 0) || f != 0 {
+			t.Errorf("expected 0 for empty input, got %v", f)
+		}
+	}
+}
+
+// TestComputeDerived_unknownModel — a model id outside the registry falls
+// back to the default 200k context window so ContextWindowPct still computes.
+// CacheSavings uses the unknown-model fallback rates (opus list price).
+func TestComputeDerived_unknownModel(t *testing.T) {
+	got := ComputeDerived(DerivedInput{
+		InputTokens:     1_000,
+		OutputTokens:    1_000,
+		CacheReadTokens: 1_000,
+		Model:           "totally-fake-model",
+	})
+	if got.ContextWindowPct == 0 {
+		t.Errorf("expected non-zero ContextWindowPct on unknown model fallback, got 0")
+	}
+	// fallback rates = opus: input 15, cache_read 1.5
+	// savings = 1000 * (15 - 1.5) / 1_000_000 = 0.0135
+	if !approx(got.CacheSavingsUSD, 0.0135) {
+		t.Errorf("CacheSavingsUSD = %v, want 0.0135 (opus fallback rates)", got.CacheSavingsUSD)
+	}
+}
+
+func approx(a, b float64) bool { return math.Abs(a-b) < 1e-9 }

--- a/internal/execution/migration.go
+++ b/internal/execution/migration.go
@@ -141,7 +141,7 @@ func BackfillFromTaskRuns(ctx context.Context, db *sql.DB) (int, error) {
 			ToolCallsJSON:     "{}",
 			LastOutput:        tr.output,
 		}
-		ComputeDerived(&r)
+		applyDerivedToRow(&r)
 
 		_, err := tx.ExecContext(ctx, `INSERT INTO execution_log (
 			id, entity_kind, entity_id, run_number, trigger, node_id, status,
@@ -188,8 +188,13 @@ func BackfillFromTaskRuns(ctx context.Context, db *sql.DB) (int, error) {
 	return inserted, nil
 }
 
-// ComputeDerived fills in ratio/derived fields on r from its raw counters.
-func ComputeDerived(r *Row) {
+// applyDerivedToRow fills the derived ratio fields on r in place. The
+// backfill path uses this so it can write a complete row in a single INSERT
+// — the runner uses the public ComputeDerived(DerivedInput) DerivedOutput
+// instead, since it builds a partial UPDATE map. This helper trusts
+// r.ModelContextSize (the backfill resolves it from LookupModel before
+// calling) instead of re-looking up by model id.
+func applyDerivedToRow(r *Row) {
 	if r.DurationMS == 0 && r.CompletedAt > r.StartedAt {
 		r.DurationMS = r.CompletedAt - r.StartedAt
 	}
@@ -212,6 +217,10 @@ func ComputeDerived(r *Row) {
 	if r.Actions > 0 {
 		r.CostPerAction = r.CostUSD / float64(r.Actions)
 	}
+
+	rates := defaultRates(r.Model)
+	r.CacheSavingsUSD = float64(r.CacheReadTokens) *
+		(rates.InputPerMTok - rates.CacheReadPerMTok) / 1_000_000
 }
 
 func terminalReason(status string) string {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -430,6 +430,12 @@ func (n *Node) InitRunner(onEvent func(string, map[string]string)) *task.Runner 
 	if n.TemplatesResolv != nil {
 		n.runner.SetTemplateResolver(n.TemplatesResolv)
 	}
+	// EL/M2-T1: hand the unified execution_log store to the runner so
+	// every run start writes a row. Nil is safe — the runner's helper
+	// is a no-op when the store is not wired.
+	if n.ExecutionLog != nil {
+		n.runner.SetExecutionLog(n.ExecutionLog)
+	}
 	// Host-metrics sampler: polls the serve process's CPU/RSS every
 	// `host_sampler_tick_seconds` (system scope, catalog default 5s) and
 	// attributes each sample to every currently-running task. Data lands

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -446,6 +446,13 @@ func (n *Node) InitRunner(onEvent func(string, map[string]string)) *task.Runner 
 	n.hostSampler = task.NewHostSampler(tick)
 	n.hostSampler.Start(context.Background())
 	n.runner.SetHostSampler(n.hostSampler)
+	// EL/M2-T3: hand the same execution_log store to the sampler so the
+	// per-tick fanout also writes rows into execution_log_samples for
+	// every attached task whose run was registered via the runner's
+	// post-Attach RegisterExecLogRun call.
+	if n.ExecutionLog != nil {
+		n.hostSampler.SetExecLogStore(n.ExecutionLog)
+	}
 	return n.runner
 }
 

--- a/internal/task/host_metrics.go
+++ b/internal/task/host_metrics.go
@@ -17,6 +17,8 @@ import (
 	gpload "github.com/shirou/gopsutil/v3/load"
 	gpmem "github.com/shirou/gopsutil/v3/mem"
 	gpnet "github.com/shirou/gopsutil/v3/net"
+
+	executionlog "github.com/k8nstantin/OpenPraxis/internal/execution"
 )
 
 // HostMetricsSample is one CPU/RSS reading of the serve process. The
@@ -76,6 +78,13 @@ type HostSampler struct {
 	pid      int
 	stopCh   chan struct{}
 	started  bool
+
+	// EL/M2-T3: per-tick fan-out also writes a row into
+	// execution_log_samples for any attached task that has been
+	// registered with an execution_log run id. Both fields are nil/empty
+	// pre-wire and the per-tick path no-ops on them.
+	execStore  *executionlog.Store
+	execRunIDs map[string]string
 }
 
 // NewHostSampler returns a sampler that polls every interval. interval
@@ -85,11 +94,38 @@ func NewHostSampler(interval time.Duration) *HostSampler {
 		interval = 5 * time.Second
 	}
 	return &HostSampler{
-		attached: make(map[string]*attachedTask),
-		interval: interval,
-		pid:      os.Getpid(),
-		stopCh:   make(chan struct{}),
+		attached:   make(map[string]*attachedTask),
+		interval:   interval,
+		pid:        os.Getpid(),
+		stopCh:     make(chan struct{}),
+		execRunIDs: make(map[string]string),
 	}
+}
+
+// SetExecLogStore wires the unified execution_log store onto the sampler so
+// the per-tick fanout can also append a row to execution_log_samples for
+// every attached task that has been registered via RegisterExecLogRun.
+// Nil is safe — the fanout simply skips the execution_log write.
+func (s *HostSampler) SetExecLogStore(store *executionlog.Store) {
+	s.mu.Lock()
+	s.execStore = store
+	s.mu.Unlock()
+}
+
+// RegisterExecLogRun associates an attached task with the execution_log
+// row id minted at run start (EL/M2-T1). Only attached tasks with a
+// registered run id participate in the per-tick execution_log_samples
+// write. Re-registering the same taskID overwrites the prior id.
+func (s *HostSampler) RegisterExecLogRun(taskID, execLogID string) {
+	if taskID == "" || execLogID == "" {
+		return
+	}
+	s.mu.Lock()
+	if s.execRunIDs == nil {
+		s.execRunIDs = make(map[string]string)
+	}
+	s.execRunIDs[taskID] = execLogID
+	s.mu.Unlock()
 }
 
 // Start launches the poll loop. Idempotent — the second call is a no-op.
@@ -144,15 +180,55 @@ func (s *HostSampler) loop(ctx context.Context) {
 // fanout snaps host CPU/RSS into each attached task's sample buffer,
 // enriching per-task fields from the Attach-time callback. Host values
 // are identical across all attached tasks in one tick.
+//
+// EL/M2-T3: in the same pass, append a row to execution_log_samples for
+// every attached task that has been registered via RegisterExecLogRun.
+// The execution_log write is best-effort — failures are logged at warn
+// and never block the in-memory buffer that backs the legacy
+// task_run_host_samples flush on Detach.
 func (s *HostSampler) fanout(hostOnly HostMetricsSample) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	for _, at := range s.attached {
+	store := s.execStore
+	type pendingExecSample struct {
+		runID string
+		smp   executionlog.Sample
+	}
+	var pending []pendingExecSample
+	for taskID, at := range s.attached {
 		sample := hostOnly
 		if at.statFn != nil {
 			sample.CostUSD, sample.Turns, sample.Actions = at.statFn()
 		}
 		at.samples = append(at.samples, sample)
+		if store != nil {
+			if runID, ok := s.execRunIDs[taskID]; ok && runID != "" {
+				pending = append(pending, pendingExecSample{
+					runID: runID,
+					smp: executionlog.Sample{
+						RunID:      runID,
+						TS:         sample.TS.UnixMilli(),
+						CPUPct:     sample.CPUPct,
+						RSSMB:      sample.RSSMB,
+						DiskUsedGB: sample.DiskUsedGB,
+						CostUSD:    sample.CostUSD,
+						Turns:      sample.Turns,
+						Actions:    sample.Actions,
+					},
+				})
+			}
+		}
+	}
+	s.mu.Unlock()
+
+	if store == nil || len(pending) == 0 {
+		return
+	}
+	ctx := context.Background()
+	for _, p := range pending {
+		if err := store.InsertSample(ctx, p.smp); err != nil {
+			slog.Warn("execution_log_samples insert failed",
+				"component", "host_sampler", "run_id", p.runID, "error", err)
+		}
 	}
 }
 
@@ -176,6 +252,7 @@ func (s *HostSampler) Detach(taskID string) ([]HostMetricsSample, HostMetrics) {
 	s.mu.Lock()
 	at := s.attached[taskID]
 	delete(s.attached, taskID)
+	delete(s.execRunIDs, taskID)
 	s.mu.Unlock()
 	if at == nil {
 		return nil, HostMetrics{}

--- a/internal/task/host_metrics_exec_log_test.go
+++ b/internal/task/host_metrics_exec_log_test.go
@@ -1,0 +1,122 @@
+package task
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	executionlog "github.com/k8nstantin/OpenPraxis/internal/execution"
+)
+
+// TestHostSampler_fanout_writes_execution_log_samples — EL/M2-T3 acceptance:
+// after two fanout() ticks, execution_log_samples has 2 rows for the
+// registered runID and 0 rows for an attached-but-unregistered task.
+func TestHostSampler_fanout_writes_execution_log_samples(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "execlog.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := executionlog.InitSchema(db); err != nil {
+		t.Fatalf("execution.InitSchema: %v", err)
+	}
+	store := executionlog.NewStore(db)
+
+	hs := NewHostSampler(time.Second)
+	hs.SetExecLogStore(store)
+
+	// Two attached tasks: one is registered with an execution_log run id,
+	// the other is intentionally left unregistered to assert the fanout
+	// only writes for tasks the runner explicitly enrolled.
+	registeredTask := "t-registered"
+	unregisteredTask := "t-no-run"
+	runID := "run-registered"
+
+	hs.Attach(registeredTask, func() (float64, int, int) { return 1.25, 7, 13 })
+	hs.Attach(unregisteredTask, func() (float64, int, int) { return 9.0, 99, 99 })
+	hs.RegisterExecLogRun(registeredTask, runID)
+
+	// Two synthetic ticks. We hand-call fanout instead of letting the
+	// real loop fire so the test is deterministic and doesn't depend on
+	// `ps` shell-out timing.
+	for i := 0; i < 2; i++ {
+		hs.fanout(HostMetricsSample{
+			TS:         time.Now().UTC(),
+			CPUPct:     12.5 + float64(i),
+			RSSMB:      256.0 + float64(i),
+			DiskUsedGB: 10.0,
+		})
+	}
+
+	got, err := store.ListSamples(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("ListSamples: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("registered run sample count = %d, want 2", len(got))
+	}
+	for i, s := range got {
+		if s.RunID != runID {
+			t.Fatalf("sample[%d].RunID = %q, want %q", i, s.RunID, runID)
+		}
+		if s.CostUSD != 1.25 {
+			t.Fatalf("sample[%d].CostUSD = %v, want 1.25 (statFn output)", i, s.CostUSD)
+		}
+		if s.Turns != 7 || s.Actions != 13 {
+			t.Fatalf("sample[%d] turns/actions = %d/%d, want 7/13", i, s.Turns, s.Actions)
+		}
+		if s.RSSMB == 0 || s.CPUPct == 0 {
+			t.Fatalf("sample[%d] CPU/RSS empty: %+v", i, s)
+		}
+		if s.DiskUsedGB != 10.0 {
+			t.Fatalf("sample[%d].DiskUsedGB = %v, want 10.0", i, s.DiskUsedGB)
+		}
+		if s.TS == 0 {
+			t.Fatalf("sample[%d].TS = 0, want unix-ms timestamp", i)
+		}
+	}
+
+	// Unregistered task must not have any rows in execution_log_samples
+	// (its samples still live in the in-memory buffer that backs the
+	// existing task_run_host_samples flush on Detach).
+	stray, err := store.ListSamples(context.Background(), "run-not-registered")
+	if err != nil {
+		t.Fatalf("ListSamples (stray): %v", err)
+	}
+	if len(stray) != 0 {
+		t.Fatalf("unregistered run sample count = %d, want 0", len(stray))
+	}
+
+	// Detach must drop the execRunIDs entry so a subsequent fanout
+	// triggered before the goroutine fully exits doesn't double-write.
+	if _, _ = hs.Detach(registeredTask); len(hs.execRunIDs) != 0 {
+		t.Fatalf("execRunIDs after Detach = %v, want empty map", hs.execRunIDs)
+	}
+}
+
+// TestHostSampler_fanout_no_exec_store_is_noop — when no execution_log
+// store is wired, fanout must still buffer per-task samples for the
+// legacy task_run_host_samples flush, but write nothing to execution_log_samples.
+func TestHostSampler_fanout_no_exec_store_is_noop(t *testing.T) {
+	hs := NewHostSampler(time.Second)
+	// Deliberately do NOT call SetExecLogStore.
+	taskID := "t-no-store"
+	hs.Attach(taskID, func() (float64, int, int) { return 0, 0, 0 })
+	// RegisterExecLogRun on a sampler with no store must also be a no-op
+	// — the fanout's own `store == nil` guard short-circuits before
+	// reading execRunIDs, so this just exercises the registration path.
+	hs.RegisterExecLogRun(taskID, "run-orphan")
+
+	hs.fanout(HostMetricsSample{TS: time.Now().UTC(), CPUPct: 1, RSSMB: 1})
+
+	// The per-task buffer should still have grown — Detach returns it.
+	samples, _ := hs.Detach(taskID)
+	if len(samples) != 1 {
+		t.Fatalf("in-memory buffer len = %d, want 1 (legacy task_run_host_samples flow must be untouched)", len(samples))
+	}
+}

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -12,7 +12,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/k8nstantin/OpenPraxis/internal/action"
+	executionlog "github.com/k8nstantin/OpenPraxis/internal/execution"
 	"github.com/k8nstantin/OpenPraxis/internal/settings"
 	"github.com/k8nstantin/OpenPraxis/internal/templates"
 )
@@ -40,6 +43,11 @@ type RunningTask struct {
 	// Model is the model id reported by the first assistant event — used to
 	// pick a pricing table and for calibration after the run.
 	Model string `json:"model"`
+	// ExecLogID is the execution_log row id minted at run start (EL/M2-T1).
+	// Empty when the runner was constructed without an execution_log store
+	// wired via SetExecutionLog. Subsequent updates (TTFB, completion,
+	// cancellation) target this id.
+	ExecLogID string `json:"exec_log_id,omitempty"`
 	// usageByMessage tracks the last-seen usage per message id so we can
 	// dedupe the repeated assistant events Claude Code emits while a single
 	// logical message streams. Not serialized; live-estimate only.
@@ -99,6 +107,54 @@ type Runner struct {
 	// are skipped (tests + pre-wire code paths). Wired via
 	// SetHostSampler from cmd/serve.go at boot.
 	hostSampler *HostSampler
+
+	// execLog is the unified-run-history store (EL/M2). Wired via
+	// SetExecutionLog. Nil → the runner skips the execution_log writes
+	// entirely, preserving pre-EL/M2 behavior for tests + harnesses
+	// that don't open a sqlite-backed store.
+	execLog *executionlog.Store
+}
+
+// SetExecutionLog wires the execution_log store onto the runner. The runner
+// inserts a row at run start (status=running) and updates it at completion.
+// Nil disables the feature — existing test harnesses that build a Runner
+// without a sqlite-backed store continue to work.
+func (r *Runner) SetExecutionLog(s *executionlog.Store) { r.execLog = s }
+
+// recordExecLogStart inserts the at-start execution_log row for a freshly
+// spawned task and stamps the new id onto rt.ExecLogID. The function is the
+// single write point for the run-start path so the test harness can exercise
+// it without spawning a subprocess. Errors are logged and swallowed — a
+// failure to write history must not abort a live run.
+func (r *Runner) recordExecLogStart(ctx context.Context, rt *RunningTask, t *Task, workDir string) {
+	if r == nil || r.execLog == nil || rt == nil || t == nil {
+		return
+	}
+	info := executionlog.LookupModel(rt.Model)
+	r.mu.RLock()
+	parallelCount := len(r.running)
+	r.mu.RUnlock()
+	row := executionlog.Row{
+		ID:               uuid.New().String(),
+		EntityKind:       executionlog.KindTask,
+		EntityID:         t.ID,
+		Trigger:          t.Schedule,
+		NodeID:           r.sourceNode,
+		Status:           "running",
+		StartedAt:        rt.StartedAt.UnixMilli(),
+		Model:            rt.Model,
+		Provider:         info.Provider,
+		ModelContextSize: info.ContextWindowSize,
+		AgentRuntime:     t.Agent,
+		ParallelTasks:    parallelCount,
+		WorktreePath:     workDir,
+	}
+	if err := r.execLog.Insert(ctx, row); err != nil {
+		slog.Warn("execution_log: insert run-start row failed",
+			"component", "runner", "task_id", t.ID, "error", err)
+		return
+	}
+	rt.ExecLogID = row.ID
 }
 
 // SetHostSampler wires a started HostSampler onto the runner. Attach is
@@ -862,6 +918,9 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 	if err := r.store.SaveRuntimeState(t.ID, t.Title, manifestTitle, t.Agent, cmd.Process.Pid, false, 0, 0, "", rt.StartedAt); err != nil {
 		slog.Error("save runtime state failed", "component", "runner", "task_id", t.ID, "error", err)
 	}
+
+	// EL/M2-T1: record the run-start row in execution_log. Nil store → no-op.
+	r.recordExecLogStart(ctx, rt, t, workDir)
 
 	if r.onEvent != nil {
 		r.onEvent("task_started", map[string]string{

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -942,6 +942,14 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 		r.hostSampler.Attach(t.ID, func() (float64, int, int) {
 			return rtRef.CumulativeCostUSD, len(rtRef.usageByMessage), rtRef.Actions
 		})
+		// EL/M2-T3: associate the attached task with the execution_log
+		// run id minted by recordExecLogStart so the per-tick fanout
+		// also writes a row into execution_log_samples. Empty
+		// ExecLogID (no exec store wired, or the start-row insert
+		// failed) is a deliberate no-op on the sampler side.
+		if rt.ExecLogID != "" {
+			r.hostSampler.RegisterExecLogRun(t.ID, rt.ExecLogID)
+		}
 	}
 
 	// Read output in background

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -157,6 +157,150 @@ func (r *Runner) recordExecLogStart(ctx context.Context, rt *RunningTask, t *Tas
 	rt.ExecLogID = row.ID
 }
 
+// completionInput bundles the loose locals the runner pulls together at the
+// end of a task run so recordExecLogCompletion stays a single readable call.
+type completionInput struct {
+	status      string
+	reason      string
+	exitCode    int
+	costUSD     float64
+	numTurns    int
+	usage       Usage
+	output      string
+	hostMetrics HostMetrics
+	workDir     string
+	baseSHA     string
+}
+
+// recordExecLogCompletion writes the EL/M2 completion-side fields onto the
+// execution_log row started by recordExecLogStart. Best-effort: a nil store
+// or empty rt.ExecLogID is a no-op (test/pre-wire harnesses); insertion or
+// update errors are logged at warn and swallowed so the task_runs source-of-
+// truth path is unaffected. All values are pulled from the runner's locals
+// at completion plus a small `git -C workDir` walk for the worktree churn
+// fields (branch / commit_sha / commits / lines / files). pr_number stays 0
+// — no current code path knows it; M3+ will fill it from a PR-watcher.
+func (r *Runner) recordExecLogCompletion(ctx context.Context, rt *RunningTask, in completionInput) {
+	if r == nil || r.execLog == nil || rt == nil || rt.ExecLogID == "" {
+		return
+	}
+
+	derived := executionlog.ComputeDerived(executionlog.DerivedInput{
+		InputTokens:       int(in.usage.InputTokens),
+		OutputTokens:      int(in.usage.OutputTokens),
+		CacheReadTokens:   int(in.usage.CacheReadTokens),
+		CacheCreateTokens: int(in.usage.CacheCreationTokens),
+		CostUSD:           in.costUSD,
+		Turns:             in.numTurns,
+		Actions:           rt.Actions,
+		Model:             rt.Model,
+	})
+
+	now := time.Now().UnixMilli()
+	durMS := time.Since(rt.StartedAt).Milliseconds()
+	if durMS < 0 {
+		durMS = 0
+	}
+
+	churn := gitChurn(in.workDir, in.baseSHA)
+
+	exit := in.exitCode
+	fields := map[string]any{
+		"status":              in.status,
+		"terminal_reason":     in.reason,
+		"completed_at":        now,
+		"duration_ms":         durMS,
+		"exit_code":           &exit,
+		"input_tokens":        int(in.usage.InputTokens),
+		"output_tokens":       int(in.usage.OutputTokens),
+		"cache_read_tokens":   int(in.usage.CacheReadTokens),
+		"cache_create_tokens": int(in.usage.CacheCreationTokens),
+		"cost_usd":            in.costUSD,
+		"turns":               in.numTurns,
+		"actions":             rt.Actions,
+		"last_output":         in.output,
+		"pricing_version":     PricingVersion,
+		"cache_hit_rate_pct":  derived.CacheHitRatePct,
+		"context_window_pct":  derived.ContextWindowPct,
+		"cost_per_turn":       derived.CostPerTurn,
+		"cost_per_action":     derived.CostPerAction,
+		"tokens_per_turn":     derived.TokensPerTurn,
+		"cache_savings_usd":   derived.CacheSavingsUSD,
+		"peak_cpu_pct":        in.hostMetrics.PeakCPUPct,
+		"avg_cpu_pct":         in.hostMetrics.AvgCPUPct,
+		"peak_rss_mb":         in.hostMetrics.PeakRSSMB,
+		"avg_rss_mb":          in.hostMetrics.AvgRSSMB,
+		"branch":              churn.branch,
+		"commit_sha":          churn.commitSHA,
+		"commits":             churn.commits,
+		"lines_added":         churn.linesAdded,
+		"lines_removed":       churn.linesRemoved,
+		"files_changed":       churn.filesChanged,
+	}
+	if err := r.execLog.UpdateCompletion(ctx, rt.ExecLogID, fields); err != nil {
+		slog.Warn("execution_log: update completion failed",
+			"component", "runner", "task_id", rt.TaskID, "error", err)
+	}
+}
+
+// gitChurnResult is the parsed worktree state recorded on completion.
+type gitChurnResult struct {
+	branch       string
+	commitSHA    string
+	commits      int
+	linesAdded   int
+	linesRemoved int
+	filesChanged int
+}
+
+// gitChurn shells out four cheap `git -C workDir` commands to capture the
+// per-run code-change footprint. Mirrors the algorithm in
+// internal/watcher/watcher.go.RunGitGate but folds the four reads into one
+// helper so the runner can stamp them onto execution_log without pulling in
+// the watcher package. Empty workDir or baseSHA returns a zero result
+// (test harness path; the caller writes zeroes which is the "unknown" code
+// that downstream charts already handle).
+func gitChurn(workDir, baseSHA string) gitChurnResult {
+	var out gitChurnResult
+	if workDir == "" {
+		return out
+	}
+	if b, err := exec.Command("git", "-C", workDir, "rev-parse", "--abbrev-ref", "HEAD").Output(); err == nil {
+		out.branch = strings.TrimSpace(string(b))
+	}
+	if b, err := exec.Command("git", "-C", workDir, "rev-parse", "HEAD").Output(); err == nil {
+		out.commitSHA = strings.TrimSpace(string(b))
+	}
+	if baseSHA == "" {
+		return out
+	}
+	if b, err := exec.Command("git", "-C", workDir, "rev-list", "--count", baseSHA+"..HEAD").Output(); err == nil {
+		fmt.Sscanf(strings.TrimSpace(string(b)), "%d", &out.commits)
+	}
+	// `git diff --shortstat A..HEAD` → " 3 files changed, 42 insertions(+), 7 deletions(-)"
+	if b, err := exec.Command("git", "-C", workDir, "diff", "--shortstat", baseSHA+"..HEAD").Output(); err == nil {
+		parseShortstat(strings.TrimSpace(string(b)), &out.filesChanged, &out.linesAdded, &out.linesRemoved)
+	}
+	return out
+}
+
+// parseShortstat extracts files/insertions/deletions from `git diff
+// --shortstat` output. Tolerant of the all-deletions and all-insertions
+// shapes ("1 file changed, 5 deletions(-)" with no insertions clause).
+func parseShortstat(s string, files, added, removed *int) {
+	for _, part := range strings.Split(s, ",") {
+		p := strings.TrimSpace(part)
+		switch {
+		case strings.Contains(p, "file"):
+			fmt.Sscanf(p, "%d", files)
+		case strings.Contains(p, "insertion"):
+			fmt.Sscanf(p, "%d", added)
+		case strings.Contains(p, "deletion"):
+			fmt.Sscanf(p, "%d", removed)
+		}
+	}
+}
+
 // SetHostSampler wires a started HostSampler onto the runner. Attach is
 // called at spawn, Detach at completion; the accumulated samples land
 // on task_run_host_samples + summary columns on task_runs.
@@ -1206,6 +1350,26 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 			}
 		}
 
+		// Detach host sampler unconditionally so the rolled-up metrics are
+		// available to BOTH the legacy task_runs.RecordHostMetrics path AND
+		// the EL/M2 execution_log UPDATE below. Detach is a no-op on a nil
+		// sampler / unattached task.
+		var (
+			hostSamples []HostMetricsSample
+			hostMetrics HostMetrics
+		)
+		if r.hostSampler != nil {
+			hostSamples, hostMetrics = r.hostSampler.Detach(t.ID)
+		}
+
+		// Capture the post-Wait exit code while cmd is still in scope. -1
+		// means "unknown" (process never started or wait failed before the
+		// kernel reaped it).
+		exitCode := -1
+		if cmd.ProcessState != nil {
+			exitCode = cmd.ProcessState.ExitCode()
+		}
+
 		// Record the run with history — always use real status, not "scheduled"
 		runID, err := r.store.RecordRun(t.ID, output, status, rt.Actions, rt.Lines, costUSD, numTurns, rt.StartedAt, finalUsage, rt.Model)
 		if err != nil {
@@ -1214,11 +1378,28 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 			// Host CPU/RSS samples accumulated during the run → persist them
 			// alongside the run row. Failure here is not fatal — loss of
 			// host metrics must not fail task completion.
-			samples, metrics := r.hostSampler.Detach(t.ID)
-			if err := r.store.RecordHostMetrics(runID, samples, metrics); err != nil {
+			if err := r.store.RecordHostMetrics(runID, hostSamples, hostMetrics); err != nil {
 				slog.Warn("record host metrics failed", "component", "runner", "task_id", t.ID, "error", err)
 			}
 		}
+
+		// EL/M2-T4: dual-write the same completion data into execution_log.
+		// Best-effort — failures log and swallow so task_runs remains the
+		// source of truth during the dual-write window. Worktree git stats
+		// are computed against baseSHA before the defer above clears the
+		// directory.
+		r.recordExecLogCompletion(bgCtx, rt, completionInput{
+			status:      status,
+			reason:      reason,
+			exitCode:    exitCode,
+			costUSD:     costUSD,
+			numTurns:    numTurns,
+			usage:       finalUsage,
+			output:      output,
+			hostMetrics: hostMetrics,
+			workDir:     workDir,
+			baseSHA:     baseSHA,
+		})
 
 		// Post-completion execution-review gate. Successful completions must
 		// carry at least one agent-authored execution_review comment on the

--- a/internal/task/runner_exec_log_completion_test.go
+++ b/internal/task/runner_exec_log_completion_test.go
@@ -1,0 +1,200 @@
+package task
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	executionlog "github.com/k8nstantin/OpenPraxis/internal/execution"
+)
+
+// TestUpdateCompletion_writes_all_fields — EL/M2-T4 acceptance: after a
+// recorded run-start row, the completion helper must populate every
+// completion-side column on the same execution_log row. This exercises the
+// helper directly (no subprocess) so the test stays fast and deterministic.
+func TestUpdateCompletion_writes_all_fields(t *testing.T) {
+	r, _, _, _ := newRunnerHarness(t)
+
+	dbPath := filepath.Join(t.TempDir(), "execlog.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := executionlog.InitSchema(db); err != nil {
+		t.Fatalf("execution.InitSchema: %v", err)
+	}
+	store := executionlog.NewStore(db)
+	r.SetExecutionLog(store)
+	r.SetSourceNode("node-test")
+
+	taskID := "t-exec-complete"
+	tk := &Task{ID: taskID, Title: "exec complete", Agent: "claude-code", Schedule: "once"}
+	rt := &RunningTask{
+		TaskID:    taskID,
+		Title:     tk.Title,
+		Agent:     tk.Agent,
+		StartedAt: time.Now().Add(-2 * time.Second),
+		Model:     "claude-sonnet-4-6",
+		Actions:   12,
+	}
+
+	// Seed the at-start row so UpdateCompletion has a target.
+	r.recordExecLogStart(context.Background(), rt, tk, "")
+
+	in := completionInput{
+		status:   "completed",
+		reason:   "success",
+		exitCode: 0,
+		costUSD:  0.04,
+		numTurns: 4,
+		usage: Usage{
+			InputTokens:         1_500,
+			OutputTokens:        800,
+			CacheReadTokens:     6_000,
+			CacheCreationTokens: 200,
+		},
+		output: "final result",
+		hostMetrics: HostMetrics{
+			PeakCPUPct: 73.5,
+			AvgCPUPct:  41.2,
+			PeakRSSMB:  912,
+			AvgRSSMB:   544,
+		},
+		// workDir empty → gitChurn returns zero result without forking.
+	}
+	r.recordExecLogCompletion(context.Background(), rt, in)
+
+	got, err := store.Get(context.Background(), rt.ExecLogID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+
+	// Status / terminal
+	if got.Status != "completed" {
+		t.Errorf("status = %q, want completed", got.Status)
+	}
+	if got.TerminalReason != "success" {
+		t.Errorf("terminal_reason = %q, want success", got.TerminalReason)
+	}
+	if got.CompletedAt == 0 {
+		t.Errorf("completed_at = 0, want non-zero")
+	}
+	if got.DurationMS <= 0 {
+		t.Errorf("duration_ms = %d, want > 0", got.DurationMS)
+	}
+	if got.ExitCode == nil || *got.ExitCode != 0 {
+		t.Errorf("exit_code = %v, want 0", got.ExitCode)
+	}
+
+	// Tokens / cost
+	if got.InputTokens != 1500 || got.OutputTokens != 800 ||
+		got.CacheReadTokens != 6000 || got.CacheCreateTokens != 200 {
+		t.Errorf("tokens mismatch: in=%d out=%d cr=%d cc=%d",
+			got.InputTokens, got.OutputTokens, got.CacheReadTokens, got.CacheCreateTokens)
+	}
+	if got.CostUSD != 0.04 {
+		t.Errorf("cost_usd = %v, want 0.04", got.CostUSD)
+	}
+	if got.Turns != 4 || got.Actions != 12 {
+		t.Errorf("turns/actions = %d/%d, want 4/12", got.Turns, got.Actions)
+	}
+	if got.LastOutput != "final result" {
+		t.Errorf("last_output = %q, want %q", got.LastOutput, "final result")
+	}
+	if got.PricingVersion == "" {
+		t.Errorf("pricing_version empty, want stamped")
+	}
+
+	// Derived ratios — verify ComputeDerived ran through and the values
+	// got persisted (exact arithmetic is in derived_test.go).
+	if got.CacheHitRatePct == 0 {
+		t.Errorf("cache_hit_rate_pct = 0, want >0")
+	}
+	if got.ContextWindowPct == 0 {
+		t.Errorf("context_window_pct = 0, want >0")
+	}
+	if got.CostPerTurn == 0 {
+		t.Errorf("cost_per_turn = 0, want >0")
+	}
+	if got.CostPerAction == 0 {
+		t.Errorf("cost_per_action = 0, want >0")
+	}
+	if got.TokensPerTurn == 0 {
+		t.Errorf("tokens_per_turn = 0, want >0")
+	}
+	if got.CacheSavingsUSD == 0 {
+		t.Errorf("cache_savings_usd = 0, want >0")
+	}
+
+	// Host metrics rollup
+	if got.PeakCPUPct != 73.5 || got.AvgCPUPct != 41.2 ||
+		got.PeakRSSMB != 912 || got.AvgRSSMB != 544 {
+		t.Errorf("host metrics mismatch: peakCPU=%v avgCPU=%v peakRSS=%v avgRSS=%v",
+			got.PeakCPUPct, got.AvgCPUPct, got.PeakRSSMB, got.AvgRSSMB)
+	}
+
+	// Empty workDir → git fields stay zero / empty (not failures).
+	if got.Branch != "" || got.CommitSHA != "" {
+		t.Errorf("expected empty git fields with empty workDir, got branch=%q sha=%q",
+			got.Branch, got.CommitSHA)
+	}
+}
+
+// TestUpdateCompletion_no_store_is_noop — without a wired execLog store, the
+// helper must not panic and must do nothing (no row, no log spam).
+func TestUpdateCompletion_no_store_is_noop(t *testing.T) {
+	r, _, _, _ := newRunnerHarness(t)
+	// Deliberately do NOT call SetExecutionLog.
+
+	rt := &RunningTask{TaskID: "t-noop", StartedAt: time.Now()}
+	r.recordExecLogCompletion(context.Background(), rt, completionInput{status: "completed"})
+}
+
+// TestUpdateCompletion_no_exec_log_id_is_noop — recordExecLogStart did not
+// fire (e.g. the store insert failed) so rt.ExecLogID is empty. The
+// completion helper must short-circuit.
+func TestUpdateCompletion_no_exec_log_id_is_noop(t *testing.T) {
+	r, _, _, _ := newRunnerHarness(t)
+
+	dbPath := filepath.Join(t.TempDir(), "execlog.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := executionlog.InitSchema(db); err != nil {
+		t.Fatalf("execution.InitSchema: %v", err)
+	}
+	r.SetExecutionLog(executionlog.NewStore(db))
+
+	rt := &RunningTask{TaskID: "t-empty-id", StartedAt: time.Now()} // no ExecLogID
+	r.recordExecLogCompletion(context.Background(), rt, completionInput{status: "completed"})
+}
+
+// TestParseShortstat — git diff --shortstat parsing is reused for the run
+// completion stats. Cover the canonical mixed-case + the edge cases where
+// only insertions or only deletions land.
+func TestParseShortstat(t *testing.T) {
+	cases := []struct {
+		in            string
+		files, ins, del int
+	}{
+		{"3 files changed, 42 insertions(+), 7 deletions(-)", 3, 42, 7},
+		{"1 file changed, 5 insertions(+)", 1, 5, 0},
+		{"1 file changed, 9 deletions(-)", 1, 0, 9},
+		{"", 0, 0, 0},
+	}
+	for _, tc := range cases {
+		var f, a, d int
+		parseShortstat(tc.in, &f, &a, &d)
+		if f != tc.files || a != tc.ins || d != tc.del {
+			t.Errorf("parseShortstat(%q) = (%d,%d,%d), want (%d,%d,%d)",
+				tc.in, f, a, d, tc.files, tc.ins, tc.del)
+		}
+	}
+}

--- a/internal/task/runner_exec_log_test.go
+++ b/internal/task/runner_exec_log_test.go
@@ -1,0 +1,113 @@
+package task
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	executionlog "github.com/k8nstantin/OpenPraxis/internal/execution"
+)
+
+// TestRunStart_writes_exec_log — EL/M2-T1 acceptance: when the runner has an
+// execution_log store wired and the run-start helper fires, exactly one row
+// lands in execution_log for the task with status=running and the identity +
+// agent + worktree fields the rest of M2 will update on completion.
+func TestRunStart_writes_exec_log(t *testing.T) {
+	r, _, _, _ := newRunnerHarness(t)
+
+	// Open a separate sqlite for the execution_log store so this test stays
+	// independent of the harness's schema.
+	dbPath := filepath.Join(t.TempDir(), "execlog.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := executionlog.InitSchema(db); err != nil {
+		t.Fatalf("execution.InitSchema: %v", err)
+	}
+	store := executionlog.NewStore(db)
+	r.SetExecutionLog(store)
+	r.SetSourceNode("node-test")
+
+	taskID := "t-exec-start"
+	tk := &Task{ID: taskID, Title: "exec start", Agent: "claude-code", Schedule: "once"}
+	rt := &RunningTask{
+		TaskID:    taskID,
+		Title:     tk.Title,
+		Agent:     tk.Agent,
+		StartedAt: time.Now(),
+		Model:     "claude-opus-4-7",
+	}
+	workDir := "/tmp/wt-exec-start"
+
+	r.recordExecLogStart(context.Background(), rt, tk, workDir)
+
+	if rt.ExecLogID == "" {
+		t.Fatalf("recordExecLogStart did not stamp ExecLogID on RunningTask")
+	}
+
+	rows, err := store.ListByEntity(context.Background(), executionlog.KindTask, taskID, 10)
+	if err != nil {
+		t.Fatalf("ListByEntity: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("ListByEntity rows = %d, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.ID != rt.ExecLogID {
+		t.Fatalf("row id = %q, want %q (rt.ExecLogID)", got.ID, rt.ExecLogID)
+	}
+	if got.Status != "running" {
+		t.Fatalf("row status = %q, want %q", got.Status, "running")
+	}
+	if got.EntityKind != executionlog.KindTask {
+		t.Fatalf("entity_kind = %q, want %q", got.EntityKind, executionlog.KindTask)
+	}
+	if got.EntityID != taskID {
+		t.Fatalf("entity_id = %q, want %q", got.EntityID, taskID)
+	}
+	if got.AgentRuntime != "claude-code" {
+		t.Fatalf("agent_runtime = %q, want %q", got.AgentRuntime, "claude-code")
+	}
+	if got.WorktreePath != workDir {
+		t.Fatalf("worktree_path = %q, want %q", got.WorktreePath, workDir)
+	}
+	if got.NodeID != "node-test" {
+		t.Fatalf("node_id = %q, want %q", got.NodeID, "node-test")
+	}
+	if got.Model != "claude-opus-4-7" {
+		t.Fatalf("model = %q, want %q", got.Model, "claude-opus-4-7")
+	}
+	if got.Provider != "anthropic" {
+		t.Fatalf("provider = %q, want %q (LookupModel should have filled this)", got.Provider, "anthropic")
+	}
+	if got.ModelContextSize != 1_000_000 {
+		t.Fatalf("model_context_size = %d, want %d", got.ModelContextSize, 1_000_000)
+	}
+	if got.Trigger != "once" {
+		t.Fatalf("trigger = %q, want %q", got.Trigger, "once")
+	}
+	if got.StartedAt == 0 {
+		t.Fatalf("started_at = 0, want non-zero (rt.StartedAt.UnixMilli)")
+	}
+}
+
+// TestRunStart_no_store_is_noop — when no execution_log store is wired, the
+// helper must be a no-op and must not stamp ExecLogID.
+func TestRunStart_no_store_is_noop(t *testing.T) {
+	r, _, _, _ := newRunnerHarness(t)
+	// Deliberately do NOT call SetExecutionLog.
+
+	rt := &RunningTask{TaskID: "t-noop", StartedAt: time.Now()}
+	tk := &Task{ID: "t-noop", Agent: "claude-code"}
+	r.recordExecLogStart(context.Background(), rt, tk, "/tmp/wt-noop")
+
+	if rt.ExecLogID != "" {
+		t.Fatalf("ExecLogID = %q, want empty (no store wired)", rt.ExecLogID)
+	}
+}


### PR DESCRIPTION
## Summary
- New \`ComputeDerived(DerivedInput) DerivedOutput\` in \`internal/execution/derived.go\` (pure, zero-input safe, replicates \`task.ModelRates\` to dodge an import cycle). Existing \`ComputeDerived(*Row)\` renamed to private \`applyDerivedToRow\`; backfill behaviour unchanged plus \`cache_savings_usd\` now populated.
- New \`Runner.recordExecLogCompletion\` helper called after \`RecordRun\`. Writes status / terminal_reason / completed_at / duration_ms / exit_code / tokens / cost / turns / actions / last_output / pricing_version, the six derived ratios (cache hit, ctx %, cost-per-turn, cost-per-action, tokens-per-turn, cache savings), the host metrics rollup, and the git churn (branch / commit_sha / commits / lines_added / lines_removed / files_changed). \`pr_number\` stays 0 — no current code path knows it.
- Host sampler is now \`Detach\`'d unconditionally so the same rollup feeds the legacy task_runs path and the new execution_log path.

## Branch parent

Branched off \`openpraxis/el-m2-t3-host-samples\` (the depends_on task), which itself sits on T1. Branching off \`main\` would not compile — \`rt.ExecLogID\` and \`r.execLog\` come from EL/M2-T1, not on \`main\` yet. Once T1 + T2 + T3 land on \`main\`, this PR's diff reduces to the T4 delta. Mirrors the precedent set by T3.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./internal/task/... ./internal/execution/...\` green
- [x] New tests: \`TestComputeDerived_values\` (all six derived formulas, hand-computed expectations), \`TestComputeDerived_zero\` (no NaN/Inf on empty input), \`TestComputeDerived_unknownModel\` (registry fallback exercised), \`TestUpdateCompletion_writes_all_fields\` (end-to-end: seed start row → call helper → reload via Get → every completion field asserted), \`TestUpdateCompletion_no_store_is_noop\`, \`TestUpdateCompletion_no_exec_log_id_is_noop\`, \`TestParseShortstat\` (the three shortstat shapes).
- [ ] Operator: end-to-end run a real task, confirm \`SELECT * FROM execution_log WHERE entity_id = ?\` shows status='completed' with non-zero tokens/cost/derived columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)