### PR TITLE
feat(M2/T2): EntityTreeNode renderer + wire react-arborist tree

### DIFF
--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,10 +49,10 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-BiCblLlP.js"></script>
+    <script type="module" crossorigin src="/assets/index-DG5HY60G.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-BCEqhk7D.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-C4D8h9Pk.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-BBiyFQd3.css">
   </head>
 
   <body>

--- a/internal/web/ui/dashboard-v2/package-lock.json
+++ b/internal/web/ui/dashboard-v2/package-lock.json
@@ -43,6 +43,7 @@
         "input-otp": "^1.4.2",
         "lucide-react": "^1.8.0",
         "react": "^19.2.5",
+        "react-arborist": "^3.5.0",
         "react-day-picker": "9.14.0",
         "react-dom": "^19.2.5",
         "react-hook-form": "^7.72.1",
@@ -309,7 +310,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1994,6 +1994,24 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/asap": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-4.0.1.tgz",
+      "integrity": "sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-2.0.0.tgz",
+      "integrity": "sha512-xL4RCQBCBDJ+GRwKTFhGUW8GXa4yoDfJrPbLblc3U09ciS+9ZJXJ3Qrcs/x2IODOdIE5kQxvMmE2UKyqUictUw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz",
+      "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==",
       "license": "MIT"
     },
     "node_modules/@reduxjs/toolkit": {
@@ -3873,6 +3891,26 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dnd-core": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-14.0.1.tgz",
+      "integrity": "sha512-+PVS2VPTgKFPYWo3vAFEA8WPbTf7/xo43TifH9G8S1KqnrQu0o77A3unrF5yOugy4mIz7K5wAVFHUcha7wsz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/asap": "^4.0.0",
+        "@react-dnd/invariant": "^2.0.0",
+        "redux": "^4.1.1"
+      }
+    },
+    "node_modules/dnd-core/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
     "node_modules/echarts": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
@@ -4378,6 +4416,21 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
@@ -5200,6 +5253,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -6127,6 +6186,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-arborist": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/react-arborist/-/react-arborist-3.5.0.tgz",
+      "integrity": "sha512-FdXOICSt7P2h+Pxin1ULN02b4qrXJznNcshgwwWVtuYMLWSJcD245PQ4HOSj/Lr2T1uEegmnEm5Lbns2hUUsqg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-dnd": "^14.0.3",
+        "react-dnd-html5-backend": "^14.0.3",
+        "react-window": "^1.8.11",
+        "redux": "^5.0.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14",
+        "react-dom": ">= 16.14"
+      }
+    },
     "node_modules/react-day-picker": {
       "version": "9.14.0",
       "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
@@ -6147,6 +6223,45 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/react-dnd": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-14.0.5.tgz",
+      "integrity": "sha512-9i1jSgbyVw0ELlEVt/NkCUkxy1hmhJOkePoCH713u75vzHGyXhPDm28oLfc2NMSBjZRM1Y+wRjHXJT3sPrTy+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/invariant": "^2.0.0",
+        "@react-dnd/shallowequal": "^2.0.0",
+        "dnd-core": "14.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-14.1.0.tgz",
+      "integrity": "sha512-6ONeqEC3XKVf4eVmMTe0oPds+c5B9Foyj8p/ZKLb7kL2qh9COYxiBHv3szd6gztqi/efkmriywLUVlPotqoJyw==",
+      "license": "MIT",
+      "dependencies": {
+        "dnd-core": "14.0.1"
       }
     },
     "node_modules/react-dom": {
@@ -6359,6 +6474,23 @@
       "peerDependencies": {
         "react": ">=16 || >=17 || >= 18 || >= 19",
         "react-dom": ">=16 || >=17 || >= 18 || >=19"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/readdirp": {

--- a/internal/web/ui/dashboard-v2/package.json
+++ b/internal/web/ui/dashboard-v2/package.json
@@ -45,6 +45,7 @@
     "input-otp": "^1.4.2",
     "lucide-react": "^1.8.0",
     "react": "^19.2.5",
+    "react-arborist": "^3.5.0",
     "react-day-picker": "9.14.0",
     "react-dom": "^19.2.5",
     "react-hook-form": "^7.72.1",

--- a/internal/web/ui/dashboard-v2/src/components/layout/app-sidebar.tsx
+++ b/internal/web/ui/dashboard-v2/src/components/layout/app-sidebar.tsx
@@ -22,8 +22,8 @@ export function AppSidebar() {
         <TeamSwitcher teams={sidebarData.teams} />
       </SidebarHeader>
       <SidebarContent className='overflow-x-hidden overflow-y-auto'>
-        <SidebarGroup className='flex flex-col min-h-0 p-0'>
-          <SidebarGroupContent className='flex flex-col min-h-0'>
+        <SidebarGroup className='shrink-0 p-0'>
+          <SidebarGroupContent>
             <EntityTree />
           </SidebarGroupContent>
         </SidebarGroup>

--- a/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
@@ -1,7 +1,119 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Tree } from 'react-arborist'
+import { useNavigate } from '@tanstack/react-router'
+import { useLiveRuns } from '@/lib/queries/entity'
+import {
+  TreeStatus,
+  overlayLiveStatus,
+  useEntityTree,
+  type TreeNode,
+} from '@/lib/queries/entity-tree'
+import { Skeleton } from '@/components/ui/skeleton'
+import { EntityTreeNode } from './EntityTreeNode'
+
+// Synthetic root group ids — surfaced as sticky headers, not navigable.
+const GROUP_SKILLS = '__skills__'
+const GROUP_LIFECYCLE = '__lifecycle__'
+const GROUP_IDS: ReadonlySet<string> = new Set([GROUP_SKILLS, GROUP_LIFECYCLE])
+
+// Live-runs sentinel for stdio sessions (no entity_uid). Filtered out so the
+// tree doesn't try to mark a non-existent node as running.
+const STDIO_SENTINEL = 'stdio'
+
+// react-arborist requires exact pixel width/height — CSS percentages cause
+// virtualized rows (rendered at absolute positions) to overflow horizontally.
+// useElementSize feeds live ResizeObserver readouts so the Tree mounts only
+// once the container has real dimensions. Inlined to avoid the
+// use-resize-observer peer-dep range mismatch with React 19.
+function useElementSize<T extends HTMLElement>() {
+  const ref = useRef<T | null>(null)
+  const [size, setSize] = useState<{ width: number; height: number }>({
+    width: 0,
+    height: 0,
+  })
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    // Seed from initial layout so we don't wait for the first ResizeObserver
+    // tick (which may not fire on mount in StrictMode dev double-invoke).
+    setSize({ width: el.clientWidth, height: el.clientHeight })
+    const ro = new ResizeObserver((entries) => {
+      const cr = entries[0]?.contentRect
+      if (cr) setSize({ width: cr.width, height: cr.height })
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+  return { ref, ...size }
+}
+
 export function EntityTree() {
+  const { ref, width, height } = useElementSize<HTMLDivElement>()
+  const { data: rawTree, isLoading } = useEntityTree()
+  const { data: liveRuns } = useLiveRuns()
+  const navigate = useNavigate()
+
+  const liveIds = new Set(
+    (liveRuns ?? [])
+      .filter((r) => r.entity_uid && r.entity_uid !== STDIO_SENTINEL)
+      .map((r) => r.entity_uid),
+  )
+  const overlaid = rawTree ? overlayLiveStatus(rawTree, liveIds) : null
+
+  const treeData: TreeNode[] = overlaid
+    ? [
+        {
+          id: GROUP_SKILLS,
+          name: 'Skills',
+          kind: 'skill',
+          status: TreeStatus.Active,
+          children: overlaid.skills,
+        },
+        {
+          id: GROUP_LIFECYCLE,
+          name: 'Entities',
+          kind: 'idea',
+          status: TreeStatus.Active,
+          children: overlaid.lifecycle,
+        },
+      ]
+    : []
+
+  const onSelect = useCallback(
+    (nodes: { id: string }[]) => {
+      const node = nodes[0]
+      if (!node || GROUP_IDS.has(node.id)) return
+      navigate({ to: '/entities/$uid', params: { uid: node.id } })
+    },
+    [navigate],
+  )
+
+  // Single mount point: ref is always attached so the ResizeObserver can fire
+  // before the query settles. Skeleton, empty state, and Tree share the box.
   return (
-    <div className='px-3 py-2 text-xs text-muted-foreground italic'>
-      Loading entities…
+    <div ref={ref} className='h-[420px] w-full overflow-hidden'>
+      {isLoading ? (
+        <div className='px-3 space-y-1 pt-2'>
+          {[1, 2, 3, 4, 5].map((i) => (
+            <Skeleton key={i} className='h-5 w-full' />
+          ))}
+        </div>
+      ) : width > 0 && height > 0 ? (
+        <Tree
+          data={treeData}
+          width={width}
+          height={height}
+          indent={16}
+          rowHeight={24}
+          overscanCount={8}
+          onSelect={onSelect}
+          openByDefault={false}
+          initialOpenState={{ [GROUP_SKILLS]: true, [GROUP_LIFECYCLE]: true }}
+          className='scrollbar-thin'
+        >
+          {EntityTreeNode}
+        </Tree>
+      ) : null}
     </div>
   )
 }

--- a/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTreeNode.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTreeNode.tsx
@@ -1,0 +1,97 @@
+import type { ElementType } from 'react'
+import type { NodeRendererProps } from 'react-arborist'
+import {
+  Boxes,
+  CheckSquare,
+  ChevronRight,
+  FileText,
+  GitBranch,
+  Lightbulb,
+  Wand2,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { EntityKind } from '@/lib/queries/entity'
+import { TreeStatus, type TreeNode } from '@/lib/queries/entity-tree'
+
+const KIND_ICON: Record<EntityKind, ElementType> = {
+  skill: Wand2,
+  idea: Lightbulb,
+  product: Boxes,
+  manifest: FileText,
+  task: CheckSquare,
+}
+
+const STATUS_COLOR: Partial<Record<string, string>> = {
+  [TreeStatus.Running]: 'text-blue-400',
+  [TreeStatus.Completed]: 'text-emerald-500',
+  [TreeStatus.Failed]: 'text-red-500',
+  [TreeStatus.Active]: 'text-amber-400',
+}
+
+const STATUS_GLYPH: Partial<Record<string, string>> = {
+  [TreeStatus.Running]: '●',
+  [TreeStatus.Completed]: '✓',
+  [TreeStatus.Failed]: '✗',
+  [TreeStatus.Active]: '⚠',
+  [TreeStatus.Draft]: '○',
+  [TreeStatus.Closed]: '○',
+  [TreeStatus.Archived]: '○',
+}
+
+// Sentinel prefix for synthetic group-header rows (e.g. __skills__, __lifecycle__).
+// The Tree data wrapper in EntityTree.tsx is the only place that creates these.
+const GROUP_PREFIX = '__'
+
+export function EntityTreeNode({ node, style, dragHandle }: NodeRendererProps<TreeNode>) {
+  // Group separator header. Render as a plain styled div — using
+  // SidebarGroupLabel here would target a sidebar wrapper ancestor that does
+  // not exist inside react-arborist's virtualized list DOM.
+  if (node.id.startsWith(GROUP_PREFIX)) {
+    return (
+      <div
+        style={style}
+        onClick={() => node.toggle()}
+        className='flex items-center px-2 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground select-none cursor-pointer hover:text-foreground'
+      >
+        {node.data.name}
+      </div>
+    )
+  }
+
+  const Icon = KIND_ICON[node.data.kind] ?? GitBranch
+  const glyph = STATUS_GLYPH[node.data.status] ?? '○'
+  const color = STATUS_COLOR[node.data.status] ?? 'text-muted-foreground'
+  const isPulsing = node.data.status === TreeStatus.Running
+
+  return (
+    <div
+      ref={dragHandle}
+      style={style}
+      onClick={() => (node.isInternal ? node.toggle() : node.select())}
+      className={cn(
+        'flex items-center gap-1 px-1 rounded-sm cursor-pointer select-none',
+        'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+        node.isSelected && 'bg-sidebar-accent text-sidebar-accent-foreground',
+      )}
+    >
+      <ChevronRight
+        className={cn(
+          'h-3 w-3 shrink-0 text-muted-foreground/60 transition-transform',
+          node.isInternal ? 'opacity-100' : 'opacity-0',
+          node.isInternal && node.isOpen && 'rotate-90',
+        )}
+      />
+      <Icon className='h-3.5 w-3.5 shrink-0 text-muted-foreground' />
+      <span className='flex-1 min-w-0 text-xs truncate'>{node.data.name}</span>
+      <span
+        className={cn(
+          'text-[10px] shrink-0 ml-1',
+          color,
+          isPulsing && 'animate-pulse',
+        )}
+      >
+        {glyph}
+      </span>
+    </div>
+  )
+}

--- a/internal/web/ui/dashboard-v2/src/lib/queries/entity-tree.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/queries/entity-tree.ts
@@ -1,0 +1,75 @@
+import { useQuery } from '@tanstack/react-query'
+import type { EntityKind } from './entity'
+
+// TreeNode mirrors the shape returned by GET /api/entities/tree.
+// Status is the wire status string: derived in the backend from entity status
+// + child rollup. Kept loose here because the renderer's status maps are the
+// canonical home for visualization decisions.
+export interface TreeNode {
+  id: string
+  name: string
+  kind: EntityKind
+  status: string
+  children?: TreeNode[]
+}
+
+export interface EntityTreePayload {
+  skills: TreeNode[]
+  lifecycle: TreeNode[]
+}
+
+async function fetchEntityTree(): Promise<EntityTreePayload> {
+  const res = await fetch('/api/entities/tree')
+  if (!res.ok) throw new Error(`/api/entities/tree → ${res.status}`)
+  const data = (await res.json()) as Partial<EntityTreePayload>
+  return { skills: data.skills ?? [], lifecycle: data.lifecycle ?? [] }
+}
+
+export function useEntityTree() {
+  return useQuery({
+    queryKey: ['entity-tree'],
+    queryFn: fetchEntityTree,
+    staleTime: 30_000,
+    refetchInterval: 10_000,
+  })
+}
+
+// Tree-display status used by the renderer's status visuals. Centralized so
+// adding a status visual is a single-file change.
+export const TreeStatus = {
+  Running: 'running',
+  Completed: 'completed',
+  Failed: 'failed',
+  Active: 'active',
+  Draft: 'draft',
+  Closed: 'closed',
+  Archived: 'archived',
+} as const
+export type TreeStatus = (typeof TreeStatus)[keyof typeof TreeStatus]
+
+// overlayLiveStatus walks the tree and marks any node whose id is in the live
+// set as Running, then re-derives parent status from its children. Pure,
+// returns a new tree.
+export function overlayLiveStatus(
+  tree: EntityTreePayload,
+  liveIds: ReadonlySet<string>,
+): EntityTreePayload {
+  function walk(n: TreeNode): TreeNode {
+    const live = liveIds.has(n.id)
+    if (n.children?.length) {
+      const ch = n.children.map(walk)
+      return { ...n, status: live ? TreeStatus.Running : deriveStatus(ch), children: ch }
+    }
+    return live ? { ...n, status: TreeStatus.Running } : n
+  }
+  return { skills: tree.skills.map(walk), lifecycle: tree.lifecycle.map(walk) }
+}
+
+function deriveStatus(ch: TreeNode[]): string {
+  if (ch.some((c) => c.status === TreeStatus.Running)) return TreeStatus.Running
+  if (ch.some((c) => c.status === TreeStatus.Failed)) return TreeStatus.Failed
+  if (ch.length > 0 && ch.every((c) => c.status === TreeStatus.Completed))
+    return TreeStatus.Completed
+  if (ch.some((c) => c.status === TreeStatus.Completed)) return TreeStatus.Active
+  return TreeStatus.Draft
+}


### PR DESCRIPTION
## Summary

- Replaces the M1/T1 EntityTree stub with a virtualized [react-arborist](https://github.com/brimdata/react-arborist) tree
- Two synthetic root groups (Skills / Entities) feed exact pixel width/height via an inlined ResizeObserver hook so virtualized rows don't overflow
- Clicking a leaf navigates to `/entities/$uid`; group headers toggle open state
- Domain values stay in `Record<EntityKind, …>` and a `TreeStatus` const so adding a new kind/status is a single-place change

## Scope

The parent manifest (M2) lists T1 (deps install + hook) and T2 (renderer + wire), but only one task entity exists. This PR ships both — `react-arborist` install, `useEntityTree`/`overlayLiveStatus` hook, `EntityTreeNode`, and the wiring that replaces the M1/T1 stub.

## Why these specific shapes

- **Pixel sizes from ResizeObserver, not CSS %.** react-window (used internally) renders rows at absolute positions and ignores percentage layout, so percentages cause horizontal overflow. The hook seeds from `clientWidth/clientHeight` on mount so a single render is enough — important under React 19 StrictMode dev double-mount.
- **SidebarGroup is `shrink-0` 420px.** SidebarContent is a flex column; with `min-h-0` siblings the tree got squeezed to ~200px. `shrink-0` keeps the tree at its full 420px viewport above the nav groups, which scroll within SidebarContent's `overflow-y-auto`.
- **Group rows are plain divs.** `SidebarGroupLabel` targets a `.group/sidebar-wrapper` ancestor that doesn't exist inside react-arborist's virtualized list DOM. The group div has its own onClick that calls `node.toggle()`.
- **`use-resize-observer` not used.** Its peer-dep range is `react@16.8.0 - 18`; React 19 forces `--legacy-peer-deps` and that breaks the install of @mantine peers needed by @blocknote. The inlined hook is a few lines and avoids the lockfile fight.

## Test plan

- [x] `make build` passes; main bundle (1.1M) under the 4MB cap
- [x] `npx tsc --noEmit` clean
- [x] No `console.*` / `debugger` in committed diff
- [x] Smoke-tested locally with seeded data dir; Playwright screenshots show:
  - "SKILLS" header with skill items (wand icon, status glyphs)
  - "ENTITIES" header with idea/product/manifest/task items (lightbulb / boxes / file / checksquare icons)
  - Group click toggles, leaf click navigates to `/entities/$uid`
  - Nav unchanged: only "Entities" + "Settings" — no per-type entries
- [ ] Operator visual review on a real data set

🤖 Generated with [Claude Code](https://claude.com/claude-code)