### PR TITLE
fix: add 'runs' to tab route validators

### DIFF
--- a/internal/web/ui/dashboard-v2/src/routes/_authenticated/ideas.tsx
+++ b/internal/web/ui/dashboard-v2/src/routes/_authenticated/ideas.tsx
@@ -4,7 +4,7 @@ import { EntityPage } from '@/features/entity'
 
 const ideasSearch = z.object({
   id: z.string().optional(),
-  tab: z.enum(['main', 'execution', 'comments', 'dependencies', 'dag'])
+  tab: z.enum(['main', 'execution', 'runs', 'comments', 'dependencies', 'dag'])
     .optional().default('main').catch('main'),
 })
 

--- a/internal/web/ui/dashboard-v2/src/routes/_authenticated/manifests.tsx
+++ b/internal/web/ui/dashboard-v2/src/routes/_authenticated/manifests.tsx
@@ -4,7 +4,7 @@ import { EntityPage } from '@/features/entity'
 
 const manifestsSearch = z.object({
   id: z.string().optional(),
-  tab: z.enum(['main', 'execution', 'comments', 'dependencies', 'dag'])
+  tab: z.enum(['main', 'execution', 'runs', 'comments', 'dependencies', 'dag'])
     .optional().default('main').catch('main'),
 })
 

--- a/internal/web/ui/dashboard-v2/src/routes/_authenticated/products.tsx
+++ b/internal/web/ui/dashboard-v2/src/routes/_authenticated/products.tsx
@@ -4,7 +4,7 @@ import { EntityPage } from '@/features/entity'
 
 const productsSearch = z.object({
   id: z.string().optional(),
-  tab: z.enum(['main', 'execution', 'comments', 'dependencies', 'dag'])
+  tab: z.enum(['main', 'execution', 'runs', 'comments', 'dependencies', 'dag'])
     .optional().default('main').catch('main'),
 })
 

--- a/internal/web/ui/dashboard-v2/src/routes/_authenticated/skills.tsx
+++ b/internal/web/ui/dashboard-v2/src/routes/_authenticated/skills.tsx
@@ -4,7 +4,7 @@ import { EntityPage } from '@/features/entity'
 
 const skillsSearch = z.object({
   id: z.string().optional(),
-  tab: z.enum(['main', 'execution', 'comments', 'dependencies', 'dag'])
+  tab: z.enum(['main', 'execution', 'runs', 'comments', 'dependencies', 'dag'])
     .optional().default('main').catch('main'),
 })
 

--- a/internal/web/ui/dashboard-v2/src/routes/_authenticated/tasks.tsx
+++ b/internal/web/ui/dashboard-v2/src/routes/_authenticated/tasks.tsx
@@ -4,7 +4,7 @@ import { EntityPage } from '@/features/entity'
 
 const tasksSearch = z.object({
   id: z.string().optional(),
-  tab: z.enum(['main', 'execution', 'comments', 'dependencies', 'dag'])
+  tab: z.enum(['main', 'execution', 'runs', 'comments', 'dependencies', 'dag'])
     .optional().default('main').catch('main'),
 })
 


### PR DESCRIPTION
Route search validators missing 'runs' tab — clicking Runs tab was silently rejected by zod.