### PR TITLE
fix: show all skills on product DAG

### DIFF
--- a/internal/web/handlers_graph.go
+++ b/internal/web/handlers_graph.go
@@ -99,7 +99,7 @@ func apiRelationshipsGraph(n *node.Node) http.HandlerFunc {
 							ViaSrc: edge.SrcID, ViaKind: relationships.EdgeOwns, Depth: 0,
 						})
 					}
-					break // one governing skill per product
+					// no break — show ALL skills linked to this product
 				}
 			}
 		}


### PR DESCRIPTION
Removed break after first skill. Products can have multiple skills — all must appear on the DAG.