### PR TITLE
feat: scheduler enforces depends_on DAG — tasks fire in declared sequence

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/k8nstantin/OpenPraxis/internal/chat"
 	"github.com/k8nstantin/OpenPraxis/internal/comments"
+	execution "github.com/k8nstantin/OpenPraxis/internal/execution"
+	"github.com/k8nstantin/OpenPraxis/internal/relationships"
 	"github.com/k8nstantin/OpenPraxis/internal/settings"
 	"github.com/k8nstantin/OpenPraxis/internal/config"
 	mcpserver "github.com/k8nstantin/OpenPraxis/internal/mcp"
@@ -202,8 +204,33 @@ var serveCmd = &cobra.Command{
 		// Task runner — spawns autonomous agent subprocesses.
 		// Architecture: schedule.Runner fires entity_uid from the schedules
 		// table → runner executes the entity → stats go to execution_log.
+		//
+		// dispatchChainFn is set after dispatchAtomicTasks is defined so the
+		// task_completed callback can chain the next DAG-ready task without a
+		// forward-declaration problem.
+		var dispatchChainFn func(ctx context.Context, parentID string, scheduleID int64) error
+
 		runner := n.InitRunner(func(event string, data map[string]string) {
 			hub.Broadcast(web.Event{Type: event, Data: data})
+			// When a task completes, re-evaluate the owning manifest so the
+			// next depends_on-unblocked task fires automatically.
+			if event == "task_completed" {
+				taskID := data["task_id"]
+				if taskID != "" && n.Relationships != nil && dispatchChainFn != nil {
+					edges, _ := n.Relationships.ListIncoming(ctx, taskID, relationships.EdgeOwns)
+					for _, e := range edges {
+						if e.SrcKind == relationships.KindManifest || e.SrcKind == relationships.KindProduct {
+							parentID := e.SrcID
+							go func() {
+								if err := dispatchChainFn(ctx, parentID, 0); err != nil {
+									slog.Info("dag-chain: dispatch after task_completed", "parent", parentID[:12], "note", err.Error())
+								}
+							}()
+							break
+						}
+					}
+				}
+			}
 		})
 
 		if err := runner.RecoverInFlight(ctx); err != nil {
@@ -460,6 +487,32 @@ var serveCmd = &cobra.Command{
 			slog.Info("dispatch: firing tasks atomically", "parent_uid", parentID[:12], "type", parent.Type, "task_count", len(taskIDs))
 			var lastErr error
 			for _, taskID := range taskIDs {
+				// DAG gate: skip tasks whose depends_on edges point to tasks
+				// that have not yet completed. The depends_on edges in the
+				// relationships table are the source of truth — the scheduler
+				// must follow the DAG, not fire everything at once.
+				if n.Relationships != nil && n.ExecutionLog != nil {
+					deps, _ := n.Relationships.ListOutgoing(ctx, taskID, relationships.EdgeDependsOn)
+					blocked := false
+					for _, dep := range deps {
+						rows, _ := n.ExecutionLog.ListByEntity(ctx, dep.DstID, 1)
+						completed := false
+						for _, row := range rows {
+							if row.Event == execution.EventCompleted {
+								completed = true
+								break
+							}
+						}
+						if !completed {
+							blocked = true
+							break
+						}
+					}
+					if blocked {
+						slog.Info("dag-chain: task blocked by unsatisfied depends_on — skipping", "task_id", taskID[:12])
+						continue
+					}
+				}
 				if err := dispatch(ctx, taskID, scheduleID); err != nil {
 					slog.Error("dispatch: task failed", "task_id", taskID[:12], "error", err)
 					lastErr = err
@@ -467,6 +520,9 @@ var serveCmd = &cobra.Command{
 			}
 			return lastErr
 		}
+
+		// Wire the chain function now that dispatchAtomicTasks is defined.
+		dispatchChainFn = dispatchAtomicTasks
 
 		// Schedule dispatcher:
 		//   task     → dispatch directly (atomic, execution recorded at task level)

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,10 +49,10 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-Bk6wp8OL.js"></script>
+    <script type="module" crossorigin src="/assets/index-BwlQwPvC.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-CGgIkkjv.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-40uRgF72.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-BVb5IsDP.css">
   </head>
 
   <body>


### PR DESCRIPTION
## Summary

- `dispatchAtomicTasks` now checks outgoing `depends_on` edges in the relationships table before firing each task
- A task is skipped if any of its dependencies has no `completed` event in `execution_log`
- On `task_completed`, the owning manifest is re-evaluated via a goroutine so the next unblocked task fires automatically
- `dispatchChainFn` pointer wires the chain callback after `dispatchAtomicTasks` is defined (avoids forward-declaration)

**Before:** scheduling a manifest fired all tasks simultaneously; `depends_on` edges were DAG-display-only  
**After:** the DAG is the source of truth — T1 fires, completes, T2 unblocks and fires, and so on

## Test plan
- [ ] Schedule a manifest with 3 sequential tasks (T1→T2→T3 via depends_on edges)
- [ ] Confirm only T1 fires on initial dispatch
- [ ] Confirm T2 fires automatically after T1 completes
- [ ] Confirm T3 fires automatically after T2 completes
- [ ] Confirm a task with no depends_on still fires immediately (no regression)
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)