### PR TITLE
fix: dag chain only advances on completed, not failed/cancelled

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -212,9 +212,11 @@ var serveCmd = &cobra.Command{
 
 		runner := n.InitRunner(func(event string, data map[string]string) {
 			hub.Broadcast(web.Event{Type: event, Data: data})
-			// When a task completes, re-evaluate the owning manifest so the
-			// next depends_on-unblocked task fires automatically.
-			if event == "task_completed" {
+			// When a task completes successfully, re-evaluate the owning manifest
+			// so the next depends_on-unblocked task fires automatically.
+			// Only advance on status=completed — a failed or cancelled task must
+			// not re-trigger the chain or the manifest re-dispatches T1 in a loop.
+			if event == "task_completed" && data["status"] == "completed" {
 				taskID := data["task_id"]
 				if taskID != "" && n.Relationships != nil && dispatchChainFn != nil {
 					edges, _ := n.Relationships.ListIncoming(ctx, taskID, relationships.EdgeOwns)


### PR DESCRIPTION
## Problem

`task_completed` fires for every terminal outcome (completed, failed, cancelled). The chain re-dispatch had no status check, so a killed or failed task caused an infinite spawn loop:

```
T1 killed → task_completed(status=failed) → chain re-evaluates manifest
→ T1 has no unsatisfied deps → fires again → killed → repeat
```

## Fix

One-line guard on the `task_completed` handler in `cmd/serve.go`:

```go
if event == "task_completed" && data["status"] == "completed" {
```

Failed and cancelled tasks stop the chain. The operator re-schedules manually after reviewing what went wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)