### PR TITLE
fix: harden DAG dep check + typed event constants

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -216,8 +216,8 @@ var serveCmd = &cobra.Command{
 			// so the next depends_on-unblocked task fires automatically.
 			// Only advance on status=completed — a failed or cancelled task must
 			// not re-trigger the chain or the manifest re-dispatches T1 in a loop.
-			if event == "task_completed" && data["status"] == "completed" {
-				taskID := data["task_id"]
+			if event == task.EventTaskCompleted && data[task.EventKeyStatus] == execution.EventCompleted {
+				taskID := data[task.EventKeyTaskID]
 				if taskID != "" && n.Relationships != nil && dispatchChainFn != nil {
 					edges, _ := n.Relationships.ListIncoming(ctx, taskID, relationships.EdgeOwns)
 					for _, e := range edges {
@@ -490,22 +490,16 @@ var serveCmd = &cobra.Command{
 			var lastErr error
 			for _, taskID := range taskIDs {
 				// DAG gate: skip tasks whose depends_on edges point to tasks
-				// that have not yet completed. The depends_on edges in the
-				// relationships table are the source of truth — the scheduler
-				// must follow the DAG, not fire everything at once.
+				// that have not yet completed. Reads the relationships table
+				// (single source of truth) and uses HasCompleted — a targeted
+				// query for the completed event rather than the most-recent-row
+				// heuristic which could return a sample row and false-negative.
 				if n.Relationships != nil && n.ExecutionLog != nil {
 					deps, _ := n.Relationships.ListOutgoing(ctx, taskID, relationships.EdgeDependsOn)
 					blocked := false
 					for _, dep := range deps {
-						rows, _ := n.ExecutionLog.ListByEntity(ctx, dep.DstID, 1)
-						completed := false
-						for _, row := range rows {
-							if row.Event == execution.EventCompleted {
-								completed = true
-								break
-							}
-						}
-						if !completed {
+						done, _ := n.ExecutionLog.HasCompleted(ctx, dep.DstID)
+						if !done {
 							blocked = true
 							break
 						}

--- a/internal/execution/store.go
+++ b/internal/execution/store.go
@@ -455,6 +455,25 @@ func (s *Store) ListByEntity(ctx context.Context, entityUID string, limit int) (
 	return collectRows(rows)
 }
 
+// HasCompleted returns true if the entity has at least one completed event in
+// execution_log. Used by the DAG dep gate to determine whether a dependency
+// has been satisfied — explicitly checks for the completed event rather than
+// relying on the most-recent-row heuristic (which could return a sample row).
+func (s *Store) HasCompleted(ctx context.Context, entityUID string) (bool, error) {
+	if entityUID == "" {
+		return false, ErrEmptyEntityID
+	}
+	var n int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM execution_log WHERE entity_uid = ? AND event = ?`,
+		entityUID, EventCompleted,
+	).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("execution: has completed: %w", err)
+	}
+	return n > 0, nil
+}
+
 // InFlightRun holds the minimal fields needed for zombie-process detection.
 type InFlightRun struct {
 	RunUID    string

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -22,6 +22,23 @@ import (
 	"github.com/k8nstantin/OpenPraxis/internal/templates"
 )
 
+// Event name and key constants for the onEvent broadcast callback.
+// Using constants prevents typo-induced bugs when reading map keys in
+// callers (e.g. the DAG chain gate in cmd/serve.go).
+const (
+	EventTaskCompleted = "task_completed"
+	EventTaskStarted   = "task_started"
+	EventTaskKilled    = "task_killed"
+	EventTaskCancelled = "task_cancelled"
+	EventTaskPaused    = "task_paused"
+	EventTaskResumed   = "task_resumed"
+	EventTaskProgress  = "task_progress"
+
+	EventKeyTaskID = "task_id"
+	EventKeyStatus = "status"
+	EventKeyReason = "reason"
+)
+
 // RunningTask tracks an actively executing task.
 type RunningTask struct {
 	TaskID    string    `json:"task_id"`
@@ -1315,8 +1332,10 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 		// already be scheduled/running.
 
 		if r.onEvent != nil {
-			r.onEvent("task_completed", map[string]string{
-				"task_id": t.ID, "status": status, "reason": reason,
+			r.onEvent(EventTaskCompleted, map[string]string{
+				EventKeyTaskID: t.ID,
+				EventKeyStatus: status,
+				EventKeyReason: reason,
 			})
 		}
 	}()


### PR DESCRIPTION
## Changes

### 1. `execution.HasCompleted` — correct dep satisfaction check

**Problem:** `dispatchAtomicTasks` used `ListByEntity(ctx, depID, 1)` to check if a dependency completed. `ListByEntity` returns the most recent non-turn event ordered by `created_at DESC`. A `sample` event emitted during a long-running task could be newer than the `completed` event, returning a false negative and permanently blocking the next task.

**Fix:** New `HasCompleted(ctx, entityUID)` method on the execution store — single `COUNT(*)` query targeting `event = 'completed'` specifically. No heuristics.

### 2. Task event constants — eliminate string-literal typo risk

**Problem (Gemini nitpick on PR #370):** The `onEvent` callback and its callers used bare `map[string]string` with string literals for both event names and key names. A typo like `"stauts"` would compile and silently break the DAG chain at runtime.

**Fix:** Exported constants on the `task` package:
```go
task.EventTaskCompleted  // "task_completed"
task.EventKeyStatus      // "status"  
task.EventKeyTaskID      // "task_id"
task.EventKeyReason      // "reason"
// + started, killed, cancelled, paused, resumed, progress
```

`cmd/serve.go` DAG chain gate now uses `task.EventTaskCompleted` and `task.EventKeyStatus` — both checked at compile time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)