### PR TITLE
feat: GET /api/relationships/incoming and /outgoing — agent DAG traversal

### DIFF
--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -536,6 +536,11 @@ func mountAPI(api *mux.Router, deps ServerDeps) {
 	// truth: the relationships SCD-2 table; Walk traversal handles the
 	// recursive descent.
 	api.HandleFunc("/relationships/graph", apiRelationshipsGraph(n)).Methods("GET")
+	// Agent DAG traversal — walk UP or DOWN the relationships table.
+	// GET /api/relationships/incoming?dst_id=...&kind=owns  → find parent of an entity
+	// GET /api/relationships/outgoing?src_id=...&kind=owns  → find children of an entity
+	api.HandleFunc("/relationships/incoming", apiRelationshipsIncoming(n)).Methods("GET")
+	api.HandleFunc("/relationships/outgoing", apiRelationshipsOutgoing(n)).Methods("GET")
 	api.HandleFunc("/visceral/by-peer", apiVisceralByPeer(n)).Methods("GET")
 	api.HandleFunc("/visceral", apiVisceralList(n)).Methods("GET")
 	api.HandleFunc("/visceral/confirmations", apiVisceralConfirmations(n)).Methods("GET")

--- a/internal/web/handlers_entity.go
+++ b/internal/web/handlers_entity.go
@@ -761,3 +761,57 @@ func apiEntityActions(n *node.Node) http.HandlerFunc {
 		writeJSON(w, actions)
 	}
 }
+
+// apiRelationshipsIncoming handles GET /api/relationships/incoming?dst_id=...&kind=...
+// Returns all current edges pointing TO dst_id with the given kind.
+// Agents use this to walk UP the DAG — find the manifest that owns a task, etc.
+func apiRelationshipsIncoming(n *node.Node) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if n.Relationships == nil {
+			writeJSON(w, []any{})
+			return
+		}
+		dstID := r.URL.Query().Get("dst_id")
+		kind := r.URL.Query().Get("kind")
+		if dstID == "" || kind == "" {
+			writeError(w, "dst_id and kind are required", http.StatusBadRequest)
+			return
+		}
+		edges, err := n.Relationships.ListIncoming(r.Context(), dstID, kind)
+		if err != nil {
+			writeError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if edges == nil {
+			edges = []relationships.Edge{}
+		}
+		writeJSON(w, edges)
+	}
+}
+
+// apiRelationshipsOutgoing handles GET /api/relationships/outgoing?src_id=...&kind=...
+// Returns all current edges pointing FROM src_id with the given kind.
+// Agents use this to walk DOWN the DAG — list tasks owned by a manifest, etc.
+func apiRelationshipsOutgoing(n *node.Node) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if n.Relationships == nil {
+			writeJSON(w, []any{})
+			return
+		}
+		srcID := r.URL.Query().Get("src_id")
+		kind := r.URL.Query().Get("kind")
+		if srcID == "" || kind == "" {
+			writeError(w, "src_id and kind are required", http.StatusBadRequest)
+			return
+		}
+		edges, err := n.Relationships.ListOutgoing(r.Context(), srcID, kind)
+		if err != nil {
+			writeError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if edges == nil {
+			edges = []relationships.Edge{}
+		}
+		writeJSON(w, edges)
+	}
+}


### PR DESCRIPTION
## Problem

Agents need to walk the DAG to read context: find the manifest that owns a task, find the product above a manifest, etc. The only way to do this was `/api/relationships/graph` (full DAG from a root), but that walks DOWN not up.

The skills referenced `GET /api/relationships?dst_id=...&kind=owns` which doesn't exist and returns the HTML dashboard. Agents spent 10+ turns getting HTML, making zero tool actions, burning context.

## Fix

Two new endpoints backed by the existing `ListIncoming` / `ListOutgoing` methods on the relationships store:

```
GET /api/relationships/incoming?dst_id={UUID}&kind=owns    → find parent of an entity
GET /api/relationships/outgoing?src_id={UUID}&kind=owns    → find children of an entity
```

Both skills rewritten to use these correct endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)