### PR TITLE
fix: complete ExecutionRow type — add missing fields, remove any casts

### DIFF
--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
@@ -136,7 +136,7 @@ export function RunsTab({ kind, entityId, onSelectLive, onSelectHistory }: RunsT
               <td className={tdCls}>{run.turns || '—'}</td>
               <td className={tdCls}>{run.actions || '—'}</td>
               <td className={tdCls}>{fmtCost(run.cost_usd)}</td>
-              <td className={`${tdCls} text-[10px] opacity-50`}>{(run as any).model || '—'}</td>
+              <td className={`${tdCls} text-[10px] opacity-50`}>{run.model || '—'}</td>
               <td className={`${tdCls} text-[10px] opacity-50`}>{fmtTime(run.created_at)}</td>
             </tr>
             {/* Expanded analytics section — T3 adds Turn Timeline, T4 adds Tools/Heatmap, T5 adds Cost/Turn */}

--- a/internal/web/ui/dashboard-v2/src/lib/types.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/types.ts
@@ -38,14 +38,22 @@ export interface ExecutionRow {
   id: string
   run_uid: string
   entity_uid: string
-  event: 'started' | 'sample' | 'completed' | 'failed'
+  event: 'started' | 'sample' | 'completed' | 'failed' | 'turn'
   run_number: number
   turns: number
+  actions: number
   input_tokens: number
   output_tokens: number
+  cost_usd: number
+  duration_ms: number
   cache_hit_rate_pct: number
   cpu_pct: number
   rss_mb: number
+  model: string
+  agent_runtime: string
+  started_at: number
+  completed_at: number
+  terminal_reason: string
   created_at: string
 }
 


### PR DESCRIPTION
ExecutionRow was missing actions, cost_usd, model, duration_ms, started_at, completed_at, terminal_reason. Added all to match Go execution.Row struct. Also added 'turn' to event union. RunsTab any-casts removed.