### PR TITLE
fix: normalize legacy comment types — execution_review and friends map to comment

### DIFF
--- a/internal/comments/types.go
+++ b/internal/comments/types.go
@@ -24,6 +24,22 @@ const (
 	TypeDescriptionRevision = TypePrompt
 )
 
+// NormalizeType maps legacy type names to the canonical two-type taxonomy.
+// Agents trained on old types (execution_review, description_revision, etc.)
+// are remapped transparently so no call ever fails on a stale type name.
+func NormalizeType(raw string) CommentType {
+	switch raw {
+	case "", "user_note", "agent_note", "watcher_finding",
+		"execution_review", "decision", "link",
+		"review_rejection", "review_approval":
+		return TypeComment
+	case "description_revision":
+		return TypePrompt
+	default:
+		return CommentType(raw)
+	}
+}
+
 func AllCommentTypes() []CommentType {
 	return []CommentType{TypePrompt, TypeComment}
 }

--- a/internal/mcp/tools_comments.go
+++ b/internal/mcp/tools_comments.go
@@ -22,10 +22,10 @@ func (s *Server) handleCommentAdd(ctx context.Context, req mcplib.CallToolReques
 	targetType := argStr(a, "target_type")
 	targetID := argStr(a, "target_id")
 	author := argStr(a, "author")
-	cType := argStr(a, "type")
-	if cType == "" {
-		cType = "comment" // default when agent omits type
-	}
+	// Normalize legacy type names → prompt or comment.
+	// Agents trained on old type taxonomy may send execution_review,
+	// description_revision, user_note, etc. Map them transparently.
+	ct := comments.NormalizeType(argStr(a, "type"))
 	body := argStr(a, "body")
 
 	if s.node.Comments == nil {
@@ -33,7 +33,6 @@ func (s *Server) handleCommentAdd(ctx context.Context, req mcplib.CallToolReques
 	}
 
 	target := comments.TargetType(targetType)
-	ct := comments.CommentType(cType)
 	if err := comments.ValidateAdd(target, targetID, author, ct, body); err != nil {
 		return errResult("validate: %v", err), nil
 	}

--- a/internal/web/handlers_comments.go
+++ b/internal/web/handlers_comments.go
@@ -315,7 +315,7 @@ func addComment(store *comments.Store, target comments.TargetType, resolve Targe
 		if !readBodyCapped(w, r, &req) {
 			return
 		}
-		cType := comments.CommentType(req.Type)
+		cType := comments.NormalizeType(req.Type)
 		if err := comments.ValidateAdd(target, id, req.Author, cType, req.Body); err != nil {
 			code, status := commentErrorStatus(err)
 			writeCommentError(w, code, err.Error(), status)


### PR DESCRIPTION
## Problem

Agents trained on the old type taxonomy send `execution_review`, `description_revision`, `user_note` etc. After the type collapse to `prompt`/`comment`, these fail validation with "unknown type".

## Fix

`comments.NormalizeType()` — single function, used at both the MCP and HTTP boundaries:

| Legacy type | Normalized to |
|---|---|
| `execution_review`, `user_note`, `agent_note`, `watcher_finding`, `decision`, `link`, `review_rejection`, `review_approval`, `` (empty) | `comment` |
| `description_revision` | `prompt` |

No agent call ever fails on a stale type name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)