### PR TITLE
refactor: UI — collapse all comment types to prompt + comment

### DIFF
--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,7 +49,7 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-wMLNUdrl.js"></script>
+    <script type="module" crossorigin src="/assets/index-D0rXM-Yw.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-CGgIkkjv.js">
     <link rel="stylesheet" crossorigin href="/assets/index-Co-bCT2d.css">

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,7 +49,7 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-D0rXM-Yw.js"></script>
+    <script type="module" crossorigin src="/assets/index-CPcrwzHf.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-CGgIkkjv.js">
     <link rel="stylesheet" crossorigin href="/assets/index-Co-bCT2d.css">

--- a/internal/web/ui/dashboard-v2/src/components/content-block/ContentBlock.tsx
+++ b/internal/web/ui/dashboard-v2/src/components/content-block/ContentBlock.tsx
@@ -4,10 +4,10 @@
  * Uses BlockNoteComposer which has native drag/drop/paste attachment support
  * via the uploadFile callback — no custom editor needed.
  *
- * Products     → label="Description"
- * Manifests    → label="Declaration"
- * Tasks        → label="Instructions"
- * Skills/Ideas → label="Description"
+ * All entity types → label="Prompt"
+ * All entity types → label="Prompt"
+ 
+ 
  */
 import { useRef, useState } from 'react'
 import { Pencil, ChevronDown, ChevronUp } from 'lucide-react'
@@ -35,7 +35,7 @@ interface ContentBlockProps {
   placeholder?: string
 }
 
-export function ContentBlock({ entityId, kind, label = 'Description', placeholder }: ContentBlockProps) {
+export function ContentBlock({ entityId, kind, label = 'Prompt', placeholder }: ContentBlockProps) {
   const [editing, setEditing] = useState(false)
   const [saving, setSaving] = useState(false)
   const [historyOpen, setHistoryOpen] = useState(false)
@@ -46,7 +46,7 @@ export function ContentBlock({ entityId, kind, label = 'Description', placeholde
   const createComment = useCreateEntityComment(kind, entityId)
   const updateEntity = useUpdateEntity(kind, entityId)
 
-  const revisions = (comments ?? []).filter(c => c.type === 'description_revision')
+  const revisions = (comments ?? []).filter(c => c.type === 'prompt')
   const latest = revisions[0]
 
   const startEdit = () => setEditing(true)
@@ -62,7 +62,7 @@ export function ContentBlock({ entityId, kind, label = 'Description', placeholde
 
       const created = await createComment.mutateAsync({
         author: 'operator',
-        type: 'description_revision',
+        type: 'prompt',
         body: body || '(attachment only)',
       }) as { id?: string } | undefined
 

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/comments.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/comments.tsx
@@ -29,21 +29,13 @@ import { BlockNoteReadView } from '@/components/blocknote-read-view'
 import { claimAttachment } from '@/lib/queries/attachments'
 
 const TYPE_LABEL: Record<string, string> = {
-  execution_review:     'Execution Review',
-  description_revision: 'Description',
-  agent_note:           'Agent Note',
-  user_note:            'Note',
-  watcher_finding:      'Watcher Finding',
-  decision:             'Decision',
-  link:                 'Link',
+  prompt:  'Prompt',
+  comment: 'Comment',
 }
 
 const COMPOSE_TYPES = [
-  'user_note',
-  'execution_review',
-  'agent_note',
-  'decision',
-  'description_revision',
+  'comment',
+  'prompt',
 ] as const
 
 function fmtTime(v: string | number | undefined): string {
@@ -61,7 +53,7 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
   const update = useUpdateEntity(kind, entityId)
 
   const [filter, setFilter] = useState('all')
-  const [composeType, setComposeType] = useState<keyof typeof TYPE_LABEL>('user_note')
+  const [composeType, setComposeType] = useState<keyof typeof TYPE_LABEL>('comment')
   const [composing, setComposing] = useState(false)
   const [posting, setPosting] = useState(false)
   const composerRef = useRef<BlockNoteComposerHandle>(null)
@@ -71,9 +63,9 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
     return comments.data.filter(c => !(c.body ?? '').includes('<dependency_revision>'))
   }, [comments.data])
 
-  // Only the most recent description_revision gets the emerald highlight
+  // Only the most recent prompt gets the emerald highlight
   const latestDescId = useMemo(() => {
-    const revs = real.filter(c => c.type === 'description_revision')
+    const revs = real.filter(c => c.type === 'prompt')
     return revs[0]?.id ?? null
   }, [real])
 
@@ -114,7 +106,7 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
       }
 
       // Description-as-comment: also PATCH the entity description field
-      if (composeType === 'description_revision' && body) {
+      if (composeType === 'prompt' && body) {
         update.mutate({ description: body } as Parameters<typeof update.mutate>[0])
       }
 
@@ -162,7 +154,7 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
               onSave={post}
               onCancel={close}
               placeholder={
-                composeType === 'description_revision'
+                composeType === 'prompt'
                   ? 'Write description… drop files, paste images, type / for blocks (Cmd-Enter to post)'
                   : 'Add a comment… drop files, paste images, type / for blocks (Cmd-Enter to post)'
               }
@@ -184,8 +176,8 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
               <Button type='button' variant='ghost' size='sm' onClick={close} disabled={posting}>Cancel</Button>
               <Button type='button' size='sm' onClick={post} disabled={posting}>
                 {posting
-                  ? composeType === 'description_revision' ? 'Saving…' : 'Posting…'
-                  : composeType === 'description_revision' ? 'Post as Description' : 'Post'}
+                  ? composeType === 'prompt' ? 'Saving…' : 'Posting…'
+                  : composeType === 'prompt' ? 'Post as Prompt' : 'Post'}
               </Button>
             </div>
           </CardContent>
@@ -211,15 +203,15 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
                   key={c.id}
                   className={cn(
                     'space-y-2 p-3 text-sm',
-                    c.type === 'description_revision' && c.id === latestDescId && 'border-l-2 border-emerald-400/60 bg-emerald-400/5',
-                    c.type === 'description_revision' && c.id !== latestDescId && 'opacity-50',
+                    c.type === 'prompt' && c.id === latestDescId && 'border-l-2 border-emerald-400/60 bg-emerald-400/5',
+                    c.type === 'prompt' && c.id !== latestDescId && 'opacity-50',
                   )}
                 >
                   <div className='flex items-center justify-between gap-2'>
                     <div className='flex items-center gap-2'>
                       <code className='font-mono text-[11px]'>{c.author.slice(0, 16)}</code>
                       <Badge
-                        variant={c.type === 'description_revision' ? 'secondary' : 'outline'}
+                        variant={c.type === 'prompt' ? 'secondary' : 'outline'}
                         className='text-[10px]'
                       >
                         {TYPE_LABEL[c.type] ?? c.type}

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/main.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/main.tsx
@@ -10,15 +10,6 @@ import { Badge } from '@/components/ui/badge'
 import { Gauge } from '@/components/gauge'
 import { ContentBlock } from '@/components/content-block'
 
-// Label shown in ContentBlock per entity type
-const CONTENT_LABEL: Record<string, string> = {
-  product:  'Prompt',
-  manifest: 'Prompt',
-  task:     'Prompt',
-  skill:    'Prompt',
-  idea:     'Prompt',
-}
-
 // Main tab — stats grid + repo card + description editor + revision
 // history. Same Markup ↔ Rendered toggle on description view; Cmd-Enter
 // saves; Escape cancels. PUT /api/entities/:id drops a new SCD-2
@@ -173,8 +164,8 @@ export function MainTab({
       <ContentBlock
         entityId={entityId}
         kind={kind}
-        label={CONTENT_LABEL[kind] ?? 'Prompt'}
-        placeholder={`Write ${(CONTENT_LABEL[kind] ?? 'description').toLowerCase()} here… Markdown supported, drag/paste files to attach`}
+        label='Prompt'
+        placeholder='Write prompt here… Markdown supported, drag/paste files to attach'
       />
 
     </div>

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/main.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/main.tsx
@@ -12,11 +12,11 @@ import { ContentBlock } from '@/components/content-block'
 
 // Label shown in ContentBlock per entity type
 const CONTENT_LABEL: Record<string, string> = {
-  product:  'Description',
-  manifest: 'Declaration',
-  task:     'Instructions',
-  skill:    'Description',
-  idea:     'Description',
+  product:  'Prompt',
+  manifest: 'Prompt',
+  task:     'Prompt',
+  skill:    'Prompt',
+  idea:     'Prompt',
 }
 
 // Main tab — stats grid + repo card + description editor + revision
@@ -169,11 +169,11 @@ export function MainTab({
         </Card>
       ) : null}
 
-      {/* ContentBlock: Description / Declaration / Instructions */}
+      {/* ContentBlock: Prompt */}
       <ContentBlock
         entityId={entityId}
         kind={kind}
-        label={CONTENT_LABEL[kind] ?? 'Description'}
+        label={CONTENT_LABEL[kind] ?? 'Prompt'}
         placeholder={`Write ${(CONTENT_LABEL[kind] ?? 'description').toLowerCase()} here… Markdown supported, drag/paste files to attach`}
       />
 

--- a/internal/web/ui/dashboard-v2/src/lib/queries/entity.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/queries/entity.ts
@@ -246,8 +246,8 @@ export function useEntityDescriptionHistory(
   return useQuery({
     queryKey: entityKeys.descriptionHistory(kind, id ?? ''),
     queryFn: async () => {
-      // Description revisions are stored as comments with type=description_revision.
-      const res = await fetch(`/api/entities/${id}/comments?type=description_revision&limit=100`)
+      // Description revisions are stored as comments with type=prompt.
+      const res = await fetch(`/api/entities/${id}/comments?type=prompt&limit=100`)
       if (!res.ok) throw new Error(`description history → ${res.status}`)
       const data = (await res.json()) as { comments: DescriptionRevision[] } | DescriptionRevision[]
       const rows = Array.isArray(data) ? data : (data.comments ?? [])
@@ -431,7 +431,7 @@ async function postDepRevision(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       author: 'operator',
-      type: 'agent_note',
+      type: 'comment',
       body: '<dependency_revision>\n' + body + '\n</dependency_revision>',
     }),
   })
@@ -762,7 +762,7 @@ export function useRestoreEntityDependencySnapshot(
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           author: 'operator',
-          type: 'agent_note',
+          type: 'comment',
           body: restoreBody,
         }),
       })

--- a/internal/web/ui/dashboard-v2/src/lib/types.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/types.ts
@@ -58,13 +58,8 @@ export interface OutputChunk {
 }
 
 export type CommentType =
-  | 'execution_review'
-  | 'description_revision'
-  | 'agent_note'
-  | 'user_note'
-  | 'watcher_finding'
-  | 'decision'
-  | 'link'
+  | 'prompt'
+  | 'comment'
   | string
 
 export interface Comment {


### PR DESCRIPTION
## Summary

- All entity types (product, manifest, task, skill, idea) → label **"Prompt"** in ContentBlock and main tab
- `TYPE_LABEL` in CommentsTab collapsed to `{ prompt: 'Prompt', comment: 'Comment' }`
- `COMPOSE_TYPES` collapsed to `['comment', 'prompt']`
- `CommentType` TS union: 9 literals → `'prompt' | 'comment' | string`
- All `type='description_revision'` references → `'prompt'`
- All `type='agent_note'` references → `'comment'`
- Button: "Post as Description" → "Post as Prompt"

🤖 Generated with [Claude Code](https://claude.com/claude-code)