### PR TITLE
fix: complete ExecutionRow type — add missing fields

### DIFF
--- a/internal/web/ui/dashboard-v2/src/lib/types.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/types.ts
@@ -38,14 +38,22 @@ export interface ExecutionRow {
   id: string
   run_uid: string
   entity_uid: string
-  event: 'started' | 'sample' | 'completed' | 'failed'
+  event: 'started' | 'sample' | 'completed' | 'failed' | 'turn'
   run_number: number
   turns: number
+  actions: number
   input_tokens: number
   output_tokens: number
+  cost_usd: number
+  duration_ms: number
   cache_hit_rate_pct: number
   cpu_pct: number
   rss_mb: number
+  model: string
+  agent_runtime: string
+  started_at: number
+  completed_at: number
+  terminal_reason: string
   created_at: string
 }
 


### PR DESCRIPTION
Re-applies the ExecutionRow fix from #355 (branch was accidentally deleted during cleanup before merge). Adds actions, cost_usd, model, duration_ms, started_at, completed_at, terminal_reason, and 'turn' to the event union.