### PR TITLE
feat(M4/T2): ⌘K palette entity search

### DIFF
--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,7 +49,7 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-DG5HY60G.js"></script>
+    <script type="module" crossorigin src="/assets/index-CzdIVZoE.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-BCEqhk7D.js">
     <link rel="stylesheet" crossorigin href="/assets/index-BBiyFQd3.css">

--- a/internal/web/ui/dashboard-v2/src/components/command-menu.tsx
+++ b/internal/web/ui/dashboard-v2/src/components/command-menu.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
-import { ArrowRight, ChevronRight, Laptop, Moon, Sun } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+import { ArrowRight, ChevronRight, GitBranch, Laptop, Moon, Sun } from 'lucide-react'
 import { useSearch } from '@/context/search-provider'
 import { useTheme } from '@/context/theme-provider'
 import {
@@ -14,11 +15,42 @@ import {
 } from '@/components/ui/command'
 import { sidebarData } from './layout/data/sidebar-data'
 import { ScrollArea } from './ui/scroll-area'
+import { KIND_ICON } from '@/features/entity/tree/EntityTreeNode'
+import type { Entity } from '@/lib/types'
+
+// UX knobs for the inline entity search inside the ⌘K palette.
+const ENTITY_QUERY_MIN_LEN = 2
+const ENTITY_QUERY_DEBOUNCE_MS = 200
+const ENTITY_QUERY_LIMIT = 20
 
 export function CommandMenu() {
   const navigate = useNavigate()
   const { setTheme } = useTheme()
   const { open, setOpen } = useSearch()
+
+  const [query, setQuery] = useState('')
+  const [debouncedQuery, setDebouncedQuery] = useState('')
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(query), ENTITY_QUERY_DEBOUNCE_MS)
+    return () => clearTimeout(t)
+  }, [query])
+
+  // Reset the query when the palette closes so the next open starts fresh.
+  useEffect(() => {
+    if (!open) setQuery('')
+  }, [open])
+
+  const { data: entityResults } = useQuery<Entity[]>({
+    queryKey: ['command-menu', 'entity-search', debouncedQuery],
+    queryFn: async () => {
+      const url = `/api/entities/search?q=${encodeURIComponent(debouncedQuery)}&limit=${ENTITY_QUERY_LIMIT}`
+      const res = await fetch(url)
+      if (!res.ok) throw new Error(`entity search → ${res.status}`)
+      return (await res.json()) as Entity[]
+    },
+    enabled: debouncedQuery.length >= ENTITY_QUERY_MIN_LEN,
+    staleTime: 30 * 1000,
+  })
 
   const runCommand = React.useCallback(
     (command: () => unknown) => {
@@ -30,10 +62,44 @@ export function CommandMenu() {
 
   return (
     <CommandDialog modal open={open} onOpenChange={setOpen}>
-      <CommandInput placeholder='Type a command or search...' />
+      <CommandInput
+        placeholder='Type a command or search...'
+        value={query}
+        onValueChange={setQuery}
+      />
       <CommandList>
         <ScrollArea type='hover' className='h-72 pe-1'>
           <CommandEmpty>No results found.</CommandEmpty>
+          {entityResults && entityResults.length > 0 && (
+            <>
+              <CommandGroup heading='Entities'>
+                {entityResults.map((e) => {
+                  const Icon = KIND_ICON[e.type] ?? GitBranch
+                  return (
+                    <CommandItem
+                      key={e.entity_uid}
+                      value={`${e.type} ${e.title} ${e.entity_uid}`}
+                      onSelect={() => {
+                        runCommand(() =>
+                          navigate({
+                            to: '/entities/$uid',
+                            params: { uid: e.entity_uid },
+                          })
+                        )
+                      }}
+                    >
+                      <Icon className='size-4 shrink-0 text-muted-foreground' />
+                      <span className='flex-1 min-w-0 truncate'>{e.title}</span>
+                      <span className='ml-2 text-[10px] text-muted-foreground capitalize shrink-0'>
+                        {e.type}
+                      </span>
+                    </CommandItem>
+                  )
+                })}
+              </CommandGroup>
+              <CommandSeparator />
+            </>
+          )}
           {sidebarData.navGroups.map((group) => (
             <CommandGroup key={group.title} heading={group.title}>
               {group.items.map((navItem, i) => {

--- a/internal/web/ui/dashboard-v2/src/features/entity/breadcrumb.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/breadcrumb.tsx
@@ -1,10 +1,10 @@
 import { Link } from '@tanstack/react-router'
 import { ChevronRight, Home } from 'lucide-react'
 import {
+  KIND,
   useEntityHierarchy,
   type EntityKind,
 } from '@/lib/queries/entity'
-import { KIND } from '@/lib/queries/entity-tree'
 import type { HierarchyNode } from '@/lib/types'
 
 // Home path for the breadcrumb root crumb, keyed by entity kind. All

--- a/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTreeNode.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTreeNode.tsx
@@ -13,7 +13,7 @@ import { cn } from '@/lib/utils'
 import type { EntityKind } from '@/lib/queries/entity'
 import { TreeStatus, type TreeNode } from '@/lib/queries/entity-tree'
 
-const KIND_ICON: Record<EntityKind, ElementType> = {
+export const KIND_ICON: Record<EntityKind, ElementType> = {
   skill: Wand2,
   idea: Lightbulb,
   product: Boxes,

--- a/internal/web/ui/dashboard-v2/src/lib/queries/entity.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/queries/entity.ts
@@ -35,7 +35,19 @@ import type {
 //   /api/{kind}s/{id}/settings                               Execution/Main tabs knobs
 //   /api/{kind}s/{id}/description/history                    Main tab revisions
 
-export type EntityKind = 'product' | 'manifest' | 'task' | 'skill' | 'idea'
+// KIND is the single source of truth for entity-kind string values.
+// EntityKind below is derived from these so the type and the runtime
+// constants cannot drift. Add a new entity kind here and the type
+// (plus everything keyed by it) updates in one place.
+export const KIND = {
+  product: 'product',
+  manifest: 'manifest',
+  task: 'task',
+  skill: 'skill',
+  idea: 'idea',
+} as const
+
+export type EntityKind = (typeof KIND)[keyof typeof KIND]
 
 // EntityRecord is the unified entity shape returned by /api/entities.
 export type EntityRecord = Entity


### PR DESCRIPTION
## Summary
- Adds a debounced live `Entities` group above the existing nav inside the ⌘K command palette. Typing 2+ chars hits `/api/entities/search?q=…&limit=20` (200 ms debounce) and renders results with the canonical kind icon; selecting one navigates to `/entities/:uid` (the universal route from M3/T1) and closes the palette.
- Centralizes `KIND` (entity-kind constants) in `@/lib/queries/entity` next to `EntityKind`, derives the type from the constant so they cannot drift, and exports `KIND_ICON` from `EntityTreeNode` so the palette and any future caller share one kind→icon map. This also unblocks `make build` — `breadcrumb.tsx` was importing `KIND` from a module that did not export it.

## Test plan
- [x] `make build` clean — Go binary embeds the rebuilt frontend.
- [x] Bundle size: `dist/assets/index-*.js` = 429 KB (well under the 4 MB gate).
- [x] No `console.*` / `debugger` introduced in TS.
- [x] `./openpraxis serve` smoke test:
  - Root `/` renders dashboard, no JS runtime errors. Sidebar shows new SKILLS + ENTITIES tree groups.
  - Cmd-K + `task` → `Entities` group appears above nav with task results (CheckSquare icon).
  - Cmd-K + `manifest` → `Entities` group appears with manifest results (FileText icon).
  - `/#/entities` landing renders left tree + "Select an entity from the tree" empty state.
- [ ] `/#/entities/:uid` detail page shows pre-existing `Loading…` stub (M3/T1's `entities/$uid.tsx` is a stub component); navigation from the palette lands on the correct route — populating that page is M3 / future scope, not M4/T2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)