### PR TITLE
fix: live output auto-scroll + expandable tool input

### DIFF
--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/comments.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/comments.tsx
@@ -54,6 +54,7 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
   const update = useUpdateEntity(kind, entityId)
 
   const [filter, setFilter] = useState('all')
+  const [rawMode, setRawMode] = useState(false)
   const [composeType, setComposeType] = useState<keyof typeof TYPE_LABEL>('comment')
   const [composing, setComposing] = useState(false)
   const [posting, setPosting] = useState(false)
@@ -138,6 +139,14 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
               ))}
             </SelectContent>
           </Select>
+          <button
+            type='button'
+            onClick={() => setRawMode(r => !r)}
+            className={`rounded px-2 py-1 text-[10px] transition-colors ${rawMode ? 'bg-amber-500/20 text-amber-300' : 'text-muted-foreground hover:text-foreground'}`}
+            title={rawMode ? 'Showing raw markdown — click for rendered' : 'Click to show raw markdown'}
+          >
+            {rawMode ? 'RAW' : 'RENDERED'}
+          </button>
           {!composing && (
             <Button type='button' size='sm' variant='outline' onClick={() => setComposing(true)} className='h-8 text-xs'>
               <Plus className='mr-1 h-3 w-3' />Add comment
@@ -221,7 +230,13 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
                     <span className='text-muted-foreground text-xs'>{fmtTime(c.created_at)}</span>
                   </div>
 
-                  <BlockNoteReadView markdown={c.body ?? ''} />
+                  {rawMode ? (
+                    <pre className='whitespace-pre-wrap break-all rounded bg-white/5 p-2 font-mono text-[11px] text-muted-foreground'>
+                      {c.body ?? ''}
+                    </pre>
+                  ) : (
+                    <BlockNoteReadView markdown={c.body ?? ''} />
+                  )}
                   <CommentAttachments commentId={c.id} />
                 </div>
               ))}

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
@@ -23,12 +23,16 @@ function useEntityActions(entityId: string, runUid: string, isLive: boolean) {
   })
 }
 
+function prettifyJson(s: string): string {
+  try { return JSON.stringify(JSON.parse(s), null, 2) } catch { return s }
+}
+
 function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) {
   const { data, isLoading } = useEntityActions(entityId, runUid, true)
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const [rawMode, setRawMode] = useState(false)
   const bottomRef = useRef<HTMLDivElement>(null)
 
-  // Auto-scroll to bottom as new actions arrive
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [data?.length])
@@ -42,8 +46,22 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
     return next
   })
 
+  const fmt = (s: string) => rawMode ? s : prettifyJson(s)
+
   return (
-    <div className='max-h-96 overflow-y-auto font-mono text-xs'>
+    <div className='font-mono text-xs'>
+      {/* Global toolbar */}
+      <div className='flex items-center justify-end gap-2 border-b border-white/5 px-3 py-1'>
+        <button
+          type='button'
+          onClick={() => setRawMode(r => !r)}
+          className={`rounded px-2 py-0.5 text-[10px] transition-colors ${rawMode ? 'bg-amber-500/20 text-amber-300' : 'text-muted-foreground hover:text-foreground'}`}
+        >
+          {rawMode ? 'RAW' : 'PARSED'}
+        </button>
+      </div>
+
+      <div className='max-h-96 overflow-y-auto'>
       {data.map((a) => {
         const isExpanded = expanded.has(a.id)
         const hasContent = !!(a.tool_input || a.tool_response)
@@ -57,9 +75,7 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
               <span className='text-blue-400 font-medium'>{a.tool_name}</span>
               {a.turn_number > 0 && <span className='text-muted-foreground text-[10px]'>turn {a.turn_number}</span>}
               {hasContent && (
-                <span className='text-muted-foreground text-[10px]'>
-                  {isExpanded ? '▲' : '▼'}
-                </span>
+                <span className='text-muted-foreground text-[10px]'>{isExpanded ? '▲' : '▼'}</span>
               )}
               <span className='text-muted-foreground ml-auto text-[10px]'>
                 {new Date(Date.parse(a.created_at)).toLocaleTimeString()}
@@ -80,7 +96,7 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
                   <div>
                     <div className='text-[10px] font-semibold text-blue-400/60 mb-0.5'>INPUT</div>
                     <div className='whitespace-pre-wrap break-all rounded bg-white/5 p-2 text-[10px] text-muted-foreground'>
-                      {a.tool_input}
+                      {fmt(a.tool_input)}
                     </div>
                   </div>
                 )}
@@ -88,7 +104,7 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
                   <div>
                     <div className='text-[10px] font-semibold text-emerald-400/60 mb-0.5'>RESPONSE</div>
                     <div className='whitespace-pre-wrap break-all rounded bg-white/5 p-2 text-[10px] text-muted-foreground'>
-                      {a.tool_response}
+                      {fmt(a.tool_response)}
                     </div>
                   </div>
                 )}
@@ -98,6 +114,7 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
         )
       })}
       <div ref={bottomRef} />
+      </div>
     </div>
   )
 }

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
@@ -28,17 +28,31 @@ function prettifyJson(s: string): string {
 }
 
 function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) {
-  const { data, isLoading } = useEntityActions(entityId, runUid, true)
+  const [paused, setPaused] = useState(false)
+  const { data, isLoading } = useEntityActions(entityId, runUid, !paused)
+  const [frozen, setFrozen] = useState<typeof data>(undefined)
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [rawMode, setRawMode] = useState(false)
   const bottomRef = useRef<HTMLDivElement>(null)
 
+  // When pausing, freeze the current snapshot. When resuming, clear it.
+  const togglePause = () => {
+    setPaused(p => {
+      if (!p) setFrozen(data)   // freeze on pause
+      else setFrozen(undefined) // unfreeze on resume
+      return !p
+    })
+  }
+
+  // Auto-scroll only when not paused
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [data?.length])
+    if (!paused) bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [data?.length, paused])
+
+  const display = paused ? frozen : data
 
   if (isLoading) return <div className='text-muted-foreground p-3 text-xs'>Loading output…</div>
-  if (!data?.length) return <div className='text-muted-foreground p-3 text-xs'>Waiting for agent to make tool calls…</div>
+  if (!display?.length) return <div className='text-muted-foreground p-3 text-xs'>Waiting for agent to make tool calls…</div>
 
   const toggle = (id: string) => setExpanded(prev => {
     const next = new Set(prev)
@@ -54,6 +68,14 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
       <div className='flex items-center justify-end gap-2 border-b border-white/5 px-3 py-1'>
         <button
           type='button'
+          onClick={togglePause}
+          className={`rounded px-2 py-0.5 text-[10px] transition-colors ${paused ? 'bg-rose-500/20 text-rose-300' : 'text-muted-foreground hover:text-foreground'}`}
+          title={paused ? 'Paused — click to resume' : 'Pause output'}
+        >
+          {paused ? '▶ RESUME' : '⏸ PAUSE'}
+        </button>
+        <button
+          type='button'
           onClick={() => setRawMode(r => !r)}
           className={`rounded px-2 py-0.5 text-[10px] transition-colors ${rawMode ? 'bg-amber-500/20 text-amber-300' : 'text-muted-foreground hover:text-foreground'}`}
         >
@@ -62,7 +84,7 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
       </div>
 
       <div className='max-h-96 overflow-y-auto'>
-      {data.map((a) => {
+      {display.map((a) => {
         const isExpanded = expanded.has(a.id)
         const hasContent = !!(a.tool_input || a.tool_response)
         return (

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
@@ -1,4 +1,4 @@
-import { useState, Fragment } from 'react'
+import { useState, Fragment, useEffect, useRef } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useEntityRuns, useLiveRuns, type EntityKind, type LiveRun } from '@/lib/queries/entity'
 import type { ExecutionRow } from '@/lib/types'
@@ -25,26 +25,54 @@ function useEntityActions(entityId: string, runUid: string, isLive: boolean) {
 
 function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) {
   const { data, isLoading } = useEntityActions(entityId, runUid, true)
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  // Auto-scroll to bottom as new actions arrive
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [data?.length])
+
   if (isLoading) return <div className='text-muted-foreground p-3 text-xs'>Loading output…</div>
   if (!data?.length) return <div className='text-muted-foreground p-3 text-xs'>Waiting for agent to make tool calls…</div>
+
+  const toggle = (id: string) => setExpanded(prev => {
+    const next = new Set(prev)
+    next.has(id) ? next.delete(id) : next.add(id)
+    return next
+  })
+
   return (
     <div className='max-h-96 overflow-y-auto font-mono text-xs'>
-      {[...data].reverse().map((a) => (
-        <div key={a.id} className='border-b border-white/5 px-3 py-1.5'>
-          <div className='flex items-center gap-2'>
-            <span className='text-blue-400 font-medium'>{a.tool_name}</span>
-            {a.turn_number > 0 && <span className='text-muted-foreground text-[10px]'>turn {a.turn_number}</span>}
-            <span className='text-muted-foreground ml-auto text-[10px]'>
-              {new Date(Date.parse(a.created_at)).toLocaleTimeString()}
-            </span>
-          </div>
-          {a.tool_input && (
-            <div className='text-muted-foreground mt-0.5 truncate text-[10px]'>
-              {a.tool_input.slice(0, 120)}
+      {data.map((a) => {
+        const isExpanded = expanded.has(a.id)
+        const hasInput = !!a.tool_input
+        return (
+          <div key={a.id} className='border-b border-white/5 px-3 py-1.5'>
+            <div
+              className={`flex items-center gap-2 ${hasInput ? 'cursor-pointer' : ''}`}
+              onClick={() => hasInput && toggle(a.id)}
+            >
+              <span className='text-blue-400 font-medium'>{a.tool_name}</span>
+              {a.turn_number > 0 && <span className='text-muted-foreground text-[10px]'>turn {a.turn_number}</span>}
+              {hasInput && (
+                <span className='text-muted-foreground text-[10px]'>
+                  {isExpanded ? '▲ collapse' : '▼ expand'}
+                </span>
+              )}
+              <span className='text-muted-foreground ml-auto text-[10px]'>
+                {new Date(Date.parse(a.created_at)).toLocaleTimeString()}
+              </span>
             </div>
-          )}
-        </div>
-      ))}
+            {hasInput && (
+              <div className={`text-muted-foreground mt-0.5 text-[10px] ${isExpanded ? 'whitespace-pre-wrap break-all' : 'truncate'}`}>
+                {isExpanded ? a.tool_input : a.tool_input.slice(0, 120)}
+              </div>
+            )}
+          </div>
+        )
+      })}
+      <div ref={bottomRef} />
     </div>
   )
 }

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
@@ -46,27 +46,52 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
     <div className='max-h-96 overflow-y-auto font-mono text-xs'>
       {data.map((a) => {
         const isExpanded = expanded.has(a.id)
-        const hasInput = !!a.tool_input
+        const hasContent = !!(a.tool_input || a.tool_response)
         return (
           <div key={a.id} className='border-b border-white/5 px-3 py-1.5'>
+            {/* Header row — click to expand */}
             <div
-              className={`flex items-center gap-2 ${hasInput ? 'cursor-pointer' : ''}`}
-              onClick={() => hasInput && toggle(a.id)}
+              className={`flex items-center gap-2 ${hasContent ? 'cursor-pointer select-none' : ''}`}
+              onClick={() => hasContent && toggle(a.id)}
             >
               <span className='text-blue-400 font-medium'>{a.tool_name}</span>
               {a.turn_number > 0 && <span className='text-muted-foreground text-[10px]'>turn {a.turn_number}</span>}
-              {hasInput && (
+              {hasContent && (
                 <span className='text-muted-foreground text-[10px]'>
-                  {isExpanded ? '▲ collapse' : '▼ expand'}
+                  {isExpanded ? '▲' : '▼'}
                 </span>
               )}
               <span className='text-muted-foreground ml-auto text-[10px]'>
                 {new Date(Date.parse(a.created_at)).toLocaleTimeString()}
               </span>
             </div>
-            {hasInput && (
-              <div className={`text-muted-foreground mt-0.5 text-[10px] ${isExpanded ? 'whitespace-pre-wrap break-all' : 'truncate'}`}>
-                {isExpanded ? a.tool_input : a.tool_input.slice(0, 120)}
+
+            {/* Collapsed preview */}
+            {!isExpanded && a.tool_input && (
+              <div className='text-muted-foreground mt-0.5 truncate text-[10px]'>
+                {a.tool_input.slice(0, 120)}
+              </div>
+            )}
+
+            {/* Expanded: full input + response */}
+            {isExpanded && (
+              <div className='mt-1 space-y-1.5'>
+                {a.tool_input && (
+                  <div>
+                    <div className='text-[10px] font-semibold text-blue-400/60 mb-0.5'>INPUT</div>
+                    <div className='whitespace-pre-wrap break-all rounded bg-white/5 p-2 text-[10px] text-muted-foreground'>
+                      {a.tool_input}
+                    </div>
+                  </div>
+                )}
+                {a.tool_response && (
+                  <div>
+                    <div className='text-[10px] font-semibold text-emerald-400/60 mb-0.5'>RESPONSE</div>
+                    <div className='whitespace-pre-wrap break-all rounded bg-white/5 p-2 text-[10px] text-muted-foreground'>
+                      {a.tool_response}
+                    </div>
+                  </div>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Changes

**`src/features/entity/tabs/runs.tsx`**

- Auto-scroll to bottom as new actions arrive — `useRef` + `useEffect` on `data.length`  
- Click any action row to expand full `tool_input` — no more 120-char truncation
- `▼ expand` / `▲ collapse` toggle per row
- Expanded: `whitespace-pre-wrap break-all` so long JSON wraps instead of overflowing

Will be merged into `openpraxis/entity-nav-ui` as part of the final UI PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)