### PR TITLE
fix: prompt field on entity create was silently dropped

### DIFF
--- a/internal/web/handlers_entity.go
+++ b/internal/web/handlers_entity.go
@@ -68,6 +68,7 @@ func apiEntityCreate(n *node.Node) http.HandlerFunc {
 			Tags       []string `json:"tags"`
 			ProjectID  string   `json:"project_id"`   // manifest → parent product
 			ManifestID string   `json:"manifest_id"`  // task → parent manifest
+			Prompt     string   `json:"prompt"`       // optional initial prompt — posted as TypePrompt comment
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Type == "" || req.Title == "" {
 			http.Error(w, "type and title are required", 400)
@@ -99,6 +100,15 @@ func apiEntityCreate(n *node.Node) http.HandlerFunc {
 					Kind:      relationships.EdgeOwns,
 					CreatedBy: "http-api",
 				})
+			}
+		}
+		// Persist optional prompt as a TypePrompt comment so it's versioned
+		// and never silently dropped. Before this fix the field was not in the
+		// request struct and Go's JSON decoder dropped it without error.
+		if req.Prompt != "" && n.Comments != nil {
+			if _, err := n.Comments.Add(r.Context(), comments.TargetEntity, e.EntityUID,
+				"http-api", comments.TypePrompt, req.Prompt); err != nil {
+				slog.Warn("entity create: failed to save prompt comment", "entity", e.EntityUID, "error", err)
 			}
 		}
 		w.WriteHeader(http.StatusCreated)

--- a/internal/web/handlers_entity.go
+++ b/internal/web/handlers_entity.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strconv"
 


### PR DESCRIPTION
## Problem

The `apiEntityCreate` handler's request struct did not include a `Prompt` field. Go's JSON decoder silently drops unknown keys — so `POST /api/entities` with `{"type":"task","prompt":"..."}` created the entity but threw the prompt away with no error returned.

This caused tasks created with prompts to have zero TypePrompt comments, making agents run without instructions.

## Fix

Add `Prompt string \`json:"prompt"\`` to the request struct. When non-empty, auto-post it as a `TypePrompt` comment on the newly created entity — versioned, append-only, exactly as if posted via `POST /api/entities/{id}/comments`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)