### PR TITLE
fix: running entity — violet pulse indicator + restore useQuery import

### DIFF
--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,10 +49,10 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-DxcHB9aj.js"></script>
+    <script type="module" crossorigin src="/assets/index-DsR8MRUI.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-CGgIkkjv.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-BVb5IsDP.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-DcB6rzjm.css">
   </head>
 
   <body>

--- a/internal/web/ui/dashboard-v2/src/features/entity/list-pane.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/list-pane.tsx
@@ -166,8 +166,8 @@ export function EntityListPane({
               >
                 {runningIds.has(row.id) ? (
                   <span className='relative mt-0.5 flex h-2 w-2 shrink-0'>
-                    <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75' />
-                    <span className='relative inline-flex h-2 w-2 rounded-full bg-emerald-500' />
+                    <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-violet-400 opacity-75' />
+                    <span className='relative inline-flex h-2 w-2 rounded-full bg-violet-500' />
                   </span>
                 ) : (
                   <span className={cn(
@@ -177,7 +177,7 @@ export function EntityListPane({
                 )}
                 <span className={cn(
                   'min-w-0 flex-1 truncate',
-                  runningIds.has(row.id) && 'text-emerald-400 font-medium'
+                  runningIds.has(row.id) && 'text-violet-400 font-medium'
                 )}>{row.title}</span>
               </button>
             ))}

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
@@ -1,4 +1,5 @@
 import { useState, Fragment } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { useEntityRuns, useLiveRuns, type EntityKind, type LiveRun } from '@/lib/queries/entity'
 import type { ExecutionRow } from '@/lib/types'
 import { TurnAnalyticsBlock } from '@/features/entity/turn-charts'


### PR DESCRIPTION
## Changes

- Running pulse color: blue → violet — distinct from active (emerald) status dots
- Restore `import { useQuery }` in `runs.tsx` that was accidentally dropped during the `useLiveRuns` refactor, causing a `ReferenceError` crash on the Runs tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)