### PR TITLE
fix: DAG chain hardening — correct completion check + startup recovery

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -420,6 +420,12 @@ var serveCmd = &cobra.Command{
 								branchPrefix = bp
 							}
 						}
+						branchRemote := "github"
+						if brRes, err2 := n.SettingsResolver.Resolve(ctx, scope, "branch_remote"); err2 == nil {
+							if br, _ := brRes.Value.(string); br != "" {
+								branchRemote = br
+							}
+						}
 						if n.Relationships != nil {
 							// Walk up to find the entity whose title drives the branch name.
 							lookupID := entityID
@@ -458,10 +464,10 @@ var serveCmd = &cobra.Command{
 							prompt += fmt.Sprintf(
 								"\n\n## Shared Branch (branch_strategy=%s)\n"+
 									"Use branch `%s` — do NOT create a new branch or PR.\n"+
-									"```bash\ngit fetch github\n"+
-									"git checkout %s 2>/dev/null || git checkout -b %s --track github/%s\n```\n"+
+									"```bash\ngit fetch %s\n"+
+									"git checkout %s 2>/dev/null || git checkout -b %s --track %s/%s\n```\n"+
 									"Push all commits to `%s`.\n",
-								strategy, sharedBranch, sharedBranch, sharedBranch, sharedBranch, sharedBranch)
+								strategy, sharedBranch, branchRemote, sharedBranch, sharedBranch, branchRemote, sharedBranch, sharedBranch)
 							slog.Info("dispatch: shared branch", "entity_uid", entityID[:12], "branch", sharedBranch, "strategy", strategy)
 						}
 					}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -239,6 +239,51 @@ var serveCmd = &cobra.Command{
 			slog.Warn("recover in-flight tasks failed", "error", err)
 		}
 
+		// DAG chain recovery: on startup, re-evaluate every active manifest so
+		// chains interrupted by a server restart resume from where they left off.
+		// dispatchChainFn is not wired yet at this point — schedule this after
+		// the runner and dispatcher are fully initialised by deferring into a
+		// short-lived goroutine that waits for the wiring to complete.
+		go func() {
+			// Brief pause to let dispatchChainFn get wired below.
+			time.Sleep(2 * time.Second)
+			if n.Relationships == nil || n.Entities == nil {
+				return
+			}
+			manifests, err := n.Entities.List("manifest", "active", 0)
+			if err != nil || len(manifests) == 0 {
+				return
+			}
+			resumed := 0
+			for _, m := range manifests {
+				// Only resume manifests that have at least one completed task
+				// (chain was in progress) and at least one not-yet-completed task.
+				edges, _ := n.Relationships.ListOutgoing(ctx, m.EntityUID, relationships.EdgeOwns)
+				hasCompleted, hasPending := false, false
+				for _, e := range edges {
+					if e.DstKind != relationships.KindTask {
+						continue
+					}
+					done, _ := n.ExecutionLog.HasCompleted(ctx, e.DstID)
+					if done {
+						hasCompleted = true
+					} else {
+						hasPending = true
+					}
+				}
+				if hasCompleted && hasPending && dispatchChainFn != nil {
+					slog.Info("dag-chain: resuming interrupted chain on startup", "manifest", m.EntityUID[:12], "title", m.Title)
+					if err := dispatchChainFn(ctx, m.EntityUID, 0); err != nil {
+						slog.Info("dag-chain: resume dispatch", "manifest", m.EntityUID[:12], "note", err.Error())
+					}
+					resumed++
+				}
+			}
+			if resumed > 0 {
+				slog.Info("dag-chain: resumed chains on startup", "count", resumed)
+			}
+		}()
+
 		// defaultSkillID is the fallback execution protocol used when an entity
 		// has no skill assigned via the DAG.
 		const defaultSkillID = "019dfecc-a7b3-78a6-acc0-1cfa638eae18"

--- a/internal/execution/store.go
+++ b/internal/execution/store.go
@@ -455,23 +455,27 @@ func (s *Store) ListByEntity(ctx context.Context, entityUID string, limit int) (
 	return collectRows(rows)
 }
 
-// HasCompleted returns true if the entity has at least one completed event in
-// execution_log. Used by the DAG dep gate to determine whether a dependency
-// has been satisfied — explicitly checks for the completed event rather than
-// relying on the most-recent-row heuristic (which could return a sample row).
+// HasCompleted returns true if the entity's most recent terminal event is
+// 'completed'. Checks the latest completed/failed event so a task that
+// completed in run-1 but failed in run-2 is correctly treated as NOT done.
 func (s *Store) HasCompleted(ctx context.Context, entityUID string) (bool, error) {
 	if entityUID == "" {
 		return false, ErrEmptyEntityID
 	}
-	var n int
+	var event string
 	err := s.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM execution_log WHERE entity_uid = ? AND event = ?`,
-		entityUID, EventCompleted,
-	).Scan(&n)
+		`SELECT event FROM execution_log
+		  WHERE entity_uid = ? AND event IN (?, ?)
+		  ORDER BY created_at DESC LIMIT 1`,
+		entityUID, EventCompleted, EventFailed,
+	).Scan(&event)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
 	if err != nil {
 		return false, fmt.Errorf("execution: has completed: %w", err)
 	}
-	return n > 0, nil
+	return event == EventCompleted, nil
 }
 
 // InFlightRun holds the minimal fields needed for zombie-process detection.

--- a/internal/settings/catalog.go
+++ b/internal/settings/catalog.go
@@ -84,6 +84,7 @@ func Catalog() []KnobDef {
 		{Key: "on_restart_behavior", Type: KnobEnum, EnumValues: []string{"restart", "stop", "fail"}, Default: "stop", Description: "What to do with tasks left in running state when serve restarts. stop=mark failed with recovery hint; restart=re-fire immediately; fail=mark failed with no auto-recovery."},
 		{Key: "branch_prefix", Type: KnobString, Default: "openpraxis", Description: "Prefix used in the agent's <git_workflow> branch name: <prefix>/<task_id>. Operators can set per-product for QA/staging branches."},
 		{Key: "branch_strategy", Type: KnobEnum, EnumValues: []string{"task", "manifest", "product"}, Default: "task", Description: "Branch scope for agent runs. task=own branch + PR per task (default). manifest=all tasks in the manifest share one branch derived from the manifest title. product=all tasks across all manifests share one branch derived from the product title."},
+		{Key: "branch_remote", Type: KnobString, Default: "github", Description: "Git remote name used in branch checkout instructions injected into agent prompts. Default is 'github'. Set to 'origin' for Bitbucket, GitLab, or any other remote."},
 		{Key: "worktree_base_dir", Type: KnobString, Default: ".openpraxis-work", Description: "Directory under the repo root where per-task git worktrees are materialised. Absolute paths are supported for out-of-tree worktrees."},
 		{Key: "allowed_tools", Type: KnobMultiselect, Default: []string{
 			"Bash", "Read", "Write", "Edit", "Glob", "Grep",


### PR DESCRIPTION
## Two fixes

### 1. HasCompleted checks most recent terminal event

**Before:** `SELECT COUNT(*) WHERE event='completed'` — returns true if the entity EVER completed, even if its most recent run failed. A task that ran twice (run-1 completed, run-2 failed) would have its dependents unblocked incorrectly.

**After:** `SELECT event FROM ... WHERE event IN ('completed','failed') ORDER BY created_at DESC LIMIT 1` — checks the most recent terminal event. Only returns true if the latest run completed.

### 2. Chain recovery on startup

**Before:** `RecoverInFlight` is a no-op. Any server restart kills an in-progress chain dead — T3/T4/T5 never run, operator must manually re-schedule.

**After:** On startup (2s after boot to let dispatcher wire up), scan all active manifests. For any manifest that has at least one completed task AND at least one pending task, re-fire `dispatchAtomicTasks`. The DAG gate skips completed tasks and fires the next unblocked one. Chain resumes from exactly where it stopped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)