### PR TITLE
feat: branch_strategy execution control knob

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/k8nstantin/OpenPraxis/internal/chat"
 	"github.com/k8nstantin/OpenPraxis/internal/comments"
+	"github.com/k8nstantin/OpenPraxis/internal/settings"
 	"github.com/k8nstantin/OpenPraxis/internal/config"
 	mcpserver "github.com/k8nstantin/OpenPraxis/internal/mcp"
 	"github.com/k8nstantin/OpenPraxis/internal/node"
@@ -28,6 +29,25 @@ import (
 )
 
 var noBrowser bool
+
+// deriveBranchName converts an entity title to a valid git branch suffix.
+// "Turn-Level Agent Events" → "openpraxis/turn-level-agent-events"
+func deriveBranchName(prefix, title string) string {
+	s := strings.ToLower(title)
+	s = strings.ReplaceAll(s, " ", "-")
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			b.WriteRune(r)
+		}
+	}
+	slug := b.String()
+	for strings.Contains(slug, "--") {
+		slug = strings.ReplaceAll(slug, "--", "-")
+	}
+	slug = strings.Trim(slug, "-")
+	return prefix + "/" + slug
+}
 
 var serveCmd = &cobra.Command{
 	Use:   "serve",
@@ -302,6 +322,70 @@ var serveCmd = &cobra.Command{
 			// fall back to the default execution protocol.
 			skillID, skillBody := skillPromptFor(ctx, entityID)
 			prompt := strings.ReplaceAll(skillBody, "{ENTITY_UUID}", entityID)
+
+			// Resolve branch_strategy knob — task (default), manifest, or product.
+			// The settings resolver walks task → manifest → product → system so
+			// setting it at any scope level cascades down to all children.
+			if n.SettingsResolver != nil {
+				scope := settings.Scope{TaskID: entityID}
+				if res, err := n.SettingsResolver.Resolve(ctx, scope, "branch_strategy"); err == nil {
+					strategy, _ := res.Value.(string)
+					if strategy == "manifest" || strategy == "product" {
+						// Derive the shared branch name from the owning entity's title.
+						sharedBranch := ""
+						branchPrefix := "openpraxis"
+						if bpRes, err2 := n.SettingsResolver.Resolve(ctx, scope, "branch_prefix"); err2 == nil {
+							if bp, _ := bpRes.Value.(string); bp != "" {
+								branchPrefix = bp
+							}
+						}
+						if n.Relationships != nil {
+							// Walk up to find the entity whose title drives the branch name.
+							lookupID := entityID
+							if strategy == "manifest" {
+								if edges, _ := n.Relationships.ListIncoming(ctx, lookupID, "owns"); len(edges) > 0 {
+									for _, edge := range edges {
+										if edge.SrcKind == "manifest" {
+											if me, _ := n.Entities.Get(edge.SrcID); me != nil {
+												sharedBranch = deriveBranchName(branchPrefix, me.Title)
+											}
+											break
+										}
+									}
+								}
+							} else { // product — walk task → manifest → product
+								if manifEdges, _ := n.Relationships.ListIncoming(ctx, lookupID, "owns"); len(manifEdges) > 0 {
+									for _, me := range manifEdges {
+										if me.SrcKind == "manifest" {
+											if prodEdges, _ := n.Relationships.ListIncoming(ctx, me.SrcID, "owns"); len(prodEdges) > 0 {
+												for _, pe := range prodEdges {
+													if pe.SrcKind == "product" {
+														if pe2, _ := n.Entities.Get(pe.SrcID); pe2 != nil {
+															sharedBranch = deriveBranchName(branchPrefix, pe2.Title)
+														}
+														break
+													}
+												}
+											}
+											break
+										}
+									}
+								}
+							}
+						}
+						if sharedBranch != "" {
+							prompt += fmt.Sprintf(
+								"\n\n## Shared Branch (branch_strategy=%s)\n"+
+									"Use branch `%s` — do NOT create a new branch or PR.\n"+
+									"```bash\ngit fetch github\n"+
+									"git checkout %s 2>/dev/null || git checkout -b %s --track github/%s\n```\n"+
+									"Push all commits to `%s`.\n",
+								strategy, sharedBranch, sharedBranch, sharedBranch, sharedBranch, sharedBranch)
+							slog.Info("dispatch: shared branch", "entity_uid", entityID[:12], "branch", sharedBranch, "strategy", strategy)
+						}
+					}
+				}
+			}
 
 			// Append visceral rules so the agent receives them even without MCP.
 			if vr := visceralRules(); vr != "" {

--- a/internal/settings/catalog.go
+++ b/internal/settings/catalog.go
@@ -83,6 +83,7 @@ func Catalog() []KnobDef {
 		{Key: "host_sampler_tick_seconds", Type: KnobInt, SliderMin: f(1), SliderMax: f(300), SliderStep: f(1), Default: 5, Unit: "seconds", Description: "Interval (seconds) for the per-run + system host samplers."},
 		{Key: "on_restart_behavior", Type: KnobEnum, EnumValues: []string{"restart", "stop", "fail"}, Default: "stop", Description: "What to do with tasks left in running state when serve restarts. stop=mark failed with recovery hint; restart=re-fire immediately; fail=mark failed with no auto-recovery."},
 		{Key: "branch_prefix", Type: KnobString, Default: "openpraxis", Description: "Prefix used in the agent's <git_workflow> branch name: <prefix>/<task_id>. Operators can set per-product for QA/staging branches."},
+		{Key: "branch_strategy", Type: KnobEnum, EnumValues: []string{"task", "manifest", "product"}, Default: "task", Description: "Branch scope for agent runs. task=own branch + PR per task (default). manifest=all tasks in the manifest share one branch derived from the manifest title. product=all tasks across all manifests share one branch derived from the product title."},
 		{Key: "worktree_base_dir", Type: KnobString, Default: ".openpraxis-work", Description: "Directory under the repo root where per-task git worktrees are materialised. Absolute paths are supported for out-of-tree worktrees."},
 		{Key: "allowed_tools", Type: KnobMultiselect, Default: []string{
 			"Bash", "Read", "Write", "Edit", "Glob", "Grep",


### PR DESCRIPTION
## Summary

New `branch_strategy` knob in the settings catalog — visible in the Execution tab on every entity.

| Value | Behavior |
|---|---|
| `task` | Own branch + PR per task (default) |
| `manifest` | All tasks in the manifest share one branch derived from manifest title |
| `product` | All tasks across all manifests share one branch derived from product title |

Set once at any scope — the settings resolver walks task → manifest → product → system so all children inherit.

## How it works

Dispatcher reads the knob, derives the shared branch name using `branch_prefix` + slugified entity title, and injects git checkout instructions into the agent prompt:

```
## Shared Branch (branch_strategy=manifest)
Use branch `openpraxis/turn-level-agent-events` — do NOT create a new branch or PR.
git fetch github
git checkout openpraxis/turn-level-agent-events 2>/dev/null || git checkout -b ...
```

No hardcoding anywhere. Set `branch_strategy=manifest` on a manifest in the Execution tab and every task under it automatically shares the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)