### PR TITLE
fix: description dedup compares against latest revision not entity title

### DIFF
--- a/internal/node/description.go
+++ b/internal/node/description.go
@@ -69,9 +69,10 @@ func (n *Node) RecordDescriptionChange(
 	return c.ID, nil
 }
 
-// currentDescription reads the entity's current denormalised body + returns
-// the full UUID so callers (and the revision insert) operate on canonical
-// ids instead of short markers. Returns ("", "", nil) for missing rows.
+// currentDescription returns the latest prompt comment body for an entity plus
+// its canonical UUID. Used by RecordDescriptionChange to dedup writes — if the
+// incoming body matches the current latest revision, no new row is inserted.
+// Returns ("", fullID, nil) when no prompt revision exists yet (first write).
 func (n *Node) currentDescription(_ comments.TargetType, idOrMarker string) (body, fullID string, err error) {
 	if n.Entities == nil {
 		return "", "", nil
@@ -80,7 +81,18 @@ func (n *Node) currentDescription(_ comments.TargetType, idOrMarker string) (bod
 	if err != nil || e == nil {
 		return "", "", err
 	}
-	return e.Title, e.EntityUID, nil
+	if n.Comments == nil {
+		return "", e.EntityUID, nil
+	}
+	ct := comments.TypePrompt
+	rows, err := n.Comments.List(context.Background(), comments.TargetEntity, e.EntityUID, 1, &ct)
+	if err != nil {
+		return "", e.EntityUID, err
+	}
+	if len(rows) == 0 {
+		return "", e.EntityUID, nil
+	}
+	return rows[0].Body, e.EntityUID, nil
 }
 
 // RevisionEntry is a single prompt presented to API / MCP


### PR DESCRIPTION
## Problem

`RecordDescriptionChange` calls `currentDescription` to check whether the
incoming body is different before writing a new revision. `currentDescription`
was returning `e.Title` (the entity title) as the "current body". Since a
description body almost never equals the entity title, the dedup never fired —
every update created a new revision, including duplicate writes with identical
content.

## Fix

`currentDescription` now fetches the latest `type=prompt` comment for the
entity via `Comments.List(..., limit=1)`. Returns `("", fullID, nil)` when no
revision exists yet, preserving the first-write path. Subsequent writes with
the same body are correctly suppressed.

## Test plan
- [ ] `go build ./...` passes
- [ ] Update an idea description twice with the same body — only one revision created
- [ ] Update with a different body — new revision created

🤖 Generated with [Claude Code](https://claude.com/claude-code)