### PR TITLE
feat: RAG entity type + Add Entity dialog

### DIFF
--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,7 +49,7 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-BwC027gG.js"></script>
+    <script type="module" crossorigin src="/assets/index-awbFx62k.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/redirect-X9XGZzhz.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-BCEqhk7D.js">

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,11 +49,11 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-USMJccg1.js"></script>
+    <script type="module" crossorigin src="/assets/index-BwC027gG.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/redirect-X9XGZzhz.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-BCEqhk7D.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-BWoESLF-.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-BV4JiVrR.css">
   </head>
 
   <body>

--- a/internal/web/ui/dashboard-v2/src/features/entity/add-entity-dialog.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/add-entity-dialog.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { Plus } from 'lucide-react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import type { EntityKind } from '@/lib/queries/entity'
+
+const ENTITY_TYPES: { value: EntityKind; label: string; description: string }[] = [
+  { value: 'skill',    label: 'Skill',    description: 'Governance rule or coding practice loaded into agent context' },
+  { value: 'product',  label: 'Product',  description: 'Top-level product with manifests and tasks' },
+  { value: 'manifest', label: 'Manifest', description: 'Spec or plan — owns a set of tasks' },
+  { value: 'task',     label: 'Task',     description: 'Atomic execution unit run by an agent' },
+  { value: 'idea',     label: 'Idea',     description: 'Unstructured concept or feature request' },
+  { value: 'RAG',      label: 'RAG',      description: 'Retrieval-augmented generation knowledge source' },
+]
+
+async function createEntity(type: EntityKind, title: string) {
+  const res = await fetch('/api/entities', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ type, title, status: 'draft' }),
+  })
+  if (!res.ok) throw new Error(`create entity → ${res.status}`)
+  return res.json()
+}
+
+export function AddEntityButton() {
+  const [open, setOpen] = useState(false)
+  const [type, setType] = useState<EntityKind>('product')
+  const [title, setTitle] = useState('')
+  const qc = useQueryClient()
+  const navigate = useNavigate()
+
+  const create = useMutation({
+    mutationFn: () => createEntity(type, title.trim()),
+    onSuccess: (entity) => {
+      qc.invalidateQueries({ queryKey: ['entity-tree'] })
+      setOpen(false)
+      setTitle('')
+      navigate({
+        to: '/entities/$uid',
+        params: { uid: entity.entity_uid },
+        search: { kind: type, tab: 'main' },
+      })
+    },
+  })
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (title.trim()) create.mutate()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button
+          type='button'
+          className='flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-white/10 hover:text-foreground transition-colors'
+          title='Add Entity'
+        >
+          <Plus className='h-3.5 w-3.5' />
+          Add
+        </button>
+      </DialogTrigger>
+      <DialogContent className='sm:max-w-md'>
+        <DialogHeader>
+          <DialogTitle>Add Entity</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className='space-y-4 pt-2'>
+          <div className='space-y-1.5'>
+            <label className='text-xs font-medium text-muted-foreground uppercase tracking-wide'>Type</label>
+            <Select value={type} onValueChange={(v) => setType(v as EntityKind)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {ENTITY_TYPES.map((t) => (
+                  <SelectItem key={t.value} value={t.value}>
+                    <div>
+                      <div className='font-medium'>{t.label}</div>
+                      <div className='text-xs text-muted-foreground'>{t.description}</div>
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className='space-y-1.5'>
+            <label className='text-xs font-medium text-muted-foreground uppercase tracking-wide'>Title</label>
+            <Input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder={`Name this ${type}…`}
+              autoFocus
+            />
+          </div>
+          <div className='flex justify-end gap-2'>
+            <Button type='button' variant='ghost' size='sm' onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type='submit' size='sm' disabled={!title.trim() || create.isPending}>
+              {create.isPending ? 'Creating…' : 'Create'}
+            </Button>
+          </div>
+          {create.isError && (
+            <p className='text-xs text-rose-400'>{String(create.error)}</p>
+          )}
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/internal/web/ui/dashboard-v2/src/features/entity/add-entity-dialog.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/add-entity-dialog.tsx
@@ -71,10 +71,10 @@ export function AddEntityButton() {
         <button
           type='button'
           className='flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-white/10 hover:text-foreground transition-colors'
-          title='Add Entity'
+          title='Create Entity'
         >
           <Plus className='h-3.5 w-3.5' />
-          Add
+          Create Entity
         </button>
       </DialogTrigger>
       <DialogContent className='sm:max-w-md'>

--- a/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
@@ -4,6 +4,7 @@ import { Tree } from 'react-arborist'
 import type { NodeApi } from 'react-arborist'
 import { useNavigate } from '@tanstack/react-router'
 import { useLiveRuns } from '@/lib/queries/entity'
+import { AddEntityButton } from '@/features/entity/add-entity-dialog'
 import {
   TreeStatus,
   overlayLiveStatus,
@@ -114,10 +115,10 @@ export function EntityTree() {
       children: overlaid
         ? [
             { id: GROUP_SKILLS,    name: 'Skills',    kind: '__group__', status: '', children: overlaid.skills },
-            { id: GROUP_RAG,       name: 'RAG',       kind: '__group__', status: '', children: overlaid.rags },
             { id: GROUP_IDEAS,     name: 'Ideas',     kind: '__group__', status: '', children: ideas },
             { id: GROUP_PRODUCTS,  name: 'Products',  kind: '__group__', status: '', children: products },
             { id: GROUP_MANIFESTS, name: 'Manifests', kind: '__group__', status: '', children: overlaid.manifests },
+            { id: GROUP_RAG,       name: 'RAG',       kind: '__group__', status: '', children: overlaid.rags },
             { id: GROUP_TASKS,     name: 'Tasks',     kind: '__group__', status: '', children: overlaid.tasks },
           ]
         : [],
@@ -151,7 +152,10 @@ export function EntityTree() {
 
   return (
     <div className='flex flex-col flex-1 min-h-0 w-full'>
-      {/* Filter input — VS Code style search in tree */}
+      {/* Add Entity button + Filter input */}
+      <div className='flex items-center gap-1 px-2 pt-1 pb-0 shrink-0'>
+        <AddEntityButton />
+      </div>
       <div className='relative px-2 py-1 shrink-0'>
         <Search className='absolute left-4 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground' />
         <input


### PR DESCRIPTION
## Summary

- **RAG entity type** — `entity.TypeRAG = "RAG"` as first-class kind alongside skill/product/manifest/task/idea. Database icon in tree, own RAG group.
- **Tree order** — Skills › Ideas › Products › Manifests › **RAG** › Tasks
- **Add Entity dialog** — `+Add` button at the top of the sidebar tree. Opens a dialog with:
  - Type selector: Skill, Product, Manifest, Task, Idea, RAG (each with description)
  - Title input
  - On create: refreshes tree, navigates directly to the new entity's Main tab

## Test plan
- [ ] Create a RAG entity via the dialog — appears in RAG group
- [ ] Create each other entity type — appears in correct tree group
- [ ] RAG entities accept `owns` and `depends_on` edges
- [ ] `POST /api/entities` with `type: "RAG"` works via API too

🤖 Generated with [Claude Code](https://claude.com/claude-code)