### PR TITLE
feat: persist turn data — turn_number on actions + EventTurn in execution_log

### DIFF
--- a/internal/action/store.go
+++ b/internal/action/store.go
@@ -70,6 +70,7 @@ func (s *Store) init() error {
 	// Migrations
 	s.db.Exec(`ALTER TABLE actions ADD COLUMN source_node TEXT NOT NULL DEFAULT ''`)
 	s.db.Exec(`ALTER TABLE actions ADD COLUMN task_id TEXT NOT NULL DEFAULT ''`)
+	s.db.Exec(`ALTER TABLE actions ADD COLUMN turn_number INTEGER NOT NULL DEFAULT 0`)
 
 	_, err = s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_actions_task ON actions(task_id)`)
 	if err != nil {
@@ -97,15 +98,16 @@ func (s *Store) Record(sessionID, sourceNode, toolName string, toolInput, toolRe
 }
 
 // RecordForTask stores an action linked to a task and returns the inserted row ID.
-func (s *Store) RecordForTask(taskID, sourceNode, toolName, toolInput, toolResponse, cwd string) (int64, error) {
+// turnNumber is the current agent turn (1-based); 0 means unknown/pre-feature rows.
+func (s *Store) RecordForTask(taskID, sourceNode, toolName, toolInput, toolResponse, cwd string, turnNumber int) (int64, error) {
 	// Truncate large responses
 	if len(toolResponse) > 5000 {
 		toolResponse = toolResponse[:5000] + "..."
 	}
 
-	result, err := s.db.Exec(`INSERT INTO actions (session_id, source_node, task_id, tool_name, tool_input, tool_response, cwd, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		"task:"+taskID, sourceNode, taskID, toolName, toolInput, toolResponse, cwd,
+	result, err := s.db.Exec(`INSERT INTO actions (session_id, source_node, task_id, tool_name, tool_input, tool_response, cwd, turn_number, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"task:"+taskID, sourceNode, taskID, toolName, toolInput, toolResponse, cwd, turnNumber,
 		time.Now().UTC().Format(time.RFC3339))
 	if err != nil {
 		return 0, err

--- a/internal/execution/store.go
+++ b/internal/execution/store.go
@@ -20,6 +20,7 @@ const (
 	EventSample    = "sample"
 	EventCompleted = "completed"
 	EventFailed    = "failed"
+	EventTurn      = "turn" // one row per turn boundary; Turns field holds the turn number
 )
 
 // Row is one append-only event row in execution_log.

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -914,11 +914,27 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 							}
 							turnCount := len(rt.usageByMessage)
 							rt.mu.Unlock()
-							if !seen && r.onEvent != nil {
-								r.onEvent("task_turn_started", map[string]string{
-									"task_id": t.ID,
-									"turn":    strconv.Itoa(turnCount),
-								})
+							if !seen {
+								// Persist turn boundary to execution_log so turn history
+								// survives beyond the in-memory RunningTask lifetime.
+								if r.executionLog != nil {
+									_ = r.executionLog.Insert(bgCtx, execution.Row{
+										RunUID:       runUID,
+										EntityUID:    t.ID,
+										Event:        execution.EventTurn,
+										Trigger:      "agent",
+										NodeID:       r.sourceNode,
+										AgentRuntime: agent,
+										Turns:        turnCount,
+										CreatedBy:    "runner",
+									})
+								}
+								if r.onEvent != nil {
+									r.onEvent("task_turn_started", map[string]string{
+										"task_id": t.ID,
+										"turn":    strconv.Itoa(turnCount),
+									})
+								}
 							}
 						}
 					}
@@ -936,11 +952,14 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 										toolID, _ := bm["id"].(string)
 										toolInput := marshalJSON(bm["input"])
 
-										// Record action immediately (response filled when tool_result arrives)
+										// Record action with current turn number.
 										var actionID int64
 										if r.actions != nil {
+											rt.mu.RLock()
+											currentTurn := len(rt.usageByMessage)
+											rt.mu.RUnlock()
 											var recErr error
-											actionID, recErr = r.actions.RecordForTask(t.ID, t.SourceNode, toolName, toolInput, "", "")
+											actionID, recErr = r.actions.RecordForTask(t.ID, t.SourceNode, toolName, toolInput, "", "", currentTurn)
 											if recErr != nil {
 												slog.Error("record action failed", "component", "runner", "task_id", t.ID, "error", recErr)
 											}


### PR DESCRIPTION
## Summary

Persists turn-level data across two existing tables so turn history survives beyond the in-memory `RunningTask` lifetime.

### `actions.turn_number`
- New column `turn_number INTEGER NOT NULL DEFAULT 0`
- `RecordForTask()` now accepts and stores the current turn number
- Each tool call is tagged with the agent turn it happened in (1-based; 0 for pre-feature rows)
- Query: `WHERE task_id=X AND turn_number=7` → all tools in turn 7

### `execution_log` EventTurn
- New event type `"turn"` — one lightweight row per turn boundary
- `Turns` field = turn number; `CreatedAt` = exact boundary timestamp
- Captures zero-tool turns (pure reasoning) invisible in `actions` alone
- ~50 extra rows for a 50-turn run (vs ~200 if we'd used separate turn_started/turn_tool events)

### Cross-reference
`actions.task_id + actions.turn_number` joins to `execution_log WHERE event='turn' AND entity_uid=task_id`

## What this enables
- Post-run turn-by-turn replay
- Turn duration (delta between consecutive EventTurn timestamps)
- Tool call distribution per turn
- Historical analysis without needing live WebSocket connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)