### PR TITLE
feat: skill-aware DAG — depth-capped skill view + skill node on product DAG

### DIFF
--- a/internal/web/handlers_graph.go
+++ b/internal/web/handlers_graph.go
@@ -30,7 +30,14 @@ func apiRelationshipsGraph(n *node.Node) http.HandlerFunc {
 			writeError(w, "root_id and root_kind required", http.StatusBadRequest)
 			return
 		}
+
+		// Skills are DAG roots governing many products. Cap depth at 1 so the
+		// graph shows only direct product children — not the entire sub-tree
+		// (which would be hundreds of manifests and tasks and unreadable).
 		depth := 10
+		if rootKind == relationships.KindSkill {
+			depth = 1
+		}
 		if v := r.URL.Query().Get("depth"); v != "" {
 			if d, err := strconv.Atoi(v); err == nil && d > 0 {
 				depth = d
@@ -48,22 +55,26 @@ func apiRelationshipsGraph(n *node.Node) http.HandlerFunc {
 		}
 
 		// Bucket node IDs by kind for batched title/status lookup.
+		skillIDs := []string{}
 		productIDs := []string{}
 		manifestIDs := []string{}
 		taskIDs := []string{}
-		for _, w := range rows {
-			switch w.Kind {
+		otherIDs := []string{}
+		for _, row := range rows {
+			switch row.Kind {
+			case relationships.KindSkill:
+				skillIDs = append(skillIDs, row.ID)
 			case relationships.KindProduct:
-				productIDs = append(productIDs, w.ID)
+				productIDs = append(productIDs, row.ID)
 			case relationships.KindManifest:
-				manifestIDs = append(manifestIDs, w.ID)
+				manifestIDs = append(manifestIDs, row.ID)
 			case relationships.KindTask:
-				taskIDs = append(taskIDs, w.ID)
+				taskIDs = append(taskIDs, row.ID)
+			default:
+				otherIDs = append(otherIDs, row.ID)
 			}
 		}
 
-		// Resolve title + status per entity. Loops are fine — node count
-		// is bounded by walk depth × fan-out (typical: < 200 entities).
 		type nodeOut struct {
 			ID     string `json:"id"`
 			Kind   string `json:"kind"`
@@ -71,6 +82,44 @@ func apiRelationshipsGraph(n *node.Node) http.HandlerFunc {
 			Status string `json:"status"`
 		}
 		nodes := make([]nodeOut, 0, len(rows))
+
+		// For products: walk UP one hop to find governing skill and prepend it
+		// so the product DAG shows: skill → product → manifests → tasks.
+		if rootKind == relationships.KindProduct && n.Relationships != nil {
+			parentEdges, _ := n.Relationships.ListIncoming(r.Context(), rootID, relationships.EdgeOwns)
+			for _, edge := range parentEdges {
+				if edge.SrcKind == relationships.KindSkill {
+					if skill, _ := n.Entities.Get(edge.SrcID); skill != nil {
+						nodes = append(nodes, nodeOut{ID: skill.EntityUID, Kind: relationships.KindSkill, Title: skill.Title, Status: skill.Status})
+						// Add the skill→product edge to the edge list below.
+						skillIDs = append(skillIDs, edge.SrcID)
+						// Inject a synthetic walk row so the edge is emitted.
+						rows = append(rows, relationships.WalkRow{
+							ID: rootID, Kind: rootKind,
+							ViaSrc: edge.SrcID, ViaKind: relationships.EdgeOwns, Depth: 0,
+						})
+					}
+					break // one governing skill per product
+				}
+			}
+		}
+
+		// Resolve title + status per entity.
+		for _, id := range skillIDs {
+			if e, _ := n.Entities.Get(id); e != nil {
+				// Avoid duplicates — skill may already be added above.
+				dup := false
+				for _, existing := range nodes {
+					if existing.ID == e.EntityUID {
+						dup = true
+						break
+					}
+				}
+				if !dup {
+					nodes = append(nodes, nodeOut{ID: e.EntityUID, Kind: relationships.KindSkill, Title: e.Title, Status: e.Status})
+				}
+			}
+		}
 		for _, id := range productIDs {
 			if e, _ := n.Entities.Get(id); e != nil {
 				nodes = append(nodes, nodeOut{ID: e.EntityUID, Kind: relationships.KindProduct, Title: e.Title, Status: e.Status})
@@ -86,9 +135,12 @@ func apiRelationshipsGraph(n *node.Node) http.HandlerFunc {
 				nodes = append(nodes, nodeOut{ID: e.EntityUID, Kind: relationships.KindTask, Title: e.Title, Status: e.Status})
 			}
 		}
+		for _, id := range otherIDs {
+			if e, _ := n.Entities.Get(id); e != nil {
+				nodes = append(nodes, nodeOut{ID: e.EntityUID, Kind: e.Type, Title: e.Title, Status: e.Status})
+			}
+		}
 
-		// Edges: every WalkRow except the root carries the edge that
-		// brought us there (ViaSrc → ID, kind = ViaKind).
 		type edgeOut struct {
 			ID     string `json:"id"`
 			Source string `json:"source"`
@@ -97,16 +149,16 @@ func apiRelationshipsGraph(n *node.Node) http.HandlerFunc {
 		}
 		edges := make([]edgeOut, 0, len(rows))
 		seen := make(map[string]bool)
-		for _, w := range rows {
-			if w.ViaSrc == "" {
+		for _, row := range rows {
+			if row.ViaSrc == "" {
 				continue
 			}
-			id := w.ViaSrc + "->" + w.ID + ":" + w.ViaKind
+			id := row.ViaSrc + "->" + row.ID + ":" + row.ViaKind
 			if seen[id] {
 				continue
 			}
 			seen[id] = true
-			edges = append(edges, edgeOut{ID: id, Source: w.ViaSrc, Target: w.ID, Kind: w.ViaKind})
+			edges = append(edges, edgeOut{ID: id, Source: row.ViaSrc, Target: row.ID, Kind: row.ViaKind})
 		}
 
 		writeJSON(w, map[string]any{"nodes": nodes, "edges": edges})

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,7 +49,7 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-B_KyBlYI.js"></script>
+    <script type="module" crossorigin src="/assets/index-CIpl3KCk.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-CGgIkkjv.js">
     <link rel="stylesheet" crossorigin href="/assets/index-Co-bCT2d.css">

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/dag.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/dag.tsx
@@ -41,21 +41,24 @@ const STATUS_BORDER: Record<string, string> = {
 }
 
 const KIND_COLOR: Record<string, string> = {
-  product: '#3b82f6', // blue-500
+  skill:    '#f59e0b', // amber-400 — root of the DAG, stands out
+  product:  '#3b82f6', // blue-500
   manifest: '#a78bfa', // violet-400
-  task: '#10b981', // emerald-500
+  task:     '#10b981', // emerald-500
 }
 
 const KIND_SYMBOL: Record<string, string> = {
-  product: 'roundRect',
+  skill:    'star',       // star = top-level governance node
+  product:  'roundRect',
   manifest: 'diamond',
-  task: 'circle',
+  task:     'circle',
 }
 
 const KIND_SIZE: Record<string, number> = {
-  product: 32,
+  skill:    42,  // largest — root of the DAG
+  product:  32,
   manifest: 26,
-  task: 18,
+  task:     18,
 }
 
 interface ChartNode {
@@ -85,8 +88,8 @@ function build(
   nodes: GraphNode[],
   edges: GraphEdge[]
 ): { data: ChartNode[]; links: ChartLink[]; categories: { name: string }[] } {
-  const categories = [{ name: 'product' }, { name: 'manifest' }, { name: 'task' }]
-  const catIndex: Record<string, number> = { product: 0, manifest: 1, task: 2 }
+  const categories = [{ name: 'skill' }, { name: 'product' }, { name: 'manifest' }, { name: 'task' }]
+  const catIndex: Record<string, number> = { skill: 0, product: 1, manifest: 2, task: 3 }
   // Per-node radial-gradient fill. ECharts accepts {type:'radial',
   // colorStops:[]} on itemStyle.color directly. Center bright →
   // periphery deeper; gives each node a soft "glow from within" look.


### PR DESCRIPTION
## Summary

**Skill root (too huge problem):** When `root_kind=skill`, graph defaults to `depth=1` — shows only direct product children, not the full sub-tree of hundreds of manifests and tasks.

**Product root (missing skill problem):** When `root_kind=product`, the handler walks UP one hop to find the governing skill and prepends it as a parent node. Product DAG now shows: **skill → product → manifests → tasks**.

**Visual:** Skill nodes use amber star symbol (★), larger size (42px), so they're immediately recognizable as DAG root nodes.

## Changes

- `handlers_graph.go` — skill depth cap + upward skill lookup for products + KindSkill bucket
- `dag.tsx` — skill added to KIND_COLOR/SYMBOL/SIZE, ECharts categories
- `relationships/store.go` — KindSkill + KindIdea added to allEntityKinds

🤖 Generated with [Claude Code](https://claude.com/claude-code)