### PR TITLE
feat(M1): Prompt Context Wiring — prior_context section + 5 new knobs

### DIFF
--- a/internal/settings/catalog.go
+++ b/internal/settings/catalog.go
@@ -76,6 +76,9 @@ func Catalog() []KnobDef {
 		// idea 019db6ba-ba0 and memory 019db6bb-a4e.
 		{Key: "prompt_max_comment_chars", Type: KnobInt, SliderMin: f(500), SliderMax: f(10000), SliderStep: f(500), Default: 2000, Description: "Max chars per comment when injected into the task-thread context block; longer comments are truncated with a pointer to the full text."},
 		{Key: "prompt_max_context_pct", Type: KnobFloat, SliderMin: f(0.1), SliderMax: f(0.9), SliderStep: f(0.05), Default: 0.4, Description: "Max fraction of the resolved model's context window that the prior-runs + other-comments block may consume; older comments drop first when over budget."},
+		{Key: "prompt_prior_runs_limit", Type: KnobInt, SliderMin: f(0), SliderMax: f(20), SliderStep: f(1), Default: 5, Description: "How many prior execution-log rows to inject into the prior_context prompt section. 0 disables."},
+		{Key: "prompt_prior_comments_limit", Type: KnobInt, SliderMin: f(0), SliderMax: f(10), SliderStep: f(1), Default: 3, Description: "How many prior agent-authored comments (type=comment) to inject into the prior_context prompt section. 0 disables."},
+		{Key: "prompt_build_timeout_seconds", Type: KnobInt, SliderMin: f(1), SliderMax: f(30), SliderStep: f(1), Default: 5, Unit: "seconds", Description: "Deadline for prompt-build history queries. Prevents a slow DB from blocking task dispatch."},
 		{Key: "compliance_checks_enabled", Type: KnobEnum, EnumValues: []string{"true", "false"}, Default: "true", Description: "When true, PostToolUse hooks run visceral-compliance + manifest-delusion embedding checks per tool call. Disable for high-throughput agents — each tool call triggers up to N × M embedding calls (N rules, M open manifests) which can peg serve CPU. Defaults true; set false at product or task scope to opt out."},
 		// RC/M5 operator knobs — cadence, restart behavior, branch prefix,
 		// worktree base dir. All inherit via task → manifest → product →

--- a/internal/task/rc_m5_test.go
+++ b/internal/task/rc_m5_test.go
@@ -33,7 +33,7 @@ func insertRunningTask(t *testing.T, db *sql.DB, taskID string) {
 // qa/<id-prefix>`) is the concrete shape we assert.
 func TestBuildPrompt_BranchPrefixOverride(t *testing.T) {
 	task := &Task{ID: "019dba9f-9c5b-76ba-8221-e7e11093887f", Title: "T", Description: "D"}
-	got, err := buildPrompt(task, "M", "m body", "", "qa", nil)
+	got, err := buildPrompt(task, "M", "m body", "", runtimeKnobs{BranchPrefix: "qa"}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildPrompt: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestBuildPrompt_BranchPrefixOverride(t *testing.T) {
 // seeded DB).
 func TestBuildPrompt_EmptyBranchPrefixFallsBack(t *testing.T) {
 	task := &Task{ID: "019dba9f-9c5b-76ba-8221-e7e11093887f", Title: "T"}
-	got, err := buildPrompt(task, "M", "m body", "", "", nil)
+	got, err := buildPrompt(task, "M", "m body", "", runtimeKnobs{}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildPrompt: %v", err)
 	}

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -730,7 +730,7 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 	}
 
 	// Build the prompt
-	prompt, err := buildPrompt(t, manifestTitle, manifestContent, visceralRules, knobs.BranchPrefix, r.tmpl)
+	prompt, err := buildPrompt(t, manifestTitle, manifestContent, visceralRules, knobs, r.tmpl, r.executionLog, r.commentsStore)
 	if err != nil {
 		return fmt.Errorf("build prompt: %w", err)
 	}
@@ -1581,16 +1581,31 @@ func (r *Runner) GetOutput(taskID string) ([]string, bool) {
 	return rt.Output, true
 }
 
-// buildPrompt assembles the runner's task prompt from the seven prompt
-// sections (RC/M1 read substrate). Each section body is resolved via
-// tmpl (task → manifest → product → agent → system) and rendered as a
+// defaultModelContextChars is the fallback context-window size used for
+// prompt budget calculations. Multiplied by knobs.PromptMaxContextPct to
+// yield the byte budget that PriorRuns + OtherComments must fit within.
+// Hardcoded number is centralized here so tuning is a single edit.
+const defaultModelContextChars = 200_000
+
+// buildPrompt assembles the runner's task prompt from the prompt sections
+// (RC/M1 read substrate). Each section body is resolved via tmpl
+// (task → manifest → product → agent → system) and rendered as a
 // text/template against a shared PromptData payload.
 //
 // When tmpl is nil, or a section resolves to "", the package defaults
 // in internal/templates are used so every historical test harness + the
 // snapshot test produce byte-identical output to the pre-RC/M1
 // hardcoded writer.
-func buildPrompt(t *Task, manifestTitle, manifestContent, visceralRules, branchPfx string, tmpl *templates.Resolver) (string, error) {
+//
+// execLog and commentsStore feed the prior_context section with run
+// digests and prior agent comments respectively. Either may be nil — the
+// section template guards on empty slices and renders nothing in that
+// case. knobs.PromptBuildTimeoutSecs bounds the history queries so a
+// slow DB cannot stall task dispatch.
+func buildPrompt(t *Task, manifestTitle, manifestContent, visceralRules string,
+	knobs runtimeKnobs, tmpl *templates.Resolver,
+	execLog *execution.Store, commentsStore *comments.Store) (string, error) {
+	branchPfx := knobs.BranchPrefix
 	if branchPfx == "" {
 		branchPfx = "openpraxis"
 	}
@@ -1611,8 +1626,63 @@ func buildPrompt(t *Task, manifestTitle, manifestContent, visceralRules, branchP
 		Now:           time.Now(),
 	}
 
+	timeoutSecs := knobs.PromptBuildTimeoutSecs
+	if timeoutSecs <= 0 {
+		timeoutSecs = 5
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSecs)*time.Second)
+	defer cancel()
+
+	if execLog != nil && knobs.PromptPriorRunsLimit > 0 {
+		rows, _ := execLog.ListByEntity(ctx, t.ID, knobs.PromptPriorRunsLimit)
+		for i, row := range rows {
+			runShort := row.RunUID
+			if len(runShort) > 8 {
+				runShort = runShort[:8]
+			}
+			line := fmt.Sprintf("Run #%d (%s) — %s/%s — %d turns, %d actions, $%.3f, %dms. Branch: %s. Lines: +%d/-%d.",
+				i+1, runShort, row.Event, row.TerminalReason,
+				row.Turns, row.Actions, row.EstimatedCostUSD, row.DurationMS,
+				row.Branch, row.LinesAdded, row.LinesRemoved)
+			if knobs.PromptMaxCommentChars > 0 && len(line) > knobs.PromptMaxCommentChars {
+				line = line[:knobs.PromptMaxCommentChars]
+			}
+			data.PriorRuns = append(data.PriorRuns, line)
+		}
+	}
+
+	if commentsStore != nil && knobs.PromptPriorCommentsLimit > 0 {
+		ct := comments.TypeComment
+		cms, _ := commentsStore.List(ctx, comments.TargetEntity, t.ID, knobs.PromptPriorCommentsLimit, &ct)
+		for _, c := range cms {
+			body := c.Body
+			if knobs.PromptMaxCommentChars > 0 && len(body) > knobs.PromptMaxCommentChars {
+				body = body[:knobs.PromptMaxCommentChars] + "\n[truncated]"
+			}
+			data.OtherComments = append(data.OtherComments, body)
+		}
+	}
+
+	if knobs.PromptMaxContextPct > 0 {
+		budget := int(float64(defaultModelContextChars) * knobs.PromptMaxContextPct)
+		used := 0
+		for _, s := range data.PriorRuns {
+			used += len(s)
+		}
+		for _, s := range data.OtherComments {
+			used += len(s)
+		}
+		for used > budget && len(data.PriorRuns) > 0 {
+			used -= len(data.PriorRuns[len(data.PriorRuns)-1])
+			data.PriorRuns = data.PriorRuns[:len(data.PriorRuns)-1]
+		}
+		for used > budget && len(data.OtherComments) > 0 {
+			used -= len(data.OtherComments[len(data.OtherComments)-1])
+			data.OtherComments = data.OtherComments[:len(data.OtherComments)-1]
+		}
+	}
+
 	defaults := templates.SystemDefaults()
-	ctx := context.Background()
 
 	var b strings.Builder
 	for _, section := range templates.Sections {

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -534,6 +534,16 @@ type runtimeKnobs struct {
 	AllowedTools    []string
 	BranchPrefix    string
 	WorktreeBaseDir string
+
+	// Prompt-context knobs — drive the prior_context section of the agent
+	// prompt. Limits and budget controls are catalog-driven so operators
+	// can dial the prior-runs / prior-comments injection per scope without
+	// a code change. See internal/settings/catalog.go for descriptions.
+	PromptMaxCommentChars    int
+	PromptMaxContextPct      float64
+	PromptPriorRunsLimit     int
+	PromptPriorCommentsLimit int
+	PromptBuildTimeoutSecs   int
 }
 
 // decodeRuntimeKnobs pulls the 11 execution-shaping knobs out of a
@@ -583,6 +593,21 @@ func decodeRuntimeKnobs(all map[string]settings.Resolved) (runtimeKnobs, error) 
 	}
 	if k.WorktreeBaseDir == "" {
 		k.WorktreeBaseDir = workspaceRoot
+	}
+	if k.PromptMaxCommentChars, err = resolvedInt(all["prompt_max_comment_chars"].Value); err != nil {
+		return k, fmt.Errorf("prompt_max_comment_chars: %w", err)
+	}
+	if k.PromptMaxContextPct, err = resolvedFloat(all["prompt_max_context_pct"].Value); err != nil {
+		return k, fmt.Errorf("prompt_max_context_pct: %w", err)
+	}
+	if k.PromptPriorRunsLimit, err = resolvedInt(all["prompt_prior_runs_limit"].Value); err != nil {
+		return k, fmt.Errorf("prompt_prior_runs_limit: %w", err)
+	}
+	if k.PromptPriorCommentsLimit, err = resolvedInt(all["prompt_prior_comments_limit"].Value); err != nil {
+		return k, fmt.Errorf("prompt_prior_comments_limit: %w", err)
+	}
+	if k.PromptBuildTimeoutSecs, err = resolvedInt(all["prompt_build_timeout_seconds"].Value); err != nil {
+		return k, fmt.Errorf("prompt_build_timeout_seconds: %w", err)
 	}
 	return k, nil
 }

--- a/internal/task/runner_exec_review_test.go
+++ b/internal/task/runner_exec_review_test.go
@@ -61,7 +61,7 @@ func openAmnesiaDB(t *testing.T) *action.Store {
 // finishing, and must interpolate the full task ID into target_id.
 func TestRunner_PromptTemplate_IncludesClosingSection(t *testing.T) {
 	task := &Task{ID: "019da142-479c-70d2-865b-d6e593883e3f", Title: "demo"}
-	got, err := buildPrompt(task, "Manifest X", "manifest body", "rules body", "openpraxis", nil)
+	got, err := buildPrompt(task, "Manifest X", "manifest body", "rules body", runtimeKnobs{BranchPrefix: "openpraxis"}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildPrompt: %v", err)
 	}

--- a/internal/task/runner_prior_context_test.go
+++ b/internal/task/runner_prior_context_test.go
@@ -1,0 +1,234 @@
+package task
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/k8nstantin/OpenPraxis/internal/comments"
+	"github.com/k8nstantin/OpenPraxis/internal/execution"
+)
+
+// openPriorContextStores spins up an in-memory sqlite DB with the
+// execution_log + comments schemas and returns wired stores. Used by
+// the prior_context tests below to exercise the real query path
+// buildPrompt takes against `*execution.Store` and `*comments.Store`.
+func openPriorContextStores(t *testing.T) (*execution.Store, *comments.Store) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", "file::memory:?cache=shared&_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := execution.InitSchema(db); err != nil {
+		t.Fatalf("execution InitSchema: %v", err)
+	}
+	if err := comments.InitSchema(db); err != nil {
+		t.Fatalf("comments InitSchema: %v", err)
+	}
+	return execution.NewStore(db), comments.NewStore(db)
+}
+
+// seedRun inserts one execution_log row for entityID with the supplied
+// summary fields. RunUID is derived from suffix so the test can assert
+// the rendered run digest deterministically.
+func seedRun(t *testing.T, store *execution.Store, entityID, runSuffix string, turns, actions int, cost float64) {
+	t.Helper()
+	row := execution.Row{
+		RunUID:           "run-" + runSuffix + "-aaaaaaaa",
+		EntityUID:        entityID,
+		Event:            execution.EventCompleted,
+		TerminalReason:   "success",
+		Turns:            turns,
+		Actions:          actions,
+		EstimatedCostUSD: cost,
+		DurationMS:       1234,
+		Branch:           "openpraxis/" + entityID,
+		LinesAdded:       10,
+		LinesRemoved:     2,
+		CreatedBy:        "test",
+	}
+	if err := store.Insert(context.Background(), row); err != nil {
+		t.Fatalf("insert run %s: %v", runSuffix, err)
+	}
+	// Stagger created_at so ListByEntity ordering is stable across rows.
+	time.Sleep(2 * time.Millisecond)
+}
+
+// TestBuildPrompt_PriorRuns_RenderedInBlock asserts that two completed
+// runs in execution_log render into the <prior_context> section of the
+// prompt with a distinct line per run.
+func TestBuildPrompt_PriorRuns_RenderedInBlock(t *testing.T) {
+	exec, cmt := openPriorContextStores(t)
+	taskID := "019dba9f-9c5b-76ba-8221-e7e11093887f"
+	seedRun(t, exec, taskID, "first", 5, 12, 0.123)
+	seedRun(t, exec, taskID, "secnd", 7, 20, 0.456)
+
+	knobs := runtimeKnobs{
+		BranchPrefix:           "openpraxis",
+		PromptMaxCommentChars:  2000,
+		PromptMaxContextPct:    0.40,
+		PromptPriorRunsLimit:   5,
+		PromptBuildTimeoutSecs: 5,
+	}
+	got, err := buildPrompt(&Task{ID: taskID, Title: "T"}, "M", "m body", "", knobs, nil, exec, cmt)
+	if err != nil {
+		t.Fatalf("buildPrompt: %v", err)
+	}
+	if !strings.Contains(got, "<prior_context>") {
+		t.Fatalf("prompt missing <prior_context> block; got:\n%s", got)
+	}
+	if !strings.Contains(got, "## Prior Runs") {
+		t.Fatalf("prior_context missing 'Prior Runs' header; got:\n%s", got)
+	}
+	if !strings.Contains(got, "Run #1 (run-secn)") || !strings.Contains(got, "Run #2 (run-firs)") {
+		t.Fatalf("prior_context missing both run digests (newest-first, 8-char run uid); got:\n%s", got)
+	}
+}
+
+// TestBuildPrompt_PriorRuns_FirstRunOmitsBlock — when no execution_log
+// rows exist for the task, the prior_context section must render empty
+// (template guard) and the block markers must not appear at all.
+func TestBuildPrompt_PriorRuns_FirstRunOmitsBlock(t *testing.T) {
+	exec, cmt := openPriorContextStores(t)
+	knobs := runtimeKnobs{
+		BranchPrefix:             "openpraxis",
+		PromptMaxCommentChars:    2000,
+		PromptMaxContextPct:      0.40,
+		PromptPriorRunsLimit:     5,
+		PromptPriorCommentsLimit: 3,
+		PromptBuildTimeoutSecs:   5,
+	}
+	got, err := buildPrompt(&Task{ID: "no-history-task", Title: "T"}, "M", "m body", "", knobs, nil, exec, cmt)
+	if err != nil {
+		t.Fatalf("buildPrompt: %v", err)
+	}
+	if strings.Contains(got, "<prior_context>") {
+		t.Fatalf("prior_context block should be absent on first run; got:\n%s", got)
+	}
+}
+
+// TestBuildPrompt_PriorRunsLimit_ZeroDisables verifies that
+// PromptPriorRunsLimit=0 fully disables run injection even when rows
+// exist. Combined with PromptPriorCommentsLimit=0 the block must
+// disappear entirely.
+func TestBuildPrompt_PriorRunsLimit_ZeroDisables(t *testing.T) {
+	exec, cmt := openPriorContextStores(t)
+	taskID := "limit-zero-task"
+	seedRun(t, exec, taskID, "first", 3, 5, 0.05)
+
+	knobs := runtimeKnobs{
+		BranchPrefix:             "openpraxis",
+		PromptMaxCommentChars:    2000,
+		PromptMaxContextPct:      0.40,
+		PromptPriorRunsLimit:     0,
+		PromptPriorCommentsLimit: 0,
+		PromptBuildTimeoutSecs:   5,
+	}
+	got, err := buildPrompt(&Task{ID: taskID, Title: "T"}, "M", "m body", "", knobs, nil, exec, cmt)
+	if err != nil {
+		t.Fatalf("buildPrompt: %v", err)
+	}
+	if strings.Contains(got, "<prior_context>") {
+		t.Fatalf("prior_context must be absent when limits are 0; got:\n%s", got)
+	}
+}
+
+// TestBuildPrompt_BudgetOverflow_DropsOldest — when the combined size
+// of PriorRuns exceeds budget=defaultModelContextChars*pct, the oldest
+// entries (tail of the slice) are dropped first until the sum fits.
+// PriorRuns is newest-first (matching ListByEntity DESC ordering), so
+// the tail is the oldest.
+func TestBuildPrompt_BudgetOverflow_DropsOldest(t *testing.T) {
+	exec, cmt := openPriorContextStores(t)
+	taskID := "budget-overflow-task"
+	// Three runs — each digest line is well under 2000 chars but sum ~600 chars.
+	seedRun(t, exec, taskID, "oldst", 1, 1, 0.01)
+	seedRun(t, exec, taskID, "midle", 2, 2, 0.02)
+	seedRun(t, exec, taskID, "newst", 3, 3, 0.03)
+
+	// pct chosen so budget = 200_000 * pct < 2 * line length.
+	// One digest line is roughly 130 chars; pct=0.001 → budget=200 chars,
+	// which fits one line and forces dropping the oldest two.
+	knobs := runtimeKnobs{
+		BranchPrefix:           "openpraxis",
+		PromptMaxCommentChars:  2000,
+		PromptMaxContextPct:    0.001,
+		PromptPriorRunsLimit:   5,
+		PromptBuildTimeoutSecs: 5,
+	}
+	got, err := buildPrompt(&Task{ID: taskID, Title: "T"}, "M", "m body", "", knobs, nil, exec, cmt)
+	if err != nil {
+		t.Fatalf("buildPrompt: %v", err)
+	}
+	if !strings.Contains(got, "<prior_context>") {
+		t.Fatalf("budget overflow should still keep at least one run; got:\n%s", got)
+	}
+	// Run UIDs are truncated to 8 chars in the digest line. "run-newst" → "run-news",
+	// "run-oldst" → "run-olds". Newest must survive; oldest must be dropped.
+	if !strings.Contains(got, "run-news") {
+		t.Fatalf("newest run digest should survive budget pruning; got:\n%s", got)
+	}
+	if strings.Contains(got, "run-olds") {
+		t.Fatalf("oldest run digest should be dropped first under budget; got:\n%s", got)
+	}
+}
+
+// TestBuildPrompt_OtherComments_RenderedInBlock — agent-authored
+// comments on the task surface as the "Related Comments" subsection.
+func TestBuildPrompt_OtherComments_RenderedInBlock(t *testing.T) {
+	exec, cmt := openPriorContextStores(t)
+	taskID := "comments-task"
+	if _, err := cmt.Add(context.Background(), comments.TargetEntity, taskID, "agent", comments.TypeComment, "first finding"); err != nil {
+		t.Fatalf("add comment: %v", err)
+	}
+
+	knobs := runtimeKnobs{
+		BranchPrefix:             "openpraxis",
+		PromptMaxCommentChars:    2000,
+		PromptMaxContextPct:      0.40,
+		PromptPriorCommentsLimit: 3,
+		PromptBuildTimeoutSecs:   5,
+	}
+	got, err := buildPrompt(&Task{ID: taskID, Title: "T"}, "M", "m body", "", knobs, nil, exec, cmt)
+	if err != nil {
+		t.Fatalf("buildPrompt: %v", err)
+	}
+	if !strings.Contains(got, "## Related Comments") {
+		t.Fatalf("prior_context missing 'Related Comments' header; got:\n%s", got)
+	}
+	if !strings.Contains(got, "first finding") {
+		t.Fatalf("comment body missing from prior_context; got:\n%s", got)
+	}
+}
+
+// TestBuildPrompt_PromptBuildTimeout_DoesNotHang — a 1-second timeout
+// must not cause buildPrompt to error or stall on the happy path. This
+// confirms the bounded context replaces the prior context.Background()
+// without breaking normal queries (regression guard).
+func TestBuildPrompt_PromptBuildTimeout_DoesNotHang(t *testing.T) {
+	exec, cmt := openPriorContextStores(t)
+	knobs := runtimeKnobs{
+		BranchPrefix:           "openpraxis",
+		PromptMaxCommentChars:  2000,
+		PromptMaxContextPct:    0.40,
+		PromptPriorRunsLimit:   5,
+		PromptBuildTimeoutSecs: 1,
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if _, err := buildPrompt(&Task{ID: "timeout-task", Title: "T"}, "M", "m body", "", knobs, nil, exec, cmt); err != nil {
+			t.Errorf("buildPrompt under 1s timeout: %v", err)
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("buildPrompt did not return within 3s under PromptBuildTimeoutSecs=1")
+	}
+}

--- a/internal/task/runner_prompt_snapshot_test.go
+++ b/internal/task/runner_prompt_snapshot_test.go
@@ -91,7 +91,7 @@ func TestRunner_BuildPrompt_ByteIdentical(t *testing.T) {
 
 	legacy := legacyBuildPrompt(sample, manifestTitle, manifestContent, visceralRules)
 
-	got, err := buildPrompt(sample, manifestTitle, manifestContent, visceralRules, "openpraxis", nil)
+	got, err := buildPrompt(sample, manifestTitle, manifestContent, visceralRules, runtimeKnobs{BranchPrefix: "openpraxis"}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildPrompt: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestRunner_BuildPrompt_ByteIdentical(t *testing.T) {
 // render as an empty wrapper.
 func TestRunner_BuildPrompt_VisceralRulesEmpty(t *testing.T) {
 	sample := &Task{ID: "abc", Title: "x"}
-	got, err := buildPrompt(sample, "M", "m body", "", "openpraxis", nil)
+	got, err := buildPrompt(sample, "M", "m body", "", runtimeKnobs{BranchPrefix: "openpraxis"}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildPrompt: %v", err)
 	}

--- a/internal/task/runner_test.go
+++ b/internal/task/runner_test.go
@@ -375,6 +375,45 @@ func TestRunner_Execute_UsesResolvedTimeout(t *testing.T) {
 	}
 }
 
+// TestRunner_Execute_PromptKnobsDecodeCatalogDefaults —
+// All five prompt-context fields on runtimeKnobs must decode cleanly when no
+// scope-specific overrides exist. The catalog defaults are the operator-facing
+// contract for first-run behavior — drift here breaks every task that relies on
+// inheritance falling through to the system tier.
+func TestRunner_Execute_PromptKnobsDecodeCatalogDefaults(t *testing.T) {
+	r, _, tasks, manifests := newRunnerHarness(t)
+	wireTask(tasks, manifests, "t-pk", "m-pk", "prod-pk")
+
+	ctx := context.Background()
+	scope, _, err := r.resolveMaxParallel(ctx, "t-pk")
+	if err != nil {
+		t.Fatalf("resolveMaxParallel: %v", err)
+	}
+	all, err := r.resolver.ResolveAll(ctx, scope)
+	if err != nil {
+		t.Fatalf("ResolveAll: %v", err)
+	}
+	knobs, err := decodeRuntimeKnobs(all)
+	if err != nil {
+		t.Fatalf("decodeRuntimeKnobs: %v", err)
+	}
+	if knobs.PromptMaxCommentChars != 2000 {
+		t.Errorf("PromptMaxCommentChars = %d, want 2000", knobs.PromptMaxCommentChars)
+	}
+	if knobs.PromptMaxContextPct != 0.4 {
+		t.Errorf("PromptMaxContextPct = %v, want 0.4", knobs.PromptMaxContextPct)
+	}
+	if knobs.PromptPriorRunsLimit != 5 {
+		t.Errorf("PromptPriorRunsLimit = %d, want 5", knobs.PromptPriorRunsLimit)
+	}
+	if knobs.PromptPriorCommentsLimit != 3 {
+		t.Errorf("PromptPriorCommentsLimit = %d, want 3", knobs.PromptPriorCommentsLimit)
+	}
+	if knobs.PromptBuildTimeoutSecs != 5 {
+		t.Errorf("PromptBuildTimeoutSecs = %d, want 5", knobs.PromptBuildTimeoutSecs)
+	}
+}
+
 // TestRunner_Execute_PerTaskAgentOverridesResolved —
 // The t.Agent column still wins over the resolver default. Tested via the
 // chooseAgent helper so the override rule is exercised without spawning a

--- a/internal/templates/defaults.go
+++ b/internal/templates/defaults.go
@@ -26,6 +26,13 @@ const defaultManifestSpec = `<manifest_spec title={{printf "%q" .Manifest.Title}
 
 `
 
+const defaultPriorContext = `{{if or .PriorRuns .OtherComments}}<prior_context>
+{{if .PriorRuns}}## Prior Runs
+{{range .PriorRuns}}{{.}}
+{{end}}{{end}}{{if .OtherComments}}## Related Comments
+{{range .OtherComments}}{{.}}
+{{end}}{{end}}</prior_context>{{end}}`
+
 const defaultTask = `<task title={{printf "%q" .Task.Title}} id={{printf "%q" .Task.ID}}>
 {{if .Task.Description}}{{.Task.Description}}
 {{end}}</task>
@@ -84,6 +91,7 @@ func SystemDefaults() map[string]string {
 		SectionPreamble:        defaultPreamble,
 		SectionVisceralRules:   defaultVisceralRules,
 		SectionManifestSpec:    defaultManifestSpec,
+		SectionPriorContext:    defaultPriorContext,
 		SectionTask:            defaultTask,
 		SectionInstructions:    defaultInstructions,
 		SectionGitWorkflow:     defaultGitWorkflow,
@@ -97,6 +105,7 @@ func SystemDefaultTitles() map[string]string {
 		SectionPreamble:        "System preamble",
 		SectionVisceralRules:   "Visceral rules block",
 		SectionManifestSpec:    "Manifest spec block",
+		SectionPriorContext:    "Prior context block",
 		SectionTask:            "Task block",
 		SectionInstructions:    "Instructions block",
 		SectionGitWorkflow:     "Git workflow block",
@@ -127,6 +136,13 @@ const markdownManifestSpec = `## Manifest: {{.Manifest.Title}}
 {{.Manifest.Content}}
 
 `
+
+const markdownPriorContext = `{{if or .PriorRuns .OtherComments}}## Prior Context
+{{if .PriorRuns}}### Prior Runs
+{{range .PriorRuns}}{{.}}
+{{end}}{{end}}{{if .OtherComments}}### Related Comments
+{{range .OtherComments}}{{.}}
+{{end}}{{end}}{{end}}`
 
 const markdownTask = `## Task: {{.Task.Title}} ({{.Task.ID}})
 
@@ -199,6 +215,7 @@ func AgentDefaults(agent string) map[string]string {
 		SectionPreamble:        preamble,
 		SectionVisceralRules:   markdownVisceralRules,
 		SectionManifestSpec:    markdownManifestSpec,
+		SectionPriorContext:    markdownPriorContext,
 		SectionTask:            markdownTask,
 		SectionInstructions:    markdownInstructions,
 		SectionGitWorkflow:     markdownGitWorkflow,
@@ -226,6 +243,7 @@ func AgentDefaultTitles(agent string) map[string]string {
 		SectionPreamble:        prefix + "preamble (markdown)",
 		SectionVisceralRules:   prefix + "visceral rules (markdown)",
 		SectionManifestSpec:    prefix + "manifest spec (markdown)",
+		SectionPriorContext:    prefix + "prior context (markdown)",
 		SectionTask:            prefix + "task block (markdown)",
 		SectionInstructions:    prefix + "instructions (markdown)",
 		SectionGitWorkflow:     prefix + "git workflow (markdown)",

--- a/internal/templates/model.go
+++ b/internal/templates/model.go
@@ -14,6 +14,7 @@ var Sections = []string{
 	SectionPreamble,
 	SectionVisceralRules,
 	SectionManifestSpec,
+	SectionPriorContext,
 	SectionTask,
 	SectionInstructions,
 	SectionGitWorkflow,
@@ -24,6 +25,7 @@ const (
 	SectionPreamble        = "preamble"
 	SectionVisceralRules   = "visceral_rules"
 	SectionManifestSpec    = "manifest_spec"
+	SectionPriorContext    = "prior_context"
 	SectionTask            = "task"
 	SectionInstructions    = "instructions"
 	SectionGitWorkflow     = "git_workflow"

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -44,12 +44,11 @@ func openTestDB(t *testing.T) *sql.DB {
 	return db
 }
 
-// TestSeed_InsertsSevenSystemRows verifies acceptance #1 from RC/M1:
-// fresh DB → seed writes exactly seven active system rows, one per
-// section. With RC/M6 layered on top, the total row count is system(7)
-// + codex(7) + cursor(7) = 21, so this test scopes its count to the
-// system tier.
-func TestSeed_InsertsSevenSystemRows(t *testing.T) {
+// TestSeed_InsertsSystemRows verifies acceptance #1 from RC/M1:
+// fresh DB → seed writes one active system row per section. M1 adds
+// SectionPriorContext, raising the count to 8. With RC/M6 layered on
+// top, agent rows mirror the same set per seeded agent.
+func TestSeed_InsertsSystemRows(t *testing.T) {
 	db := openTestDB(t)
 	store := NewStore(db)
 	ctx := context.Background()
@@ -58,20 +57,21 @@ func TestSeed_InsertsSevenSystemRows(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 
+	want := len(SystemDefaults())
 	var sys int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM prompt_templates WHERE scope='system'`).Scan(&sys); err != nil {
 		t.Fatalf("count: %v", err)
 	}
-	if sys != 7 {
-		t.Fatalf("system row count = %d, want 7", sys)
+	if sys != want {
+		t.Fatalf("system row count = %d, want %d", sys, want)
 	}
 
 	rows, err := store.List(ctx, ScopeSystem, "")
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
-	if len(rows) != 7 {
-		t.Fatalf("system rows = %d, want 7", len(rows))
+	if len(rows) != want {
+		t.Fatalf("system rows = %d, want %d", len(rows), want)
 	}
 
 	seen := map[string]bool{}
@@ -114,19 +114,23 @@ func TestSeed_Idempotent(t *testing.T) {
 	_ = db.QueryRow(`SELECT COUNT(*) FROM prompt_templates`).Scan(&total)
 	_ = db.QueryRow(`SELECT COUNT(*) FROM prompt_templates WHERE scope='system'`).Scan(&sys)
 	_ = db.QueryRow(`SELECT COUNT(*) FROM prompt_templates WHERE scope='agent'`).Scan(&agent)
-	if sys != 7 {
-		t.Fatalf("after re-seed system count = %d, want 7", sys)
+	wantSys := len(SystemDefaults())
+	wantAgentEach := len(AgentDefaults(SeededAgents[0]))
+	wantAgent := wantAgentEach * len(SeededAgents)
+	wantTotal := wantSys + wantAgent
+	if sys != wantSys {
+		t.Fatalf("after re-seed system count = %d, want %d", sys, wantSys)
 	}
-	if agent != 14 {
-		t.Fatalf("after re-seed agent count = %d, want 14", agent)
+	if agent != wantAgent {
+		t.Fatalf("after re-seed agent count = %d, want %d", agent, wantAgent)
 	}
-	if total != 21 {
-		t.Fatalf("after re-seed total count = %d, want 21", total)
+	if total != wantTotal {
+		t.Fatalf("after re-seed total count = %d, want %d", total, wantTotal)
 	}
 }
 
 // TestSeed_InsertsAgentRows verifies RC/M6 acceptance #1: fresh seed
-// writes 14 active agent-scope rows (7 codex + 7 cursor).
+// writes one active agent-scope row per section, per seeded agent.
 func TestSeed_InsertsAgentRows(t *testing.T) {
 	db := openTestDB(t)
 	store := NewStore(db)
@@ -140,8 +144,10 @@ func TestSeed_InsertsAgentRows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list agent: %v", err)
 	}
-	if len(rows) != 14 {
-		t.Fatalf("agent rows = %d, want 14", len(rows))
+	wantPerAgent := len(AgentDefaults(SeededAgents[0]))
+	wantTotal := wantPerAgent * len(SeededAgents)
+	if len(rows) != wantTotal {
+		t.Fatalf("agent rows = %d, want %d", len(rows), wantTotal)
 	}
 
 	byAgent := map[string]map[string]string{}
@@ -153,8 +159,8 @@ func TestSeed_InsertsAgentRows(t *testing.T) {
 	}
 	for _, agent := range SeededAgents {
 		sections := byAgent[agent]
-		if len(sections) != 7 {
-			t.Fatalf("%s rows = %d, want 7", agent, len(sections))
+		if len(sections) != wantPerAgent {
+			t.Fatalf("%s rows = %d, want %d", agent, len(sections), wantPerAgent)
 		}
 		for _, s := range Sections {
 			if sections[s] == "" {
@@ -195,8 +201,9 @@ func TestSeed_IdempotentPerBucket(t *testing.T) {
 	for _, agent := range SeededAgents {
 		var n int
 		_ = db.QueryRow(`SELECT COUNT(*) FROM prompt_templates WHERE scope='agent' AND scope_id=?`, agent).Scan(&n)
-		if n != 7 {
-			t.Fatalf("agent %s rows = %d, want 7", agent, n)
+		want := len(AgentDefaults(agent))
+		if n != want {
+			t.Fatalf("agent %s rows = %d, want %d", agent, n, want)
 		}
 	}
 }
@@ -344,6 +351,48 @@ func TestResolver_AgentScope(t *testing.T) {
 	}
 	if !strings.Contains(pCursor, "Cursor") {
 		t.Errorf("cursor preamble missing Cursor identifier: %q", pCursor)
+	}
+}
+
+// TestRender_PriorContext verifies M1/T2 acceptance: the prior_context
+// section renders empty when both PriorRuns and OtherComments are nil
+// (first run — no regression) and renders a wrapped <prior_context>
+// block when either slice is populated.
+func TestRender_PriorContext(t *testing.T) {
+	body := SystemDefaults()[SectionPriorContext]
+
+	empty, err := Render(body, PromptData{})
+	if err != nil {
+		t.Fatalf("render empty: %v", err)
+	}
+	if empty != "" {
+		t.Errorf("empty render = %q, want empty string", empty)
+	}
+
+	full, err := Render(body, PromptData{
+		PriorRuns:     []string{"Run #1 — 5 turns, $0.10"},
+		OtherComments: []string{"prior agent finding"},
+	})
+	if err != nil {
+		t.Fatalf("render full: %v", err)
+	}
+	if !strings.Contains(full, "<prior_context>") || !strings.Contains(full, "</prior_context>") {
+		t.Errorf("populated render missing wrapper tags: %q", full)
+	}
+	if !strings.Contains(full, "Run #1 — 5 turns, $0.10") {
+		t.Errorf("populated render missing prior run line: %q", full)
+	}
+	if !strings.Contains(full, "prior agent finding") {
+		t.Errorf("populated render missing comment body: %q", full)
+	}
+
+	// Either slice alone is sufficient to emit the block.
+	runsOnly, err := Render(body, PromptData{PriorRuns: []string{"x"}})
+	if err != nil {
+		t.Fatalf("render runs-only: %v", err)
+	}
+	if !strings.Contains(runsOnly, "<prior_context>") {
+		t.Errorf("runs-only render missing wrapper: %q", runsOnly)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements M1 of the Trace-Grounded Feedback Loop product. Every task run now receives a `<prior_context>` block containing digests of prior executions and prior agent comments. Agents stop repeating known mistakes on retries.

## Changes

**T1 — `internal/settings/catalog.go`, `internal/task/runner.go`**
- 3 new Prompt Context knobs: `prompt_prior_runs_limit` (default 5), `prompt_prior_comments_limit` (default 3), `prompt_build_timeout_seconds` (default 5s)
- 5 new fields on `runtimeKnobs`: `PromptMaxCommentChars`, `PromptMaxContextPct`, `PromptPriorRunsLimit`, `PromptPriorCommentsLimit`, `PromptBuildTimeoutSecs`

**T2 — `internal/templates/model.go`, `internal/templates/defaults.go`**
- New `SectionPriorContext = "prior_context"` at position 3 (between `manifest_spec` and `task`)
- Default body renders `<prior_context>` block; renders empty string on first run (nil slices)

**T3 — `internal/task/runner.go`**
- `buildPrompt` extended to accept `runtimeKnobs`, `*execution.Store`, `*comments.Store`
- `const defaultModelContextChars = 200_000` — no hardcoded literals
- Bounded context via `PromptBuildTimeoutSecs` — no more `context.Background()` hang risk
- Prior run digests formatted: `Run #N (sha[:8]) — event/terminal_reason — turns, actions, cost, duration, branch, lines`
- Budget enforcement drops oldest entries first when over `PromptMaxContextPct × defaultModelContextChars`
- 234-line test file `runner_prior_context_test.go` + 39 lines added to `runner_test.go`

## Test coverage

- First run (no history) → `<prior_context>` absent
- Task with 2 prior runs → block present with both entries
- `prompt_prior_runs_limit=0` → block absent
- Budget overflow → oldest entries dropped first
- All existing prompt render tests still pass

## Part of

Product `019e0d76` — Trace-Grounded Feedback Loop — Meta-Harness for OpenPraxis
Manifest `019e0d97-fb05` — M1 Prompt Context Wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)