### PR TITLE
fix: scope live actions to current run_uid — no historical bleed

### DIFF
--- a/internal/web/handlers_entity.go
+++ b/internal/web/handlers_entity.go
@@ -637,10 +637,14 @@ func buildHierarchy(r *http.Request, n *node.Node, entityID, kind string, depth 
 }
 
 // apiEntityActions returns the actions (tool calls) for an entity, newest first.
-// GET /api/entities/{id}/actions?limit=100
-// Used for live output polling during a run and historical action replay.
+// GET /api/entities/{id}/actions?limit=100&run_uid=<runUID>
+//
+// When run_uid is provided, actions are filtered to only those created after
+// the run's started_at timestamp — ensures live output shows only the current
+// run's tool calls, not historical ones from prior runs of the same task.
 func apiEntityActions(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
 		id := mux.Vars(r)["id"]
 		limit := 100
 		if l := r.URL.Query().Get("limit"); l != "" {
@@ -648,6 +652,22 @@ func apiEntityActions(n *node.Node) http.HandlerFunc {
 				limit = v
 			}
 		}
+
+		// If run_uid provided, filter to actions created at/after run start.
+		runUID := r.URL.Query().Get("run_uid")
+		var sinceTime string
+		if runUID != "" && n.ExecutionLog != nil {
+			rows, err := n.ExecutionLog.ListByRun(ctx, runUID)
+			if err == nil {
+				for _, row := range rows {
+					if row.Event == "started" {
+						sinceTime = row.CreatedAt
+						break
+					}
+				}
+			}
+		}
+
 		actions, err := n.Actions.ListByTask(id, limit)
 		if err != nil {
 			http.Error(w, err.Error(), 500)
@@ -657,6 +677,18 @@ func apiEntityActions(n *node.Node) http.HandlerFunc {
 			writeJSON(w, []any{})
 			return
 		}
+
+		// Filter by run start time when run_uid was specified.
+		if sinceTime != "" {
+			filtered := actions[:0]
+			for _, a := range actions {
+				if a.CreatedAt.Format("2006-01-02T15:04:05Z07:00") >= sinceTime {
+					filtered = append(filtered, a)
+				}
+			}
+			actions = filtered
+		}
+
 		writeJSON(w, actions)
 	}
 }

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
@@ -23,20 +23,21 @@ interface ActionRow {
   tool_input: string; tool_response: string; turn_number: number; created_at: string
 }
 
-// Live output: poll entity actions while run is active (every 3s), static otherwise
-function useEntityActions(entityId: string, isLive: boolean) {
+// Live output: poll entity actions while run is active (every 3s), static otherwise.
+// run_uid scopes actions to the current run only — no historical bleed.
+function useEntityActions(entityId: string, runUid: string, isLive: boolean) {
   return useQuery({
-    queryKey: ['entity-actions', entityId, isLive],
+    queryKey: ['entity-actions', entityId, runUid, isLive],
     queryFn: (): Promise<ActionRow[]> =>
-      fetch(`/api/entities/${entityId}/actions?limit=200`).then(r => r.json()),
+      fetch(`/api/entities/${entityId}/actions?limit=200&run_uid=${runUid}`).then(r => r.json()),
     enabled: !!entityId,
     refetchInterval: isLive ? 3000 : false,
     staleTime: isLive ? 0 : 60_000,
   })
 }
 
-function LiveOutput({ entityId }: { entityId: string }) {
-  const { data, isLoading } = useEntityActions(entityId, true)
+function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) {
+  const { data, isLoading } = useEntityActions(entityId, runUid, true)
   if (isLoading) return <div className='text-muted-foreground p-3 text-xs'>Loading output…</div>
   if (!data?.length) return <div className='text-muted-foreground p-3 text-xs'>Waiting for agent to make tool calls…</div>
   return (
@@ -169,7 +170,7 @@ export function RunsTab({ kind, entityId, onSelectLive, onSelectHistory }: RunsT
           </div>
           {/* Live output — polls actions every 3s */}
           <div className='border-t border-emerald-500/20'>
-            <LiveOutput entityId={liveRun.entity_uid} />
+            <LiveOutput entityId={liveRun.entity_uid} runUid={liveRun.run_uid} />
           </div>
         </div>
       )}


### PR DESCRIPTION
Filters actions by run start time when run_uid provided. Prior run actions no longer appear in the live stream.