### PR TITLE
fix: skip already-completed tasks in DAG dispatch

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -495,6 +495,12 @@ var serveCmd = &cobra.Command{
 				// query for the completed event rather than the most-recent-row
 				// heuristic which could return a sample row and false-negative.
 				if n.Relationships != nil && n.ExecutionLog != nil {
+					// Skip tasks that already completed — prevents re-firing
+					// tasks with no deps (they'd pass the gate every time).
+					if done, _ := n.ExecutionLog.HasCompleted(ctx, taskID); done {
+						slog.Info("dag-chain: task already completed — skipping", "task_id", taskID[:12])
+						continue
+					}
 					deps, _ := n.Relationships.ListOutgoing(ctx, taskID, relationships.EdgeDependsOn)
 					blocked := false
 					for _, dep := range deps {


### PR DESCRIPTION
## Problem

Tasks with no `depends_on` edges always passed the DAG gate, so every time `dispatchAtomicTasks` ran (triggered by `task_completed`), T1 would re-fire instead of advancing to T2. T1 would complete in ~10s, trigger the chain, re-fire itself, repeat forever.

## Fix

Check `HasCompleted(ctx, taskID)` on the task itself before evaluating its deps. Already-completed tasks are skipped unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)