### PR TITLE
feat: wire execution skill as universal dispatcher prompt

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
@@ -189,94 +190,45 @@ var serveCmd = &cobra.Command{
 			slog.Warn("recover in-flight tasks failed", "error", err)
 		}
 
-		// entityDesc returns the prompt body for an entity,
-		// falling back to the entity title when no revision comment exists.
-		entityDesc := func(ctx context.Context, entityID, fallback string) string {
-			ct := comments.TypeDescriptionRevision
-			revs, _ := n.Comments.List(ctx, comments.TargetEntity, entityID, 1, &ct)
-			if len(revs) > 0 && revs[0].Body != "" {
+		// executionSkillID is the UUID of the "OpenPraxis Execution Protocol"
+		// skill entity. The dispatcher loads its prompt at startup and uses it
+		// as the universal agent invocation template for every scheduled entity.
+		const executionSkillID = "019dfecc-a7b3-78a6-acc0-1cfa638eae18"
+
+		// loadSkillPrompt fetches the latest prompt-type comment from the
+		// execution skill. Falls back to a minimal inline prompt if the skill
+		// entity or its prompt is missing.
+		loadSkillPrompt := func(ctx context.Context) string {
+			ct := comments.TypePrompt
+			revs, err := n.Comments.List(ctx, comments.TargetEntity, executionSkillID, 1, &ct)
+			if err == nil && len(revs) > 0 && revs[0].Body != "" {
 				return revs[0].Body
 			}
-			return fallback
+			slog.Warn("execution skill prompt not found — using inline fallback", "skill_id", executionSkillID)
+			return "You are an experienced software engineer executing a scheduled OpenPraxis entity.\n\n" +
+				"Entity UUID: {ENTITY_UUID}\n\n" +
+				"Read the entity prompt and comments via the API, assemble full DAG context, execute, report back."
 		}
+
+		skillPrompt := loadSkillPrompt(context.Background())
+		slog.Info("execution skill loaded", "skill_id", executionSkillID[:12], "prompt_len", len(skillPrompt))
 
 		// visceralRules loads all visceral rules into a numbered string.
 		visceralRules := func() string {
 			rules, _ := n.Index.ListByType("visceral", 100)
-			var s string
+			var sb strings.Builder
 			for i, r := range rules {
-				s += fmt.Sprintf("%d. [%s] %s\n", i+1, r.ID, r.L2)
+				sb.WriteString(fmt.Sprintf("%d. [%s] %s\n", i+1, r.ID, r.L2))
 			}
-			return s
+			return sb.String()
 		}
 
-		// parentContext walks UP the DAG from entityID to collect manifest
-		// and product context. For a task it walks task→manifest→product;
-		// for a manifest it walks manifest→product; for a product it stops.
-		// Returns formatted context sections ready for prompt inclusion.
-		type parentCtx struct {
-			manifestID, manifestTitle, manifestDesc string
-			productID, productTitle, productDesc    string
-		}
-		walkUp := func(ctx context.Context, entityID, entityType string) parentCtx {
-			if n.Relationships == nil {
-				return parentCtx{}
-			}
-			var pc parentCtx
-			lookupID := entityID
-
-			// For a task: find owning manifest first.
-			if entityType == "task" {
-				if edges, _ := n.Relationships.ListIncoming(ctx, lookupID, "owns"); len(edges) > 0 {
-					for _, edge := range edges {
-						if edge.SrcKind == "manifest" {
-							pc.manifestID = edge.SrcID
-							break
-						}
-					}
-				}
-				if pc.manifestID != "" {
-					if me, _ := n.Entities.Get(pc.manifestID); me != nil {
-						pc.manifestTitle = me.Title
-						pc.manifestDesc = entityDesc(ctx, pc.manifestID, me.Title)
-					}
-					lookupID = pc.manifestID
-				}
-			}
-
-			// For a task (after finding manifest) or manifest: find owning product.
-			if entityType == "task" || entityType == "manifest" {
-				if edges, _ := n.Relationships.ListIncoming(ctx, lookupID, "owns"); len(edges) > 0 {
-					for _, edge := range edges {
-						if edge.SrcKind == "product" {
-							pc.productID = edge.SrcID
-							break
-						}
-					}
-				}
-				if pc.productID != "" {
-					if pe, _ := n.Entities.Get(pc.productID); pe != nil {
-						pc.productTitle = pe.Title
-						pc.productDesc = entityDesc(ctx, pc.productID, pe.Title)
-					}
-				}
-			}
-			return pc
-		}
-
-		// dispatch is the universal handler for any scheduled entity kind.
-		// Every prompt includes the full 3-tier context regardless of entry
-		// point: product (big picture) + manifest (refinement) + task
-		// (instructions). Context above the entry point is pre-fetched by
-		// walking UP the DAG via relationships. Context below is handed to
-		// the agent to traverse via MCP tools at runtime.
+		// dispatch is the universal handler for every scheduled entity kind.
+		// It injects the entity UUID into the execution skill prompt and fires
+		// one agent. The agent owns full DAG traversal — it reads prompts and
+		// comments at every level via the HTTP API and assembles its own context.
 		dispatch := func(ctx context.Context, entityID string, scheduleID int64) error {
 			// System-level concurrency guard: only one agent at a time.
-			// Products, manifests, and tasks all share the same codebase —
-			// concurrent agents conflict on branches and PRs.
-			// Check both the in-memory runner (current session) AND the
-			// execution_log (survives server restarts — agents can outlive
-			// the server process that spawned them).
 			if runner.RunningCount() > 0 {
 				running := runner.ListRunning()
 				titles := make([]string, 0, len(running))
@@ -286,8 +238,6 @@ var serveCmd = &cobra.Command{
 				return fmt.Errorf("agent already running (%v) — refusing to start %s concurrently", titles, entityID)
 			}
 			// Check execution_log for in-flight runs from previous sessions.
-			// For each, verify the agent process is still alive via its PID.
-			// Dead processes are auto-closed; live ones block the dispatch.
 			if n.ExecutionLog != nil {
 				inFlight, err := n.ExecutionLog.ListInFlight(ctx)
 				if err != nil {
@@ -306,7 +256,6 @@ var serveCmd = &cobra.Command{
 						return fmt.Errorf("agent PID %d still running (run %s) — refusing to start %s concurrently",
 							ifr.AgentPID, ifr.RunUID[:12], entityID)
 					}
-					// Process is dead — close the orphaned run and continue.
 					slog.Info("concurrency guard: closing zombie run", "run_uid", ifr.RunUID[:12], "pid", ifr.AgentPID)
 					_ = n.ExecutionLog.MarkFailed(ctx, ifr.RunUID, ifr.EntityUID, "process-not-found")
 				}
@@ -317,85 +266,17 @@ var serveCmd = &cobra.Command{
 				return fmt.Errorf("entity not found: %s", entityID)
 			}
 
-			desc := entityDesc(ctx, entityID, e.Title)
-			pc := walkUp(ctx, entityID, e.Type)
+			// Substitute entity UUID into the skill prompt. The agent reads all
+			// context itself via the HTTP API — no pre-fetching in Go.
+			prompt := strings.ReplaceAll(skillPrompt, "{ENTITY_UUID}", entityID)
 
-			// Build the context header — whatever sits above the entry point.
-			var contextSection string
-			if pc.productTitle != "" {
-				contextSection += fmt.Sprintf("## Product Context (Big Picture)\n**%s** [%s]\n\n%s\n\n",
-					pc.productTitle, pc.productID, pc.productDesc)
-			}
-			if pc.manifestTitle != "" {
-				contextSection += fmt.Sprintf("## Manifest Context (Refinement)\n**%s** [%s]\n\n%s\n\n",
-					pc.manifestTitle, pc.manifestID, pc.manifestDesc)
-			}
-
-			// For a product, walk DOWN to pre-fetch all manifest descriptions
-			// so the agent has full context without extra MCP roundtrips.
-			var manifestsSection string
-			if e.Type == "product" && n.Relationships != nil {
-				manifEdges, _ := n.Relationships.ListOutgoing(ctx, entityID, "owns")
-				for _, me := range manifEdges {
-					if me.DstKind != "manifest" {
-						continue
-					}
-					mEnt, err2 := n.Entities.Get(me.DstID)
-					if err2 != nil || mEnt == nil || mEnt.Status == "archived" || mEnt.Status == "closed" {
-						continue
-					}
-					mDesc := entityDesc(ctx, me.DstID, mEnt.Title)
-					manifestsSection += fmt.Sprintf("### Manifest: %s [%s]\n%s\n\n", mEnt.Title, me.DstID, mDesc)
-				}
-			}
-
-			var prompt string
-			switch e.Type {
-			case "product":
-				manifestCtx := ""
-				if manifestsSection != "" {
-					manifestCtx = "## Manifest Context (Refinement)\n" + manifestsSection
-				}
-				prompt = fmt.Sprintf(
-					"## Product Context (Big Picture)\n**%s** [%s]\n\n%s\n\n"+
-						"%s"+ // manifest context if present
-						"## Your Job\n"+
-						"Use the product and manifest context above to guide your work.\n"+
-						"Use OpenPraxis MCP tools to travel the DAG:\n"+
-						"1. For each manifest listed above find its active tasks via relationships\n"+
-						"2. Execute each task with the full product + manifest context in mind\n"+
-						"3. Honour depends_on ordering between tasks\n"+
-						"4. Post results/findings back to this product via comment_add\n\n"+
-						"## Visceral Rules\n%s",
-					e.Title, entityID, desc, manifestCtx, visceralRules(),
-				)
-			case "manifest":
-				prompt = fmt.Sprintf(
-					"%s"+ // product context if present
-						"## Manifest Context (Refinement)\n**%s** [%s]\n\n%s\n\n"+
-						"## Your Job\n"+
-						"Use OpenPraxis MCP tools to travel the DAG:\n"+
-						"1. Find all active tasks under this manifest via relationships\n"+
-						"2. Execute each task with the product + manifest context above in mind\n"+
-						"3. Honour depends_on ordering between tasks\n"+
-						"4. Post results back via comment_add\n\n"+
-						"## Visceral Rules\n%s",
-					contextSection, e.Title, entityID, desc, visceralRules(),
-				)
-			default: // task
-				prompt = fmt.Sprintf(
-					"%s"+ // product + manifest context if present
-						"## Task Instructions\n**%s** [%s]\n\n%s\n\n"+
-						"Execute the task instructions above. The product and manifest context\n"+
-						"sections define the big picture and constraints — follow them.\n\n"+
-						"## Visceral Rules\n%s",
-					contextSection, e.Title, entityID, desc, visceralRules(),
-				)
+			// Append visceral rules so the agent receives them even without MCP.
+			if vr := visceralRules(); vr != "" {
+				prompt += "\n\n---\n\n## Visceral Rules\n" + vr
 			}
 
 			slog.Info("schedule: dispatching entity",
-				"entity_uid", entityID, "type", e.Type, "title", e.Title,
-				"manifest_id", pc.manifestID, "product_id", pc.productID)
+				"entity_uid", entityID, "type", e.Type, "title", e.Title)
 
 			t := &task.Task{
 				ID:     entityID,

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,7 +49,7 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-wMLNUdrl.js"></script>
+    <script type="module" crossorigin src="/assets/index-D0rXM-Yw.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-CGgIkkjv.js">
     <link rel="stylesheet" crossorigin href="/assets/index-Co-bCT2d.css">

--- a/internal/web/ui/dashboard-v2/src/components/content-block/ContentBlock.tsx
+++ b/internal/web/ui/dashboard-v2/src/components/content-block/ContentBlock.tsx
@@ -4,10 +4,10 @@
  * Uses BlockNoteComposer which has native drag/drop/paste attachment support
  * via the uploadFile callback — no custom editor needed.
  *
- * Products     → label="Description"
- * Manifests    → label="Declaration"
- * Tasks        → label="Instructions"
- * Skills/Ideas → label="Description"
+ * All entity types → label="Prompt"
+ * All entity types → label="Prompt"
+ 
+ 
  */
 import { useRef, useState } from 'react'
 import { Pencil, ChevronDown, ChevronUp } from 'lucide-react'
@@ -35,7 +35,7 @@ interface ContentBlockProps {
   placeholder?: string
 }
 
-export function ContentBlock({ entityId, kind, label = 'Description', placeholder }: ContentBlockProps) {
+export function ContentBlock({ entityId, kind, label = 'Prompt', placeholder }: ContentBlockProps) {
   const [editing, setEditing] = useState(false)
   const [saving, setSaving] = useState(false)
   const [historyOpen, setHistoryOpen] = useState(false)
@@ -46,7 +46,7 @@ export function ContentBlock({ entityId, kind, label = 'Description', placeholde
   const createComment = useCreateEntityComment(kind, entityId)
   const updateEntity = useUpdateEntity(kind, entityId)
 
-  const revisions = (comments ?? []).filter(c => c.type === 'description_revision')
+  const revisions = (comments ?? []).filter(c => c.type === 'prompt')
   const latest = revisions[0]
 
   const startEdit = () => setEditing(true)
@@ -62,7 +62,7 @@ export function ContentBlock({ entityId, kind, label = 'Description', placeholde
 
       const created = await createComment.mutateAsync({
         author: 'operator',
-        type: 'description_revision',
+        type: 'prompt',
         body: body || '(attachment only)',
       }) as { id?: string } | undefined
 

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/comments.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/comments.tsx
@@ -29,21 +29,13 @@ import { BlockNoteReadView } from '@/components/blocknote-read-view'
 import { claimAttachment } from '@/lib/queries/attachments'
 
 const TYPE_LABEL: Record<string, string> = {
-  execution_review:     'Execution Review',
-  description_revision: 'Description',
-  agent_note:           'Agent Note',
-  user_note:            'Note',
-  watcher_finding:      'Watcher Finding',
-  decision:             'Decision',
-  link:                 'Link',
+  prompt:  'Prompt',
+  comment: 'Comment',
 }
 
 const COMPOSE_TYPES = [
-  'user_note',
-  'execution_review',
-  'agent_note',
-  'decision',
-  'description_revision',
+  'comment',
+  'prompt',
 ] as const
 
 function fmtTime(v: string | number | undefined): string {
@@ -61,7 +53,7 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
   const update = useUpdateEntity(kind, entityId)
 
   const [filter, setFilter] = useState('all')
-  const [composeType, setComposeType] = useState<keyof typeof TYPE_LABEL>('user_note')
+  const [composeType, setComposeType] = useState<keyof typeof TYPE_LABEL>('comment')
   const [composing, setComposing] = useState(false)
   const [posting, setPosting] = useState(false)
   const composerRef = useRef<BlockNoteComposerHandle>(null)
@@ -71,9 +63,9 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
     return comments.data.filter(c => !(c.body ?? '').includes('<dependency_revision>'))
   }, [comments.data])
 
-  // Only the most recent description_revision gets the emerald highlight
+  // Only the most recent prompt gets the emerald highlight
   const latestDescId = useMemo(() => {
-    const revs = real.filter(c => c.type === 'description_revision')
+    const revs = real.filter(c => c.type === 'prompt')
     return revs[0]?.id ?? null
   }, [real])
 
@@ -114,7 +106,7 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
       }
 
       // Description-as-comment: also PATCH the entity description field
-      if (composeType === 'description_revision' && body) {
+      if (composeType === 'prompt' && body) {
         update.mutate({ description: body } as Parameters<typeof update.mutate>[0])
       }
 
@@ -162,7 +154,7 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
               onSave={post}
               onCancel={close}
               placeholder={
-                composeType === 'description_revision'
+                composeType === 'prompt'
                   ? 'Write description… drop files, paste images, type / for blocks (Cmd-Enter to post)'
                   : 'Add a comment… drop files, paste images, type / for blocks (Cmd-Enter to post)'
               }
@@ -184,8 +176,8 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
               <Button type='button' variant='ghost' size='sm' onClick={close} disabled={posting}>Cancel</Button>
               <Button type='button' size='sm' onClick={post} disabled={posting}>
                 {posting
-                  ? composeType === 'description_revision' ? 'Saving…' : 'Posting…'
-                  : composeType === 'description_revision' ? 'Post as Description' : 'Post'}
+                  ? composeType === 'prompt' ? 'Saving…' : 'Posting…'
+                  : composeType === 'prompt' ? 'Post as Prompt' : 'Post'}
               </Button>
             </div>
           </CardContent>
@@ -211,15 +203,15 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
                   key={c.id}
                   className={cn(
                     'space-y-2 p-3 text-sm',
-                    c.type === 'description_revision' && c.id === latestDescId && 'border-l-2 border-emerald-400/60 bg-emerald-400/5',
-                    c.type === 'description_revision' && c.id !== latestDescId && 'opacity-50',
+                    c.type === 'prompt' && c.id === latestDescId && 'border-l-2 border-emerald-400/60 bg-emerald-400/5',
+                    c.type === 'prompt' && c.id !== latestDescId && 'opacity-50',
                   )}
                 >
                   <div className='flex items-center justify-between gap-2'>
                     <div className='flex items-center gap-2'>
                       <code className='font-mono text-[11px]'>{c.author.slice(0, 16)}</code>
                       <Badge
-                        variant={c.type === 'description_revision' ? 'secondary' : 'outline'}
+                        variant={c.type === 'prompt' ? 'secondary' : 'outline'}
                         className='text-[10px]'
                       >
                         {TYPE_LABEL[c.type] ?? c.type}

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/main.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/main.tsx
@@ -12,11 +12,11 @@ import { ContentBlock } from '@/components/content-block'
 
 // Label shown in ContentBlock per entity type
 const CONTENT_LABEL: Record<string, string> = {
-  product:  'Description',
-  manifest: 'Declaration',
-  task:     'Instructions',
-  skill:    'Description',
-  idea:     'Description',
+  product:  'Prompt',
+  manifest: 'Prompt',
+  task:     'Prompt',
+  skill:    'Prompt',
+  idea:     'Prompt',
 }
 
 // Main tab — stats grid + repo card + description editor + revision
@@ -169,11 +169,11 @@ export function MainTab({
         </Card>
       ) : null}
 
-      {/* ContentBlock: Description / Declaration / Instructions */}
+      {/* ContentBlock: Prompt */}
       <ContentBlock
         entityId={entityId}
         kind={kind}
-        label={CONTENT_LABEL[kind] ?? 'Description'}
+        label={CONTENT_LABEL[kind] ?? 'Prompt'}
         placeholder={`Write ${(CONTENT_LABEL[kind] ?? 'description').toLowerCase()} here… Markdown supported, drag/paste files to attach`}
       />
 

--- a/internal/web/ui/dashboard-v2/src/lib/queries/entity.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/queries/entity.ts
@@ -246,8 +246,8 @@ export function useEntityDescriptionHistory(
   return useQuery({
     queryKey: entityKeys.descriptionHistory(kind, id ?? ''),
     queryFn: async () => {
-      // Description revisions are stored as comments with type=description_revision.
-      const res = await fetch(`/api/entities/${id}/comments?type=description_revision&limit=100`)
+      // Description revisions are stored as comments with type=prompt.
+      const res = await fetch(`/api/entities/${id}/comments?type=prompt&limit=100`)
       if (!res.ok) throw new Error(`description history → ${res.status}`)
       const data = (await res.json()) as { comments: DescriptionRevision[] } | DescriptionRevision[]
       const rows = Array.isArray(data) ? data : (data.comments ?? [])
@@ -431,7 +431,7 @@ async function postDepRevision(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       author: 'operator',
-      type: 'agent_note',
+      type: 'comment',
       body: '<dependency_revision>\n' + body + '\n</dependency_revision>',
     }),
   })
@@ -762,7 +762,7 @@ export function useRestoreEntityDependencySnapshot(
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           author: 'operator',
-          type: 'agent_note',
+          type: 'comment',
           body: restoreBody,
         }),
       })

--- a/internal/web/ui/dashboard-v2/src/lib/types.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/types.ts
@@ -58,13 +58,8 @@ export interface OutputChunk {
 }
 
 export type CommentType =
-  | 'execution_review'
-  | 'description_revision'
-  | 'agent_note'
-  | 'user_note'
-  | 'watcher_finding'
-  | 'decision'
-  | 'link'
+  | 'prompt'
+  | 'comment'
   | string
 
 export interface Comment {


### PR DESCRIPTION
## Summary

The OpenPraxis Execution Protocol skill (`019dfecc`) is now the universal prompt for every scheduled entity.

At startup, the dispatcher loads the skill's latest `prompt` type comment. On each dispatch, it substitutes `{ENTITY_UUID}` with the actual entity UUID and fires the agent.

The agent owns the full execution chain:
1. Read entity prompt + comments via HTTP API
2. Walk UP the DAG — read manifest prompt + comments, product prompt + comments
3. Assemble full context
4. Execute the task prompt
5. Post report back

## What was removed

153 lines of Go-side context pre-fetching: `walkUp`, `entityDesc`, per-type prompt building (`switch e.Type`). The dispatcher is now: **load skill → substitute UUID → fire agent.**

## Fallback

If the skill entity or its prompt is missing at startup, a minimal inline prompt is used and a warning is logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)