### PR TITLE
fix: auto-push uses actual git branch not computed task-strategy name

### DIFF
--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -1158,7 +1158,16 @@ func (r *Runner) Execute(t *Task, manifestTitle, manifestContent, visceralRules 
 				shouldPush = finalStatus == execution.EventCompleted
 			}
 			if shouldPush && workDir != "" && knobs.BranchRemote != "" {
-				branchName := knobs.BranchPrefix + "/" + t.ID
+				// Use the actual checked-out branch name from git — most reliable for all
+				// branch strategies (task/manifest/product). The agent may have checked out
+				// a manifest-derived shared branch; knobs.Branch is only populated for
+				// strategy=task so we can't rely on it here.
+				branchName, _ := runGit(workDir, "rev-parse", "--abbrev-ref", "HEAD")
+				branchName = strings.TrimSpace(branchName)
+				if branchName == "" || branchName == "HEAD" {
+					// Detached HEAD or error — fall back to task-strategy name
+					branchName = knobs.BranchPrefix + "/" + t.ID
+				}
 				out, pushErr := runGit(workDir, "push", "--set-upstream", knobs.BranchRemote, branchName)
 				if pushErr != nil {
 					slog.Warn("auto-push failed — branch may be local only",


### PR DESCRIPTION
## Problem

Auto-push before worktree cleanup used `knobs.BranchPrefix + "/" + t.ID` (task-strategy branch name) even when `branch_strategy=manifest` or `product`. The agent checks out a manifest-derived shared branch (e.g. `openpraxis/m1-sidebar-restructure-nav-cleanup`) but the push went to `openpraxis/<task-id>` — wrong branch, push failed silently, work lost.

## Fix

Use `git rev-parse --abbrev-ref HEAD` to get the actual checked-out branch from the worktree. This is reliable for all strategies. Falls back to task-strategy name only if HEAD is detached.

## Impact

This was causing silent data loss on every autonomous product run using `branch_strategy=manifest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)