### PR TITLE
fix: DAG chain crosses manifest boundaries via depends_on

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -227,6 +227,41 @@ var serveCmd = &cobra.Command{
 								if err := dispatchChainFn(ctx, parentID, 0); err != nil {
 									slog.Info("dag-chain: dispatch after task_completed", "parent", parentID[:12], "note", err.Error())
 								}
+								// After dispatching within the manifest, check if the
+								// manifest itself is now fully done (all owned tasks
+								// completed). If so, fire any manifests that depend on
+								// it via manifest-level depends_on edges.
+								if e.SrcKind != relationships.KindManifest || n.ExecutionLog == nil {
+									return
+								}
+								manifestID := e.SrcID
+								ownedTasks, _ := n.Relationships.ListOutgoing(ctx, manifestID, relationships.EdgeOwns)
+								allDone := len(ownedTasks) > 0
+								for _, ot := range ownedTasks {
+									if ot.DstKind != relationships.KindTask {
+										continue
+									}
+									done, _ := n.ExecutionLog.HasCompleted(ctx, ot.DstID)
+									if !done {
+										allDone = false
+										break
+									}
+								}
+								if !allDone {
+									return
+								}
+								// All tasks complete — fire downstream manifests.
+								downstreams, _ := n.Relationships.ListIncoming(ctx, manifestID, relationships.EdgeDependsOn)
+								for _, ds := range downstreams {
+									if ds.SrcKind != relationships.KindManifest {
+										continue
+									}
+									dsID := ds.SrcID
+									slog.Info("dag-chain: manifest complete — firing downstream manifest", "done", manifestID[:12], "next", dsID[:12])
+									if err := dispatchChainFn(ctx, dsID, 0); err != nil {
+										slog.Info("dag-chain: downstream manifest dispatch", "manifest", dsID[:12], "note", err.Error())
+									}
+								}
 							}()
 							break
 						}


### PR DESCRIPTION
## Problem

When all tasks in a manifest completed, the DAG chain dispatcher stopped. It fired tasks within the same manifest but never crossed to the next manifest via manifest-level `depends_on` edges. Running a full product required manually scheduling the first task of each manifest.

## Fix

In the `task_completed` callback in `cmd/serve.go`: after dispatching tasks within the completed task's manifest, check if ALL tasks in that manifest are now done. If so, walk `ListIncoming(manifestID, depends_on)` to find downstream manifests and call `dispatchChainFn` on each.

The chain now runs end-to-end: M1 → M2 → M3 → M4 without operator intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)