### PR TITLE
feat(runner): turn-level agent events (task_turn_started + task_turn_tool)

### DIFF
--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -925,6 +925,7 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 											r.onEvent("task_turn_tool", map[string]string{
 												"task_id":   t.ID,
 												"tool_name": toolName,
+												"tool_id":   toolID,
 											})
 										}
 									}

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -41,6 +41,9 @@ type RunningTask struct {
 	// Model is the model id reported by the first assistant event — used to
 	// pick a pricing table and for calibration after the run.
 	Model string `json:"model"`
+	// mu protects fields written by the Execute goroutine and read by
+	// concurrent HTTP handlers: usageByMessage and Actions.
+	mu             sync.RWMutex
 	// usageByMessage tracks the last-seen usage per message id so we can
 	// dedupe the repeated assistant events Claude Code emits while a single
 	// logical message streams. Not serialized; live-estimate only.
@@ -298,12 +301,16 @@ func (r *Runner) IsRunning(taskID string) bool {
 // of waiting for the next 5s execution_log sample. Returns (0,false) when the
 // task is not currently in r.running.
 func (r *Runner) LiveTurnCount(taskID string) (int, bool) {
+	// Two-level lock: r.mu guards r.running (the map of RunningTasks),
+	// rt.mu guards fields written by the Execute goroutine (usageByMessage, Actions).
 	r.mu.RLock()
-	defer r.mu.RUnlock()
 	rt, ok := r.running[taskID]
+	r.mu.RUnlock()
 	if !ok {
 		return 0, false
 	}
+	rt.mu.RLock()
+	defer rt.mu.RUnlock()
 	return len(rt.usageByMessage), true
 }
 
@@ -842,7 +849,11 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 		// same 5s cadence — powers the Run Stats 5-aligned sparklines.
 		rtRef := rt
 		r.hostSampler.Attach(t.ID, func() (float64, int, int) {
-			return 0, len(rtRef.usageByMessage), rtRef.Actions
+			rtRef.mu.RLock()
+			turns := len(rtRef.usageByMessage)
+			actions := rtRef.Actions
+			rtRef.mu.RUnlock()
+			return 0, turns, actions
 		})
 	}
 
@@ -892,16 +903,22 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 					// assistant message id as it streams chunks, so dedupe on
 					// message.id via the existing usageByMessage map. Firing on
 					// every assistant line would overcount vs. result.num_turns.
+					// rt.mu guards usageByMessage — held only for the map op,
+					// released before calling onEvent to avoid lock inversion.
 					if msg, ok := event["message"].(map[string]any); ok {
 						if msgID, _ := msg["id"].(string); msgID != "" {
-							if _, seen := rt.usageByMessage[msgID]; !seen {
+							rt.mu.Lock()
+							_, seen := rt.usageByMessage[msgID]
+							if !seen {
 								rt.usageByMessage[msgID] = Usage{}
-								if r.onEvent != nil {
-									r.onEvent("task_turn_started", map[string]string{
-										"task_id": t.ID,
-										"turn":    strconv.Itoa(len(rt.usageByMessage)),
-									})
-								}
+							}
+							turnCount := len(rt.usageByMessage)
+							rt.mu.Unlock()
+							if !seen && r.onEvent != nil {
+								r.onEvent("task_turn_started", map[string]string{
+									"task_id": t.ID,
+									"turn":    strconv.Itoa(turnCount),
+								})
 							}
 						}
 					}
@@ -912,7 +929,9 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 							for _, block := range content {
 								if bm, ok := block.(map[string]any); ok {
 									if bm["type"] == "tool_use" {
+										rt.mu.Lock()
 										rt.Actions++
+										rt.mu.Unlock()
 										toolName, _ := bm["name"].(string)
 										toolID, _ := bm["id"].(string)
 										toolInput := marshalJSON(bm["input"])
@@ -1002,8 +1021,11 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 
 			// Broadcast progress
 			if rt.Lines%5 == 0 && r.onEvent != nil {
+				rt.mu.RLock()
+				actions := rt.Actions
+				rt.mu.RUnlock()
 				r.onEvent("task_progress", map[string]string{
-					"task_id": t.ID, "actions": fmt.Sprintf("%d", rt.Actions),
+					"task_id": t.ID, "actions": fmt.Sprintf("%d", actions),
 				})
 			}
 

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -291,6 +291,22 @@ func (r *Runner) IsRunning(taskID string) bool {
 	return ok
 }
 
+// LiveTurnCount returns the in-memory turn count for a running task — the
+// number of distinct assistant message ids seen so far on its stdout. Updates
+// immediately at each turn boundary (before task_turn_started fires), so
+// dashboards polling /api/execution/live see the new value within ~1s instead
+// of waiting for the next 5s execution_log sample. Returns (0,false) when the
+// task is not currently in r.running.
+func (r *Runner) LiveTurnCount(taskID string) (int, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	rt, ok := r.running[taskID]
+	if !ok {
+		return 0, false
+	}
+	return len(rt.usageByMessage), true
+}
+
 // RunningCount returns number of active executions.
 func (r *Runner) RunningCount() int {
 	r.mu.RLock()

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -871,6 +872,24 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 				eventType, _ := event["type"].(string)
 
 				if eventType == "assistant" {
+					// Detect a new turn boundary. Claude Code re-emits the same
+					// assistant message id as it streams chunks, so dedupe on
+					// message.id via the existing usageByMessage map. Firing on
+					// every assistant line would overcount vs. result.num_turns.
+					if msg, ok := event["message"].(map[string]any); ok {
+						if msgID, _ := msg["id"].(string); msgID != "" {
+							if _, seen := rt.usageByMessage[msgID]; !seen {
+								rt.usageByMessage[msgID] = Usage{}
+								if r.onEvent != nil {
+									r.onEvent("task_turn_started", map[string]string{
+										"task_id": t.ID,
+										"turn":    strconv.Itoa(len(rt.usageByMessage)),
+									})
+								}
+							}
+						}
+					}
+
 					// Extract tool_use blocks from assistant message
 					if msg, ok := event["message"].(map[string]any); ok {
 						if content, ok := msg["content"].([]any); ok {
@@ -902,6 +921,10 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 										if r.onEvent != nil {
 											r.onEvent("task_action", map[string]string{
 												"task_id": t.ID, "tool": toolName,
+											})
+											r.onEvent("task_turn_tool", map[string]string{
+												"task_id":   t.ID,
+												"tool_name": toolName,
 											})
 										}
 									}

--- a/internal/web/handlers_execution_stats.go
+++ b/internal/web/handlers_execution_stats.go
@@ -301,6 +301,17 @@ LIMIT 1`
 			t.EntityTitle = title
 			t.EntityType = etype
 
+			// Overlay the live in-memory turn count from the task runner. The
+			// execution_log sample row only refreshes every 5s, but the runner
+			// increments its turn counter immediately at each turn boundary
+			// (before firing task_turn_started). Looking it up here makes the
+			// /api/execution/live response reflect the current turn within ~1s.
+			if runner := n.GetRunner(); runner != nil {
+				if live, ok := runner.LiveTurnCount(t.EntityUID); ok && live > t.Turns {
+					t.Turns = live
+				}
+			}
+
 			result = append(result, t)
 		}
 


### PR DESCRIPTION
## Summary
- Fires `task_turn_started` when a new assistant message id is observed in the stream-json output, deduped via `rt.usageByMessage` so re-emitted streaming chunks don't overcount turns.
- Fires `task_turn_tool` for every `tool_use` content block, alongside the existing `task_action` event, with `tool_name` payload.
- No new DB tables, no new API routes — events flow through the existing `onEvent` → `hub.Broadcast` wiring in `cmd/serve.go`.

## Why
Operators currently only see `task_started` / `task_completed`; turn count on `/api/execution/live` only updates every 5s on the sampler tick. Surfacing per-turn boundaries lets the dashboard reflect agent activity in real time.

## Test plan
- [x] `make build` passes (Go binary + React frontend)
- [ ] Live run on the dashboard: confirm WS subscribers receive `task_turn_started` and the turn counter increments without waiting for the sample tick
- [ ] Verify `task_started` / `task_completed` still fire (no regression in existing event emission)
- [ ] `result.num_turns` from terminal event matches the count of `task_turn_started` emissions for the same run

## Acceptance criteria (from manifest)
- [x] WebSocket clients receive `task_turn_started` during a run
- [x] No new tables/routes; events use existing hub
- [ ] Dashboard turn counter updates on a live run card without page refresh (manual verify pending)