### PR TITLE
feat(M2): Frontier Queries and Pass-Rate API

### DIFF
--- a/internal/execution/store.go
+++ b/internal/execution/store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -21,6 +22,14 @@ const (
 	EventCompleted = "completed"
 	EventFailed    = "failed"
 	EventTurn      = "turn" // one row per turn boundary; Turns field holds the turn number
+)
+
+// Terminal-reason values populated on terminal (completed/failed) rows.
+// Used for pass-rate classification — see PassRateByEntity.
+const (
+	TerminalReasonSuccess  = "success"
+	TerminalReasonMaxTurns = "max_turns"
+	TerminalReasonTimeout  = "timeout"
 )
 
 // Row is one append-only event row in execution_log.
@@ -96,6 +105,21 @@ type Row struct {
 	TestsPassed        int      `json:"tests_passed"`
 	TestsFailed        int      `json:"tests_failed"`
 	AgentPID           int      `json:"agent_pid"` // OS PID of the spawned agent process; 0 if unknown
+}
+
+// PassRateSummary aggregates terminal execution-log rows for one entity.
+// TotalRuns == 0 means the entity has never run — callers must check this
+// before treating PassRate as meaningful.
+type PassRateSummary struct {
+	EntityUID    string
+	TotalRuns    int
+	SuccessRuns  int
+	FailedRuns   int
+	MaxTurnsRuns int
+	TimeoutRuns  int
+	AvgTurns     float64
+	AvgCostUSD   float64
+	PassRate     float64 // SuccessRuns / TotalRuns; 0.0 when TotalRuns == 0
 }
 
 // OutputChunk is one live text chunk in execution_output.
@@ -496,6 +520,102 @@ func (s *Store) HasCompletedSince(ctx context.Context, entityUID string, since t
 		return false, fmt.Errorf("execution: has completed since: %w", err)
 	}
 	return n > 0, nil
+}
+
+// PassRateByEntity aggregates terminal execution-log rows for a single entity
+// over the trailing windowDays window (windowDays <= 0 disables the filter).
+// Returns a zero summary tagged with entityUID when the entity has never run.
+func (s *Store) PassRateByEntity(ctx context.Context, entityUID string, windowDays int) (PassRateSummary, error) {
+	if entityUID == "" {
+		return PassRateSummary{}, ErrEmptyEntityID
+	}
+	m, err := s.FrontierByManifest(ctx, []string{entityUID}, windowDays)
+	if err != nil {
+		return PassRateSummary{}, err
+	}
+	if sum, ok := m[entityUID]; ok {
+		return sum, nil
+	}
+	return PassRateSummary{EntityUID: entityUID}, nil
+}
+
+// FrontierByManifest aggregates terminal execution-log rows for the given
+// task IDs in a single SQL pass, classifying terminal_reason into the
+// success / max_turns / timeout / failed buckets. Tasks absent from the
+// returned map have no terminal runs in the window. Empty taskIDs returns
+// an empty (non-nil) map without querying.
+func (s *Store) FrontierByManifest(ctx context.Context, taskIDs []string, windowDays int) (map[string]PassRateSummary, error) {
+	out := make(map[string]PassRateSummary, len(taskIDs))
+	if len(taskIDs) == 0 {
+		return out, nil
+	}
+
+	placeholders := make([]string, len(taskIDs))
+	for i := range taskIDs {
+		placeholders[i] = "?"
+	}
+
+	args := make([]any, 0, 6+len(taskIDs)+1)
+	// CASE WHEN args (must precede WHERE args in placeholder order).
+	args = append(args, TerminalReasonSuccess, "")
+	args = append(args, TerminalReasonMaxTurns)
+	args = append(args, TerminalReasonTimeout)
+	// WHERE entity_uid IN (...).
+	for _, id := range taskIDs {
+		args = append(args, id)
+	}
+	// WHERE event IN (?, ?).
+	args = append(args, EventCompleted, EventFailed)
+
+	windowClause := ""
+	if windowDays > 0 {
+		cutoff := time.Now().UTC().Add(-time.Duration(windowDays) * 24 * time.Hour).Format(time.RFC3339Nano)
+		windowClause = " AND created_at >= ?"
+		args = append(args, cutoff)
+	}
+
+	query := fmt.Sprintf(`SELECT entity_uid,
+			COUNT(*),
+			SUM(CASE WHEN terminal_reason IN (?, ?) THEN 1 ELSE 0 END),
+			SUM(CASE WHEN terminal_reason = ? THEN 1 ELSE 0 END),
+			SUM(CASE WHEN terminal_reason = ? THEN 1 ELSE 0 END),
+			AVG(turns),
+			AVG(cost_usd)
+		FROM execution_log
+		WHERE entity_uid IN (%s)
+			AND event IN (?, ?)%s
+		GROUP BY entity_uid`,
+		strings.Join(placeholders, ","), windowClause)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("execution: frontier by manifest: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var sum PassRateSummary
+		if err := rows.Scan(
+			&sum.EntityUID,
+			&sum.TotalRuns,
+			&sum.SuccessRuns,
+			&sum.MaxTurnsRuns,
+			&sum.TimeoutRuns,
+			&sum.AvgTurns,
+			&sum.AvgCostUSD,
+		); err != nil {
+			return nil, fmt.Errorf("execution: frontier by manifest: scan: %w", err)
+		}
+		sum.FailedRuns = sum.TotalRuns - sum.SuccessRuns - sum.MaxTurnsRuns - sum.TimeoutRuns
+		if sum.TotalRuns > 0 {
+			sum.PassRate = float64(sum.SuccessRuns) / float64(sum.TotalRuns)
+		}
+		out[sum.EntityUID] = sum
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("execution: frontier by manifest: rows: %w", err)
+	}
+	return out, nil
 }
 
 // InFlightRun holds the minimal fields needed for zombie-process detection.

--- a/internal/execution/store_test.go
+++ b/internal/execution/store_test.go
@@ -356,6 +356,277 @@ func insertTaskRun(t *testing.T, db *sql.DB, taskID string, runNum int, status s
 	}
 }
 
+// insertTerminalRow is a small helper used by pass-rate / frontier tests.
+// It writes a terminal execution_log row with the given event, terminal_reason,
+// turns, cost, and an explicit created_at so window-filter tests can backdate.
+func insertTerminalRow(t *testing.T, s *Store, runID, entityUID, event, reason string, turns int, cost float64, createdAt time.Time) {
+	t.Helper()
+	if err := s.Insert(context.Background(), Row{
+		ID:             runID,
+		RunUID:         runID,
+		EntityUID:      entityUID,
+		Event:          event,
+		TerminalReason: reason,
+		Turns:          turns,
+		CostUSD:        cost,
+		CreatedAt:      createdAt.UTC().Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatalf("insert %s: %v", runID, err)
+	}
+}
+
+func TestFrontierByManifest_emptyTaskIDs(t *testing.T) {
+	db := openTestDB(t)
+	if err := InitSchema(db); err != nil {
+		t.Fatal(err)
+	}
+	s := NewStore(db)
+
+	got, err := s.FrontierByManifest(context.Background(), nil, 30)
+	if err != nil {
+		t.Fatalf("FrontierByManifest(nil): %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil empty map, got nil")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty map, got %d entries", len(got))
+	}
+
+	got, err = s.FrontierByManifest(context.Background(), []string{}, 30)
+	if err != nil {
+		t.Fatalf("FrontierByManifest([]): %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil empty map, got nil")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty map, got %d entries", len(got))
+	}
+}
+
+func TestPassRateByEntity_singleSuccess(t *testing.T) {
+	db := openTestDB(t)
+	if err := InitSchema(db); err != nil {
+		t.Fatal(err)
+	}
+	s := NewStore(db)
+	now := time.Now().UTC()
+	insertTerminalRow(t, s, "run-1", "task-pass", EventCompleted, TerminalReasonSuccess, 4, 0.10, now)
+
+	got, err := s.PassRateByEntity(context.Background(), "task-pass", 30)
+	if err != nil {
+		t.Fatalf("PassRateByEntity: %v", err)
+	}
+	if got.EntityUID != "task-pass" {
+		t.Errorf("EntityUID: got %q want task-pass", got.EntityUID)
+	}
+	if got.TotalRuns != 1 || got.SuccessRuns != 1 {
+		t.Errorf("counts: total=%d success=%d, want 1/1", got.TotalRuns, got.SuccessRuns)
+	}
+	if got.PassRate != 1.0 {
+		t.Errorf("PassRate: got %v want 1.0", got.PassRate)
+	}
+	if got.FailedRuns != 0 || got.MaxTurnsRuns != 0 || got.TimeoutRuns != 0 {
+		t.Errorf("non-success buckets: failed=%d max_turns=%d timeout=%d, want 0",
+			got.FailedRuns, got.MaxTurnsRuns, got.TimeoutRuns)
+	}
+}
+
+func TestPassRateByEntity_singleMaxTurns(t *testing.T) {
+	db := openTestDB(t)
+	if err := InitSchema(db); err != nil {
+		t.Fatal(err)
+	}
+	s := NewStore(db)
+	now := time.Now().UTC()
+	insertTerminalRow(t, s, "run-mt", "task-mt", EventCompleted, TerminalReasonMaxTurns, 100, 0.50, now)
+
+	got, err := s.PassRateByEntity(context.Background(), "task-mt", 30)
+	if err != nil {
+		t.Fatalf("PassRateByEntity: %v", err)
+	}
+	if got.TotalRuns != 1 || got.MaxTurnsRuns != 1 || got.SuccessRuns != 0 {
+		t.Errorf("counts: total=%d success=%d max_turns=%d, want 1/0/1",
+			got.TotalRuns, got.SuccessRuns, got.MaxTurnsRuns)
+	}
+	if got.PassRate != 0.0 {
+		t.Errorf("PassRate: got %v want 0.0", got.PassRate)
+	}
+}
+
+func TestPassRateByEntity_mixed(t *testing.T) {
+	db := openTestDB(t)
+	if err := InitSchema(db); err != nil {
+		t.Fatal(err)
+	}
+	s := NewStore(db)
+	now := time.Now().UTC()
+	insertTerminalRow(t, s, "run-a", "task-mix", EventCompleted, TerminalReasonSuccess, 5, 0.10, now)
+	insertTerminalRow(t, s, "run-b", "task-mix", EventCompleted, TerminalReasonMaxTurns, 100, 0.30, now.Add(time.Second))
+
+	got, err := s.PassRateByEntity(context.Background(), "task-mix", 30)
+	if err != nil {
+		t.Fatalf("PassRateByEntity: %v", err)
+	}
+	if got.TotalRuns != 2 {
+		t.Errorf("TotalRuns: got %d want 2", got.TotalRuns)
+	}
+	if got.SuccessRuns != 1 || got.MaxTurnsRuns != 1 {
+		t.Errorf("counts: success=%d max_turns=%d, want 1/1", got.SuccessRuns, got.MaxTurnsRuns)
+	}
+	if got.PassRate != 0.5 {
+		t.Errorf("PassRate: got %v want 0.5", got.PassRate)
+	}
+}
+
+func TestPassRateByEntity_neverRun(t *testing.T) {
+	db := openTestDB(t)
+	if err := InitSchema(db); err != nil {
+		t.Fatal(err)
+	}
+	s := NewStore(db)
+
+	got, err := s.PassRateByEntity(context.Background(), "task-ghost", 30)
+	if err != nil {
+		t.Fatalf("PassRateByEntity: %v", err)
+	}
+	if got.EntityUID != "task-ghost" {
+		t.Errorf("EntityUID: got %q want task-ghost", got.EntityUID)
+	}
+	if got.TotalRuns != 0 {
+		t.Errorf("TotalRuns: got %d want 0", got.TotalRuns)
+	}
+	if got.PassRate != 0.0 {
+		t.Errorf("PassRate: got %v want 0.0", got.PassRate)
+	}
+}
+
+func TestPassRateByEntity_classification(t *testing.T) {
+	db := openTestDB(t)
+	if err := InitSchema(db); err != nil {
+		t.Fatal(err)
+	}
+	s := NewStore(db)
+	now := time.Now().UTC()
+	// One of each terminal-reason bucket plus an arbitrary other reason.
+	insertTerminalRow(t, s, "run-s", "task-c", EventCompleted, TerminalReasonSuccess, 1, 0, now)
+	insertTerminalRow(t, s, "run-empty", "task-c", EventCompleted, "", 1, 0, now.Add(time.Millisecond))
+	insertTerminalRow(t, s, "run-mt", "task-c", EventCompleted, TerminalReasonMaxTurns, 1, 0, now.Add(2*time.Millisecond))
+	insertTerminalRow(t, s, "run-to", "task-c", EventFailed, TerminalReasonTimeout, 1, 0, now.Add(3*time.Millisecond))
+	insertTerminalRow(t, s, "run-be", "task-c", EventFailed, "build_fail", 1, 0, now.Add(4*time.Millisecond))
+	insertTerminalRow(t, s, "run-pe", "task-c", EventFailed, "process_error", 1, 0, now.Add(5*time.Millisecond))
+
+	got, err := s.PassRateByEntity(context.Background(), "task-c", 30)
+	if err != nil {
+		t.Fatalf("PassRateByEntity: %v", err)
+	}
+	if got.TotalRuns != 6 {
+		t.Errorf("TotalRuns: got %d want 6", got.TotalRuns)
+	}
+	if got.SuccessRuns != 2 {
+		t.Errorf("SuccessRuns: got %d want 2 (success + empty reason)", got.SuccessRuns)
+	}
+	if got.MaxTurnsRuns != 1 {
+		t.Errorf("MaxTurnsRuns: got %d want 1", got.MaxTurnsRuns)
+	}
+	if got.TimeoutRuns != 1 {
+		t.Errorf("TimeoutRuns: got %d want 1", got.TimeoutRuns)
+	}
+	if got.FailedRuns != 2 {
+		t.Errorf("FailedRuns: got %d want 2 (build_fail + process_error)", got.FailedRuns)
+	}
+}
+
+func TestPassRateByEntity_windowFiltersOldRows(t *testing.T) {
+	db := openTestDB(t)
+	if err := InitSchema(db); err != nil {
+		t.Fatal(err)
+	}
+	s := NewStore(db)
+	now := time.Now().UTC()
+	// One recent (in-window), one 48h old (out-of-window for windowDays=1).
+	insertTerminalRow(t, s, "run-recent", "task-win", EventCompleted, TerminalReasonSuccess, 1, 0, now)
+	insertTerminalRow(t, s, "run-old", "task-win", EventCompleted, TerminalReasonMaxTurns, 1, 0, now.Add(-48*time.Hour))
+
+	got, err := s.PassRateByEntity(context.Background(), "task-win", 1)
+	if err != nil {
+		t.Fatalf("PassRateByEntity windowDays=1: %v", err)
+	}
+	if got.TotalRuns != 1 {
+		t.Errorf("windowDays=1 TotalRuns: got %d want 1 (old row should be excluded)", got.TotalRuns)
+	}
+	if got.SuccessRuns != 1 {
+		t.Errorf("windowDays=1 SuccessRuns: got %d want 1", got.SuccessRuns)
+	}
+
+	// windowDays=30 includes both rows.
+	got, err = s.PassRateByEntity(context.Background(), "task-win", 30)
+	if err != nil {
+		t.Fatalf("PassRateByEntity windowDays=30: %v", err)
+	}
+	if got.TotalRuns != 2 {
+		t.Errorf("windowDays=30 TotalRuns: got %d want 2", got.TotalRuns)
+	}
+
+	// windowDays<=0 disables the filter — both rows included.
+	got, err = s.PassRateByEntity(context.Background(), "task-win", 0)
+	if err != nil {
+		t.Fatalf("PassRateByEntity windowDays=0: %v", err)
+	}
+	if got.TotalRuns != 2 {
+		t.Errorf("windowDays=0 TotalRuns: got %d want 2 (no filter)", got.TotalRuns)
+	}
+}
+
+func TestFrontierByManifest_perTaskMap(t *testing.T) {
+	db := openTestDB(t)
+	if err := InitSchema(db); err != nil {
+		t.Fatal(err)
+	}
+	s := NewStore(db)
+	now := time.Now().UTC()
+	insertTerminalRow(t, s, "run-a1", "task-a", EventCompleted, TerminalReasonSuccess, 3, 0.10, now)
+	insertTerminalRow(t, s, "run-a2", "task-a", EventFailed, TerminalReasonTimeout, 5, 0.20, now.Add(time.Second))
+	insertTerminalRow(t, s, "run-b1", "task-b", EventCompleted, TerminalReasonMaxTurns, 100, 0.50, now)
+	// task-c has zero runs and should be absent from result.
+
+	got, err := s.FrontierByManifest(context.Background(), []string{"task-a", "task-b", "task-c"}, 30)
+	if err != nil {
+		t.Fatalf("FrontierByManifest: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got): %d want 2 (task-c absent)", len(got))
+	}
+	if _, ok := got["task-c"]; ok {
+		t.Error("task-c should be absent from result map (no runs)")
+	}
+	a := got["task-a"]
+	if a.TotalRuns != 2 || a.SuccessRuns != 1 || a.TimeoutRuns != 1 {
+		t.Errorf("task-a: total=%d success=%d timeout=%d, want 2/1/1",
+			a.TotalRuns, a.SuccessRuns, a.TimeoutRuns)
+	}
+	if a.PassRate != 0.5 {
+		t.Errorf("task-a PassRate: got %v want 0.5", a.PassRate)
+	}
+	b := got["task-b"]
+	if b.TotalRuns != 1 || b.MaxTurnsRuns != 1 || b.PassRate != 0.0 {
+		t.Errorf("task-b: total=%d max_turns=%d pass=%v, want 1/1/0.0",
+			b.TotalRuns, b.MaxTurnsRuns, b.PassRate)
+	}
+}
+
+func TestPassRateByEntity_emptyEntityUID(t *testing.T) {
+	db := openTestDB(t)
+	if err := InitSchema(db); err != nil {
+		t.Fatal(err)
+	}
+	s := NewStore(db)
+	if _, err := s.PassRateByEntity(context.Background(), "", 30); err != ErrEmptyEntityID {
+		t.Errorf("expected ErrEmptyEntityID, got %v", err)
+	}
+}
+
 func TestBackfill_idempotent(t *testing.T) {
 	db := openTestDB(t)
 	if err := InitSchema(db); err != nil {

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -503,6 +503,7 @@ func mountAPI(api *mux.Router, deps ServerDeps) {
 	// Legacy hierarchy route — used by the product list-pane tree expansion.
 	api.HandleFunc("/products/{id}/hierarchy", apiProductHierarchy(n)).Methods("GET")
 	api.HandleFunc("/execution/live", apiExecutionLive(n)).Methods("GET")
+	api.HandleFunc("/execution/frontier", apiExecutionFrontier(n)).Methods("GET")
 	api.HandleFunc("/execution/{runUid}/output", apiExecutionOutput(n)).Methods("GET")
 	api.HandleFunc("/execution/{runUid}", apiExecutionLog(n)).Methods("GET")
 	api.HandleFunc("/delusions/by-peer", apiDelusionsByPeer(n)).Methods("GET")

--- a/internal/web/handlers_entity.go
+++ b/internal/web/handlers_entity.go
@@ -328,6 +328,12 @@ func apiExecutionLog(n *node.Node) http.HandlerFunc {
 			http.Error(w, err.Error(), 500)
 			return
 		}
+		// Recompute cost_per_turn / cost_per_action (and other ratios) so the
+		// response is correct even for legacy rows persisted before
+		// ComputeDerived was wired into the write path. Idempotent.
+		for i := range rows {
+			execution.ComputeDerived(&rows[i])
+		}
 		writeJSON(w, rows)
 	}
 }

--- a/internal/web/handlers_execution_frontier.go
+++ b/internal/web/handlers_execution_frontier.go
@@ -1,0 +1,162 @@
+package web
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/k8nstantin/OpenPraxis/internal/node"
+	"github.com/k8nstantin/OpenPraxis/internal/relationships"
+	"github.com/k8nstantin/OpenPraxis/internal/settings"
+)
+
+// defaultFrontierWindowDays is the lookback window applied when neither the
+// query string nor the `frontier_window_days` settings knob supplies one.
+const defaultFrontierWindowDays = 30
+
+// frontierTaskView is the per-task aggregate returned by /execution/frontier.
+// Mirrors execution.PassRateSummary with snake_case JSON tags so the wire
+// shape matches the response shape contracted in the M2/T2 spec.
+type frontierTaskView struct {
+	EntityUID    string  `json:"entity_uid"`
+	TotalRuns    int     `json:"total_runs"`
+	SuccessRuns  int     `json:"success_runs"`
+	FailedRuns   int     `json:"failed_runs"`
+	MaxTurnsRuns int     `json:"max_turns_runs"`
+	TimeoutRuns  int     `json:"timeout_runs"`
+	AvgTurns     float64 `json:"avg_turns"`
+	AvgCostUSD   float64 `json:"avg_cost_usd"`
+	PassRate     float64 `json:"pass_rate"`
+}
+
+// frontierBest names the highest-pass-rate task among those with runs.
+// Null in the response when the manifest has no terminal runs.
+type frontierBest struct {
+	TaskID   string  `json:"task_id"`
+	PassRate float64 `json:"pass_rate"`
+}
+
+type frontierResponse struct {
+	ManifestID  string                      `json:"manifest_id"`
+	WindowDays  int                         `json:"window_days"`
+	Tasks       map[string]frontierTaskView `json:"tasks"`
+	Best        *frontierBest               `json:"best"`
+	AvgPassRate float64                     `json:"avg_pass_rate"`
+}
+
+// resolveFrontierWindowDays reads `frontier_window_days` at system scope.
+// Falls back to defaultFrontierWindowDays when the resolver is wired but
+// the key is missing, the value is non-positive, or the type is unexpected.
+// A nil resolver also yields the default — keeps tests building a minimal
+// Node viable.
+func resolveFrontierWindowDays(r *http.Request, n *node.Node) int {
+	if n == nil || n.SettingsResolver == nil {
+		return defaultFrontierWindowDays
+	}
+	res, err := n.SettingsResolver.Resolve(r.Context(), settings.Scope{}, "frontier_window_days")
+	if err != nil {
+		return defaultFrontierWindowDays
+	}
+	switch v := res.Value.(type) {
+	case int:
+		if v > 0 {
+			return v
+		}
+	case int64:
+		if v > 0 {
+			return int(v)
+		}
+	case float64:
+		if v > 0 {
+			return int(v)
+		}
+	}
+	return defaultFrontierWindowDays
+}
+
+// apiExecutionFrontier returns per-task pass-rate aggregates for every task
+// owned by `manifest_id`, plus a manifest-wide average and the best task.
+// Tasks with zero terminal runs are omitted from the `tasks` map; the
+// avg_pass_rate denominator excludes them too. `best` is null when no task
+// has any runs.
+func apiExecutionFrontier(n *node.Node) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		manifestID := r.URL.Query().Get("manifest_id")
+		if manifestID == "" {
+			writeError(w, "manifest_id is required", http.StatusBadRequest)
+			return
+		}
+
+		windowDays := resolveFrontierWindowDays(r, n)
+		if v := r.URL.Query().Get("window_days"); v != "" {
+			if d, err := strconv.Atoi(v); err == nil && d > 0 {
+				windowDays = d
+			}
+		}
+
+		ctx := r.Context()
+
+		// Walk owns-edges out of the manifest to gather task ids. Filtering
+		// by DstKind keeps the set type-correct even if a future edge variant
+		// puts non-task children under a manifest.
+		var taskIDs []string
+		if n != nil && n.Relationships != nil {
+			edges, err := n.Relationships.ListOutgoing(ctx, manifestID, relationships.EdgeOwns)
+			if err != nil {
+				writeError(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			for _, e := range edges {
+				if e.DstKind == relationships.KindTask {
+					taskIDs = append(taskIDs, e.DstID)
+				}
+			}
+		}
+
+		summaries, err := n.ExecutionLog.FrontierByManifest(ctx, taskIDs, windowDays)
+		if err != nil {
+			writeError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		tasks := make(map[string]frontierTaskView, len(summaries))
+		var (
+			best    *frontierBest
+			passSum float64
+			counted int
+		)
+		for taskID, sum := range summaries {
+			if sum.TotalRuns == 0 {
+				continue
+			}
+			tasks[taskID] = frontierTaskView{
+				EntityUID:    sum.EntityUID,
+				TotalRuns:    sum.TotalRuns,
+				SuccessRuns:  sum.SuccessRuns,
+				FailedRuns:   sum.FailedRuns,
+				MaxTurnsRuns: sum.MaxTurnsRuns,
+				TimeoutRuns:  sum.TimeoutRuns,
+				AvgTurns:     sum.AvgTurns,
+				AvgCostUSD:   sum.AvgCostUSD,
+				PassRate:     sum.PassRate,
+			}
+			passSum += sum.PassRate
+			counted++
+			if best == nil || sum.PassRate > best.PassRate {
+				best = &frontierBest{TaskID: taskID, PassRate: sum.PassRate}
+			}
+		}
+
+		var avg float64
+		if counted > 0 {
+			avg = passSum / float64(counted)
+		}
+
+		writeJSON(w, frontierResponse{
+			ManifestID:  manifestID,
+			WindowDays:  windowDays,
+			Tasks:       tasks,
+			Best:        best,
+			AvgPassRate: avg,
+		})
+	}
+}

--- a/internal/web/handlers_execution_frontier_test.go
+++ b/internal/web/handlers_execution_frontier_test.go
@@ -1,0 +1,189 @@
+package web
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/k8nstantin/OpenPraxis/internal/execution"
+	"github.com/k8nstantin/OpenPraxis/internal/node"
+	"github.com/k8nstantin/OpenPraxis/internal/relationships"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// newFrontierNode wires the minimum stores apiExecutionFrontier touches:
+// execution_log + relationships, both backed by an isolated SQLite file.
+// SettingsResolver is left nil so the handler exercises the
+// resolver-missing fallback to defaultFrontierWindowDays.
+func newFrontierNode(t *testing.T) *node.Node {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "frontier.db")
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		t.Fatalf("set WAL: %v", err)
+	}
+	if err := execution.InitSchema(db); err != nil {
+		t.Fatalf("execution InitSchema: %v", err)
+	}
+	rels, err := relationships.New(db)
+	if err != nil {
+		t.Fatalf("relationships.New: %v", err)
+	}
+	return &node.Node{
+		ExecutionLog:  execution.NewStore(db),
+		Relationships: rels,
+	}
+}
+
+// seedTerminalRun appends one terminal execution_log row for entityID.
+// reason picks the bucket: success / max_turns / timeout / "" (counts as
+// failed via FrontierByManifest's residual classification).
+func seedTerminalRun(t *testing.T, store *execution.Store, entityID, runUID, reason string, turns int, cost float64) {
+	t.Helper()
+	event := execution.EventCompleted
+	if reason != execution.TerminalReasonSuccess && reason != "" {
+		event = execution.EventFailed
+	}
+	row := execution.Row{
+		RunUID:         runUID,
+		EntityUID:      entityID,
+		Event:          event,
+		TerminalReason: reason,
+		Turns:          turns,
+		CostUSD:        cost,
+		CreatedBy:      "test",
+	}
+	if err := store.Insert(context.Background(), row); err != nil {
+		t.Fatalf("insert run %s: %v", runUID, err)
+	}
+}
+
+func addOwnsEdge(t *testing.T, rels *relationships.Store, manifestID, taskID string) {
+	t.Helper()
+	if err := rels.Create(context.Background(), relationships.Edge{
+		SrcKind: relationships.KindManifest,
+		SrcID:   manifestID,
+		DstKind: relationships.KindTask,
+		DstID:   taskID,
+		Kind:    relationships.EdgeOwns,
+	}); err != nil {
+		t.Fatalf("create owns edge: %v", err)
+	}
+}
+
+func decodeFrontier(t *testing.T, rec *httptest.ResponseRecorder) frontierResponse {
+	t.Helper()
+	var got frontierResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v body=%s", err, rec.Body.String())
+	}
+	return got
+}
+
+func TestApiExecutionFrontier_MissingManifestID(t *testing.T) {
+	n := newFrontierNode(t)
+	rec := doGET(t, apiExecutionFrontier(n), "/api/execution/frontier")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: want 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestApiExecutionFrontier_NoTasks(t *testing.T) {
+	n := newFrontierNode(t)
+	rec := doGET(t, apiExecutionFrontier(n), "/api/execution/frontier?manifest_id=mf-empty")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rec.Code, rec.Body.String())
+	}
+	got := decodeFrontier(t, rec)
+	if got.ManifestID != "mf-empty" {
+		t.Fatalf("manifest_id mismatch: %q", got.ManifestID)
+	}
+	if got.WindowDays != defaultFrontierWindowDays {
+		t.Fatalf("window_days: want %d, got %d", defaultFrontierWindowDays, got.WindowDays)
+	}
+	if len(got.Tasks) != 0 {
+		t.Fatalf("tasks: want empty, got %+v", got.Tasks)
+	}
+	if got.Best != nil {
+		t.Fatalf("best: want nil, got %+v", got.Best)
+	}
+	if got.AvgPassRate != 0 {
+		t.Fatalf("avg_pass_rate: want 0, got %v", got.AvgPassRate)
+	}
+}
+
+func TestApiExecutionFrontier_TaskWithNoRunsAbsent(t *testing.T) {
+	n := newFrontierNode(t)
+	addOwnsEdge(t, n.Relationships, "mf-1", "tk-runs")
+	addOwnsEdge(t, n.Relationships, "mf-1", "tk-noruns")
+	seedTerminalRun(t, n.ExecutionLog, "tk-runs", "run-1aaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", execution.TerminalReasonSuccess, 4, 0.10)
+
+	rec := doGET(t, apiExecutionFrontier(n), "/api/execution/frontier?manifest_id=mf-1")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rec.Code, rec.Body.String())
+	}
+	got := decodeFrontier(t, rec)
+	if _, ok := got.Tasks["tk-noruns"]; ok {
+		t.Fatalf("task with zero runs should be absent from tasks map: %+v", got.Tasks)
+	}
+	if _, ok := got.Tasks["tk-runs"]; !ok {
+		t.Fatalf("task with runs missing: %+v", got.Tasks)
+	}
+	if got.AvgPassRate != 1.0 {
+		t.Fatalf("avg_pass_rate: want 1.0, got %v", got.AvgPassRate)
+	}
+	if got.Best == nil || got.Best.TaskID != "tk-runs" || got.Best.PassRate != 1.0 {
+		t.Fatalf("best mismatch: %+v", got.Best)
+	}
+}
+
+func TestApiExecutionFrontier_BestAndAvgAcrossTasks(t *testing.T) {
+	n := newFrontierNode(t)
+	addOwnsEdge(t, n.Relationships, "mf-2", "tk-A")
+	addOwnsEdge(t, n.Relationships, "mf-2", "tk-B")
+	// tk-A: 2 success, 2 failure → 0.5
+	seedTerminalRun(t, n.ExecutionLog, "tk-A", "run-a1aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", execution.TerminalReasonSuccess, 5, 0.20)
+	seedTerminalRun(t, n.ExecutionLog, "tk-A", "run-a2aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", execution.TerminalReasonSuccess, 5, 0.20)
+	seedTerminalRun(t, n.ExecutionLog, "tk-A", "run-a3aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", execution.TerminalReasonMaxTurns, 50, 1.50)
+	seedTerminalRun(t, n.ExecutionLog, "tk-A", "run-a4aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", execution.TerminalReasonTimeout, 30, 0.80)
+	// tk-B: 1 success → 1.0
+	seedTerminalRun(t, n.ExecutionLog, "tk-B", "run-b1aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", execution.TerminalReasonSuccess, 3, 0.05)
+
+	rec := doGET(t, apiExecutionFrontier(n), "/api/execution/frontier?manifest_id=mf-2&window_days=7")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rec.Code, rec.Body.String())
+	}
+	got := decodeFrontier(t, rec)
+	if got.WindowDays != 7 {
+		t.Fatalf("window_days override ignored: %d", got.WindowDays)
+	}
+	if len(got.Tasks) != 2 {
+		t.Fatalf("tasks: want 2, got %d (%+v)", len(got.Tasks), got.Tasks)
+	}
+	a, ok := got.Tasks["tk-A"]
+	if !ok {
+		t.Fatalf("tk-A missing")
+	}
+	if a.TotalRuns != 4 || a.SuccessRuns != 2 || a.MaxTurnsRuns != 1 || a.TimeoutRuns != 1 || a.FailedRuns != 0 {
+		t.Fatalf("tk-A buckets wrong: %+v", a)
+	}
+	if a.PassRate != 0.5 {
+		t.Fatalf("tk-A pass_rate: want 0.5, got %v", a.PassRate)
+	}
+	if got.Best == nil || got.Best.TaskID != "tk-B" || got.Best.PassRate != 1.0 {
+		t.Fatalf("best should be tk-B@1.0: %+v", got.Best)
+	}
+	wantAvg := (0.5 + 1.0) / 2.0
+	if got.AvgPassRate != wantAvg {
+		t.Fatalf("avg_pass_rate: want %v, got %v", wantAvg, got.AvgPassRate)
+	}
+}


### PR DESCRIPTION
## Summary

Implements M2 of the Trace-Grounded Feedback Loop product. Per-task and per-manifest pass rates are now queryable via HTTP. Powers the Phase 3 proposer and surfaces execution health on the dashboard.

## Changes

**T1 — `internal/execution/store.go`**
- New `PassRateSummary` struct: TotalRuns, SuccessRuns, FailedRuns, MaxTurnsRuns, TimeoutRuns, AvgTurns, AvgCostUSD, PassRate
- `PassRateByEntity(ctx, entityUID, windowDays)` — per-task aggregation over execution_log terminal rows
- `FrontierByManifest(ctx, taskIDs, windowDays)` — single SQL pass across all task IDs, returns per-task map
- 271-line test file covering: empty input, single success, mixed outcomes, window filtering

**T2 — `internal/web/handlers_execution_frontier.go`, `handler.go`, `handlers_entity.go`**
- `GET /api/execution/frontier?manifest_id=X&window_days=N` — returns per-task pass rates, best task, avg_pass_rate
- `window_days` defaults to `frontier_window_days` knob (system scope), falls back to 30
- Tasks with zero runs absent from response map
- `cost_per_turn` and `cost_per_action` added to run detail response (were computed but not serialized)
- 189-line test file

## Part of

Product `019e0d76` — Trace-Grounded Feedback Loop — Meta-Harness for OpenPraxis
Manifest `019e0d97-ffbc` — M2 Frontier Queries and Pass-Rate API

🤖 Generated with [Claude Code](https://claude.com/claude-code)