### PR TITLE
feat: Unified Entity Navigation — tree sidebar + master detail (all or nothing)

### DIFF
--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -480,6 +480,7 @@ func mountAPI(api *mux.Router, deps ServerDeps) {
 	api.HandleFunc("/amnesia/{id}/confirm", apiAmnesiaUpdate(n, "confirmed")).Methods("POST")
 	api.HandleFunc("/amnesia/{id}/dismiss", apiAmnesiaUpdate(n, "dismissed")).Methods("POST")
 	api.HandleFunc("/entities/search", apiEntitySearch(n)).Methods("GET")
+	api.HandleFunc("/entities/tree", apiEntityTree(n)).Methods("GET")
 	api.HandleFunc("/entities", apiEntityList(n)).Methods("GET")
 	api.HandleFunc("/entities", apiEntityCreate(n)).Methods("POST")
 	api.HandleFunc("/entities/{id}/history", apiEntityHistory(n)).Methods("GET")

--- a/internal/web/handlers_entity_tree.go
+++ b/internal/web/handlers_entity_tree.go
@@ -1,0 +1,262 @@
+package web
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/k8nstantin/OpenPraxis/internal/entity"
+	"github.com/k8nstantin/OpenPraxis/internal/node"
+	"github.com/k8nstantin/OpenPraxis/internal/relationships"
+)
+
+// treeNode is the wire shape for a single node in the entity tree response.
+type treeNode struct {
+	ID       string      `json:"id"`
+	Name     string      `json:"name"`
+	Kind     string      `json:"kind"`
+	Status   string      `json:"status"`
+	Children []*treeNode `json:"children,omitempty"`
+}
+
+// Tree-level execution status constants — distinct from entity.Status*
+// because tasks carry runtime states (running/failed/completed) that
+// don't map 1:1 to entity lifecycle status.
+const (
+	treeStatusRunning   = "running"
+	treeStatusFailed    = "failed"
+	treeStatusCompleted = "completed"
+	treeStatusActive    = "active"
+	treeStatusDraft     = "draft"
+)
+
+// GET /api/entities/tree
+//
+// Returns the full sidebar entity tree in one response — no client-side
+// relationship fan-out required. Queries:
+//   1. List all entities by type (5 parallel goroutines)
+//   2. ListOutgoingForMany on all IDs (one SQL IN query)
+//   3. Assemble tree in Go
+//
+// Response: { "skills": [treeNode, ...], "lifecycle": [treeNode, ...] }
+func apiEntityTree(n *node.Node) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		if n.Entities == nil || n.Relationships == nil {
+			writeJSON(w, map[string]any{"skills": []any{}, "lifecycle": []any{}})
+			return
+		}
+
+		// ── 1. Fetch all entities by type in parallel ────────────────────
+		type listResult struct {
+			kind  string
+			items []*entity.Entity
+			err   error
+		}
+		kinds := []string{
+			entity.TypeSkill,
+			entity.TypeIdea,
+			entity.TypeProduct,
+			entity.TypeManifest,
+			entity.TypeTask,
+		}
+		ch := make(chan listResult, len(kinds))
+		for _, k := range kinds {
+			go func(kind string) {
+				items, err := n.Entities.List(kind, "", 500)
+				ch <- listResult{kind: kind, items: items, err: err}
+			}(k)
+		}
+		byKind := make(map[string][]*entity.Entity, len(kinds))
+		for range kinds {
+			res := <-ch
+			if res.err == nil {
+				byKind[res.kind] = res.items
+			}
+		}
+
+		// ── 2. Build entity lookup + collect all IDs ─────────────────────
+		entityByID := make(map[string]*entity.Entity)
+		var allIDs []string
+		for _, items := range byKind {
+			for _, e := range items {
+				entityByID[e.EntityUID] = e
+				allIDs = append(allIDs, e.EntityUID)
+			}
+		}
+
+		// ── 3. One bulk outgoing-relationship query ───────────────────────
+		allEdges, err := n.Relationships.ListOutgoingForMany(ctx, allIDs, "")
+		if err != nil {
+			writeError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// Adjacency: srcID → []edge
+		type adjEdge struct{ dst, dstKind, kind string }
+		adj := make(map[string][]adjEdge, len(allEdges))
+		for srcID, edges := range allEdges {
+			for _, e := range edges {
+				adj[srcID] = append(adj[srcID], adjEdge{
+					dst:     e.DstID,
+					dstKind: e.DstKind,
+					kind:    e.Kind,
+				})
+			}
+		}
+
+		// ── 4. Assemble tree ─────────────────────────────────────────────
+
+		var buildTask func(id string) *treeNode
+		var buildManifest func(id string) *treeNode
+		var buildProduct func(id string) *treeNode
+		var buildIdea func(id string, linkedProducts map[string]bool) *treeNode
+
+		buildTask = func(id string) *treeNode {
+			e := entityByID[id]
+			if e == nil {
+				return nil
+			}
+			return &treeNode{ID: e.EntityUID, Name: e.Title, Kind: entity.TypeTask, Status: e.Status}
+		}
+
+		buildManifest = func(id string) *treeNode {
+			e := entityByID[id]
+			if e == nil {
+				return nil
+			}
+			var children []*treeNode
+			for _, ed := range adj[id] {
+				if ed.kind == relationships.EdgeOwns && ed.dstKind == entity.TypeTask {
+					if t := buildTask(ed.dst); t != nil {
+						children = append(children, t)
+					}
+				}
+			}
+			sort.Slice(children, func(i, j int) bool { return children[i].Name < children[j].Name })
+			status := e.Status
+			if len(children) > 0 {
+				status = deriveTreeStatus(children)
+			}
+			return &treeNode{ID: e.EntityUID, Name: e.Title, Kind: entity.TypeManifest, Status: status, Children: children}
+		}
+
+		buildProduct = func(id string) *treeNode {
+			e := entityByID[id]
+			if e == nil {
+				return nil
+			}
+			var children []*treeNode
+			for _, ed := range adj[id] {
+				if ed.kind == relationships.EdgeOwns && ed.dstKind == entity.TypeManifest {
+					if m := buildManifest(ed.dst); m != nil {
+						children = append(children, m)
+					}
+				}
+			}
+			sort.Slice(children, func(i, j int) bool { return children[i].Name < children[j].Name })
+			status := e.Status
+			if len(children) > 0 {
+				status = deriveTreeStatus(children)
+			}
+			return &treeNode{ID: e.EntityUID, Name: e.Title, Kind: entity.TypeProduct, Status: status, Children: children}
+		}
+
+		buildIdea = func(id string, linkedProducts map[string]bool) *treeNode {
+			e := entityByID[id]
+			if e == nil {
+				return nil
+			}
+			var children []*treeNode
+			for _, ed := range adj[id] {
+				if ed.kind == relationships.EdgeLinksTo && ed.dstKind == entity.TypeProduct {
+					linkedProducts[ed.dst] = true
+					if p := buildProduct(ed.dst); p != nil {
+						children = append(children, p)
+					}
+				}
+			}
+			sort.Slice(children, func(i, j int) bool { return children[i].Name < children[j].Name })
+			status := e.Status
+			if len(children) > 0 {
+				status = deriveTreeStatus(children)
+			}
+			nd := &treeNode{ID: e.EntityUID, Name: e.Title, Kind: entity.TypeIdea, Status: status}
+			if len(children) > 0 {
+				nd.Children = children
+			}
+			return nd
+		}
+
+		// Skills — flat, sorted, exclude archived
+		skills := make([]*treeNode, 0, len(byKind[entity.TypeSkill]))
+		for _, s := range byKind[entity.TypeSkill] {
+			if s.Status == entity.StatusArchived {
+				continue
+			}
+			skills = append(skills, &treeNode{ID: s.EntityUID, Name: s.Title, Kind: entity.TypeSkill, Status: s.Status})
+		}
+		sort.Slice(skills, func(i, j int) bool { return skills[i].Name < skills[j].Name })
+
+		// Lifecycle: ideas (with linked products), then unlinked products
+		linkedProducts := make(map[string]bool)
+		lifecycle := make([]*treeNode, 0)
+		for _, i := range byKind[entity.TypeIdea] {
+			if nd := buildIdea(i.EntityUID, linkedProducts); nd != nil {
+				lifecycle = append(lifecycle, nd)
+			}
+		}
+		sort.Slice(lifecycle, func(i, j int) bool { return lifecycle[i].Name < lifecycle[j].Name })
+
+		var unlinked []*treeNode
+		for _, p := range byKind[entity.TypeProduct] {
+			if !linkedProducts[p.EntityUID] && p.Status != entity.StatusArchived {
+				if nd := buildProduct(p.EntityUID); nd != nil {
+					unlinked = append(unlinked, nd)
+				}
+			}
+		}
+		sort.Slice(unlinked, func(i, j int) bool { return unlinked[i].Name < unlinked[j].Name })
+		if len(unlinked) > 0 {
+			lifecycle = append(lifecycle, &treeNode{
+				ID:       "unlinked-products",
+				Name:     "Unlinked Products",
+				Kind:     entity.TypeIdea,
+				Status:   deriveTreeStatus(unlinked),
+				Children: unlinked,
+			})
+		}
+
+		writeJSON(w, map[string]any{"skills": skills, "lifecycle": lifecycle})
+	}
+}
+
+// deriveTreeStatus rolls up children execution states.
+// Priority: running > failed > completed > active > draft.
+// Kind-agnostic — works for any internal node.
+func deriveTreeStatus(children []*treeNode) string {
+	for _, c := range children {
+		if c.Status == treeStatusRunning {
+			return treeStatusRunning
+		}
+	}
+	for _, c := range children {
+		if c.Status == treeStatusFailed {
+			return treeStatusFailed
+		}
+	}
+	allDone, anyDone := true, false
+	for _, c := range children {
+		if c.Status == treeStatusCompleted {
+			anyDone = true
+		} else {
+			allDone = false
+		}
+	}
+	if allDone && anyDone {
+		return treeStatusCompleted
+	}
+	if anyDone {
+		return treeStatusActive
+	}
+	return treeStatusDraft
+}

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,12 +49,12 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-CaV3PZ0B.js"></script>
+    <script type="module" crossorigin src="/assets/index-b7bxI7hx.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/redirect-CvqrVikk.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-Cu7Iu-c-.js">
-    <link rel="modulepreload" crossorigin href="/assets/index-CaV3PZ0B.js">
-    <link rel="modulepreload" crossorigin href="/assets/FloatingThreadController-C-63cAxQ-BRhMI9f3.js">
+    <link rel="modulepreload" crossorigin href="/assets/index-b7bxI7hx.js">
+    <link rel="modulepreload" crossorigin href="/assets/FloatingThreadController-C-63cAxQ-BeFovwf5.js">
     <link rel="stylesheet" crossorigin href="/assets/index-2Kv9lNX3.css">
   </head>
 

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,7 +49,7 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-DsR8MRUI.js"></script>
+    <script type="module" crossorigin src="/assets/index-CNRWy0GB.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-CGgIkkjv.js">
     <link rel="stylesheet" crossorigin href="/assets/index-DcB6rzjm.css">

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,10 +49,13 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-DsR8MRUI.js"></script>
+    <script type="module" crossorigin src="/assets/index-CaV3PZ0B.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
-    <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-CGgIkkjv.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-DcB6rzjm.css">
+    <link rel="modulepreload" crossorigin href="/assets/redirect-CvqrVikk.js">
+    <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-Cu7Iu-c-.js">
+    <link rel="modulepreload" crossorigin href="/assets/index-CaV3PZ0B.js">
+    <link rel="modulepreload" crossorigin href="/assets/FloatingThreadController-C-63cAxQ-BRhMI9f3.js">
+    <link rel="stylesheet" crossorigin href="/assets/index-2Kv9lNX3.css">
   </head>
 
   <body>

--- a/internal/web/ui/dashboard-v2/package-lock.json
+++ b/internal/web/ui/dashboard-v2/package-lock.json
@@ -43,6 +43,7 @@
         "input-otp": "^1.4.2",
         "lucide-react": "^1.8.0",
         "react": "^19.2.5",
+        "react-arborist": "^3.5.0",
         "react-day-picker": "9.14.0",
         "react-dom": "^19.2.5",
         "react-hook-form": "^7.72.1",
@@ -309,7 +310,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1994,6 +1994,24 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/asap": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-4.0.1.tgz",
+      "integrity": "sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-2.0.0.tgz",
+      "integrity": "sha512-xL4RCQBCBDJ+GRwKTFhGUW8GXa4yoDfJrPbLblc3U09ciS+9ZJXJ3Qrcs/x2IODOdIE5kQxvMmE2UKyqUictUw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz",
+      "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==",
       "license": "MIT"
     },
     "node_modules/@reduxjs/toolkit": {
@@ -3873,6 +3891,26 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dnd-core": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-14.0.1.tgz",
+      "integrity": "sha512-+PVS2VPTgKFPYWo3vAFEA8WPbTf7/xo43TifH9G8S1KqnrQu0o77A3unrF5yOugy4mIz7K5wAVFHUcha7wsz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/asap": "^4.0.0",
+        "@react-dnd/invariant": "^2.0.0",
+        "redux": "^4.1.1"
+      }
+    },
+    "node_modules/dnd-core/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
     "node_modules/echarts": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
@@ -4378,6 +4416,21 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
@@ -5200,6 +5253,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -6127,6 +6186,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-arborist": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/react-arborist/-/react-arborist-3.5.0.tgz",
+      "integrity": "sha512-FdXOICSt7P2h+Pxin1ULN02b4qrXJznNcshgwwWVtuYMLWSJcD245PQ4HOSj/Lr2T1uEegmnEm5Lbns2hUUsqg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-dnd": "^14.0.3",
+        "react-dnd-html5-backend": "^14.0.3",
+        "react-window": "^1.8.11",
+        "redux": "^5.0.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14",
+        "react-dom": ">= 16.14"
+      }
+    },
     "node_modules/react-day-picker": {
       "version": "9.14.0",
       "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
@@ -6147,6 +6223,45 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/react-dnd": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-14.0.5.tgz",
+      "integrity": "sha512-9i1jSgbyVw0ELlEVt/NkCUkxy1hmhJOkePoCH713u75vzHGyXhPDm28oLfc2NMSBjZRM1Y+wRjHXJT3sPrTy+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/invariant": "^2.0.0",
+        "@react-dnd/shallowequal": "^2.0.0",
+        "dnd-core": "14.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-14.1.0.tgz",
+      "integrity": "sha512-6ONeqEC3XKVf4eVmMTe0oPds+c5B9Foyj8p/ZKLb7kL2qh9COYxiBHv3szd6gztqi/efkmriywLUVlPotqoJyw==",
+      "license": "MIT",
+      "dependencies": {
+        "dnd-core": "14.0.1"
       }
     },
     "node_modules/react-dom": {
@@ -6359,6 +6474,23 @@
       "peerDependencies": {
         "react": ">=16 || >=17 || >= 18 || >= 19",
         "react-dom": ">=16 || >=17 || >= 18 || >=19"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/readdirp": {

--- a/internal/web/ui/dashboard-v2/package.json
+++ b/internal/web/ui/dashboard-v2/package.json
@@ -45,6 +45,7 @@
     "input-otp": "^1.4.2",
     "lucide-react": "^1.8.0",
     "react": "^19.2.5",
+    "react-arborist": "^3.5.0",
     "react-day-picker": "9.14.0",
     "react-dom": "^19.2.5",
     "react-hook-form": "^7.72.1",

--- a/internal/web/ui/dashboard-v2/src/components/command-menu.tsx
+++ b/internal/web/ui/dashboard-v2/src/components/command-menu.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useNavigate } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
 import { ArrowRight, ChevronRight, Laptop, Moon, Sun } from 'lucide-react'
 import { useSearch } from '@/context/search-provider'
 import { useTheme } from '@/context/theme-provider'
@@ -12,13 +13,41 @@ import {
   CommandList,
   CommandSeparator,
 } from '@/components/ui/command'
+import { EntityKindIcon } from '@/features/entity/tree/EntityTreeNode'
+import type { Entity } from '@/lib/types'
 import { sidebarData } from './layout/data/sidebar-data'
 import { ScrollArea } from './ui/scroll-area'
+
+const ENTITY_QUERY_MIN_LEN = 2
+const ENTITY_QUERY_DEBOUNCE_MS = 200
+const ENTITY_QUERY_LIMIT = 20
 
 export function CommandMenu() {
   const navigate = useNavigate()
   const { setTheme } = useTheme()
   const { open, setOpen } = useSearch()
+  const [query, setQuery] = React.useState('')
+  const [debouncedQuery, setDebouncedQuery] = React.useState('')
+
+  React.useEffect(() => {
+    const t = setTimeout(
+      () => setDebouncedQuery(query.trim()),
+      ENTITY_QUERY_DEBOUNCE_MS
+    )
+    return () => clearTimeout(t)
+  }, [query])
+
+  const enabled = debouncedQuery.length >= ENTITY_QUERY_MIN_LEN
+  const { data: results } = useQuery({
+    queryKey: ['entity-search-cmd', debouncedQuery],
+    queryFn: async (): Promise<Entity[]> => {
+      const url = `/api/entities/search?q=${encodeURIComponent(debouncedQuery)}&limit=${ENTITY_QUERY_LIMIT}`
+      const res = await fetch(url)
+      if (!res.ok) throw new Error(`${url} → ${res.status}`)
+      return (await res.json()) as Entity[]
+    },
+    enabled,
+  })
 
   const runCommand = React.useCallback(
     (command: () => unknown) => {
@@ -30,10 +59,41 @@ export function CommandMenu() {
 
   return (
     <CommandDialog modal open={open} onOpenChange={setOpen}>
-      <CommandInput placeholder='Type a command or search...' />
+      <CommandInput
+        placeholder='Search entities or type a command...'
+        value={query}
+        onValueChange={setQuery}
+      />
       <CommandList>
         <ScrollArea type='hover' className='h-72 pe-1'>
           <CommandEmpty>No results found.</CommandEmpty>
+          {enabled && results && results.length > 0 && (
+            <CommandGroup heading='Entities'>
+              {results.map((entity) => (
+                <CommandItem
+                  key={entity.entity_uid}
+                  value={`${entity.type} ${entity.title} ${entity.entity_uid}`}
+                  onSelect={() =>
+                    runCommand(() =>
+                      navigate({
+                        to: '/entities/$uid',
+                        params: { uid: entity.entity_uid },
+                      })
+                    )
+                  }
+                >
+                  <EntityKindIcon
+                    kind={entity.type}
+                    className='mr-2 h-4 w-4 text-muted-foreground'
+                  />
+                  <span className='flex-1 truncate'>{entity.title}</span>
+                  <span className='ml-2 text-xs text-muted-foreground capitalize'>
+                    {entity.type}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
           {sidebarData.navGroups.map((group) => (
             <CommandGroup key={group.title} heading={group.title}>
               {group.items.map((navItem, i) => {

--- a/internal/web/ui/dashboard-v2/src/components/content-block/ContentBlock.tsx
+++ b/internal/web/ui/dashboard-v2/src/components/content-block/ContentBlock.tsx
@@ -11,6 +11,7 @@
  */
 import { useRef, useState } from 'react'
 import { Pencil, ChevronDown, ChevronUp } from 'lucide-react'
+import { CopyButton } from '@/components/copy-button'
 import { useQueryClient } from '@tanstack/react-query'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -94,11 +95,16 @@ export function ContentBlock({ entityId, kind, label = 'Prompt', placeholder }: 
         <div className='rounded-lg border bg-card'>
           <div className='flex items-center justify-between px-4 py-2 border-b'>
             <span className='text-xs font-medium text-muted-foreground uppercase tracking-wide'>{label}</span>
-            {!editing && (
-              <Button variant='ghost' size='sm' className='h-7 px-2 text-xs' onClick={startEdit}>
-                <Pencil className='mr-1 h-3 w-3' />Edit
-              </Button>
-            )}
+            <div className='flex items-center gap-1'>
+              {!editing && latest?.body && (
+                <CopyButton text={latest.body} title={`Copy ${label}`} />
+              )}
+              {!editing && (
+                <Button variant='ghost' size='sm' className='h-7 px-2 text-xs' onClick={startEdit}>
+                  <Pencil className='mr-1 h-3 w-3' />Edit
+                </Button>
+              )}
+            </div>
           </div>
           {!editing && (
             <>
@@ -172,7 +178,10 @@ export function ContentBlock({ entityId, kind, label = 'Prompt', placeholder }: 
             <div className='mt-2 space-y-2'>
               {revisions.slice(1).map(rev => (
                 <div key={rev.id} className='rounded border border-dashed p-3 opacity-60'>
-                  <div className='mb-1 font-mono text-[10px] text-muted-foreground'>{rev.created_at}</div>
+                  <div className='flex items-center gap-2 mb-1'>
+                    <span className='font-mono text-[10px] text-muted-foreground'>{rev.created_at}</span>
+                    {rev.body && <CopyButton text={rev.body} title='Copy revision' className='ml-auto' />}
+                  </div>
                   <BlockNoteReadView markdown={rev.body ?? ''} />
                 </div>
               ))}

--- a/internal/web/ui/dashboard-v2/src/components/content-block/ContentBlock.tsx
+++ b/internal/web/ui/dashboard-v2/src/components/content-block/ContentBlock.tsx
@@ -4,11 +4,8 @@
  * Uses BlockNoteComposer which has native drag/drop/paste attachment support
  * via the uploadFile callback — no custom editor needed.
  *
- * All entity types → label="Prompt"
- * All entity types → label="Prompt"
- 
- 
- */
+ * All entity types use label="Prompt" for their description block.
+*/
 import { useRef, useState } from 'react'
 import { Pencil, ChevronDown, ChevronUp } from 'lucide-react'
 import { CopyButton } from '@/components/copy-button'

--- a/internal/web/ui/dashboard-v2/src/components/copy-button.tsx
+++ b/internal/web/ui/dashboard-v2/src/components/copy-button.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+import { Check, Copy } from 'lucide-react'
+
+interface CopyButtonProps {
+  text: string
+  label?: string       // optional visible label; defaults to icon-only
+  className?: string
+  title?: string
+}
+
+export function CopyButton({ text, label, className = '', title = 'Copy' }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    })
+  }
+
+  return (
+    <button
+      type='button'
+      onClick={handleCopy}
+      title={title}
+      className={`inline-flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors ${className}`}
+    >
+      {copied
+        ? <Check className='h-3 w-3 text-emerald-400' />
+        : <Copy className='h-3 w-3' />}
+      {label && <span className='text-[10px]'>{copied ? 'Copied!' : label}</span>}
+    </button>
+  )
+}

--- a/internal/web/ui/dashboard-v2/src/components/layout/app-sidebar.tsx
+++ b/internal/web/ui/dashboard-v2/src/components/layout/app-sidebar.tsx
@@ -3,6 +3,9 @@ import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarHeader,
   SidebarRail,
 } from '@/components/ui/sidebar'
@@ -12,7 +15,11 @@ import { NavGroup } from './nav-group'
 import { NavUser } from './nav-user'
 import { TeamSwitcher } from './team-switcher'
 
-export function AppSidebar() {
+type AppSidebarProps = {
+  entityTree?: React.ReactNode
+}
+
+export function AppSidebar({ entityTree = null }: AppSidebarProps = {}) {
   const { collapsible, variant } = useLayout()
   return (
     <Sidebar collapsible={collapsible} variant={variant}>
@@ -27,6 +34,12 @@ export function AppSidebar() {
         {sidebarData.navGroups.map((props) => (
           <NavGroup key={props.title} {...props} />
         ))}
+        {entityTree !== null && (
+          <SidebarGroup>
+            <SidebarGroupLabel>Entities</SidebarGroupLabel>
+            <SidebarGroupContent>{entityTree}</SidebarGroupContent>
+          </SidebarGroup>
+        )}
       </SidebarContent>
       <SidebarFooter>
         <NavUser user={sidebarData.user} />

--- a/internal/web/ui/dashboard-v2/src/components/layout/app-sidebar.tsx
+++ b/internal/web/ui/dashboard-v2/src/components/layout/app-sidebar.tsx
@@ -3,9 +3,13 @@ import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarHeader,
   SidebarRail,
 } from '@/components/ui/sidebar'
+import { EntityTree } from '@/features/entity/tree/EntityTree'
 // import { AppTitle } from './app-title'
 import { sidebarData } from './data/sidebar-data'
 import { NavGroup } from './nav-group'
@@ -24,6 +28,14 @@ export function AppSidebar() {
         {/* <AppTitle /> */}
       </SidebarHeader>
       <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Entities</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <div className='h-[420px] overflow-hidden'>
+              <EntityTree />
+            </div>
+          </SidebarGroupContent>
+        </SidebarGroup>
         {sidebarData.navGroups.map((props) => (
           <NavGroup key={props.title} {...props} />
         ))}

--- a/internal/web/ui/dashboard-v2/src/components/layout/authenticated-layout.tsx
+++ b/internal/web/ui/dashboard-v2/src/components/layout/authenticated-layout.tsx
@@ -18,7 +18,7 @@ export function AuthenticatedLayout({ children }: AuthenticatedLayoutProps) {
       <LayoutProvider>
         <SidebarProvider defaultOpen={defaultOpen}>
           <SkipToMain />
-          <AppSidebar />
+          <AppSidebar entityTree={null} />
           <SidebarInset
             className={cn(
               // Set content container, so we can use container queries

--- a/internal/web/ui/dashboard-v2/src/components/layout/data/sidebar-data.ts
+++ b/internal/web/ui/dashboard-v2/src/components/layout/data/sidebar-data.ts
@@ -2,19 +2,15 @@ import {
   Activity,
   AlertTriangle,
   BarChart3,
-  Boxes,
   Brain,
   CalendarClock,
-  CheckSquare,
   Command,
-  FileText,
+  GitBranch,
   Inbox,
-  Lightbulb,
   LayoutDashboard,
   ScrollText,
   Settings,
   TrendingUp,
-  Wand2,
 } from 'lucide-react'
 import { type SidebarData } from '../types'
 
@@ -50,29 +46,9 @@ export const sidebarData: SidebarData = {
           icon: ScrollText,
         },
         {
-          title: 'Products',
-          url: '/products',
-          icon: Boxes,
-        },
-        {
-          title: 'Manifests',
-          url: '/manifests',
-          icon: FileText,
-        },
-        {
-          title: 'Tasks',
-          url: '/tasks',
-          icon: CheckSquare,
-        },
-        {
-          title: 'Skills',
-          url: '/skills',
-          icon: Wand2,
-        },
-        {
-          title: 'Ideas',
-          url: '/ideas',
-          icon: Lightbulb,
+          title: 'Entities',
+          url: '/entities',
+          icon: GitBranch,
         },
         {
           title: 'Schedules',

--- a/internal/web/ui/dashboard-v2/src/features/actions/index.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/actions/index.tsx
@@ -11,6 +11,7 @@ import {
   Wrench,
   X,
 } from 'lucide-react'
+import { CopyButton } from '@/components/copy-button'
 import { Header } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { Card, CardContent } from '@/components/ui/card'
@@ -430,8 +431,9 @@ function Pane({
         : 'border-zinc-700'
   return (
     <div className={cn('overflow-hidden rounded-md border', border)}>
-      <div className='bg-zinc-900/50 px-2 py-1 text-[10px] uppercase tracking-wider text-muted-foreground'>
-        {label}
+      <div className='flex items-center bg-zinc-900/50 px-2 py-1'>
+        <span className='text-[10px] uppercase tracking-wider text-muted-foreground flex-1'>{label}</span>
+        {content && content !== '—' && <CopyButton text={content} title={`Copy ${label}`} />}
       </div>
       <pre className='max-h-[40vh] overflow-auto bg-zinc-950 p-2 text-[11px] leading-relaxed font-mono whitespace-pre-wrap break-words'>
         {content || '—'}

--- a/internal/web/ui/dashboard-v2/src/features/entity/breadcrumb.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/breadcrumb.tsx
@@ -1,10 +1,13 @@
 import { Link } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
 import { ChevronRight, Home } from 'lucide-react'
 import {
+  useEntityByUid,
   useEntityHierarchy,
   type EntityKind,
 } from '@/lib/queries/entity'
-import type { HierarchyNode } from '@/lib/types'
+import { EDGE, KIND } from '@/lib/queries/entity-tree'
+import type { Entity, HierarchyNode } from '@/lib/types'
 
 // Walk the hierarchy tree to find the path from the root to the
 // target entity id. Returns null if the target isn't reachable.
@@ -22,14 +25,31 @@ function findPath(
   return null
 }
 
-// Generic entity breadcrumb. Branches on kind:
-//   product  → Products › <ProductTitle>
-//   manifest → Products › <ParentProductTitle> › Manifests › <ManifestTitle>
+// Index-page label and path for each kind. The home crumb in the
+// per-kind breadcrumbs links here; entity-ancestor crumbs always link
+// to /entities/$uid.
+const KIND_HOME_LABEL: Record<EntityKind, string> = {
+  [KIND.product]: 'Products',
+  [KIND.manifest]: 'Manifests',
+  [KIND.task]: 'Tasks',
+  [KIND.skill]: 'Skills',
+  [KIND.idea]: 'Ideas',
+}
+
+const KIND_HOME_PATH: Record<EntityKind, string> = {
+  [KIND.product]: '/products',
+  [KIND.manifest]: '/manifests',
+  [KIND.task]: '/tasks',
+  [KIND.skill]: '/skills',
+  [KIND.idea]: '/ideas',
+}
+
+// Kind-aware dispatcher — used by the legacy per-kind detail pages
+// (EntityPage). Branches on kind:
+//   product            → walks the product hierarchy via useEntityHierarchy
+//   manifest|task|idea|skill → flat "<KindName> › <EntityTitle>"
 //
-// Manifest's parent product is resolved via manifest.project_id; the
-// product detail load surfaces its title for the parent crumb. If the
-// manifest isn't linked to a product (project_id empty), the parent
-// crumb is dropped.
+// Internal entity-ancestor links always navigate to /entities/$uid.
 export function EntityBreadcrumb({
   kind,
   entityId,
@@ -39,7 +59,7 @@ export function EntityBreadcrumb({
   entityId: string
   entityTitle?: string
 }) {
-  if (kind === 'product') {
+  if (kind === KIND.product) {
     return (
       <ProductBreadcrumb
         productId={entityId}
@@ -47,13 +67,11 @@ export function EntityBreadcrumb({
       />
     )
   }
-  if (kind === 'task') {
-    return <TaskBreadcrumb taskId={entityId} taskTitle={entityTitle} />
-  }
   return (
-    <ManifestBreadcrumb
-      manifestId={entityId}
-      manifestTitle={entityTitle}
+    <FlatBreadcrumb
+      kind={kind}
+      entityId={entityId}
+      entityTitle={entityTitle}
     />
   )
 }
@@ -65,7 +83,7 @@ function ProductBreadcrumb({
   productId: string
   productTitle?: string
 }) {
-  const hierarchy = useEntityHierarchy('product', productId)
+  const hierarchy = useEntityHierarchy(KIND.product, productId)
   const path = hierarchy.data ? findPath(hierarchy.data, productId) : null
 
   return (
@@ -74,11 +92,11 @@ function ProductBreadcrumb({
       className='text-muted-foreground flex items-center gap-1.5 text-sm'
     >
       <Link
-        to='/products'
+        to={KIND_HOME_PATH[KIND.product]}
         className='hover:text-foreground inline-flex items-center gap-1'
       >
         <Home className='h-3.5 w-3.5' />
-        Products
+        {KIND_HOME_LABEL[KIND.product]}
       </Link>
       {path && path.length > 0 ? (
         path.map((node) => (
@@ -88,8 +106,8 @@ function ProductBreadcrumb({
               <span className='text-foreground font-medium'>{node.title}</span>
             ) : (
               <Link
-                to='/products'
-                search={{ id: node.id, tab: 'main' }}
+                to='/entities/$uid'
+                params={{ uid: node.id }}
                 className='hover:text-foreground'
               >
                 {node.title}
@@ -107,16 +125,18 @@ function ProductBreadcrumb({
   )
 }
 
-// Tasks: flat 2-crumb breadcrumb (Tasks › <TaskTitle>). The parent
-// manifest relationship lives in the relationships table, not on the
-// entity. The breadcrumb shows Tasks › <title> only; drill up via
-// the Manifests menu to reach the parent.
-function TaskBreadcrumb({
-  taskId,
-  taskTitle,
+// Flat breadcrumb — kind home root, then the entity title. Used for
+// every kind that doesn't have a dedicated hierarchy walker (manifest,
+// task, idea, skill). Entity-ancestor relationships are not surfaced
+// here; operators drill up via the kind-scoped index.
+function FlatBreadcrumb({
+  kind,
+  entityId,
+  entityTitle,
 }: {
-  taskId: string
-  taskTitle?: string
+  kind: EntityKind
+  entityId: string
+  entityTitle?: string
 }) {
   return (
     <nav
@@ -124,47 +144,109 @@ function TaskBreadcrumb({
       className='text-muted-foreground flex items-center gap-1.5 text-sm'
     >
       <Link
-        to='/tasks'
+        to={KIND_HOME_PATH[kind]}
         className='hover:text-foreground inline-flex items-center gap-1'
       >
         <Home className='h-3.5 w-3.5' />
-        Tasks
+        {KIND_HOME_LABEL[kind]}
       </Link>
       <span className='inline-flex items-center gap-1.5'>
         <ChevronRight className='h-3.5 w-3.5 opacity-50' />
         <span className='text-foreground font-medium'>
-          {taskTitle ?? taskId.slice(0, 12)}
+          {entityTitle ?? entityId.slice(0, 12)}
         </span>
       </span>
     </nav>
   )
 }
 
-function ManifestBreadcrumb({
-  manifestId,
-  manifestTitle,
-}: {
-  manifestId: string
-  manifestTitle?: string
-}) {
-  // Parent product is resolved via relationships, not a field on the entity.
-  // Show Manifests › <title> — operator can navigate to Products to drill up.
+// ── Universal breadcrumb ─────────────────────────────────────────────
+//
+// Walks the `owns` chain from this entity up to the root. Each ancestor
+// is rendered as a link to /entities/$uid; the leaf (current entity) is
+// rendered as plain text. Used by the /entities/$uid route — kind
+// doesn't matter, the same walker handles every entity type.
+
+interface RelationshipRow {
+  SrcID: string
+  SrcKind: EntityKind
+  DstID: string
+  DstKind: EntityKind
+  Kind: string
+}
+
+interface AncestorCrumb {
+  id: string
+  title: string
+}
+
+const UNIVERSAL_WALK_DEPTH_CAP = 16
+
+async function fetchAncestry(uid: string): Promise<AncestorCrumb[]> {
+  const chain: AncestorCrumb[] = []
+  let cursor: string | undefined = uid
+  const seen = new Set<string>()
+  for (let i = 0; i < UNIVERSAL_WALK_DEPTH_CAP && cursor; i++) {
+    if (seen.has(cursor)) break
+    seen.add(cursor)
+    const incoming = await fetch(
+      `/api/relationships/incoming?dst_id=${cursor}&kind=${EDGE.owns}`
+    )
+    if (!incoming.ok) break
+    const rows = ((await incoming.json()) as RelationshipRow[] | null) ?? []
+    if (rows.length === 0) break
+    const parentId = rows[0].SrcID
+    const parentRes = await fetch(`/api/entities/${parentId}`)
+    if (!parentRes.ok) break
+    const parent = (await parentRes.json()) as Entity
+    chain.push({ id: parent.entity_uid, title: parent.title })
+    cursor = parent.entity_uid
+  }
+  return chain.reverse()
+}
+
+function useUniversalAncestry(uid: string | undefined) {
+  return useQuery({
+    queryKey: ['entity', 'ancestry', uid ?? ''] as const,
+    queryFn: () => fetchAncestry(uid as string),
+    enabled: !!uid,
+    staleTime: 30 * 1000,
+  })
+}
+
+export function UniversalBreadcrumb({ uid }: { uid: string }) {
+  const entity = useEntityByUid(uid)
+  const ancestry = useUniversalAncestry(uid)
+  const ancestors = ancestry.data ?? []
+
   return (
     <nav
       aria-label='Breadcrumb'
-      className='text-muted-foreground flex items-center gap-1.5 text-sm'
+      className='text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm'
     >
       <Link
-        to='/manifests'
+        to='/entities'
         className='hover:text-foreground inline-flex items-center gap-1'
       >
         <Home className='h-3.5 w-3.5' />
-        Manifests
+        Entities
       </Link>
+      {ancestors.map((node) => (
+        <span key={node.id} className='inline-flex items-center gap-1.5'>
+          <ChevronRight className='h-3.5 w-3.5 opacity-50' />
+          <Link
+            to='/entities/$uid'
+            params={{ uid: node.id }}
+            className='hover:text-foreground'
+          >
+            {node.title}
+          </Link>
+        </span>
+      ))}
       <span className='inline-flex items-center gap-1.5'>
         <ChevronRight className='h-3.5 w-3.5 opacity-50' />
         <span className='text-foreground font-medium'>
-          {manifestTitle ?? manifestId.slice(0, 12)}
+          {entity.data?.title ?? uid.slice(0, 12)}
         </span>
       </span>
     </nav>

--- a/internal/web/ui/dashboard-v2/src/features/entity/breadcrumb.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/breadcrumb.tsx
@@ -36,12 +36,13 @@ const KIND_HOME_LABEL: Record<EntityKind, string> = {
   [KIND.idea]: 'Ideas',
 }
 
+// All entity types navigate through the unified /entities route.
 const KIND_HOME_PATH: Record<EntityKind, string> = {
-  [KIND.product]: '/products',
-  [KIND.manifest]: '/manifests',
-  [KIND.task]: '/tasks',
-  [KIND.skill]: '/skills',
-  [KIND.idea]: '/ideas',
+  [KIND.product]: '/entities',
+  [KIND.manifest]: '/entities',
+  [KIND.task]: '/entities',
+  [KIND.skill]: '/entities',
+  [KIND.idea]: '/entities',
 }
 
 // Kind-aware dispatcher — used by the legacy per-kind detail pages

--- a/internal/web/ui/dashboard-v2/src/features/entity/detail-pane.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/detail-pane.tsx
@@ -13,7 +13,9 @@ import { MainTab } from './tabs/main'
 import { RunsTab } from './tabs/runs'
 
 // Tabs: Main · Execution · Runs · Comments · Dependencies · DAG
-const TAB_IDS = [
+// Exported so route validators (e.g. /entities/$uid) build their tab
+// schema from the same source of truth — adding a tab here propagates.
+export const TAB_IDS = [
   'main',
   'execution',
   'runs',

--- a/internal/web/ui/dashboard-v2/src/features/entity/detail-pane.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/detail-pane.tsx
@@ -31,11 +31,13 @@ export function EntityDetailPane({
   entityId,
   tab,
   onTabChange,
+  breadcrumb,
 }: {
   kind: EntityKind
   entityId?: string
   tab: EntityTabId
   onTabChange: (tab: EntityTabId) => void
+  breadcrumb?: React.ReactNode
 }) {
   const entity = useEntity(kind, entityId)
   const iconMap: Record<string, React.ElementType> = {
@@ -62,11 +64,13 @@ export function EntityDetailPane({
     <div className='flex h-full min-h-0 flex-col'>
       <ScrollArea className='min-h-0 flex-1'>
         <div className='space-y-4 p-4'>
-          <EntityBreadcrumb
-            kind={kind}
-            entityId={entityId}
-            entityTitle={entity.data?.title}
-          />
+          {breadcrumb ?? (
+            <EntityBreadcrumb
+              kind={kind}
+              entityId={entityId}
+              entityTitle={entity.data?.title}
+            />
+          )}
 
           <div>
             {entity.isLoading ? (

--- a/internal/web/ui/dashboard-v2/src/features/entity/detail-pane.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/detail-pane.tsx
@@ -1,5 +1,6 @@
 import { useEntity, type EntityKind } from '@/lib/queries/entity'
 import { Boxes, CheckSquare, FileText } from 'lucide-react'
+import { CopyButton } from '@/components/copy-button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -85,9 +86,12 @@ export function EntityDetailPane({
                   <h1 className='text-2xl font-bold tracking-tight'>
                     {entity.data.title}
                   </h1>
-                  <code className='text-muted-foreground font-mono text-xs'>
-                    {entity.data.entity_uid}
-                  </code>
+                  <div className='flex items-center gap-1.5'>
+                    <code className='text-muted-foreground font-mono text-xs'>
+                      {entity.data.entity_uid}
+                    </code>
+                    <CopyButton text={entity.data.entity_uid} title='Copy UID' />
+                  </div>
                 </div>
                 <EntityStatusControl
                   kind={kind}

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/comments.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/comments.tsx
@@ -19,6 +19,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { cn } from '@/lib/utils'
+import { CopyButton } from '@/components/copy-button'
 import { useQueryClient } from '@tanstack/react-query'
 import { CommentAttachments } from '@/components/comment-attachments'
 import {
@@ -227,7 +228,10 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
                         {TYPE_LABEL[c.type] ?? c.type}
                       </Badge>
                     </div>
-                    <span className='text-muted-foreground text-xs'>{fmtTime(c.created_at)}</span>
+                    <div className='flex items-center gap-2'>
+                      <CopyButton text={c.body ?? ''} title='Copy body' />
+                      <span className='text-muted-foreground text-xs'>{fmtTime(c.created_at)}</span>
+                    </div>
                   </div>
 
                   {rawMode ? (

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/comments.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/comments.tsx
@@ -54,6 +54,7 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
   const update = useUpdateEntity(kind, entityId)
 
   const [filter, setFilter] = useState('all')
+  const [rawMode, setRawMode] = useState(false)
   const [composeType, setComposeType] = useState<keyof typeof TYPE_LABEL>('comment')
   const [composing, setComposing] = useState(false)
   const [posting, setPosting] = useState(false)
@@ -138,6 +139,14 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
               ))}
             </SelectContent>
           </Select>
+          <button
+            type='button'
+            onClick={() => setRawMode(r => !r)}
+            className={`rounded px-2 py-1 text-[10px] transition-colors ${rawMode ? 'bg-amber-500/20 text-amber-300' : 'text-muted-foreground hover:text-foreground'}`}
+            title={rawMode ? 'Showing raw markdown — click for rendered' : 'Click to show raw markdown'}
+          >
+            {rawMode ? 'RAW' : 'RENDERED'}
+          </button>
           {!composing && (
             <Button type='button' size='sm' variant='outline' onClick={() => setComposing(true)} className='h-8 text-xs'>
               <Plus className='mr-1 h-3 w-3' />Add comment
@@ -221,7 +230,13 @@ export function CommentsTab({ kind, entityId }: { kind: EntityKind; entityId: st
                     <span className='text-muted-foreground text-xs'>{fmtTime(c.created_at)}</span>
                   </div>
 
-                  <BlockNoteReadView markdown={c.body ?? ''} />
+                  {rawMode ? (
+                    <pre className='whitespace-pre-wrap break-all rounded bg-white/5 p-2 font-mono text-[11px] text-muted-foreground'>
+                      {c.body ?? ''}
+                    </pre>
+                  ) : (
+                    <BlockNoteReadView markdown={c.body ?? ''} />
+                  )}
                   <CommentAttachments commentId={c.id} />
                 </div>
               ))}

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
@@ -23,12 +23,16 @@ function useEntityActions(entityId: string, runUid: string, isLive: boolean) {
   })
 }
 
+function prettifyJson(s: string): string {
+  try { return JSON.stringify(JSON.parse(s), null, 2) } catch { return s }
+}
+
 function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) {
   const { data, isLoading } = useEntityActions(entityId, runUid, true)
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const [rawMode, setRawMode] = useState(false)
   const bottomRef = useRef<HTMLDivElement>(null)
 
-  // Auto-scroll to bottom as new actions arrive
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [data?.length])
@@ -42,8 +46,22 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
     return next
   })
 
+  const fmt = (s: string) => rawMode ? s : prettifyJson(s)
+
   return (
-    <div className='max-h-96 overflow-y-auto font-mono text-xs'>
+    <div className='font-mono text-xs'>
+      {/* Global toolbar */}
+      <div className='flex items-center justify-end gap-2 border-b border-white/5 px-3 py-1'>
+        <button
+          type='button'
+          onClick={() => setRawMode(r => !r)}
+          className={`rounded px-2 py-0.5 text-[10px] transition-colors ${rawMode ? 'bg-amber-500/20 text-amber-300' : 'text-muted-foreground hover:text-foreground'}`}
+        >
+          {rawMode ? 'RAW' : 'PARSED'}
+        </button>
+      </div>
+
+      <div className='max-h-96 overflow-y-auto'>
       {data.map((a) => {
         const isExpanded = expanded.has(a.id)
         const hasContent = !!(a.tool_input || a.tool_response)
@@ -57,9 +75,7 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
               <span className='text-blue-400 font-medium'>{a.tool_name}</span>
               {a.turn_number > 0 && <span className='text-muted-foreground text-[10px]'>turn {a.turn_number}</span>}
               {hasContent && (
-                <span className='text-muted-foreground text-[10px]'>
-                  {isExpanded ? '▲' : '▼'}
-                </span>
+                <span className='text-muted-foreground text-[10px]'>{isExpanded ? '▲' : '▼'}</span>
               )}
               <span className='text-muted-foreground ml-auto text-[10px]'>
                 {new Date(Date.parse(a.created_at)).toLocaleTimeString()}
@@ -80,7 +96,7 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
                   <div>
                     <div className='text-[10px] font-semibold text-blue-400/60 mb-0.5'>INPUT</div>
                     <div className='whitespace-pre-wrap break-all rounded bg-white/5 p-2 text-[10px] text-muted-foreground'>
-                      {a.tool_input}
+                      {fmt(a.tool_input)}
                     </div>
                   </div>
                 )}
@@ -88,7 +104,7 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
                   <div>
                     <div className='text-[10px] font-semibold text-emerald-400/60 mb-0.5'>RESPONSE</div>
                     <div className='whitespace-pre-wrap break-all rounded bg-white/5 p-2 text-[10px] text-muted-foreground'>
-                      {a.tool_response}
+                      {fmt(a.tool_response)}
                     </div>
                   </div>
                 )}
@@ -98,6 +114,7 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
         )
       })}
       <div ref={bottomRef} />
+      </div>
     </div>
   )
 }

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
@@ -28,17 +28,31 @@ function prettifyJson(s: string): string {
 }
 
 function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) {
-  const { data, isLoading } = useEntityActions(entityId, runUid, true)
+  const [paused, setPaused] = useState(false)
+  const { data, isLoading } = useEntityActions(entityId, runUid, !paused)
+  const [frozen, setFrozen] = useState<typeof data>(undefined)
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [rawMode, setRawMode] = useState(false)
   const bottomRef = useRef<HTMLDivElement>(null)
 
+  // When pausing, freeze the current snapshot. When resuming, clear it.
+  const togglePause = () => {
+    setPaused(p => {
+      if (!p) setFrozen(data)   // freeze on pause
+      else setFrozen(undefined) // unfreeze on resume
+      return !p
+    })
+  }
+
+  // Auto-scroll only when not paused
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [data?.length])
+    if (!paused) bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [data?.length, paused])
+
+  const display = paused ? frozen : data
 
   if (isLoading) return <div className='text-muted-foreground p-3 text-xs'>Loading output…</div>
-  if (!data?.length) return <div className='text-muted-foreground p-3 text-xs'>Waiting for agent to make tool calls…</div>
+  if (!display?.length) return <div className='text-muted-foreground p-3 text-xs'>Waiting for agent to make tool calls…</div>
 
   const toggle = (id: string) => setExpanded(prev => {
     const next = new Set(prev)
@@ -54,6 +68,14 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
       <div className='flex items-center justify-end gap-2 border-b border-white/5 px-3 py-1'>
         <button
           type='button'
+          onClick={togglePause}
+          className={`rounded px-2 py-0.5 text-[10px] transition-colors ${paused ? 'bg-rose-500/20 text-rose-300' : 'text-muted-foreground hover:text-foreground'}`}
+          title={paused ? 'Paused — click to resume' : 'Pause output'}
+        >
+          {paused ? '▶ RESUME' : '⏸ PAUSE'}
+        </button>
+        <button
+          type='button'
           onClick={() => setRawMode(r => !r)}
           className={`rounded px-2 py-0.5 text-[10px] transition-colors ${rawMode ? 'bg-amber-500/20 text-amber-300' : 'text-muted-foreground hover:text-foreground'}`}
         >
@@ -62,7 +84,7 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
       </div>
 
       <div className='max-h-96 overflow-y-auto'>
-      {data.map((a) => {
+      {display.map((a) => {
         const isExpanded = expanded.has(a.id)
         const hasContent = !!(a.tool_input || a.tool_response)
         return (

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
@@ -1,4 +1,5 @@
 import { useState, Fragment, useEffect, useRef } from 'react'
+import { CopyButton } from '@/components/copy-button'
 import { useQuery } from '@tanstack/react-query'
 import { useEntityRuns, useLiveRuns, type EntityKind, type LiveRun } from '@/lib/queries/entity'
 import type { ExecutionRow } from '@/lib/types'
@@ -118,8 +119,7 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
                   <div>
                     <div className='flex items-center gap-2 mb-0.5'>
                       <span className='text-[10px] font-semibold text-blue-400/60'>INPUT</span>
-                      <button type='button' onClick={(e) => { e.stopPropagation(); navigator.clipboard.writeText(fmt(a.tool_input)) }}
-                        className='text-[10px] text-muted-foreground hover:text-foreground ml-auto'>copy</button>
+                      <CopyButton text={fmt(a.tool_input)} className='ml-auto' title='Copy input' />
                     </div>
                     <div className='whitespace-pre-wrap break-all rounded bg-white/5 p-2 text-[10px] text-muted-foreground'>
                       {fmt(a.tool_input)}
@@ -130,8 +130,7 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
                   <div>
                     <div className='flex items-center gap-2 mb-0.5'>
                       <span className='text-[10px] font-semibold text-emerald-400/60'>RESPONSE</span>
-                      <button type='button' onClick={(e) => { e.stopPropagation(); navigator.clipboard.writeText(fmt(a.tool_response)) }}
-                        className='text-[10px] text-muted-foreground hover:text-foreground ml-auto'>copy</button>
+                      <CopyButton text={fmt(a.tool_response)} className='ml-auto' title='Copy response' />
                     </div>
                     <div className='whitespace-pre-wrap break-all rounded bg-white/5 p-2 text-[10px] text-muted-foreground'>
                       {fmt(a.tool_response)}

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
@@ -116,7 +116,11 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
               <div className='mt-1 space-y-1.5'>
                 {a.tool_input && (
                   <div>
-                    <div className='text-[10px] font-semibold text-blue-400/60 mb-0.5'>INPUT</div>
+                    <div className='flex items-center gap-2 mb-0.5'>
+                      <span className='text-[10px] font-semibold text-blue-400/60'>INPUT</span>
+                      <button type='button' onClick={(e) => { e.stopPropagation(); navigator.clipboard.writeText(fmt(a.tool_input)) }}
+                        className='text-[10px] text-muted-foreground hover:text-foreground ml-auto'>copy</button>
+                    </div>
                     <div className='whitespace-pre-wrap break-all rounded bg-white/5 p-2 text-[10px] text-muted-foreground'>
                       {fmt(a.tool_input)}
                     </div>
@@ -124,7 +128,11 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
                 )}
                 {a.tool_response && (
                   <div>
-                    <div className='text-[10px] font-semibold text-emerald-400/60 mb-0.5'>RESPONSE</div>
+                    <div className='flex items-center gap-2 mb-0.5'>
+                      <span className='text-[10px] font-semibold text-emerald-400/60'>RESPONSE</span>
+                      <button type='button' onClick={(e) => { e.stopPropagation(); navigator.clipboard.writeText(fmt(a.tool_response)) }}
+                        className='text-[10px] text-muted-foreground hover:text-foreground ml-auto'>copy</button>
+                    </div>
                     <div className='whitespace-pre-wrap break-all rounded bg-white/5 p-2 text-[10px] text-muted-foreground'>
                       {fmt(a.tool_response)}
                     </div>

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
@@ -1,4 +1,4 @@
-import { useState, Fragment } from 'react'
+import { useState, Fragment, useEffect, useRef } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useEntityRuns, useLiveRuns, type EntityKind, type LiveRun } from '@/lib/queries/entity'
 import type { ExecutionRow } from '@/lib/types'
@@ -25,26 +25,54 @@ function useEntityActions(entityId: string, runUid: string, isLive: boolean) {
 
 function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) {
   const { data, isLoading } = useEntityActions(entityId, runUid, true)
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  // Auto-scroll to bottom as new actions arrive
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [data?.length])
+
   if (isLoading) return <div className='text-muted-foreground p-3 text-xs'>Loading output…</div>
   if (!data?.length) return <div className='text-muted-foreground p-3 text-xs'>Waiting for agent to make tool calls…</div>
+
+  const toggle = (id: string) => setExpanded(prev => {
+    const next = new Set(prev)
+    next.has(id) ? next.delete(id) : next.add(id)
+    return next
+  })
+
   return (
     <div className='max-h-96 overflow-y-auto font-mono text-xs'>
-      {[...data].reverse().map((a) => (
-        <div key={a.id} className='border-b border-white/5 px-3 py-1.5'>
-          <div className='flex items-center gap-2'>
-            <span className='text-blue-400 font-medium'>{a.tool_name}</span>
-            {a.turn_number > 0 && <span className='text-muted-foreground text-[10px]'>turn {a.turn_number}</span>}
-            <span className='text-muted-foreground ml-auto text-[10px]'>
-              {new Date(Date.parse(a.created_at)).toLocaleTimeString()}
-            </span>
-          </div>
-          {a.tool_input && (
-            <div className='text-muted-foreground mt-0.5 truncate text-[10px]'>
-              {a.tool_input.slice(0, 120)}
+      {data.map((a) => {
+        const isExpanded = expanded.has(a.id)
+        const hasInput = !!a.tool_input
+        return (
+          <div key={a.id} className='border-b border-white/5 px-3 py-1.5'>
+            <div
+              className={`flex items-center gap-2 ${hasInput ? 'cursor-pointer' : ''}`}
+              onClick={() => hasInput && toggle(a.id)}
+            >
+              <span className='text-blue-400 font-medium'>{a.tool_name}</span>
+              {a.turn_number > 0 && <span className='text-muted-foreground text-[10px]'>turn {a.turn_number}</span>}
+              {hasInput && (
+                <span className='text-muted-foreground text-[10px]'>
+                  {isExpanded ? '▲ collapse' : '▼ expand'}
+                </span>
+              )}
+              <span className='text-muted-foreground ml-auto text-[10px]'>
+                {new Date(Date.parse(a.created_at)).toLocaleTimeString()}
+              </span>
             </div>
-          )}
-        </div>
-      ))}
+            {hasInput && (
+              <div className={`text-muted-foreground mt-0.5 text-[10px] ${isExpanded ? 'whitespace-pre-wrap break-all' : 'truncate'}`}>
+                {isExpanded ? a.tool_input : a.tool_input.slice(0, 120)}
+              </div>
+            )}
+          </div>
+        )
+      })}
+      <div ref={bottomRef} />
     </div>
   )
 }

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
@@ -46,27 +46,52 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
     <div className='max-h-96 overflow-y-auto font-mono text-xs'>
       {data.map((a) => {
         const isExpanded = expanded.has(a.id)
-        const hasInput = !!a.tool_input
+        const hasContent = !!(a.tool_input || a.tool_response)
         return (
           <div key={a.id} className='border-b border-white/5 px-3 py-1.5'>
+            {/* Header row — click to expand */}
             <div
-              className={`flex items-center gap-2 ${hasInput ? 'cursor-pointer' : ''}`}
-              onClick={() => hasInput && toggle(a.id)}
+              className={`flex items-center gap-2 ${hasContent ? 'cursor-pointer select-none' : ''}`}
+              onClick={() => hasContent && toggle(a.id)}
             >
               <span className='text-blue-400 font-medium'>{a.tool_name}</span>
               {a.turn_number > 0 && <span className='text-muted-foreground text-[10px]'>turn {a.turn_number}</span>}
-              {hasInput && (
+              {hasContent && (
                 <span className='text-muted-foreground text-[10px]'>
-                  {isExpanded ? '▲ collapse' : '▼ expand'}
+                  {isExpanded ? '▲' : '▼'}
                 </span>
               )}
               <span className='text-muted-foreground ml-auto text-[10px]'>
                 {new Date(Date.parse(a.created_at)).toLocaleTimeString()}
               </span>
             </div>
-            {hasInput && (
-              <div className={`text-muted-foreground mt-0.5 text-[10px] ${isExpanded ? 'whitespace-pre-wrap break-all' : 'truncate'}`}>
-                {isExpanded ? a.tool_input : a.tool_input.slice(0, 120)}
+
+            {/* Collapsed preview */}
+            {!isExpanded && a.tool_input && (
+              <div className='text-muted-foreground mt-0.5 truncate text-[10px]'>
+                {a.tool_input.slice(0, 120)}
+              </div>
+            )}
+
+            {/* Expanded: full input + response */}
+            {isExpanded && (
+              <div className='mt-1 space-y-1.5'>
+                {a.tool_input && (
+                  <div>
+                    <div className='text-[10px] font-semibold text-blue-400/60 mb-0.5'>INPUT</div>
+                    <div className='whitespace-pre-wrap break-all rounded bg-white/5 p-2 text-[10px] text-muted-foreground'>
+                      {a.tool_input}
+                    </div>
+                  </div>
+                )}
+                {a.tool_response && (
+                  <div>
+                    <div className='text-[10px] font-semibold text-emerald-400/60 mb-0.5'>RESPONSE</div>
+                    <div className='whitespace-pre-wrap break-all rounded bg-white/5 p-2 text-[10px] text-muted-foreground'>
+                      {a.tool_response}
+                    </div>
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
@@ -30,17 +30,7 @@ const GROUP_ID = {
 
 const GROUP_ID_SET: ReadonlySet<string> = new Set(Object.values(GROUP_ID))
 
-// Where to navigate when the user selects an entity. The unified
-// `/entities/$uid` route is M3/T1's deliverable; until then, drop into
-// the kind-scoped page that already exists. Single map => one line to
-// flip when M3/T1 lands.
-const KIND_TO_PATH: Record<EntityKind, string> = {
-  [KIND.product]: '/products',
-  [KIND.manifest]: '/manifests',
-  [KIND.task]: '/tasks',
-  [KIND.skill]: '/skills',
-  [KIND.idea]: '/ideas',
-}
+// All entity types navigate to the unified /entities/$uid route.
 
 const OPEN_STATE_KEY = 'entity-tree-open'
 
@@ -152,10 +142,7 @@ export function EntityTree() {
     (nodes: { id: string; data: TreeNode }[]) => {
       const node = nodes[0]
       if (!node || GROUP_ID_SET.has(node.id)) return
-      const path = KIND_TO_PATH[node.data.kind]
-      if (!path) return
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      navigate({ to: path, search: { id: node.id, tab: 'main' } } as any)
+      navigate({ to: '/entities/$uid', params: { uid: node.id } } as any)
     },
     [navigate],
   )

--- a/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { Tree } from 'react-arborist'
+import type { NodeRendererProps } from 'react-arborist'
+import type { EntityKind } from '@/lib/queries/entity'
+import {
+  KIND,
+  STATUS,
+  useEntityTree,
+  type TreeNode,
+} from '@/lib/queries/entity-tree'
+import { EntityTreeNode } from './EntityTreeNode'
+
+// Sentinel IDs for the two synthetic group headers. Prefixed with `__`
+// so they cannot collide with real UUID v7 entity IDs.
+const GROUP_ID = {
+  skills: '__skills__',
+  lifecycle: '__lifecycle__',
+} as const
+
+const GROUP_ID_SET: ReadonlySet<string> = new Set(Object.values(GROUP_ID))
+
+// Where to navigate when the user selects an entity. The unified
+// `/entities/$uid` route is M3/T1's deliverable; until then, drop into
+// the kind-scoped page that already exists. Single map => one line to
+// flip when M3/T1 lands.
+const KIND_TO_PATH: Record<EntityKind, string> = {
+  [KIND.product]: '/products',
+  [KIND.manifest]: '/manifests',
+  [KIND.task]: '/tasks',
+  [KIND.skill]: '/skills',
+  [KIND.idea]: '/ideas',
+}
+
+const OPEN_STATE_KEY = 'entity-tree-open'
+
+function readOpenState(): Record<string, boolean> {
+  if (typeof window === 'undefined') return {}
+  try {
+    const raw = window.localStorage.getItem(OPEN_STATE_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object') {
+      return parsed as Record<string, boolean>
+    }
+  } catch {
+    // corrupted entry — ignore and start fresh
+  }
+  return {}
+}
+
+function writeOpenState(map: Record<string, boolean>): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(OPEN_STATE_KEY, JSON.stringify(map))
+  } catch {
+    // quota or privacy mode — silently degrade
+  }
+}
+
+function TreeSkeleton() {
+  return (
+    <div className='space-y-1.5 px-2 py-1'>
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div
+          key={i}
+          className='h-4 bg-sidebar-accent/40 rounded-sm animate-pulse'
+          style={{ width: `${60 + ((i * 13) % 35)}%` }}
+        />
+      ))}
+    </div>
+  )
+}
+
+export function EntityTree() {
+  const { data, isLoading } = useEntityTree()
+  const navigate = useNavigate()
+
+  // We can't observe react-arborist's internal open state directly, so
+  // mirror it: seeded from localStorage, mutated on every onToggle.
+  const openMapRef = useRef<Record<string, boolean>>(readOpenState())
+  const [, forceTick] = useState(0)
+
+  const treeData = useMemo<TreeNode[]>(
+    () => [
+      {
+        id: GROUP_ID.skills,
+        name: 'Skills',
+        kind: KIND.skill,
+        status: STATUS.active,
+        children: data?.skills ?? [],
+      },
+      {
+        id: GROUP_ID.lifecycle,
+        name: 'Work Lifecycle',
+        kind: KIND.idea,
+        status: STATUS.active,
+        children: data?.lifecycle ?? [],
+      },
+    ],
+    [data],
+  )
+
+  const handleToggle = useCallback((id: string) => {
+    const next = { ...openMapRef.current, [id]: !openMapRef.current[id] }
+    openMapRef.current = next
+    writeOpenState(next)
+    forceTick((n) => n + 1)
+  }, [])
+
+  const handleSelect = useCallback(
+    (nodes: { id: string; data: TreeNode }[]) => {
+      const node = nodes[0]
+      if (!node || GROUP_ID_SET.has(node.id)) return
+      const path = KIND_TO_PATH[node.data.kind]
+      if (!path) return
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      navigate({ to: path, search: { id: node.id, tab: 'main' } } as any)
+    },
+    [navigate],
+  )
+
+  if (isLoading) return <TreeSkeleton />
+
+  return (
+    <Tree<TreeNode>
+      data={treeData}
+      openByDefault={false}
+      initialOpenState={openMapRef.current}
+      onToggle={handleToggle}
+      onSelect={handleSelect}
+      width='100%'
+      indent={16}
+      rowHeight={28}
+      overscanCount={8}
+    >
+      {(props: NodeRendererProps<TreeNode>) => {
+        if (GROUP_ID_SET.has(props.node.id)) {
+          return (
+            <div
+              style={props.style}
+              className='px-2 py-1 text-xs font-semibold text-muted-foreground uppercase tracking-wider'
+            >
+              {props.node.data.name}
+            </div>
+          )
+        }
+        return <EntityTreeNode {...props} />
+      }}
+    </Tree>
+  )
+}

--- a/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
@@ -1,15 +1,25 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
+import { useQueryClient } from '@tanstack/react-query'
 import { Tree } from 'react-arborist'
 import type { NodeRendererProps } from 'react-arborist'
 import type { EntityKind } from '@/lib/queries/entity'
+import { useLiveRuns } from '@/lib/queries/entity'
 import {
   KIND,
   STATUS,
+  entityTreeKeys,
+  overlayLiveStatus,
   useEntityTree,
   type TreeNode,
 } from '@/lib/queries/entity-tree'
 import { EntityTreeNode } from './EntityTreeNode'
+
+// Sentinel `entity_uid` for non-entity runs (bare-stdio MCP sessions).
+// Mirrored from runs.tsx — the live-runs endpoint emits this when an
+// agent is connected via stdio without a backing task UUID, so it must
+// not flip a tree node to running.
+const NON_ENTITY_RUN_UID = 'stdio'
 
 // Sentinel IDs for the two synthetic group headers. Prefixed with `__`
 // so they cannot collide with real UUID v7 entity IDs.
@@ -74,12 +84,42 @@ function TreeSkeleton() {
 
 export function EntityTree() {
   const { data, isLoading } = useEntityTree()
+  const liveRuns = useLiveRuns()
+  const queryClient = useQueryClient()
   const navigate = useNavigate()
 
   // We can't observe react-arborist's internal open state directly, so
   // mirror it: seeded from localStorage, mutated on every onToggle.
   const openMapRef = useRef<Record<string, boolean>>(readOpenState())
   const [, forceTick] = useState(0)
+
+  // Set of entity ids currently executing — pulled from the live-runs
+  // poll (4s while any agent runs, 10s idle). Memoised on a stable
+  // signature so referential identity only changes when membership does.
+  const liveSignature = useMemo(() => {
+    const ids = (liveRuns.data ?? [])
+      .map((r) => r.entity_uid)
+      .filter((id) => id && id !== NON_ENTITY_RUN_UID)
+      .sort()
+    return ids.join(',')
+  }, [liveRuns.data])
+
+  const liveTaskIds = useMemo<ReadonlySet<string>>(
+    () => new Set(liveSignature ? liveSignature.split(',') : []),
+    [liveSignature],
+  )
+
+  // When the running set flips, invalidate the tree so the next render
+  // pulls authoritative status from the API. Until that resolves, the
+  // overlay below keeps the dot in sync visually.
+  useEffect(() => {
+    queryClient.invalidateQueries({ queryKey: entityTreeKeys.all() })
+  }, [liveSignature, queryClient])
+
+  const overlaid = useMemo(() => {
+    if (!data) return undefined
+    return overlayLiveStatus(data, liveTaskIds)
+  }, [data, liveTaskIds])
 
   const treeData = useMemo<TreeNode[]>(
     () => [
@@ -88,17 +128,17 @@ export function EntityTree() {
         name: 'Skills',
         kind: KIND.skill,
         status: STATUS.active,
-        children: data?.skills ?? [],
+        children: overlaid?.skills ?? [],
       },
       {
         id: GROUP_ID.lifecycle,
         name: 'Work Lifecycle',
         kind: KIND.idea,
         status: STATUS.active,
-        children: data?.lifecycle ?? [],
+        children: overlaid?.lifecycle ?? [],
       },
     ],
-    [data],
+    [overlaid],
   )
 
   const handleToggle = useCallback((id: string) => {

--- a/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTreeNode.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTreeNode.tsx
@@ -1,0 +1,129 @@
+import {
+  Boxes,
+  CheckSquare,
+  ChevronRight,
+  FileText,
+  Lightbulb,
+  Wand2,
+  type LucideIcon,
+} from 'lucide-react'
+import type { NodeRendererProps } from 'react-arborist'
+import { cn } from '@/lib/utils'
+import type { EntityKind } from '@/lib/queries/entity'
+import {
+  KIND,
+  STATUS,
+  type TreeNode,
+  type TreeStatus,
+} from '@/lib/queries/entity-tree'
+
+// Icon per kind. Record<EntityKind, …> forces every kind to be mapped —
+// adding a new kind to EntityKind makes this fail to typecheck until an
+// icon is supplied. Single source of truth for kind→icon visualization.
+const KIND_ICON: Record<EntityKind, LucideIcon> = {
+  [KIND.skill]: Wand2,
+  [KIND.idea]: Lightbulb,
+  [KIND.product]: Boxes,
+  [KIND.manifest]: FileText,
+  [KIND.task]: CheckSquare,
+}
+
+export function EntityKindIcon({
+  kind,
+  className,
+}: {
+  kind: EntityKind
+  className?: string
+}) {
+  const Icon = KIND_ICON[kind]
+  return <Icon className={className} />
+}
+
+// Status dot — only meaningful for executable entities (task is the
+// source of truth; manifest/product are derived upward). Skills and
+// ideas have no execution surface so render nothing.
+const STATUS_VISIBLE_FOR: ReadonlySet<EntityKind> = new Set<EntityKind>([
+  KIND.task,
+  KIND.manifest,
+  KIND.product,
+])
+
+type StatusVisual = { glyph: string; className: string }
+
+const STATUS_VISUALS: Record<TreeStatus, StatusVisual> = {
+  [STATUS.running]: { glyph: '●', className: 'animate-pulse text-blue-400' },
+  [STATUS.completed]: { glyph: '✓', className: 'text-emerald-500' },
+  [STATUS.failed]: { glyph: '✗', className: 'text-red-500' },
+  [STATUS.active]: { glyph: '⚠', className: 'text-amber-400' },
+  [STATUS.draft]: { glyph: '○', className: 'text-muted-foreground' },
+  [STATUS.closed]: { glyph: '○', className: 'text-muted-foreground' },
+  [STATUS.archived]: { glyph: '○', className: 'text-muted-foreground' },
+}
+
+export function StatusDot({
+  status,
+  kind,
+}: {
+  status: TreeStatus
+  kind: EntityKind
+}) {
+  if (!STATUS_VISIBLE_FOR.has(kind)) return null
+  const visual = STATUS_VISUALS[status]
+  return (
+    <span
+      aria-label={`status: ${status}`}
+      className={cn('text-xs leading-none shrink-0', visual.className)}
+    >
+      {visual.glyph}
+    </span>
+  )
+}
+
+export function EntityTreeNode({
+  node,
+  style,
+  dragHandle,
+}: NodeRendererProps<TreeNode>) {
+  const isSelected = node.isSelected
+  const data = node.data
+  const childCount = data.children?.length ?? 0
+
+  return (
+    <div
+      ref={dragHandle}
+      style={style}
+      onClick={() => (node.isInternal ? node.toggle() : node.select())}
+      className={cn(
+        'flex items-center gap-1.5 px-2 py-0.5 rounded-sm cursor-pointer text-sm',
+        'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+        isSelected && 'bg-sidebar-accent text-sidebar-accent-foreground font-medium',
+      )}
+    >
+      {node.isInternal ? (
+        <ChevronRight
+          className={cn(
+            'h-3 w-3 shrink-0 text-muted-foreground transition-transform',
+            node.isOpen && 'rotate-90',
+          )}
+        />
+      ) : (
+        <span className='w-3' />
+      )}
+
+      <EntityKindIcon
+        kind={data.kind}
+        className='h-3.5 w-3.5 shrink-0 text-muted-foreground'
+      />
+
+      <span className='truncate flex-1 min-w-0'>{data.name}</span>
+
+      <StatusDot status={data.status} kind={data.kind} />
+
+      {node.isInternal && !node.isOpen && childCount > 0 && (
+        <span className='text-xs text-muted-foreground ml-auto'>
+          {childCount}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/internal/web/ui/dashboard-v2/src/lib/queries/entity-tree.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/queries/entity-tree.ts
@@ -273,6 +273,51 @@ async function fetchEntityTree(): Promise<EntityTree> {
   return { skills, lifecycle }
 }
 
+// ── Live status overlay ───────────────────────────────────────────────
+//
+// The tree is fetched on a 10s poll; useLiveRuns polls every 4s while
+// any agent is running. Overlaying the live set on top of the cached
+// tree gives 1–2s visual latency for state transitions without forcing
+// a full tree refetch on every poll.
+//
+// Walk depth-first: leaf-tasks whose id is in `liveTaskIds` flip to
+// running; internal nodes re-derive from their (possibly-overridden)
+// children via the same deriveStatus used at fetch time. The walk is
+// kind-agnostic — any internal node with children re-derives, so a new
+// entity kind would slot in for free.
+
+export function overlayLiveStatus(
+  tree: EntityTree,
+  liveTaskIds: ReadonlySet<string>,
+): EntityTree {
+  if (liveTaskIds.size === 0) return tree
+  return {
+    skills: tree.skills.map((n) => overlayNode(n, liveTaskIds)),
+    lifecycle: tree.lifecycle.map((n) => overlayNode(n, liveTaskIds)),
+  }
+}
+
+function overlayNode(
+  node: TreeNode,
+  liveTaskIds: ReadonlySet<string>,
+): TreeNode {
+  // A live run on the node itself is authoritative — overrides any
+  // derived child rollup. Otherwise, re-derive internal nodes from
+  // (possibly-overridden) children. Leaf nodes pass through unchanged.
+  const liveOverride: TreeStatus | null = liveTaskIds.has(node.id)
+    ? STATUS.running
+    : null
+  if (node.children && node.children.length > 0) {
+    const children = node.children.map((c) => overlayNode(c, liveTaskIds))
+    return {
+      ...node,
+      status: liveOverride ?? deriveStatus(children),
+      children,
+    }
+  }
+  return liveOverride ? { ...node, status: liveOverride } : node
+}
+
 // ── Hook ──────────────────────────────────────────────────────────────
 
 export const entityTreeKeys = {
@@ -293,4 +338,4 @@ export { fetchEntityTree }
 
 // Test/dev helpers — exported so children-of-different-shapes tests can
 // assert the derivation rules without reaching into the closure.
-export const __test__ = { deriveStatus, normalizeStatus }
+export const __test__ = { deriveStatus, normalizeStatus, overlayLiveStatus }

--- a/internal/web/ui/dashboard-v2/src/lib/queries/entity-tree.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/queries/entity-tree.ts
@@ -1,0 +1,295 @@
+import { useQuery } from '@tanstack/react-query'
+
+import type { EntityKind } from './entity'
+
+// useEntityTree — assembles the full sidebar tree from REST endpoints.
+//
+// Two top-level groups feed react-arborist:
+//   1. Skills        (global governance — flat leaf list)
+//   2. Lifecycle     (Idea → Product → Manifest → Task, nested via DAG edges)
+//
+// All relationship lookups within a depth fan out via Promise.all — the
+// whole tree resolves in (number-of-levels) round-trips, not per-node.
+//
+// Status on parent nodes is derived client-side from children
+// (see deriveStatus). Parent rows in `entities` carry their own status
+// (active/draft/closed/archived), but execution liveness lives on tasks
+// — we surface that upward so the tree shows aggregate health.
+
+// ── Single-point-of-change constants ─────────────────────────────────
+// Domain values that flow into URLs. Defined once here so a rename in
+// the backend requires changing exactly one line.
+const KIND = {
+  skill: 'skill',
+  idea: 'idea',
+  product: 'product',
+  manifest: 'manifest',
+  task: 'task',
+} as const satisfies Record<EntityKind, EntityKind>
+
+const EDGE = {
+  owns: 'owns',
+  linksTo: 'links_to',
+} as const
+
+const STATUS = {
+  draft: 'draft',
+  active: 'active',
+  running: 'running',
+  completed: 'completed',
+  failed: 'failed',
+  closed: 'closed',
+  archived: 'archived',
+} as const
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+export type TreeStatus = (typeof STATUS)[keyof typeof STATUS]
+
+export interface TreeNode {
+  id: string
+  name: string
+  kind: EntityKind
+  status: TreeStatus
+  children?: TreeNode[]
+}
+
+export interface EntityTree {
+  skills: TreeNode[]
+  lifecycle: TreeNode[]
+}
+
+// ── Wire shapes ───────────────────────────────────────────────────────
+// /api/entities returns a flat list with snake_case fields.
+interface EntityRow {
+  entity_uid: string
+  type: EntityKind
+  title: string
+  status: string
+}
+
+// /api/relationships/{incoming,outgoing} returns Go's PascalCase fields.
+interface RelationshipRow {
+  SrcID: string
+  SrcKind: EntityKind
+  DstID: string
+  DstKind: EntityKind
+  Kind: string
+}
+
+// ── Fetch helpers ─────────────────────────────────────────────────────
+
+async function fetchJSON<T>(path: string): Promise<T> {
+  const res = await fetch(path)
+  if (!res.ok) throw new Error(`${path} → ${res.status}`)
+  return res.json() as Promise<T>
+}
+
+async function fetchEntities(
+  type: EntityKind,
+  params: { status?: string; limit: number },
+): Promise<EntityRow[]> {
+  const qs = new URLSearchParams({ type, limit: String(params.limit) })
+  if (params.status) qs.set('status', params.status)
+  const rows = await fetchJSON<EntityRow[] | null>(`/api/entities?${qs}`)
+  return rows ?? []
+}
+
+async function fetchEntity(id: string): Promise<EntityRow | null> {
+  try {
+    return await fetchJSON<EntityRow>(`/api/entities/${id}`)
+  } catch {
+    return null
+  }
+}
+
+async function fetchOutgoing(
+  srcID: string,
+  edgeKind: string,
+): Promise<RelationshipRow[]> {
+  const qs = new URLSearchParams({ src_id: srcID, kind: edgeKind })
+  const rows = await fetchJSON<RelationshipRow[] | null>(
+    `/api/relationships/outgoing?${qs}`,
+  )
+  return rows ?? []
+}
+
+async function fetchIncoming(
+  dstID: string,
+  edgeKind: string,
+): Promise<RelationshipRow[]> {
+  const qs = new URLSearchParams({ dst_id: dstID, kind: edgeKind })
+  const rows = await fetchJSON<RelationshipRow[] | null>(
+    `/api/relationships/incoming?${qs}`,
+  )
+  return rows ?? []
+}
+
+// ── Status derivation ─────────────────────────────────────────────────
+
+function normalizeStatus(s: string): TreeStatus {
+  const known: TreeStatus[] = [
+    STATUS.draft,
+    STATUS.active,
+    STATUS.running,
+    STATUS.completed,
+    STATUS.failed,
+    STATUS.closed,
+    STATUS.archived,
+  ]
+  return (known as string[]).includes(s) ? (s as TreeStatus) : STATUS.draft
+}
+
+export function deriveStatus(children: TreeNode[]): TreeStatus {
+  if (children.length === 0) return STATUS.draft
+  if (children.some((c) => c.status === STATUS.running)) return STATUS.running
+  if (children.some((c) => c.status === STATUS.failed)) return STATUS.failed
+  if (children.every((c) => c.status === STATUS.completed))
+    return STATUS.completed
+  if (children.some((c) => c.status === STATUS.completed)) return STATUS.active
+  return STATUS.draft
+}
+
+// ── Tree builders ─────────────────────────────────────────────────────
+
+async function buildManifestNode(manifest: EntityRow): Promise<TreeNode> {
+  const taskEdges = await fetchOutgoing(manifest.entity_uid, EDGE.owns)
+  const tasks = await Promise.all(
+    taskEdges
+      .filter((e) => e.DstKind === KIND.task)
+      .map(async (e) => {
+        const t = await fetchEntity(e.DstID)
+        if (!t) return null
+        const node: TreeNode = {
+          id: t.entity_uid,
+          name: t.title,
+          kind: KIND.task,
+          status: normalizeStatus(t.status),
+        }
+        return node
+      }),
+  )
+  const children = tasks.filter((t): t is TreeNode => t !== null)
+  return {
+    id: manifest.entity_uid,
+    name: manifest.title,
+    kind: KIND.manifest,
+    status: children.length ? deriveStatus(children) : normalizeStatus(manifest.status),
+    children,
+  }
+}
+
+async function buildProductNode(product: EntityRow): Promise<TreeNode> {
+  const manifestEdges = await fetchOutgoing(product.entity_uid, EDGE.owns)
+  const manifests = await Promise.all(
+    manifestEdges
+      .filter((e) => e.DstKind === KIND.manifest)
+      .map(async (e) => {
+        const m = await fetchEntity(e.DstID)
+        if (!m) return null
+        return buildManifestNode(m)
+      }),
+  )
+  const children = manifests.filter((m): m is TreeNode => m !== null)
+  return {
+    id: product.entity_uid,
+    name: product.title,
+    kind: KIND.product,
+    status: children.length ? deriveStatus(children) : normalizeStatus(product.status),
+    children,
+  }
+}
+
+async function buildIdeaNode(
+  idea: EntityRow,
+  linkedProductIDs: Set<string>,
+  productByID: Map<string, EntityRow>,
+): Promise<TreeNode> {
+  const productEdges = await fetchOutgoing(idea.entity_uid, EDGE.linksTo)
+  const productIDs = productEdges
+    .filter((e) => e.DstKind === KIND.product)
+    .map((e) => e.DstID)
+  for (const id of productIDs) linkedProductIDs.add(id)
+
+  const products = await Promise.all(
+    productIDs.map(async (id) => {
+      const p = productByID.get(id) ?? (await fetchEntity(id))
+      if (!p) return null
+      return buildProductNode(p)
+    }),
+  )
+  const children = products.filter((p): p is TreeNode => p !== null)
+  return {
+    id: idea.entity_uid,
+    name: idea.title,
+    kind: KIND.idea,
+    status: children.length ? deriveStatus(children) : normalizeStatus(idea.status),
+    children: children.length ? children : undefined,
+  }
+}
+
+async function fetchEntityTree(): Promise<EntityTree> {
+  // Group 1 + initial fan-out for Group 2 in parallel.
+  const [skillRows, ideaRows, productRows] = await Promise.all([
+    fetchEntities(KIND.skill, { status: STATUS.active, limit: 100 }),
+    fetchEntities(KIND.idea, { limit: 200 }),
+    fetchEntities(KIND.product, { limit: 200 }),
+  ])
+
+  const skills: TreeNode[] = skillRows.map((s) => ({
+    id: s.entity_uid,
+    name: s.title,
+    kind: KIND.skill,
+    status: normalizeStatus(s.status),
+  }))
+
+  const productByID = new Map(productRows.map((p) => [p.entity_uid, p]))
+  const linkedProductIDs = new Set<string>()
+
+  const ideaNodes = await Promise.all(
+    ideaRows.map((i) => buildIdeaNode(i, linkedProductIDs, productByID)),
+  )
+
+  // Products not linked to any idea → "Unlinked Products" group.
+  const unlinkedProducts = productRows.filter(
+    (p) => !linkedProductIDs.has(p.entity_uid),
+  )
+  const unlinkedNodes = await Promise.all(
+    unlinkedProducts.map((p) => buildProductNode(p)),
+  )
+
+  const lifecycle: TreeNode[] = [...ideaNodes]
+  if (unlinkedNodes.length) {
+    lifecycle.push({
+      id: 'unlinked-products',
+      name: 'Unlinked Products',
+      kind: KIND.idea,
+      status: deriveStatus(unlinkedNodes),
+      children: unlinkedNodes,
+    })
+  }
+
+  return { skills, lifecycle }
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────
+
+export const entityTreeKeys = {
+  all: () => ['entity-tree'] as const,
+}
+
+export function useEntityTree() {
+  return useQuery({
+    queryKey: entityTreeKeys.all(),
+    queryFn: fetchEntityTree,
+    staleTime: 30_000,
+    refetchInterval: 10_000,
+  })
+}
+
+// Re-exports — let consumers import via this module (tree-friendly).
+export { fetchEntityTree }
+
+// Test/dev helpers — exported so children-of-different-shapes tests can
+// assert the derivation rules without reaching into the closure.
+export const __test__ = { deriveStatus, normalizeStatus }

--- a/internal/web/ui/dashboard-v2/src/lib/queries/entity-tree.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/queries/entity-tree.ts
@@ -28,7 +28,7 @@ export const KIND = {
   task: 'task',
 } as const satisfies Record<EntityKind, EntityKind>
 
-const EDGE = {
+export const EDGE = {
   owns: 'owns',
   linksTo: 'links_to',
 } as const

--- a/internal/web/ui/dashboard-v2/src/lib/queries/entity-tree.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/queries/entity-tree.ts
@@ -229,48 +229,23 @@ async function buildIdeaNode(
   }
 }
 
+// Single request to the backend tree endpoint — no N+1 fan-out.
+// The Go handler assembles the full tree in 5+1 bulk queries.
 async function fetchEntityTree(): Promise<EntityTree> {
-  // Group 1 + initial fan-out for Group 2 in parallel.
-  const [skillRows, ideaRows, productRows] = await Promise.all([
-    fetchEntities(KIND.skill, { status: STATUS.active, limit: 100 }),
-    fetchEntities(KIND.idea, { limit: 200 }),
-    fetchEntities(KIND.product, { limit: 200 }),
-  ])
-
-  const skills: TreeNode[] = skillRows.map((s) => ({
-    id: s.entity_uid,
-    name: s.title,
-    kind: KIND.skill,
-    status: normalizeStatus(s.status),
-  }))
-
-  const productByID = new Map(productRows.map((p) => [p.entity_uid, p]))
-  const linkedProductIDs = new Set<string>()
-
-  const ideaNodes = await Promise.all(
-    ideaRows.map((i) => buildIdeaNode(i, linkedProductIDs, productByID)),
-  )
-
-  // Products not linked to any idea → "Unlinked Products" group.
-  const unlinkedProducts = productRows.filter(
-    (p) => !linkedProductIDs.has(p.entity_uid),
-  )
-  const unlinkedNodes = await Promise.all(
-    unlinkedProducts.map((p) => buildProductNode(p)),
-  )
-
-  const lifecycle: TreeNode[] = [...ideaNodes]
-  if (unlinkedNodes.length) {
-    lifecycle.push({
-      id: 'unlinked-products',
-      name: 'Unlinked Products',
-      kind: KIND.idea,
-      status: deriveStatus(unlinkedNodes),
-      children: unlinkedNodes,
-    })
+  const res = await fetch('/api/entities/tree')
+  if (!res.ok) throw new Error(`/api/entities/tree → ${res.status}`)
+  const data = await res.json() as EntityTree
+  // Normalise statuses so the overlay logic works correctly.
+  const normalizeNodes = (nodes: TreeNode[]): TreeNode[] =>
+    nodes.map(n => ({
+      ...n,
+      status: normalizeStatus(n.status),
+      children: n.children ? normalizeNodes(n.children) : undefined,
+    }))
+  return {
+    skills: normalizeNodes(data.skills ?? []),
+    lifecycle: normalizeNodes(data.lifecycle ?? []),
   }
-
-  return { skills, lifecycle }
 }
 
 // ── Live status overlay ───────────────────────────────────────────────

--- a/internal/web/ui/dashboard-v2/src/lib/queries/entity-tree.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/queries/entity-tree.ts
@@ -18,8 +18,9 @@ import type { EntityKind } from './entity'
 
 // ── Single-point-of-change constants ─────────────────────────────────
 // Domain values that flow into URLs. Defined once here so a rename in
-// the backend requires changing exactly one line.
-const KIND = {
+// the backend requires changing exactly one line. Re-exported for any
+// consumer that branches on kind/status (renderers, navigation, etc.).
+export const KIND = {
   skill: 'skill',
   idea: 'idea',
   product: 'product',
@@ -32,7 +33,7 @@ const EDGE = {
   linksTo: 'links_to',
 } as const
 
-const STATUS = {
+export const STATUS = {
   draft: 'draft',
   active: 'active',
   running: 'running',

--- a/internal/web/ui/dashboard-v2/src/lib/queries/entity.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/queries/entity.ts
@@ -135,6 +135,19 @@ export function useEntity(kind: EntityKind, id: string | undefined) {
   })
 }
 
+// Kind-agnostic lookup. The unified /api/entities/:uid endpoint resolves
+// any entity by its UUID and returns the row with `type` populated, so
+// callers that don't know the kind upfront (e.g. /entities/$uid route)
+// can resolve it before rendering.
+export function useEntityByUid(uid: string | undefined) {
+  return useQuery({
+    queryKey: ['entity', 'by-uid', uid ?? ''] as const,
+    queryFn: () => fetchJSON<Entity>(`/api/entities/${uid}`),
+    enabled: !!uid,
+    staleTime: 15 * 1000,
+  })
+}
+
 // Hierarchy is products-only — manifests don't expose recursive
 // descendants. For manifests we synthesize a minimal hierarchy from the
 // detail row + children + deps in the DAG tab; this hook just returns

--- a/internal/web/ui/dashboard-v2/src/routeTree.gen.ts
+++ b/internal/web/ui/dashboard-v2/src/routeTree.gen.ts
@@ -30,11 +30,14 @@ import { Route as errors404RouteImport } from './routes/(errors)/404'
 import { Route as errors403RouteImport } from './routes/(errors)/403'
 import { Route as errors401RouteImport } from './routes/(errors)/401'
 import { Route as AuthenticatedSettingsRouteRouteImport } from './routes/_authenticated/settings/route'
+import { Route as AuthenticatedEntitiesRouteRouteImport } from './routes/_authenticated/entities/route'
 import { Route as AuthenticatedSettingsIndexRouteImport } from './routes/_authenticated/settings/index'
+import { Route as AuthenticatedEntitiesIndexRouteImport } from './routes/_authenticated/entities/index'
 import { Route as AuthenticatedSettingsNotificationsRouteImport } from './routes/_authenticated/settings/notifications'
 import { Route as AuthenticatedSettingsDisplayRouteImport } from './routes/_authenticated/settings/display'
 import { Route as AuthenticatedSettingsAppearanceRouteImport } from './routes/_authenticated/settings/appearance'
 import { Route as AuthenticatedSettingsAccountRouteImport } from './routes/_authenticated/settings/account'
+import { Route as AuthenticatedEntitiesUidRouteImport } from './routes/_authenticated/entities/$uid'
 
 const AuthenticatedRouteRoute = AuthenticatedRouteRouteImport.update({
   id: '/_authenticated',
@@ -142,11 +145,23 @@ const AuthenticatedSettingsRouteRoute =
     path: '/settings',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
+const AuthenticatedEntitiesRouteRoute =
+  AuthenticatedEntitiesRouteRouteImport.update({
+    id: '/entities',
+    path: '/entities',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 const AuthenticatedSettingsIndexRoute =
   AuthenticatedSettingsIndexRouteImport.update({
     id: '/',
     path: '/',
     getParentRoute: () => AuthenticatedSettingsRouteRoute,
+  } as any)
+const AuthenticatedEntitiesIndexRoute =
+  AuthenticatedEntitiesIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedEntitiesRouteRoute,
   } as any)
 const AuthenticatedSettingsNotificationsRoute =
   AuthenticatedSettingsNotificationsRouteImport.update({
@@ -172,9 +187,16 @@ const AuthenticatedSettingsAccountRoute =
     path: '/account',
     getParentRoute: () => AuthenticatedSettingsRouteRoute,
   } as any)
+const AuthenticatedEntitiesUidRoute =
+  AuthenticatedEntitiesUidRouteImport.update({
+    id: '/$uid',
+    path: '/$uid',
+    getParentRoute: () => AuthenticatedEntitiesRouteRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof AuthenticatedIndexRoute
+  '/entities': typeof AuthenticatedEntitiesRouteRouteWithChildren
   '/settings': typeof AuthenticatedSettingsRouteRouteWithChildren
   '/401': typeof errors401Route
   '/403': typeof errors403Route
@@ -194,10 +216,12 @@ export interface FileRoutesByFullPath {
   '/skills': typeof AuthenticatedSkillsRoute
   '/stats': typeof AuthenticatedStatsRoute
   '/tasks': typeof AuthenticatedTasksRoute
+  '/entities/$uid': typeof AuthenticatedEntitiesUidRoute
   '/settings/account': typeof AuthenticatedSettingsAccountRoute
   '/settings/appearance': typeof AuthenticatedSettingsAppearanceRoute
   '/settings/display': typeof AuthenticatedSettingsDisplayRoute
   '/settings/notifications': typeof AuthenticatedSettingsNotificationsRoute
+  '/entities/': typeof AuthenticatedEntitiesIndexRoute
   '/settings/': typeof AuthenticatedSettingsIndexRoute
 }
 export interface FileRoutesByTo {
@@ -220,15 +244,18 @@ export interface FileRoutesByTo {
   '/stats': typeof AuthenticatedStatsRoute
   '/tasks': typeof AuthenticatedTasksRoute
   '/': typeof AuthenticatedIndexRoute
+  '/entities/$uid': typeof AuthenticatedEntitiesUidRoute
   '/settings/account': typeof AuthenticatedSettingsAccountRoute
   '/settings/appearance': typeof AuthenticatedSettingsAppearanceRoute
   '/settings/display': typeof AuthenticatedSettingsDisplayRoute
   '/settings/notifications': typeof AuthenticatedSettingsNotificationsRoute
+  '/entities': typeof AuthenticatedEntitiesIndexRoute
   '/settings': typeof AuthenticatedSettingsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_authenticated': typeof AuthenticatedRouteRouteWithChildren
+  '/_authenticated/entities': typeof AuthenticatedEntitiesRouteRouteWithChildren
   '/_authenticated/settings': typeof AuthenticatedSettingsRouteRouteWithChildren
   '/(errors)/401': typeof errors401Route
   '/(errors)/403': typeof errors403Route
@@ -249,16 +276,19 @@ export interface FileRoutesById {
   '/_authenticated/stats': typeof AuthenticatedStatsRoute
   '/_authenticated/tasks': typeof AuthenticatedTasksRoute
   '/_authenticated/': typeof AuthenticatedIndexRoute
+  '/_authenticated/entities/$uid': typeof AuthenticatedEntitiesUidRoute
   '/_authenticated/settings/account': typeof AuthenticatedSettingsAccountRoute
   '/_authenticated/settings/appearance': typeof AuthenticatedSettingsAppearanceRoute
   '/_authenticated/settings/display': typeof AuthenticatedSettingsDisplayRoute
   '/_authenticated/settings/notifications': typeof AuthenticatedSettingsNotificationsRoute
+  '/_authenticated/entities/': typeof AuthenticatedEntitiesIndexRoute
   '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/entities'
     | '/settings'
     | '/401'
     | '/403'
@@ -278,10 +308,12 @@ export interface FileRouteTypes {
     | '/skills'
     | '/stats'
     | '/tasks'
+    | '/entities/$uid'
     | '/settings/account'
     | '/settings/appearance'
     | '/settings/display'
     | '/settings/notifications'
+    | '/entities/'
     | '/settings/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -304,14 +336,17 @@ export interface FileRouteTypes {
     | '/stats'
     | '/tasks'
     | '/'
+    | '/entities/$uid'
     | '/settings/account'
     | '/settings/appearance'
     | '/settings/display'
     | '/settings/notifications'
+    | '/entities'
     | '/settings'
   id:
     | '__root__'
     | '/_authenticated'
+    | '/_authenticated/entities'
     | '/_authenticated/settings'
     | '/(errors)/401'
     | '/(errors)/403'
@@ -332,10 +367,12 @@ export interface FileRouteTypes {
     | '/_authenticated/stats'
     | '/_authenticated/tasks'
     | '/_authenticated/'
+    | '/_authenticated/entities/$uid'
     | '/_authenticated/settings/account'
     | '/_authenticated/settings/appearance'
     | '/_authenticated/settings/display'
     | '/_authenticated/settings/notifications'
+    | '/_authenticated/entities/'
     | '/_authenticated/settings/'
   fileRoutesById: FileRoutesById
 }
@@ -497,12 +534,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSettingsRouteRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/entities': {
+      id: '/_authenticated/entities'
+      path: '/entities'
+      fullPath: '/entities'
+      preLoaderRoute: typeof AuthenticatedEntitiesRouteRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/settings/': {
       id: '/_authenticated/settings/'
       path: '/'
       fullPath: '/settings/'
       preLoaderRoute: typeof AuthenticatedSettingsIndexRouteImport
       parentRoute: typeof AuthenticatedSettingsRouteRoute
+    }
+    '/_authenticated/entities/': {
+      id: '/_authenticated/entities/'
+      path: '/'
+      fullPath: '/entities/'
+      preLoaderRoute: typeof AuthenticatedEntitiesIndexRouteImport
+      parentRoute: typeof AuthenticatedEntitiesRouteRoute
     }
     '/_authenticated/settings/notifications': {
       id: '/_authenticated/settings/notifications'
@@ -532,8 +583,31 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSettingsAccountRouteImport
       parentRoute: typeof AuthenticatedSettingsRouteRoute
     }
+    '/_authenticated/entities/$uid': {
+      id: '/_authenticated/entities/$uid'
+      path: '/$uid'
+      fullPath: '/entities/$uid'
+      preLoaderRoute: typeof AuthenticatedEntitiesUidRouteImport
+      parentRoute: typeof AuthenticatedEntitiesRouteRoute
+    }
   }
 }
+
+interface AuthenticatedEntitiesRouteRouteChildren {
+  AuthenticatedEntitiesUidRoute: typeof AuthenticatedEntitiesUidRoute
+  AuthenticatedEntitiesIndexRoute: typeof AuthenticatedEntitiesIndexRoute
+}
+
+const AuthenticatedEntitiesRouteRouteChildren: AuthenticatedEntitiesRouteRouteChildren =
+  {
+    AuthenticatedEntitiesUidRoute: AuthenticatedEntitiesUidRoute,
+    AuthenticatedEntitiesIndexRoute: AuthenticatedEntitiesIndexRoute,
+  }
+
+const AuthenticatedEntitiesRouteRouteWithChildren =
+  AuthenticatedEntitiesRouteRoute._addFileChildren(
+    AuthenticatedEntitiesRouteRouteChildren,
+  )
 
 interface AuthenticatedSettingsRouteRouteChildren {
   AuthenticatedSettingsAccountRoute: typeof AuthenticatedSettingsAccountRoute
@@ -559,6 +633,7 @@ const AuthenticatedSettingsRouteRouteWithChildren =
   )
 
 interface AuthenticatedRouteRouteChildren {
+  AuthenticatedEntitiesRouteRoute: typeof AuthenticatedEntitiesRouteRouteWithChildren
   AuthenticatedSettingsRouteRoute: typeof AuthenticatedSettingsRouteRouteWithChildren
   AuthenticatedActionsRoute: typeof AuthenticatedActionsRoute
   AuthenticatedActivityRoute: typeof AuthenticatedActivityRoute
@@ -577,6 +652,7 @@ interface AuthenticatedRouteRouteChildren {
 }
 
 const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
+  AuthenticatedEntitiesRouteRoute: AuthenticatedEntitiesRouteRouteWithChildren,
   AuthenticatedSettingsRouteRoute: AuthenticatedSettingsRouteRouteWithChildren,
   AuthenticatedActionsRoute: AuthenticatedActionsRoute,
   AuthenticatedActivityRoute: AuthenticatedActivityRoute,

--- a/internal/web/ui/dashboard-v2/src/routes/_authenticated/entities/$uid.tsx
+++ b/internal/web/ui/dashboard-v2/src/routes/_authenticated/entities/$uid.tsx
@@ -1,0 +1,58 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { z } from 'zod'
+import { Skeleton } from '@/components/ui/skeleton'
+import { EntityDetailPane, TAB_IDS } from '@/features/entity/detail-pane'
+import { useEntityByUid, type EntityKind } from '@/lib/queries/entity'
+
+const entitySearch = z.object({
+  tab: z
+    .enum(TAB_IDS)
+    .optional()
+    .default(TAB_IDS[0])
+    .catch(TAB_IDS[0]),
+})
+
+export const Route = createFileRoute('/_authenticated/entities/$uid')({
+  validateSearch: entitySearch,
+  component: EntityDetailRoute,
+})
+
+function EntityDetailRoute() {
+  const { uid } = Route.useParams()
+  const { tab } = Route.useSearch()
+  const navigate = useNavigate()
+  const { data: entity, isLoading } = useEntityByUid(uid)
+
+  if (isLoading) {
+    return (
+      <div className='space-y-3 p-6'>
+        <Skeleton className='h-8 w-64' />
+        <Skeleton className='h-4 w-48' />
+        <Skeleton className='h-64 w-full' />
+      </div>
+    )
+  }
+
+  if (!entity) {
+    return (
+      <div className='text-muted-foreground flex h-full items-center justify-center'>
+        Entity not found
+      </div>
+    )
+  }
+
+  return (
+    <EntityDetailPane
+      kind={entity.type as EntityKind}
+      entityId={entity.entity_uid}
+      tab={tab}
+      onTabChange={(newTab) =>
+        navigate({
+          to: '/entities/$uid',
+          params: { uid },
+          search: { tab: newTab },
+        })
+      }
+    />
+  )
+}

--- a/internal/web/ui/dashboard-v2/src/routes/_authenticated/entities/$uid.tsx
+++ b/internal/web/ui/dashboard-v2/src/routes/_authenticated/entities/$uid.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { z } from 'zod'
 import { Skeleton } from '@/components/ui/skeleton'
+import { UniversalBreadcrumb } from '@/features/entity/breadcrumb'
 import { EntityDetailPane, TAB_IDS } from '@/features/entity/detail-pane'
 import { useEntityByUid, type EntityKind } from '@/lib/queries/entity'
 
@@ -53,6 +54,7 @@ function EntityDetailRoute() {
           search: { tab: newTab },
         })
       }
+      breadcrumb={<UniversalBreadcrumb uid={entity.entity_uid} />}
     />
   )
 }

--- a/internal/web/ui/dashboard-v2/src/routes/_authenticated/entities/index.tsx
+++ b/internal/web/ui/dashboard-v2/src/routes/_authenticated/entities/index.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated/entities/')({
+  component: EntitiesIndex,
+})
+
+function EntitiesIndex() {
+  return (
+    <div className='text-muted-foreground flex h-full items-center justify-center'>
+      Select an entity from the tree
+    </div>
+  )
+}

--- a/internal/web/ui/dashboard-v2/src/routes/_authenticated/entities/route.tsx
+++ b/internal/web/ui/dashboard-v2/src/routes/_authenticated/entities/route.tsx
@@ -1,0 +1,5 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated/entities')({
+  component: Outlet,
+})

--- a/internal/web/ui/dashboard-v2/src/routes/_authenticated/ideas.tsx
+++ b/internal/web/ui/dashboard-v2/src/routes/_authenticated/ideas.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 import { z } from 'zod'
 import { EntityPage } from '@/features/entity'
 
@@ -10,5 +10,10 @@ const ideasSearch = z.object({
 
 export const Route = createFileRoute('/_authenticated/ideas')({
   validateSearch: ideasSearch,
+  beforeLoad: ({ search }) => {
+    if (search.id) {
+      throw redirect({ to: '/entities/$uid', params: { uid: search.id } })
+    }
+  },
   component: () => <EntityPage kind='idea' />,
 })

--- a/internal/web/ui/dashboard-v2/src/routes/_authenticated/manifests.tsx
+++ b/internal/web/ui/dashboard-v2/src/routes/_authenticated/manifests.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 import { z } from 'zod'
 import { EntityPage } from '@/features/entity'
 
@@ -10,5 +10,10 @@ const manifestsSearch = z.object({
 
 export const Route = createFileRoute('/_authenticated/manifests')({
   validateSearch: manifestsSearch,
+  beforeLoad: ({ search }) => {
+    if (search.id) {
+      throw redirect({ to: '/entities/$uid', params: { uid: search.id } })
+    }
+  },
   component: () => <EntityPage kind='manifest' />,
 })

--- a/internal/web/ui/dashboard-v2/src/routes/_authenticated/products.tsx
+++ b/internal/web/ui/dashboard-v2/src/routes/_authenticated/products.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 import { z } from 'zod'
 import { EntityPage } from '@/features/entity'
 
@@ -10,5 +10,10 @@ const productsSearch = z.object({
 
 export const Route = createFileRoute('/_authenticated/products')({
   validateSearch: productsSearch,
+  beforeLoad: ({ search }) => {
+    if (search.id) {
+      throw redirect({ to: '/entities/$uid', params: { uid: search.id } })
+    }
+  },
   component: () => <EntityPage kind='product' />,
 })

--- a/internal/web/ui/dashboard-v2/src/routes/_authenticated/skills.tsx
+++ b/internal/web/ui/dashboard-v2/src/routes/_authenticated/skills.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 import { z } from 'zod'
 import { EntityPage } from '@/features/entity'
 
@@ -10,5 +10,10 @@ const skillsSearch = z.object({
 
 export const Route = createFileRoute('/_authenticated/skills')({
   validateSearch: skillsSearch,
+  beforeLoad: ({ search }) => {
+    if (search.id) {
+      throw redirect({ to: '/entities/$uid', params: { uid: search.id } })
+    }
+  },
   component: () => <EntityPage kind='skill' />,
 })

--- a/internal/web/ui/dashboard-v2/src/routes/_authenticated/tasks.tsx
+++ b/internal/web/ui/dashboard-v2/src/routes/_authenticated/tasks.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 import { z } from 'zod'
 import { EntityPage } from '@/features/entity'
 
@@ -10,5 +10,10 @@ const tasksSearch = z.object({
 
 export const Route = createFileRoute('/_authenticated/tasks')({
   validateSearch: tasksSearch,
+  beforeLoad: ({ search }) => {
+    if (search.id) {
+      throw redirect({ to: '/entities/$uid', params: { uid: search.id } })
+    }
+  },
   component: () => <EntityPage kind='task' />,
 })


### PR DESCRIPTION
## All or Nothing

This is the complete UI redo. All 4 manifests + live output fixes in one PR. Merge it or close it — nothing partial.

## What ships

### Navigation
- **Products, Manifests, Tasks, Ideas, Skills tabs removed** from nav
- Single **Entities** entry replaces all five
- Nav: Overview · Entities · Running · Stats · Activity · Settings

### Entity Tree (left panel)
- `react-arborist` virtualized tree
- **Skills** (global governance) at top — flat collapsible group
- **Work lifecycle** below — Idea → Product → Manifest → Task hierarchy
- Status dots pulse upstream: task running → manifest → product all show ●
- Click any node → full entity detail in right panel
- Keyboard navigation (↑↓ arrows, → expand, ← collapse, Enter select)
- Expand/collapse state persisted in localStorage

### Master-Detail Layout
- `react-resizable-panels` — tree left (~280px, resizable), detail right
- `/entities/$uid` universal route — resolves entity type, renders existing detail
- All existing tabs unchanged (Overview, DAG, Settings, Comments, Runs, etc.)
- Breadcrumb ancestry chain in detail header

### Live Status
- Status derived from children: task status pulses up to manifest and product
- Polling via `useLiveRuns()` — instant update when task starts/stops

### ⌘K Entity Search
- `cmdk` extended with entity search — type 2+ chars to find any entity
- Results grouped by type with icons
- Select → navigate to `/entities/:uid`

### Live Output Panel (Runs tab)
- Auto-scroll to bottom as new actions arrive
- Click any action row → expand full **INPUT** + **RESPONSE**
- Global **⏸ PAUSE** / **▶ RESUME** — freezes snapshot, stops polling
- Global **PARSED** / **RAW** toggle — pretty-printed JSON vs raw string

### Comments / Prompts
- Global **RENDERED** / **RAW** toggle — BlockNote rendered markdown vs raw source
- Applies to all entity types, all prompts and comments

## Rollback
Close this PR. Nothing merges until you approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)