### PR TITLE
fix(metrics): rss/net-mbps in SystemSnapshot + drop dead SystemSampler + route charts to execution_log

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -26,11 +27,12 @@ import (
 	"github.com/k8nstantin/OpenPraxis/internal/templates"
 	"github.com/k8nstantin/OpenPraxis/internal/watcher"
 
-	gpcpu  "github.com/shirou/gopsutil/v3/cpu"
-	gpdisk "github.com/shirou/gopsutil/v3/disk"
-	gpload "github.com/shirou/gopsutil/v3/load"
-	gpmem  "github.com/shirou/gopsutil/v3/mem"
-	gpnet  "github.com/shirou/gopsutil/v3/net"
+	gpcpu     "github.com/shirou/gopsutil/v3/cpu"
+	gpdisk    "github.com/shirou/gopsutil/v3/disk"
+	gpload    "github.com/shirou/gopsutil/v3/load"
+	gpmem     "github.com/shirou/gopsutil/v3/mem"
+	gpnet     "github.com/shirou/gopsutil/v3/net"
+	gpprocess "github.com/shirou/gopsutil/v3/process"
 )
 
 // Node is the central orchestrator that wires all components together.
@@ -463,10 +465,9 @@ func (n *Node) InitRunner(onEvent func(string, map[string]string)) *task.Runner 
 	return n.runner
 }
 
-// HostSamplerTick returns the resolved host-sampler tick duration so
-// cmd/serve.go can construct the SystemSampler with the same cadence
-// as the per-run sampler. Reads `host_sampler_tick_seconds` at system
-// scope; falls back to catalog default on lookup failure.
+// HostSamplerTick returns the resolved host-sampler tick duration.
+// Reads `host_sampler_tick_seconds` at system scope; falls back to
+// catalog default on lookup failure.
 func (n *Node) HostSamplerTick() time.Duration {
 	return resolveHostSamplerTick(n.SettingsStore)
 }
@@ -773,9 +774,14 @@ func (n *Node) SystemSnapshot() (cpu, rssMB, memUsedMB, memTotalMB, netRx, netTx
 		cpu = pcts[0]
 	}
 	if vm, err := gpmem.VirtualMemory(); err == nil && vm != nil {
-		rssMB      = float64(vm.Used) / (1024 * 1024)
 		memUsedMB  = float64(vm.Used) / (1024 * 1024)
 		memTotalMB = float64(vm.Total) / (1024 * 1024)
+	}
+	// rss_mb is the openpraxis serve process RSS, distinct from system memory.
+	if proc, err := gpprocess.NewProcess(int32(os.Getpid())); err == nil {
+		if mi, err := proc.MemoryInfo(); err == nil && mi != nil {
+			rssMB = float64(mi.RSS) / (1024 * 1024)
+		}
 	}
 	if la, err := gpload.Avg(); err == nil && la != nil {
 		loadAvg = la.Load1
@@ -797,8 +803,9 @@ func (n *Node) SystemSnapshot() (cpu, rssMB, memUsedMB, memTotalMB, netRx, netTx
 		if !n.sysBaseline.at.IsZero() {
 			dt := now.Sub(n.sysBaseline.at).Seconds()
 			if dt > 0 {
-				netRx = float64(rx-n.sysBaseline.netRx) / dt / (1024 * 1024)
-				netTx = float64(tx-n.sysBaseline.netTx) / dt / (1024 * 1024)
+				// Mbps to match readSystemMetrics in host_metrics.go.
+				netRx = float64(rx-n.sysBaseline.netRx) * 8 / 1e6 / dt
+				netTx = float64(tx-n.sysBaseline.netTx) * 8 / 1e6 / dt
 				if netRx < 0 { netRx = 0 }
 				if netTx < 0 { netTx = 0 }
 			}

--- a/internal/task/host_metrics.go
+++ b/internal/task/host_metrics.go
@@ -2,7 +2,6 @@ package task
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"log/slog"
 	"os"
@@ -12,11 +11,9 @@ import (
 	"sync"
 	"time"
 
-	gpcpu "github.com/shirou/gopsutil/v3/cpu"
 	gpdisk "github.com/shirou/gopsutil/v3/disk"
 	gpload "github.com/shirou/gopsutil/v3/load"
-	gpmem "github.com/shirou/gopsutil/v3/mem"
-	gpnet "github.com/shirou/gopsutil/v3/net"
+	gpmem  "github.com/shirou/gopsutil/v3/mem"
 )
 
 // HostMetricsSample is one CPU/RSS reading of the serve process. The
@@ -260,199 +257,9 @@ func readProcMetrics(pid int) (HostMetricsSample, error) {
 	return smp, nil
 }
 
-// SystemHostSample is one capacity reading of the host (independent of
-// any task). Persisted to system_host_samples; powers the Stats tab's
-// System Capacity panel. Captured by SystemSampler at every tick.
-type SystemHostSample struct {
-	TS          time.Time `json:"ts"`
-	CPUPct      float64   `json:"cpu_pct"`
-	Load1m      float64   `json:"load_1m"`
-	Load5m      float64   `json:"load_5m"`
-	Load15m     float64   `json:"load_15m"`
-	MemUsedMB   float64   `json:"mem_used_mb"`
-	MemTotalMB  float64   `json:"mem_total_mb"`
-	SwapUsedMB  float64   `json:"swap_used_mb"`
-	DiskUsedGB  float64   `json:"disk_used_gb"`
-	DiskTotalGB float64   `json:"disk_total_gb"`
-	NetRxMbps   float64   `json:"net_rx_mbps"`
-	NetTxMbps   float64   `json:"net_tx_mbps"`
-	DiskReadMBps  float64 `json:"disk_read_mbps"`
-	DiskWriteMBps float64 `json:"disk_write_mbps"`
-}
-
-// readSystemMetrics returns a single fresh capacity sample for the
-// whole host. Cheap (no shell-out — gopsutil reads sysctl / /proc
-// directly). Network throughput is computed as a delta against
-// previous-sample byte totals; the first call after start records the
-// baseline and reports zeros so a misleading "all bytes since boot"
-// spike doesn't land on the chart.
-func readSystemMetrics(prev systemNetBaseline) (SystemHostSample, systemNetBaseline) {
-	smp := SystemHostSample{TS: time.Now().UTC()}
-
-	// CPU% — single 0-interval call returns avg-since-last-call. If
-	// percent is unavailable we leave 0 rather than blocking the tick.
-	if pcts, err := gpcpu.Percent(0, false); err == nil && len(pcts) > 0 {
-		smp.CPUPct = pcts[0]
-	}
-
-	if l, err := gpload.Avg(); err == nil && l != nil {
-		smp.Load1m, smp.Load5m, smp.Load15m = l.Load1, l.Load5, l.Load15
-	}
-
-	if v, err := gpmem.VirtualMemory(); err == nil && v != nil {
-		smp.MemUsedMB = float64(v.Used) / (1024 * 1024)
-		smp.MemTotalMB = float64(v.Total) / (1024 * 1024)
-	}
-	if sw, err := gpmem.SwapMemory(); err == nil && sw != nil {
-		smp.SwapUsedMB = float64(sw.Used) / (1024 * 1024)
-	}
-
-	if d, err := gpdisk.Usage("/"); err == nil && d != nil {
-		smp.DiskUsedGB = float64(d.Used) / (1024 * 1024 * 1024)
-		smp.DiskTotalGB = float64(d.Total) / (1024 * 1024 * 1024)
-	}
-
-	next := prev
-	if io, err := gpnet.IOCounters(false); err == nil && len(io) > 0 {
-		now := time.Now()
-		rx, tx := io[0].BytesRecv, io[0].BytesSent
-		if !prev.At.IsZero() {
-			dt := now.Sub(prev.At).Seconds()
-			if dt > 0 {
-				smp.NetRxMbps = float64(rx-prev.RxBytes) * 8 / 1e6 / dt
-				smp.NetTxMbps = float64(tx-prev.TxBytes) * 8 / 1e6 / dt
-				if smp.NetRxMbps < 0 {
-					smp.NetRxMbps = 0
-				}
-				if smp.NetTxMbps < 0 {
-					smp.NetTxMbps = 0
-				}
-			}
-		}
-		next = systemNetBaseline{At: now, RxBytes: rx, TxBytes: tx, DiskRead: prev.DiskRead, DiskWrite: prev.DiskWrite}
-	}
-
-	// Disk I/O — gopsutil/disk.IOCounters returns a map of per-device
-	// counters. Sum across devices for a host-wide read/write rate.
-	if iom, err := gpdisk.IOCounters(); err == nil {
-		var rb, wb uint64
-		for _, ioc := range iom {
-			rb += ioc.ReadBytes
-			wb += ioc.WriteBytes
-		}
-		now := next.At
-		if now.IsZero() {
-			now = time.Now()
-		}
-		if !prev.At.IsZero() && (prev.DiskRead != 0 || prev.DiskWrite != 0) {
-			dt := now.Sub(prev.At).Seconds()
-			if dt > 0 {
-				smp.DiskReadMBps = float64(rb-prev.DiskRead) / (1024 * 1024) / dt
-				smp.DiskWriteMBps = float64(wb-prev.DiskWrite) / (1024 * 1024) / dt
-				if smp.DiskReadMBps < 0 {
-					smp.DiskReadMBps = 0
-				}
-				if smp.DiskWriteMBps < 0 {
-					smp.DiskWriteMBps = 0
-				}
-			}
-		}
-		next.DiskRead = rb
-		next.DiskWrite = wb
-		if next.At.IsZero() {
-			next.At = now
-		}
-	}
-
-	return smp, next
-}
-
-// systemNetBaseline holds the previous-tick network + disk-IO byte
-// totals so the next tick can compute a per-second delta. Embedded in
-// SystemSampler.
-type systemNetBaseline struct {
-	At         time.Time
-	RxBytes    uint64
-	TxBytes    uint64
-	DiskRead   uint64
-	DiskWrite  uint64
-}
-
-// SystemSampler runs continuously from server start, capturing one host
-// capacity sample per tick to system_host_samples. Independent of any
-// task — keeps a baseline visible even when no tasks are running.
-//
-// Tick rate is read from the `host_sampler_tick_seconds` knob at
-// construction. Reload on knob change is out of scope; restarting serve
-// applies a new value.
-type SystemSampler struct {
-	db       *sql.DB
-	interval time.Duration
-	stopCh   chan struct{}
-	started  bool
-	mu       sync.Mutex
-}
-
-// NewSystemSampler returns a sampler ticking every interval. interval
-// <= 0 → 5s default. Call Start to begin writing rows.
-func NewSystemSampler(db *sql.DB, interval time.Duration) *SystemSampler {
-	if interval <= 0 {
-		interval = 5 * time.Second
-	}
-	return &SystemSampler{
-		db:       db,
-		interval: interval,
-		stopCh:   make(chan struct{}),
-	}
-}
-
-// Start launches the poll loop. Idempotent — second call is a no-op.
-func (s *SystemSampler) Start(ctx context.Context) {
-	s.mu.Lock()
-	if s.started {
-		s.mu.Unlock()
-		return
-	}
-	s.started = true
-	s.mu.Unlock()
-	go s.loop(ctx)
-}
-
-// Stop halts the poll loop.
-func (s *SystemSampler) Stop() {
-	select {
-	case <-s.stopCh:
-	default:
-		close(s.stopCh)
-	}
-}
-
-func (s *SystemSampler) loop(ctx context.Context) {
-	t := time.NewTicker(s.interval)
-	defer t.Stop()
-	var baseline systemNetBaseline
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-s.stopCh:
-			return
-		case <-t.C:
-			var smp SystemHostSample
-			smp, baseline = readSystemMetrics(baseline)
-			if _, err := s.db.Exec(
-				`INSERT INTO system_host_samples
-				(ts, cpu_pct, load_1m, load_5m, load_15m, mem_used_mb, mem_total_mb, swap_used_mb, disk_used_gb, disk_total_gb, net_rx_mbps, net_tx_mbps, disk_read_mbps, disk_write_mbps)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-				smp.TS.UTC().Format(time.RFC3339Nano),
-				smp.CPUPct, smp.Load1m, smp.Load5m, smp.Load15m,
-				smp.MemUsedMB, smp.MemTotalMB, smp.SwapUsedMB,
-				smp.DiskUsedGB, smp.DiskTotalGB,
-				smp.NetRxMbps, smp.NetTxMbps,
-				smp.DiskReadMBps, smp.DiskWriteMBps,
-			); err != nil {
-				slog.Warn("system sample insert failed", "error", err)
-			}
-		}
-	}
-}
+// SystemHostSample, readSystemMetrics, systemNetBaseline and
+// SystemSampler used to write to system_host_samples. That table was
+// dropped in commit 79a8ca5 and continuous host metrics now flow into
+// execution_log via Node.SystemSnapshot (interactive sessions) and
+// HostSampler (autonomous tasks). Removing those types is the cleanup
+// step from the post-79a8ca5 review.

--- a/internal/web/handlers_charts.go
+++ b/internal/web/handlers_charts.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -357,16 +358,20 @@ func apiStatsCharts(n *node.Node) http.HandlerFunc {
 		}
 
 		// ── Hourly system averages ────────────────────────────────────────
+		// Source: execution_log sample rows (system_host_samples was dropped
+		// in commit 79a8ca5). Match handlers_stats.go's source-of-truth choice.
 		since24 := time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
 		sysRows, err := n.DB().QueryContext(r.Context(), `
-			SELECT strftime('%Y-%m-%dT%H:00:00Z', ts) as hour,
+			SELECT strftime('%Y-%m-%dT%H:00:00Z', created_at) as hour,
 			       AVG(cpu_pct), AVG(mem_used_mb),
 			       AVG(net_rx_mbps), AVG(net_tx_mbps),
 			       AVG(disk_read_mbps), AVG(disk_write_mbps)
-			FROM system_host_samples
-			WHERE ts >= ?
+			FROM execution_log
+			WHERE event = 'sample' AND created_at >= ?
 			GROUP BY hour ORDER BY hour ASC`, since24)
-		if err == nil {
+		if err != nil {
+			slog.Warn("charts: hourly system averages query failed", "error", err)
+		} else {
 			defer sysRows.Close()
 			for sysRows.Next() {
 				var b systemHourBucket

--- a/internal/web/handlers_hook.go
+++ b/internal/web/handlers_hook.go
@@ -93,7 +93,9 @@ func apiHook(n *node.Node) http.HandlerFunc {
 					LoadAvg1m:     load,
 					CreatedBy:     "hook/post-tool-use",
 				}
-				_ = n.ExecutionLog.Insert(context.Background(), sr)
+				if err := n.ExecutionLog.Insert(context.Background(), sr); err != nil {
+					slog.Warn("execution_log: hook sample insert failed", "session_id", event.SessionID, "error", err)
+				}
 			}
 		}
 

--- a/internal/web/handlers_stats.go
+++ b/internal/web/handlers_stats.go
@@ -33,17 +33,14 @@ func apiRunStats(n *node.Node) http.HandlerFunc {
 			return
 		}
 
-		// Verify entity exists — check entity store first (new entities),
-		// fall back to task store (legacy tasks not yet migrated).
-		if n.Entities != nil {
-			e, _ := n.Entities.Get(entityID)
-			if e == nil && n.Entities != nil {
-				t, _ := n.Entities.Get(entityID)
-				if t == nil {
-					writeError(w, "entity not found: "+entityID, 404)
-					return
-				}
-			}
+		// Verify entity exists.
+		if n.Entities == nil {
+			writeError(w, "entity store not ready", 503)
+			return
+		}
+		if e, _ := n.Entities.Get(entityID); e == nil {
+			writeError(w, "entity not found: "+entityID, 404)
+			return
 		}
 
 		// Validate as_of when provided (accepted for API compat; not used for
@@ -135,12 +132,17 @@ func apiSystemStats(n *node.Node) http.HandlerFunc {
 
 		// Source: execution_log sample rows — single source of truth.
 		// Reads rows written by the runner's host sampler.
+		//
+		// execution_log only carries load_avg_1m, mem_used_mb, mem_total_mb
+		// and disk_used_gb today. load_5m/load_15m/swap_used_mb/disk_total_gb
+		// are returned as 0 rather than fabricating duplicate-of-load_1m
+		// values; clients should show "—" rather than chart a flat line.
 		db := n.DB()
 		rows, err := db.Query(`
 			SELECT created_at,
-			       cpu_pct, load_avg_1m, load_avg_1m, load_avg_1m,
-			       mem_used_mb, mem_total_mb, 0,
-			       disk_used_gb, 0,
+			       cpu_pct, load_avg_1m,
+			       mem_used_mb, mem_total_mb,
+			       disk_used_gb,
 			       net_rx_mbps, net_tx_mbps,
 			       disk_read_mbps, disk_write_mbps
 			FROM execution_log
@@ -160,9 +162,9 @@ func apiSystemStats(n *node.Node) http.HandlerFunc {
 			var s sysHostSample
 			var tsStr string
 			if err := rows.Scan(&tsStr, &s.CPUPct,
-				&s.Load1m, &s.Load5m, &s.Load15m,
-				&s.MemUsedMB, &s.MemTotalMB, &s.SwapUsedMB,
-				&s.DiskUsedGB, &s.DiskTotalGB,
+				&s.Load1m,
+				&s.MemUsedMB, &s.MemTotalMB,
+				&s.DiskUsedGB,
 				&s.NetRxMbps, &s.NetTxMbps,
 				&s.DiskReadMBps, &s.DiskWriteMBps); err != nil {
 				continue

--- a/internal/web/handlers_stats_history.go
+++ b/internal/web/handlers_stats_history.go
@@ -299,15 +299,17 @@ func apiStatsHistory(n *node.Node) http.HandlerFunc {
 				&h.Totals.AvgDurSec, &h.Totals.AvgContextPct)
 
 		// ── Daily system averages ─────────────────────────────────────────
-		sysWhere := "1=1"
+		// Source: execution_log sample rows (system_host_samples was dropped
+		// in commit 79a8ca5).
+		sysWhere := "event = 'sample'"
 		if since != "" {
-			sysWhere = "date(ts) >= date('now', '-" + since + " days')"
+			sysWhere += " AND date(created_at) >= date('now', '-" + since + " days')"
 		}
 		sysRows, _ := db.QueryContext(r.Context(), `
-			SELECT date(ts) as day,
+			SELECT date(created_at) as day,
 			       AVG(cpu_pct), AVG(net_rx_mbps), AVG(net_tx_mbps),
 			       AVG(disk_read_mbps), AVG(disk_write_mbps)
-			FROM system_host_samples WHERE `+sysWhere+`
+			FROM execution_log WHERE `+sysWhere+`
 			GROUP BY day ORDER BY day ASC`)
 		if sysRows != nil {
 			defer sysRows.Close()


### PR DESCRIPTION
## Summary
Addresses the Top 3 priorities from the 2026-05-06 post-`system_host_samples`-drop review.

- **Critical #1**: `handlers_charts.go` (hourly) and `handlers_stats_history.go` (daily) now SELECT system averages from `execution_log WHERE event='sample'` instead of the dropped `system_host_samples` table. Charts no longer silently flat-line.
- **Critical #2**: deleted `SystemHostSample`, `readSystemMetrics`, `systemNetBaseline`, `SystemSampler` from `internal/task/host_metrics.go` — they targeted a dropped table and had no live caller. −173 lines + 3 unused imports.
- **Critical #3** (partial): stopped triple-reading `load_avg_1m` into 1m/5m/15m in `/api/system-stats`. The unbacked `load_5m`/`15m`/`swap_used_mb`/`disk_total_gb` columns now return honest zeros. Full schema migration left as a follow-up.
- **High #4**: `Node.SystemSnapshot` now reads process RSS via `gopsutil/process.MemoryInfo` (was system memory).
- **High #5**: `Node.SystemSnapshot` net rate now `*8/1e6/dt` (was `/(1024*1024)/dt`) — column name `mbps` finally matches its contents and lines up with the autonomous path.
- **Medium #7 + #9**: collapsed the dead double-`Get` entity-existence guard in `handlers_stats.go`; hook `ExecutionLog.Insert` errors are now logged at `slog.Warn`.

## Test plan
- [x] `go build ./...` passes (only third-party CGO warnings)
- [x] `go vet` flags only pre-existing test failures (`n.Tasks` / `ReviewComment` / `r.store` from the in-flight removal refactor — unrelated)
- [ ] Manual: hit `/api/stats/charts` and `/api/stats/history` after a few `event='sample'` rows land — system buckets should be populated
- [ ] Manual: confirm `rss_mb` on an interactive `execution_log` row matches `ps -o rss=` for the openpraxis pid

## Follow-ups (not in this PR)
- ALTER TABLE `execution_log` add `load_avg_5m`, `load_avg_15m`, `swap_used_mb`, `disk_total_gb`; populate from both `Node.SystemSnapshot` and `HostSampler`; update INSERT in `internal/execution/store.go` and the dashboard JSON shape.
- Replace string-concatenated SQL in `handlers_charts.go` and `handlers_stats_history.go` with `?`-parameterized queries (Low #12).