### PR TITLE
feat: entity_types table — DB-driven entity kinds, dynamic DAG + menu

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -285,7 +285,7 @@ var serveCmd = &cobra.Command{
 			if n.Relationships == nil || n.Entities == nil {
 				return
 			}
-			manifests, err := n.Entities.List("manifest", "active", 0)
+			manifests, err := n.Entities.List(relationships.KindManifest, "active", 0)
 			if err != nil || len(manifests) == 0 {
 				return
 			}
@@ -355,9 +355,9 @@ var serveCmd = &cobra.Command{
 			// Limit to 4 hops: task → manifest → product → skill.
 			current := entityID
 			for hop := 0; hop < 4; hop++ {
-				edges, _ := n.Relationships.ListIncoming(ctx, current, "owns")
+				edges, _ := n.Relationships.ListIncoming(ctx, current, relationships.EdgeOwns)
 				for _, edge := range edges {
-					if edge.SrcKind == "skill" {
+					if edge.SrcKind == relationships.KindSkill {
 						// Collect all skills — do not stop at the first one.
 						revs, err := n.Comments.List(ctx, comments.TargetEntity, edge.SrcID, 1, &ct)
 						if err == nil && len(revs) > 0 && revs[0].Body != "" {
@@ -461,7 +461,12 @@ var serveCmd = &cobra.Command{
 				scope := settings.Scope{TaskID: entityID}
 				if res, err := n.SettingsResolver.Resolve(ctx, scope, "branch_strategy"); err == nil {
 					strategy, _ := res.Value.(string)
-					if strategy == "manifest" || strategy == "product" {
+					// Normalise: any unrecognised strategy is treated like "product" so
+					// custom entity types work without requiring a server code change.
+					if strategy != relationships.KindManifest && strategy != relationships.KindProduct && strategy != "" {
+						strategy = relationships.KindProduct
+					}
+					if strategy == relationships.KindManifest || strategy == relationships.KindProduct {
 						// Derive the shared branch name from the owning entity's title.
 						sharedBranch := ""
 						branchPrefix := "openpraxis"
@@ -479,10 +484,10 @@ var serveCmd = &cobra.Command{
 						if n.Relationships != nil {
 							// Walk up to find the entity whose title drives the branch name.
 							lookupID := entityID
-							if strategy == "manifest" {
-								if edges, _ := n.Relationships.ListIncoming(ctx, lookupID, "owns"); len(edges) > 0 {
+							if strategy == relationships.KindManifest {
+								if edges, _ := n.Relationships.ListIncoming(ctx, lookupID, relationships.EdgeOwns); len(edges) > 0 {
 									for _, edge := range edges {
-										if edge.SrcKind == "manifest" {
+										if edge.SrcKind == relationships.KindManifest {
 											if me, _ := n.Entities.Get(edge.SrcID); me != nil {
 												sharedBranch = deriveBranchName(branchPrefix, me.Title)
 											}
@@ -490,13 +495,13 @@ var serveCmd = &cobra.Command{
 										}
 									}
 								}
-							} else { // product — walk task → manifest → product
-								if manifEdges, _ := n.Relationships.ListIncoming(ctx, lookupID, "owns"); len(manifEdges) > 0 {
+							} else { // product (or normalised-to-product) — walk up the owns chain
+								if manifEdges, _ := n.Relationships.ListIncoming(ctx, lookupID, relationships.EdgeOwns); len(manifEdges) > 0 {
 									for _, me := range manifEdges {
-										if me.SrcKind == "manifest" {
-											if prodEdges, _ := n.Relationships.ListIncoming(ctx, me.SrcID, "owns"); len(prodEdges) > 0 {
+										if me.SrcKind == relationships.KindManifest {
+											if prodEdges, _ := n.Relationships.ListIncoming(ctx, me.SrcID, relationships.EdgeOwns); len(prodEdges) > 0 {
 												for _, pe := range prodEdges {
-													if pe.SrcKind == "product" {
+													if pe.SrcKind == relationships.KindProduct {
 														if pe2, _ := n.Entities.Get(pe.SrcID); pe2 != nil {
 															sharedBranch = deriveBranchName(branchPrefix, pe2.Title)
 														}
@@ -555,32 +560,26 @@ var serveCmd = &cobra.Command{
 				return fmt.Errorf("entity not found: %s", parentID)
 			}
 
-			// Collect all tasks under this entity (one or two hops down).
+			// Collect all tasks under this entity by recursively walking owns edges.
+			// Any entity type that owns tasks (directly or transitively) is handled
+			// uniformly — no hardcoded type checks.
 			var taskIDs []string
-			collectTasks := func(srcID string) {
-				edges, _ := n.Relationships.ListOutgoing(ctx, srcID, "owns")
+			var collectAll func(id string)
+			collectAll = func(id string) {
+				edges, _ := n.Relationships.ListOutgoing(ctx, id, relationships.EdgeOwns)
 				for _, edge := range edges {
-					if edge.DstKind == "task" {
+					if edge.DstKind == relationships.KindTask {
 						if te, _ := n.Entities.Get(edge.DstID); te != nil &&
 							te.Status != "archived" && te.Status != "closed" {
 							taskIDs = append(taskIDs, edge.DstID)
 						}
+					} else {
+						// non-task owned entity — recurse
+						collectAll(edge.DstID)
 					}
 				}
 			}
-
-			if parent.Type == "manifest" {
-				collectTasks(parentID)
-			} else { // product — walk manifest → tasks
-				manifEdges, _ := n.Relationships.ListOutgoing(ctx, parentID, "owns")
-				for _, me := range manifEdges {
-					if me.DstKind == "manifest" {
-						collectTasks(me.DstID)
-					}
-				}
-				// Also collect tasks directly under the product
-				collectTasks(parentID)
-			}
+			collectAll(parentID)
 
 			if len(taskIDs) == 0 {
 				slog.Info("dispatch: no active tasks found", "parent_uid", parentID[:12], "type", parent.Type)
@@ -632,11 +631,14 @@ var serveCmd = &cobra.Command{
 		//   manifest → fire each owned task individually (execution recorded per task)
 		//   product  → fire each task across all manifests individually
 		//   skill    → fire each task across all owned products
+		//   *        → fallback for any entity type added via the entity_types
+		//              table at runtime; dispatches the same way as manifest/product
 		scheduleRunner := schedule.NewRunner(n.Schedules, map[string]schedule.DispatchFunc{
-			"task":     dispatch,
-			"manifest": dispatchAtomicTasks,
-			"product":  dispatchAtomicTasks,
-			"skill":    dispatchAtomicTasks,
+			relationships.KindTask:     dispatch,
+			relationships.KindManifest: dispatchAtomicTasks,
+			relationships.KindProduct:  dispatchAtomicTasks,
+			relationships.KindSkill:    dispatchAtomicTasks,
+			"*":                        dispatchAtomicTasks,
 		})
 		n.ScheduleRunner = scheduleRunner
 		if err := scheduleRunner.Start(ctx); err != nil {
@@ -651,10 +653,10 @@ var serveCmd = &cobra.Command{
 		if rules, err := n.Index.ListByType("visceral", 100); err == nil && len(rules) > 0 {
 			fmt.Printf("  Visceral:  %d rules\n", len(rules))
 		}
-		if active, err := n.Entities.List("task", "active", 0); err == nil {
+		if active, err := n.Entities.List(relationships.KindTask, "active", 0); err == nil {
 			fmt.Printf("  Tasks:     %d active\n", len(active))
 		}
-		if manifests, err := n.Entities.List("manifest", "active", 0); err == nil {
+		if manifests, err := n.Entities.List(relationships.KindManifest, "active", 0); err == nil {
 			fmt.Printf("  Manifests: %d active\n", len(manifests))
 		}
 		fmt.Println("  =====================")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/k8nstantin/OpenPraxis/internal/chat"
 	"github.com/k8nstantin/OpenPraxis/internal/comments"
+	"github.com/k8nstantin/OpenPraxis/internal/entity"
 	execution "github.com/k8nstantin/OpenPraxis/internal/execution"
 	"github.com/k8nstantin/OpenPraxis/internal/relationships"
 	"github.com/k8nstantin/OpenPraxis/internal/settings"
@@ -564,16 +565,25 @@ var serveCmd = &cobra.Command{
 			// Any entity type that owns tasks (directly or transitively) is handled
 			// uniformly — no hardcoded type checks.
 			var taskIDs []string
+			seen := map[string]bool{parentID: true}
 			var collectAll func(id string)
 			collectAll = func(id string) {
 				edges, _ := n.Relationships.ListOutgoing(ctx, id, relationships.EdgeOwns)
 				for _, edge := range edges {
 					if edge.DstKind == relationships.KindTask {
+						if seen[edge.DstID] {
+							continue
+						}
+						seen[edge.DstID] = true
 						if te, _ := n.Entities.Get(edge.DstID); te != nil &&
-							te.Status != "archived" && te.Status != "closed" {
+							te.Status != entity.StatusArchived && te.Status != entity.StatusClosed {
 							taskIDs = append(taskIDs, edge.DstID)
 						}
 					} else {
+						if seen[edge.DstID] {
+							continue
+						}
+						seen[edge.DstID] = true
 						// non-task owned entity — recurse
 						collectAll(edge.DstID)
 					}

--- a/internal/entity/store.go
+++ b/internal/entity/store.go
@@ -311,7 +311,7 @@ func (s *Store) ListByIDs(ids []string) ([]*Entity, error) {
 // Pass status="" to skip status filtering. limit=0 returns all rows.
 func (s *Store) ListByTypes(types []string, status string, limit int) ([]*Entity, error) {
 	if len(types) == 0 {
-		return nil, nil
+		return []*Entity{}, nil
 	}
 	placeholders := make([]string, len(types))
 	args := make([]any, len(types))

--- a/internal/entity/store.go
+++ b/internal/entity/store.go
@@ -305,6 +305,40 @@ func (s *Store) ListByIDs(ids []string) ([]*Entity, error) {
 	return scanEntities(rows)
 }
 
+// ListByTypes returns all current (valid_to = '') entities whose type is in
+// the provided list. Executes a single query using IN (...) instead of one
+// query per type, which is more efficient for the tree handler fan-out.
+// Pass status="" to skip status filtering. limit=0 returns all rows.
+func (s *Store) ListByTypes(types []string, status string, limit int) ([]*Entity, error) {
+	if len(types) == 0 {
+		return nil, nil
+	}
+	placeholders := make([]string, len(types))
+	args := make([]any, len(types))
+	for i, t := range types {
+		placeholders[i] = "?"
+		args[i] = t
+	}
+	query := `SELECT row_id, entity_uid, type, title, status, tags,
+		valid_from, valid_to, changed_by, change_reason, created_at
+		FROM entities WHERE valid_to = '' AND type IN (` + strings.Join(placeholders, ",") + `)`
+	if status != "" {
+		query += ` AND status = ?`
+		args = append(args, status)
+	}
+	query += ` ORDER BY created_at DESC`
+	if limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, limit)
+	}
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("entity: list_by_types: %w", err)
+	}
+	defer rows.Close()
+	return scanEntities(rows)
+}
+
 // Search returns current rows where title contains query (case-insensitive
 // substring), optionally filtered by entityType. limit=0 returns all matches.
 func (s *Store) Search(query, entityType string, limit int) ([]*Entity, error) {

--- a/internal/entity/types_store.go
+++ b/internal/entity/types_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -23,8 +24,16 @@ type EntityType struct {
 }
 
 // TypesStore manages the entity_types table.
+//
+// createMu serializes Create's close-then-insert transaction. Same
+// rationale as relationships.Store.createMu: SQLite WAL snapshot
+// isolation lets two concurrent Creates both see "no current row",
+// close-then-insert concurrently, and produce two rows with valid_to='',
+// breaking the SCD-2 invariant. The mutex makes the close + insert
+// atomic across goroutines.
 type TypesStore struct {
-	db *sql.DB
+	db       *sql.DB
+	createMu sync.Mutex
 }
 
 // NewTypesStore creates a TypesStore and runs the idempotent schema migration.
@@ -105,10 +114,12 @@ func (s *TypesStore) Seed(ctx context.Context) error {
 			return fmt.Errorf("entity_types: seed: check %q: %w", t.name, err)
 		}
 		if exists {
-			// Update color/icon in-place for existing built-in types so that
-			// adding these columns to an existing DB picks up the correct values.
+			// Only backfill color/icon if they still hold the DB-DEFAULT values —
+			// meaning the columns were just added via ALTER TABLE. If an operator
+			// has customized them, leave them alone (respect SCD-2 spirit).
 			_, _ = s.db.ExecContext(ctx,
-				`UPDATE entity_types SET color=?, icon=? WHERE name=? AND valid_to=''`,
+				`UPDATE entity_types SET color=?, icon=?
+				 WHERE name=? AND valid_to='' AND color='#6366f1' AND icon='Database'`,
 				t.color, t.icon, t.name)
 			continue
 		}
@@ -155,6 +166,10 @@ func (s *TypesStore) Create(ctx context.Context, name, displayName, description,
 
 	typeUID := uuid.Must(uuid.NewV7()).String()
 	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	// Serialize close-then-insert across goroutines; see createMu docstring.
+	s.createMu.Lock()
+	defer s.createMu.Unlock()
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -204,4 +219,74 @@ func (s *TypesStore) Exists(ctx context.Context, name string) (bool, error) {
 		return false, fmt.Errorf("entity_types: exists: %w", err)
 	}
 	return count > 0, nil
+}
+
+// Rename closes the current row for oldName and inserts a new row with
+// the SAME type_uid so that entity references remain stable across renames.
+// Create() is for genuinely new types (always generates a fresh UUID);
+// Rename() is for "same logical type, different name" mutations.
+//
+// Returns ErrNotFound (as a wrapped error) if no current row for oldName exists.
+func (s *TypesStore) Rename(ctx context.Context, oldName, newName, displayName, description, color, icon, changedBy string) (*EntityType, error) {
+	if color == "" {
+		color = "#6366f1"
+	}
+	if icon == "" {
+		icon = "Database"
+	}
+	if displayName == "" {
+		displayName = newName
+	}
+
+	s.createMu.Lock()
+	defer s.createMu.Unlock()
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	// Fetch the existing type_uid so the new row inherits it.
+	var existingUID string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT type_uid FROM entity_types WHERE name = ? AND valid_to = '' LIMIT 1`, oldName).Scan(&existingUID)
+	if err != nil {
+		return nil, fmt.Errorf("entity_types: rename: fetch uid for %q: %w", oldName, err)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("entity_types: rename: begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Close the current row for oldName.
+	_, err = tx.ExecContext(ctx,
+		`UPDATE entity_types SET valid_to = ? WHERE name = ? AND valid_to = ''`, now, oldName)
+	if err != nil {
+		return nil, fmt.Errorf("entity_types: rename: close prior: %w", err)
+	}
+
+	// Insert new row with the same type_uid.
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO entity_types
+		(type_uid, name, display_name, description, color, icon, valid_from, valid_to, changed_by, change_reason, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, '', ?, 'rename', ?)`,
+		existingUID, newName, displayName, description, color, icon, now, changedBy, now)
+	if err != nil {
+		return nil, fmt.Errorf("entity_types: rename: insert: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("entity_types: rename: commit: %w", err)
+	}
+
+	return &EntityType{
+		TypeUID:     existingUID,
+		Name:        newName,
+		DisplayName: displayName,
+		Description: description,
+		Color:       color,
+		Icon:        icon,
+		ValidFrom:   now,
+		ValidTo:     "",
+		CreatedAt:   now,
+	}, nil
 }

--- a/internal/entity/types_store.go
+++ b/internal/entity/types_store.go
@@ -1,0 +1,207 @@
+package entity
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// EntityType is one SCD-2 row in the entity_types table.
+type EntityType struct {
+	TypeUID     string `json:"type_uid"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Description string `json:"description"`
+	Color       string `json:"color"`
+	Icon        string `json:"icon"`
+	ValidFrom   string `json:"valid_from"`
+	ValidTo     string `json:"valid_to"`
+	CreatedAt   string `json:"created_at"`
+}
+
+// TypesStore manages the entity_types table.
+type TypesStore struct {
+	db *sql.DB
+}
+
+// NewTypesStore creates a TypesStore and runs the idempotent schema migration.
+func NewTypesStore(db *sql.DB) (*TypesStore, error) {
+	s := &TypesStore{db: db}
+	if err := s.InitSchema(db); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// InitSchema creates the entity_types table and its indexes if they do not exist.
+// For existing DBs the color and icon columns are added via ALTER TABLE if missing.
+func (s *TypesStore) InitSchema(db *sql.DB) error {
+	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS entity_types (
+		row_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+		type_uid      TEXT NOT NULL,
+		name          TEXT NOT NULL,
+		display_name  TEXT NOT NULL,
+		description   TEXT NOT NULL DEFAULT '',
+		color         TEXT NOT NULL DEFAULT '#6366f1',
+		icon          TEXT NOT NULL DEFAULT 'Database',
+		valid_from    TEXT NOT NULL,
+		valid_to      TEXT NOT NULL DEFAULT '',
+		changed_by    TEXT NOT NULL DEFAULT '',
+		change_reason TEXT NOT NULL DEFAULT '',
+		created_at    TEXT NOT NULL
+	)`)
+	if err != nil {
+		return fmt.Errorf("entity_types: init: create table: %w", err)
+	}
+
+	// Idempotent ALTER TABLE for existing DBs that predate color/icon columns.
+	for _, col := range []struct{ name, def string }{
+		{"color", "TEXT NOT NULL DEFAULT '#6366f1'"},
+		{"icon", "TEXT NOT NULL DEFAULT 'Database'"},
+	} {
+		_, _ = db.Exec(`ALTER TABLE entity_types ADD COLUMN ` + col.name + ` ` + col.def)
+	}
+
+	_, err = db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_entity_types_current
+		ON entity_types(name) WHERE valid_to = ''`)
+	if err != nil {
+		return fmt.Errorf("entity_types: init: create current index: %w", err)
+	}
+
+	_, err = db.Exec(`CREATE INDEX IF NOT EXISTS idx_entity_types_uid
+		ON entity_types(type_uid, valid_to)`)
+	if err != nil {
+		return fmt.Errorf("entity_types: init: create uid index: %w", err)
+	}
+
+	return nil
+}
+
+// builtinTypes is the seed set of entity types.
+var builtinTypes = []struct {
+	name        string
+	displayName string
+	description string
+	color       string
+	icon        string
+}{
+	{"skill", "Skill", "Governance rule or coding practice", "#f59e0b", "Wand2"},
+	{"product", "Product", "Top-level product with manifests and tasks", "#3b82f6", "Boxes"},
+	{"manifest", "Manifest", "Spec or plan that owns a set of tasks", "#a78bfa", "FileText"},
+	{"task", "Task", "Atomic execution unit run by an agent", "#10b981", "CheckSquare"},
+	{"idea", "Idea", "Unstructured concept or feature request", "#f97316", "Lightbulb"},
+	{"RAG", "RAG", "Retrieval-augmented generation knowledge source", "#06b6d4", "Database"},
+}
+
+// Seed inserts the built-in entity types if they do not already exist.
+// Idempotent — calling it multiple times is safe.
+func (s *TypesStore) Seed(ctx context.Context) error {
+	for _, t := range builtinTypes {
+		exists, err := s.Exists(ctx, t.name)
+		if err != nil {
+			return fmt.Errorf("entity_types: seed: check %q: %w", t.name, err)
+		}
+		if exists {
+			// Update color/icon in-place for existing built-in types so that
+			// adding these columns to an existing DB picks up the correct values.
+			_, _ = s.db.ExecContext(ctx,
+				`UPDATE entity_types SET color=?, icon=? WHERE name=? AND valid_to=''`,
+				t.color, t.icon, t.name)
+			continue
+		}
+		if _, err := s.Create(ctx, t.name, t.displayName, t.description, t.color, t.icon, "system"); err != nil {
+			return fmt.Errorf("entity_types: seed: insert %q: %w", t.name, err)
+		}
+	}
+	return nil
+}
+
+// List returns all current entity types (valid_to = '').
+func (s *TypesStore) List(ctx context.Context) ([]EntityType, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT type_uid, name, display_name, description,
+		color, icon, valid_from, valid_to, created_at
+		FROM entity_types WHERE valid_to = ''
+		ORDER BY name ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("entity_types: list: %w", err)
+	}
+	defer rows.Close()
+
+	var out []EntityType
+	for rows.Next() {
+		var et EntityType
+		if err := rows.Scan(&et.TypeUID, &et.Name, &et.DisplayName, &et.Description,
+			&et.Color, &et.Icon, &et.ValidFrom, &et.ValidTo, &et.CreatedAt); err != nil {
+			return nil, fmt.Errorf("entity_types: list: scan: %w", err)
+		}
+		out = append(out, et)
+	}
+	return out, rows.Err()
+}
+
+// Create inserts a new current row for the given entity type name using
+// SCD-2 semantics. If a current row already exists, it is closed and a
+// new row is inserted in a single transaction.
+func (s *TypesStore) Create(ctx context.Context, name, displayName, description, color, icon, changedBy string) (*EntityType, error) {
+	if color == "" {
+		color = "#6366f1"
+	}
+	if icon == "" {
+		icon = "Database"
+	}
+
+	typeUID := uuid.Must(uuid.NewV7()).String()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("entity_types: create: begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Close any existing current row for this name.
+	_, err = tx.ExecContext(ctx, `UPDATE entity_types SET valid_to = ?
+		WHERE name = ? AND valid_to = ''`, now, name)
+	if err != nil {
+		return nil, fmt.Errorf("entity_types: create: close prior: %w", err)
+	}
+
+	// Insert the new current row.
+	_, err = tx.ExecContext(ctx, `INSERT INTO entity_types
+		(type_uid, name, display_name, description, color, icon, valid_from, valid_to, changed_by, change_reason, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, '', ?, '', ?)`,
+		typeUID, name, displayName, description, color, icon, now, changedBy, now)
+	if err != nil {
+		return nil, fmt.Errorf("entity_types: create: insert: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("entity_types: create: commit: %w", err)
+	}
+
+	return &EntityType{
+		TypeUID:     typeUID,
+		Name:        name,
+		DisplayName: displayName,
+		Description: description,
+		Color:       color,
+		Icon:        icon,
+		ValidFrom:   now,
+		ValidTo:     "",
+		CreatedAt:   now,
+	}, nil
+}
+
+// Exists returns true if a current row (valid_to = '') exists for name.
+func (s *TypesStore) Exists(ctx context.Context, name string) (bool, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM entity_types WHERE name = ? AND valid_to = ''`, name).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("entity_types: exists: %w", err)
+	}
+	return count > 0, nil
+}

--- a/internal/entity/types_store.go
+++ b/internal/entity/types_store.go
@@ -117,9 +117,12 @@ func (s *TypesStore) Seed(ctx context.Context) error {
 			// Only backfill color/icon if they still hold the DB-DEFAULT values —
 			// meaning the columns were just added via ALTER TABLE. If an operator
 			// has customized them, leave them alone (respect SCD-2 spirit).
+			// Backfill color/icon if EITHER still holds the DB-default value
+			// (column was just added via ALTER TABLE). If an operator has
+			// customized BOTH, leave them alone.
 			_, _ = s.db.ExecContext(ctx,
 				`UPDATE entity_types SET color=?, icon=?
-				 WHERE name=? AND valid_to='' AND color='#6366f1' AND icon='Database'`,
+				 WHERE name=? AND valid_to='' AND (color='#6366f1' OR icon='Database')`,
 				t.color, t.icon, t.name)
 			continue
 		}

--- a/internal/mcp/tools_entity.go
+++ b/internal/mcp/tools_entity.go
@@ -13,8 +13,8 @@ import (
 func (s *Server) registerEntityTools() {
 	s.mcp.AddTool(
 		mcplib.NewTool("entity_create",
-			mcplib.WithDescription("Create an entity — a generic SCD-2 versioned object. Types: skill, product, manifest, task, idea."),
-			mcplib.WithString("type", mcplib.Required(), mcplib.Description("Entity type: skill, product, manifest, task, idea")),
+			mcplib.WithDescription("Create an entity — a generic SCD-2 versioned object. Types: any type from entity_types table (built-in: skill, product, manifest, task, idea, RAG; extensible via POST /api/entity-types)."),
+			mcplib.WithString("type", mcplib.Required(), mcplib.Description("Entity type — any name from the entity_types table (built-in: skill, product, manifest, task, idea, RAG)")),
 			mcplib.WithString("title", mcplib.Required(), mcplib.Description("Entity title")),
 			mcplib.WithString("description", mcplib.Description("Initial prompt/instructions body (stored as first revision)")),
 			mcplib.WithString("status", mcplib.Description("draft, active, closed, archived. Default: draft")),
@@ -25,8 +25,8 @@ func (s *Server) registerEntityTools() {
 
 	s.mcp.AddTool(
 		mcplib.NewTool("entity_list",
-			mcplib.WithDescription("List entities, optionally filtered by type and/or status."),
-			mcplib.WithString("type", mcplib.Description("Filter by type: skill, product, manifest, task, idea")),
+			mcplib.WithDescription("List entities, optionally filtered by type and/or status. Types are DB-driven — use entity_types table for the full list of available types."),
+			mcplib.WithString("type", mcplib.Description("Filter by type — any name from the entity_types table (built-in: skill, product, manifest, task, idea, RAG)")),
 			mcplib.WithString("status", mcplib.Description("Filter by status: draft, active, closed, archived")),
 			mcplib.WithNumber("limit", mcplib.Description("Max results. Default: 50")),
 		),
@@ -64,9 +64,9 @@ func (s *Server) registerEntityTools() {
 
 	s.mcp.AddTool(
 		mcplib.NewTool("entity_search",
-			mcplib.WithDescription("Search entities by title substring (case-insensitive)."),
+			mcplib.WithDescription("Search entities by title substring (case-insensitive). Types are DB-driven — use entity_types table for the full list of available types."),
 			mcplib.WithString("query", mcplib.Required(), mcplib.Description("Search query")),
-			mcplib.WithString("type", mcplib.Description("Filter by type: skill, product, manifest, task, idea")),
+			mcplib.WithString("type", mcplib.Description("Filter by type — any name from the entity_types table (built-in: skill, product, manifest, task, idea, RAG)")),
 			mcplib.WithNumber("limit", mcplib.Description("Max results. Default: 20")),
 		),
 		s.handleEntitySearch,

--- a/internal/mcp/tools_relationships_test.go
+++ b/internal/mcp/tools_relationships_test.go
@@ -79,9 +79,11 @@ func TestRelCreate_HappyPath(t *testing.T) {
 }
 
 func TestRelCreate_ValidationError(t *testing.T) {
+	// validKind now accepts any non-empty string (entity_types DB is the
+	// source of truth). Empty string is still rejected.
 	s := newTestServerWithRelationships(t)
 	res, _ := s.handleRelCreate(context.Background(), buildReq(map[string]any{
-		"src_kind": "garbage", "src_id": "M1",
+		"src_kind": "", "src_id": "M1",
 		"dst_kind": "manifest", "dst_id": "M2",
 		"kind": "depends_on",
 	}))

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -71,6 +71,9 @@ type Node struct {
 	// ExecutionLog is the unified run-history store (EL/M1). Replaces
 	// task_runs + task_run_host_samples in EL/M5.
 	ExecutionLog *executionlog.Store
+	// EntityTypes is the DB-driven entity type registry. Seeded on boot
+	// with built-in types; new types can be added via /api/entity-types.
+	EntityTypes *entity.TypesStore
 	runner       *task.Runner
 	hostSampler  *task.HostSampler
 	Embedder     *embedding.Engine
@@ -250,6 +253,13 @@ func New(cfg *config.Config) (*Node, error) {
 	}
 	executionStore := executionlog.NewStore(index.DB())
 
+	entityTypesStore, err := entity.NewTypesStore(index.DB())
+	if err != nil {
+		return nil, fmt.Errorf("init entity types store: %w", err)
+	}
+	if err := entityTypesStore.Seed(context.Background()); err != nil {
+		return nil, fmt.Errorf("seed entity types: %w", err)
+	}
 
 	n := &Node{
 		Config:           cfg,
@@ -269,6 +279,7 @@ func New(cfg *config.Config) (*Node, error) {
 		Relationships:    relationshipsStore,
 		Schedules:        scheduleStore,
 		ExecutionLog:     executionStore,
+		EntityTypes:      entityTypesStore,
 		Embedder:         embedder,
 		StartedAt:        time.Now(),
 	}

--- a/internal/relationships/store.go
+++ b/internal/relationships/store.go
@@ -74,16 +74,14 @@ func AllEdgeKinds() []string {
 	return out
 }
 
-// validKind returns true if k is one of the enumerated entity kinds.
-// Iterates allEntityKinds so adding a new entity kind only requires
-// extending the slice — no validator edit needed.
+// validKind returns true if k is a non-empty string. The DB-driven
+// entity_types table is now the source of truth for valid entity kinds;
+// Go-side validation only rejects the empty string (which would silently
+// corrupt the DAG). Edge kinds are still code-defined and validated via
+// validEdgeKind. The allEntityKinds slice is retained for callers that
+// enumerate built-in kinds (e.g. the relationships constants).
 func validKind(k string) bool {
-	for _, v := range allEntityKinds {
-		if k == v {
-			return true
-		}
-	}
-	return false
+	return k != ""
 }
 
 // validEdgeKind returns true if k is one of the enumerated edge kinds.

--- a/internal/relationships/store.go
+++ b/internal/relationships/store.go
@@ -552,9 +552,8 @@ func validateAsOf(asOf string) error {
 // ListOutgoing returns all CURRENT edges leaving srcID, optionally
 // filtered to a specific edge kind. "Current" means valid_to == ''.
 //
-// edgeKind == "" returns every kind (owns + depends_on + reviews +
-// links_to). Pass a specific kind to restrict (e.g. EdgeDependsOn for
-// just the dep graph).
+// edgeKind == "" returns every kind (owns + depends_on).
+// Pass a specific kind to restrict (e.g. EdgeDependsOn for just the dep graph).
 //
 // Hits the partial index idx_rel_src_current — O(log n + matches) on
 // current state regardless of how much history accumulates.
@@ -825,7 +824,7 @@ type WalkRow struct {
 // appear in the walk.
 //
 // edgeKinds filters which edge kinds to follow:
-//   - nil or empty: follow ALL edge kinds (owns + depends_on + reviews + links_to)
+//   - nil or empty: follow ALL edge kinds (owns + depends_on)
 //   - otherwise: only follow edges whose kind is in the slice
 //
 // maxDepth caps recursion. 0 means "root only" (anchor row only — the

--- a/internal/relationships/store.go
+++ b/internal/relationships/store.go
@@ -56,14 +56,13 @@ var ErrSelfLoop = errors.New("relationships: a node cannot have an edge to itsel
 // rejects empty IDs at the top so corrupted-state never propagates.
 var ErrEmptyID = errors.New("relationships: src_id and dst_id must be non-empty")
 
-// allEntityKinds and allEdgeKinds are the source of truth for valid
-// kind values. validKind / validEdgeKind iterate these slices instead
-// of hard-coding equality chains; the constant declarations below
-// reference these slices via the validators, so adding a new kind in
-// ONE place (the slice) auto-extends both the validator AND keeps the
-// constants iterable for callers that want to enumerate. Was: two
-// hard-coded == chains that drifted whenever a constant was added.
-var allEntityKinds = []string{KindProduct, KindManifest, KindTask, KindSkill, KindIdea, KindRAG}
+// allEdgeKinds is the source of truth for valid edge kind values.
+// Entity kinds are no longer validated against a static slice — the
+// DB-driven entity_types table is the authoritative source of truth for
+// which entity kinds exist. validKind() only rejects the empty string.
+// The named Kind constants below remain for use as typed references in
+// application code; adding a new built-in kind only requires a new const
+// and a row in entity_types (no slice to update).
 var allEdgeKinds = []string{EdgeOwns, EdgeDependsOn}
 
 // AllEdgeKinds returns all valid edge kinds. Use this instead of repeating
@@ -75,11 +74,10 @@ func AllEdgeKinds() []string {
 }
 
 // validKind returns true if k is a non-empty string. The DB-driven
-// entity_types table is now the source of truth for valid entity kinds;
+// entity_types table is the source of truth for valid entity kinds;
 // Go-side validation only rejects the empty string (which would silently
 // corrupt the DAG). Edge kinds are still code-defined and validated via
-// validEdgeKind. The allEntityKinds slice is retained for callers that
-// enumerate built-in kinds (e.g. the relationships constants).
+// validEdgeKind.
 func validKind(k string) bool {
 	return k != ""
 }
@@ -107,10 +105,11 @@ func nowUTC() string {
 }
 
 // Standard entity kinds. Stored as TEXT in src_kind / dst_kind columns.
-// Schema is portable — no CHECK constraint enforces this set; Go-side
-// validKind() is the only gate. Adding a new kind: extend allEntityKinds
-// (which the validator iterates) AND add the const; the schema needs
-// no migration since it's just TEXT.
+// These constants are used as typed references in application code.
+// Adding a new built-in kind: add the const here AND a seed row in
+// entity_types — no slice to update, no schema migration needed
+// (it is just TEXT). validKind() accepts any non-empty string because
+// the entity_types table is the authoritative domain validator.
 const (
 	KindProduct  = "product"
 	KindManifest = "manifest"

--- a/internal/relationships/store_test.go
+++ b/internal/relationships/store_test.go
@@ -185,13 +185,18 @@ func TestCreate_ValidationErrors(t *testing.T) {
 			wantErr: ErrEmptyID,
 		},
 		{
+			// validKind accepts any non-empty string — the DB-driven entity_types
+			// table is the source of truth for valid kinds. Only the empty string
+			// is rejected here (would silently corrupt the DAG).
 			name: "bad src_kind",
-			edge: Edge{SrcKind: "garbage", SrcID: "A", DstKind: KindManifest, DstID: "B", Kind: EdgeDependsOn},
+			edge: Edge{SrcKind: "", SrcID: "A", DstKind: KindManifest, DstID: "B", Kind: EdgeDependsOn},
 			wantErr: ErrInvalidKind,
 		},
 		{
+			// Same rationale as bad_src_kind: empty dst_kind is rejected;
+			// non-empty strings are accepted because entity_types is authoritative.
 			name: "bad dst_kind",
-			edge: Edge{SrcKind: KindManifest, SrcID: "A", DstKind: "garbage", DstID: "B", Kind: EdgeDependsOn},
+			edge: Edge{SrcKind: KindManifest, SrcID: "A", DstKind: "", DstID: "B", Kind: EdgeDependsOn},
 			wantErr: ErrInvalidKind,
 		},
 		{

--- a/internal/schedule/runner.go
+++ b/internal/schedule/runner.go
@@ -168,9 +168,17 @@ func (r *Runner) makeJob(id int64, kind, entityID string) func() {
 		}
 		dispatch, ok := r.dispatchers[kind]
 		if !ok {
-			slog.Warn("schedule.Runner: no dispatcher for kind",
+			// Fall back to the wildcard dispatcher ("*") so entity types added
+			// at runtime (via entity_types table) are handled without a server
+			// restart. Unknown kinds with no fallback are logged + skipped.
+			dispatch, ok = r.dispatchers["*"]
+			if !ok {
+				slog.Warn("schedule.Runner: no dispatcher for kind",
+					"schedule_id", id, "entity_kind", kind, "entity_id", entityID)
+				return
+			}
+			slog.Info("schedule.Runner: using fallback dispatcher for kind",
 				"schedule_id", id, "entity_kind", kind, "entity_id", entityID)
-			return
 		}
 		if err := dispatch(ctx, entityID, id); err != nil {
 			// Don't MarkFired on dispatch failure — leave the row to

--- a/internal/schedule/store.go
+++ b/internal/schedule/store.go
@@ -38,21 +38,20 @@ var ErrEmptyEntityID = errors.New("schedule: entity_id must be non-empty")
 var ErrEmptyRunAt = errors.New("schedule: run_at must be non-empty")
 
 // Standard entity kinds for schedules. Stored as TEXT in entity_kind.
-// Add a new kind: extend allEntityKinds (which the validator iterates)
-// AND add the const; the schema needs no migration.
+// These constants are used as typed references in application code.
+// Adding a new kind: add the const here AND a seed row in entity_types —
+// the entity_types table is the authoritative domain validator; validKind()
+// accepts any non-empty string. No schema migration needed.
 const (
 	KindProduct  = "product"
 	KindManifest = "manifest"
 	KindTask     = "task"
 )
 
-var allEntityKinds = []string{KindProduct, KindManifest, KindTask}
-
 // validKind returns true if k is a non-empty string. The DB-driven
-// entity_types table is now the source of truth for valid entity kinds;
+// entity_types table is the source of truth for valid entity kinds;
 // Go-side validation only rejects the empty string (which would silently
-// corrupt the schedule index). The allEntityKinds slice is retained for
-// callers that enumerate built-in kinds (e.g. seed logic, tests).
+// corrupt the schedule index).
 func validKind(k string) bool {
 	return k != ""
 }

--- a/internal/schedule/store.go
+++ b/internal/schedule/store.go
@@ -48,14 +48,13 @@ const (
 
 var allEntityKinds = []string{KindProduct, KindManifest, KindTask}
 
-// validKind returns true if k is one of the enumerated entity kinds.
+// validKind returns true if k is a non-empty string. The DB-driven
+// entity_types table is now the source of truth for valid entity kinds;
+// Go-side validation only rejects the empty string (which would silently
+// corrupt the schedule index). The allEntityKinds slice is retained for
+// callers that enumerate built-in kinds (e.g. seed logic, tests).
 func validKind(k string) bool {
-	for _, v := range allEntityKinds {
-		if k == v {
-			return true
-		}
-	}
-	return false
+	return k != ""
 }
 
 // nowUTC returns the current time as RFC3339Nano in UTC. Composite-PK

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -495,6 +495,7 @@ func mountAPI(api *mux.Router, deps ServerDeps) {
 	api.HandleFunc("/entities/{id}", apiEntityUpdate(n)).Methods("PUT")
 	api.HandleFunc("/entity-types", apiEntityTypesList(n)).Methods("GET")
 	api.HandleFunc("/entity-types", apiEntityTypesCreate(n)).Methods("POST")
+	api.HandleFunc("/entity-types/{name}", apiEntityTypesUpdate(n)).Methods("PUT")
 	// Legacy dependency management routes — used by the Dependencies tab.
 	// Products expose downstream sub-products; manifests expose upstream deps.
 	api.HandleFunc("/products/{id}/dependencies", apiEntityDependencies(n, "product")).Methods("GET")

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -493,6 +493,8 @@ func mountAPI(api *mux.Router, deps ServerDeps) {
 	api.HandleFunc("/entities/{id}/comments", apiEntityCommentsAdd(n)).Methods("POST")
 	api.HandleFunc("/entities/{id}", apiEntityGet(n)).Methods("GET")
 	api.HandleFunc("/entities/{id}", apiEntityUpdate(n)).Methods("PUT")
+	api.HandleFunc("/entity-types", apiEntityTypesList(n)).Methods("GET")
+	api.HandleFunc("/entity-types", apiEntityTypesCreate(n)).Methods("POST")
 	// Legacy dependency management routes — used by the Dependencies tab.
 	// Products expose downstream sub-products; manifests expose upstream deps.
 	api.HandleFunc("/products/{id}/dependencies", apiEntityDependencies(n, "product")).Methods("GET")

--- a/internal/web/handlers_entity.go
+++ b/internal/web/handlers_entity.go
@@ -206,7 +206,9 @@ func apiEntityUpdate(n *node.Node) http.HandlerFunc {
 		// Handle project_id (manifest → product ownership edge).
 		if req.ProjectID != nil && n.Relationships != nil {
 			newProjectID := *req.ProjectID
-			// Remove old owns edge(s) pointing to this manifest from any product.
+			// Remove ALL incoming owns edges to this entity regardless of SrcKind —
+			// with dynamic entity types, any entity can own any other entity.
+			// Filtering by SrcKind == KindProduct was an old hardcoded assumption.
 			incoming, err := n.Relationships.ListIncoming(r.Context(), existing.EntityUID, relationships.EdgeOwns)
 			if err != nil {
 				slog.Error("re-parent: list incoming failed", "entity", existing.EntityUID, "err", err)
@@ -214,20 +216,24 @@ func apiEntityUpdate(n *node.Node) http.HandlerFunc {
 				return
 			}
 			for _, e := range incoming {
-				if e.SrcKind == relationships.KindProduct {
-					if err := n.Relationships.Remove(r.Context(), e.SrcID, existing.EntityUID, relationships.EdgeOwns, "http-api", "re-parent"); err != nil {
-						slog.Error("re-parent: remove old edge failed", "src", e.SrcID, "dst", existing.EntityUID, "err", err)
-						http.Error(w, "failed to remove old relationship", 500)
-						return
-					}
+				if err := n.Relationships.Remove(r.Context(), e.SrcID, existing.EntityUID, relationships.EdgeOwns, "http-api", "re-parent"); err != nil {
+					slog.Error("re-parent: remove old edge failed", "src", e.SrcID, "dst", existing.EntityUID, "err", err)
+					http.Error(w, "failed to remove old relationship", 500)
+					return
 				}
 			}
 			// Add new owns edge if non-empty project_id.
+			// Resolve actual src kind from the parent entity so the edge is
+			// stamped correctly regardless of parent entity type.
 			if newProjectID != "" {
+				srcKind := relationships.KindProduct // default fallback
+				if parent, _ := n.Entities.Get(newProjectID); parent != nil {
+					srcKind = parent.Type
+				}
 				if err := n.Relationships.Create(r.Context(), relationships.Edge{
-					SrcKind:   relationships.KindProduct,
+					SrcKind:   srcKind,
 					SrcID:     newProjectID,
-					DstKind:   relationships.KindManifest,
+					DstKind:   existing.Type,
 					DstID:     existing.EntityUID,
 					Kind:      relationships.EdgeOwns,
 					CreatedBy: "http-api",
@@ -242,6 +248,9 @@ func apiEntityUpdate(n *node.Node) http.HandlerFunc {
 		// Handle manifest_id (task → manifest ownership edge).
 		if req.ManifestID != nil && n.Relationships != nil {
 			newManifestID := *req.ManifestID
+			// Remove ALL incoming owns edges regardless of SrcKind — with dynamic
+			// entity types, any entity can own any other entity. Filtering by
+			// SrcKind == KindManifest was an old hardcoded assumption.
 			incoming, err := n.Relationships.ListIncoming(r.Context(), existing.EntityUID, relationships.EdgeOwns)
 			if err != nil {
 				slog.Error("re-parent: list incoming failed", "entity", existing.EntityUID, "err", err)
@@ -249,19 +258,23 @@ func apiEntityUpdate(n *node.Node) http.HandlerFunc {
 				return
 			}
 			for _, e := range incoming {
-				if e.SrcKind == relationships.KindManifest {
-					if err := n.Relationships.Remove(r.Context(), e.SrcID, existing.EntityUID, relationships.EdgeOwns, "http-api", "re-parent"); err != nil {
-						slog.Error("re-parent: remove old edge failed", "src", e.SrcID, "dst", existing.EntityUID, "err", err)
-						http.Error(w, "failed to remove old relationship", 500)
-						return
-					}
+				if err := n.Relationships.Remove(r.Context(), e.SrcID, existing.EntityUID, relationships.EdgeOwns, "http-api", "re-parent"); err != nil {
+					slog.Error("re-parent: remove old edge failed", "src", e.SrcID, "dst", existing.EntityUID, "err", err)
+					http.Error(w, "failed to remove old relationship", 500)
+					return
 				}
 			}
+			// Resolve actual src kind from the parent entity so the edge is
+			// stamped correctly regardless of parent entity type.
 			if newManifestID != "" {
+				srcKind := relationships.KindManifest // default fallback
+				if parent, _ := n.Entities.Get(newManifestID); parent != nil {
+					srcKind = parent.Type
+				}
 				if err := n.Relationships.Create(r.Context(), relationships.Edge{
-					SrcKind:   relationships.KindManifest,
+					SrcKind:   srcKind,
 					SrcID:     newManifestID,
-					DstKind:   relationships.KindTask,
+					DstKind:   existing.Type,
 					DstID:     existing.EntityUID,
 					Kind:      relationships.EdgeOwns,
 					CreatedBy: "http-api",

--- a/internal/web/handlers_entity.go
+++ b/internal/web/handlers_entity.go
@@ -81,12 +81,20 @@ func apiEntityCreate(n *node.Node) http.HandlerFunc {
 			return
 		}
 		// Wire the owns edge from parent to the newly created entity.
+		// ProjectID and ManifestID wiring is not restricted to specific entity
+		// types — any entity can be owned by any other entity via EdgeOwns.
+		// SrcKind is resolved by looking up the parent entity so the edge is
+		// stamped with the correct kind regardless of parent type.
 		if n.Relationships != nil {
-			if req.ProjectID != "" && req.Type == "manifest" {
+			if req.ProjectID != "" {
+				srcKind := relationships.KindProduct // default for ProjectID
+				if parent, _ := n.Entities.Get(req.ProjectID); parent != nil {
+					srcKind = parent.Type
+				}
 				if err := n.Relationships.Create(r.Context(), relationships.Edge{
-					SrcKind:   relationships.KindProduct,
+					SrcKind:   srcKind,
 					SrcID:     req.ProjectID,
-					DstKind:   relationships.KindManifest,
+					DstKind:   e.Type,
 					DstID:     e.EntityUID,
 					Kind:      relationships.EdgeOwns,
 					CreatedBy: "http-api",
@@ -94,11 +102,15 @@ func apiEntityCreate(n *node.Node) http.HandlerFunc {
 					slog.Error("entity create: wire owns edge failed", "src", req.ProjectID, "dst", e.EntityUID, "err", err)
 				}
 			}
-			if req.ManifestID != "" && req.Type == "task" {
+			if req.ManifestID != "" {
+				srcKind := relationships.KindManifest // default for ManifestID
+				if parent, _ := n.Entities.Get(req.ManifestID); parent != nil {
+					srcKind = parent.Type
+				}
 				if err := n.Relationships.Create(r.Context(), relationships.Edge{
-					SrcKind:   relationships.KindManifest,
+					SrcKind:   srcKind,
 					SrcID:     req.ManifestID,
-					DstKind:   relationships.KindTask,
+					DstKind:   e.Type,
 					DstID:     e.EntityUID,
 					Kind:      relationships.EdgeOwns,
 					CreatedBy: "http-api",
@@ -354,10 +366,12 @@ func apiEntityExecutionLog(n *node.Node) http.HandlerFunc {
 
 		// For task entities return the flat atomic run list (existing behaviour).
 		// For manifests and products walk the DAG and return a hierarchical shape:
-		//   manifest → [{task_id, task_title, runs:[...ExecutionRow]}]
-		//   product  → [{manifest_id, manifest_title, tasks:[{task_id, task_title, runs:[...]}]}]
+		//   task-kind     → flat [{...ExecutionRow}]
+		//   manifest-kind → [{task_id, task_title, runs:[...ExecutionRow]}]
+		//   product-kind  → [{manifest_id, manifest_title, tasks:[{task_id, task_title, runs:[...]}]}]
+		//   any other kind → generic walk: same shape as product (recursive owns traversal)
 		e, _ := n.Entities.Get(id)
-		if e == nil || e.Type == "task" || n.Relationships == nil {
+		if e == nil || e.Type == relationships.KindTask || n.Relationships == nil {
 			rows, err := n.ExecutionLog.ListByEntity(ctx, id, limit)
 			if err != nil {
 				http.Error(w, err.Error(), 500)
@@ -387,14 +401,14 @@ func apiEntityExecutionLog(n *node.Node) http.HandlerFunc {
 			return taskRuns{TaskID: taskID, TaskTitle: taskTitle, Runs: rows}
 		}
 
-		if e.Type == "manifest" {
+		if e.Type == relationships.KindManifest {
 			// manifest → tasks
-			edges, _ := n.Relationships.ListOutgoing(ctx, id, "owns")
+			edges, _ := n.Relationships.ListOutgoing(ctx, id, relationships.EdgeOwns)
 
 			// Collect all task IDs first, then batch-fetch titles.
 			var taskIDs []string
 			for _, edge := range edges {
-				if edge.DstKind == "task" {
+				if edge.DstKind == relationships.KindTask {
 					taskIDs = append(taskIDs, edge.DstID)
 				}
 			}
@@ -412,7 +426,7 @@ func apiEntityExecutionLog(n *node.Node) http.HandlerFunc {
 
 			result := []taskRuns{}
 			for _, edge := range edges {
-				if edge.DstKind == "task" {
+				if edge.DstKind == relationships.KindTask {
 					title := edge.DstID
 					if t, ok := titleByID[edge.DstID]; ok {
 						title = t
@@ -424,8 +438,10 @@ func apiEntityExecutionLog(n *node.Node) http.HandlerFunc {
 			return
 		}
 
-		// product → manifests → tasks
-		manifEdges, _ := n.Relationships.ListOutgoing(ctx, id, "owns")
+		// product (or any unknown type) → manifests → tasks
+		// Unknown entity types are treated generically like "product": walk all
+		// owned non-task entities as "manifest groups", collect their tasks.
+		manifEdges, _ := n.Relationships.ListOutgoing(ctx, id, relationships.EdgeOwns)
 
 		// Pass 1: collect manifest IDs and, per manifest, their task edges.
 		// This is O(manifests) relationship queries — unavoidable without a
@@ -438,14 +454,16 @@ func apiEntityExecutionLog(n *node.Node) http.HandlerFunc {
 		var allTaskIDs []string
 		var manifIDs []string
 		for _, me := range manifEdges {
-			if me.DstKind != "manifest" {
+			// Include any non-task owned entity as a "manifest group" —
+			// works for manifest-kind and any custom intermediate entity type.
+			if me.DstKind == relationships.KindTask {
 				continue
 			}
 			manifIDs = append(manifIDs, me.DstID)
-			tEdges, _ := n.Relationships.ListOutgoing(ctx, me.DstID, "owns")
+			tEdges, _ := n.Relationships.ListOutgoing(ctx, me.DstID, relationships.EdgeOwns)
 			md := manifData{id: me.DstID, taskEdges: tEdges}
 			for _, te := range tEdges {
-				if te.DstKind == "task" {
+				if te.DstKind == relationships.KindTask {
 					allTaskIDs = append(allTaskIDs, te.DstID)
 				}
 			}
@@ -483,7 +501,7 @@ func apiEntityExecutionLog(n *node.Node) http.HandlerFunc {
 			}
 			tasks := []taskRuns{}
 			for _, te := range md.taskEdges {
-				if te.DstKind != "task" {
+				if te.DstKind != relationships.KindTask {
 					continue
 				}
 				tTitle := te.DstID

--- a/internal/web/handlers_entity_tree.go
+++ b/internal/web/handlers_entity_tree.go
@@ -60,23 +60,15 @@ func apiEntityTree(n *node.Node) http.HandlerFunc {
 			kinds = builtinKinds
 		}
 
-		type res struct {
-			kind  string
-			items []*entity.Entity
-			err   error
-		}
-		ch := make(chan res, len(kinds))
-		for _, k := range kinds {
-			go func(kind string) {
-				items, err := n.Entities.List(kind, "", 500)
-				ch <- res{kind: kind, items: items, err: err}
-			}(k)
-		}
+		// Fetch all entities for the active kinds in a single IN-query instead
+		// of spawning one goroutine per kind. SQLite serialises writes but reads
+		// are still serialised through the connection pool, so the fan-out goroutine
+		// approach added goroutine overhead without any real concurrency benefit.
 		byKind := make(map[string][]*entity.Entity)
-		for range kinds {
-			r := <-ch
-			if r.err == nil {
-				byKind[r.kind] = r.items
+		allEntities, err := n.Entities.ListByTypes(kinds, "", 500*len(kinds))
+		if err == nil {
+			for _, e := range allEntities {
+				byKind[e.Type] = append(byKind[e.Type], e)
 			}
 		}
 

--- a/internal/web/handlers_entity_tree.go
+++ b/internal/web/handlers_entity_tree.go
@@ -203,9 +203,10 @@ func apiEntityTree(n *node.Node) http.HandlerFunc {
 		}
 		sort.Slice(rags, func(i, j int) bool { return rags[i].ID > rags[j].ID })
 
-		// knownSpecial is derived from builtinKinds — single source of truth.
-		// Any kind NOT in this set is included in by_type only and as an extra
-		// section in the response.
+		// knownSpecial intentionally uses builtinKinds (not the active kinds slice).
+		// Custom types from entity_types must NOT be in knownSpecial — they should
+		// flow to extra_types where the frontend builds dynamic sidebar groups.
+		// Only the 6 builtin kinds get their own dedicated named response sections.
 		knownSpecial := make(map[string]bool, len(builtinKinds))
 		for _, k := range builtinKinds {
 			knownSpecial[k] = true

--- a/internal/web/handlers_entity_tree.go
+++ b/internal/web/handlers_entity_tree.go
@@ -203,16 +203,12 @@ func apiEntityTree(n *node.Node) http.HandlerFunc {
 		}
 		sort.Slice(rags, func(i, j int) bool { return rags[i].ID > rags[j].ID })
 
-		// knownSpecial tracks the kinds that are already handled in the named
-		// top-level sections. Any kind NOT in this set is included in by_type
-		// only and as an extra section in the response.
-		knownSpecial := map[string]bool{
-			entity.TypeSkill:    true,
-			entity.TypeIdea:     true,
-			entity.TypeProduct:  true,
-			entity.TypeManifest: true,
-			entity.TypeTask:     true,
-			entity.TypeRAG:      true,
+		// knownSpecial is derived from builtinKinds — single source of truth.
+		// Any kind NOT in this set is included in by_type only and as an extra
+		// section in the response.
+		knownSpecial := make(map[string]bool, len(builtinKinds))
+		for _, k := range builtinKinds {
+			knownSpecial[k] = true
 		}
 
 		// by_type: all entity types keyed by name — for forwards-compatible frontend consumption.

--- a/internal/web/handlers_entity_tree.go
+++ b/internal/web/handlers_entity_tree.go
@@ -37,18 +37,33 @@ func apiEntityTree(n *node.Node) http.HandlerFunc {
 			return
 		}
 
-		type res struct {
-			kind  string
-			items []*entity.Entity
-			err   error
-		}
-		kinds := []string{
+		// Build the kinds slice from entity_types table when available;
+		// fall back to the built-in set if the store is nil or returns an error.
+		builtinKinds := []string{
 			entity.TypeSkill,
 			entity.TypeIdea,
 			entity.TypeProduct,
 			entity.TypeManifest,
 			entity.TypeTask,
 			entity.TypeRAG,
+		}
+		var kinds []string
+		if n.EntityTypes != nil {
+			if etypes, err := n.EntityTypes.List(ctx); err == nil && len(etypes) > 0 {
+				kinds = make([]string, 0, len(etypes))
+				for _, et := range etypes {
+					kinds = append(kinds, et.Name)
+				}
+			}
+		}
+		if len(kinds) == 0 {
+			kinds = builtinKinds
+		}
+
+		type res struct {
+			kind  string
+			items []*entity.Entity
+			err   error
 		}
 		ch := make(chan res, len(kinds))
 		for _, k := range kinds {
@@ -196,12 +211,49 @@ func apiEntityTree(n *node.Node) http.HandlerFunc {
 		}
 		sort.Slice(rags, func(i, j int) bool { return rags[i].ID > rags[j].ID })
 
+		// knownSpecial tracks the kinds that are already handled in the named
+		// top-level sections. Any kind NOT in this set is included in by_type
+		// only and as an extra section in the response.
+		knownSpecial := map[string]bool{
+			entity.TypeSkill:    true,
+			entity.TypeIdea:     true,
+			entity.TypeProduct:  true,
+			entity.TypeManifest: true,
+			entity.TypeTask:     true,
+			entity.TypeRAG:      true,
+		}
+
+		// by_type: all entity types keyed by name — for forwards-compatible frontend consumption.
+		byType := make(map[string][]*treeNode, len(kinds))
+		for _, k := range kinds {
+			nodes := make([]*treeNode, 0)
+			for _, e := range byKind[k] {
+				if e.Status != entity.StatusArchived {
+					if nd := buildNode(e.EntityUID, make(map[string]bool)); nd != nil {
+						nodes = append(nodes, nd)
+					}
+				}
+			}
+			sort.Slice(nodes, func(i, j int) bool { return nodes[i].ID > nodes[j].ID })
+			byType[k] = nodes
+		}
+
+		// extra_types: unknown/custom entity kinds not handled as named sections.
+		extraTypes := make(map[string][]*treeNode)
+		for _, k := range kinds {
+			if !knownSpecial[k] {
+				extraTypes[k] = byType[k]
+			}
+		}
+
 		writeJSON(w, map[string]any{
-			"skills":    skills,
-			"lifecycle": lifecycle,
-			"manifests": manifests,
-			"tasks":     tasks,
-			"rags":      rags,
+			"skills":      skills,
+			"lifecycle":   lifecycle,
+			"manifests":   manifests,
+			"tasks":       tasks,
+			"rags":        rags,
+			"by_type":     byType,
+			"extra_types": extraTypes,
 		})
 	}
 }

--- a/internal/web/handlers_entity_types.go
+++ b/internal/web/handlers_entity_types.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/k8nstantin/OpenPraxis/internal/entity"
 	"github.com/k8nstantin/OpenPraxis/internal/node"
+
+	"github.com/gorilla/mux"
 )
 
 // apiEntityTypesList handles GET /api/entity-types.
@@ -74,6 +76,53 @@ func apiEntityTypesCreate(n *node.Node) http.HandlerFunc {
 			return
 		}
 		w.WriteHeader(http.StatusCreated)
+		writeJSON(w, et)
+	}
+}
+
+// apiEntityTypesUpdate handles PUT /api/entity-types/:name.
+// Accepts {"display_name", "description", "color", "icon", "new_name"} and updates the type.
+func apiEntityTypesUpdate(n *node.Node) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if n.EntityTypes == nil {
+			http.Error(w, "entity types not available", http.StatusServiceUnavailable)
+			return
+		}
+		name := mux.Vars(r)["name"]
+		if name == "" {
+			http.Error(w, "name is required", http.StatusBadRequest)
+			return
+		}
+		var body struct {
+			DisplayName string `json:"display_name"`
+			Description string `json:"description"`
+			Color       string `json:"color"`
+			Icon        string `json:"icon"`
+			NewName     string `json:"new_name"` // optional rename
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid JSON body", http.StatusBadRequest)
+			return
+		}
+		// Verify the type exists
+		exists, err := n.EntityTypes.Exists(r.Context(), name)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if !exists {
+			http.Error(w, "entity type '"+name+"' not found", http.StatusNotFound)
+			return
+		}
+		targetName := name
+		if body.NewName != "" {
+			targetName = strings.TrimSpace(body.NewName)
+		}
+		et, err := n.EntityTypes.Rename(r.Context(), name, targetName, body.DisplayName, body.Description, body.Color, body.Icon, "operator")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 		writeJSON(w, et)
 	}
 }

--- a/internal/web/handlers_entity_types.go
+++ b/internal/web/handlers_entity_types.go
@@ -3,6 +3,7 @@ package web
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/k8nstantin/OpenPraxis/internal/entity"
 	"github.com/k8nstantin/OpenPraxis/internal/node"
@@ -12,6 +13,10 @@ import (
 // Returns all current entity types as {"types": [...]}.
 func apiEntityTypesList(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if n.EntityTypes == nil {
+			http.Error(w, "entity types not available", http.StatusServiceUnavailable)
+			return
+		}
 		types, err := n.EntityTypes.List(r.Context())
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -28,6 +33,10 @@ func apiEntityTypesList(n *node.Node) http.HandlerFunc {
 // Accepts {"name", "display_name", "description", "color", "icon"} and creates a new type.
 func apiEntityTypesCreate(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if n.EntityTypes == nil {
+			http.Error(w, "entity types not available", http.StatusServiceUnavailable)
+			return
+		}
 		var body struct {
 			Name        string `json:"name"`
 			DisplayName string `json:"display_name"`
@@ -39,6 +48,7 @@ func apiEntityTypesCreate(n *node.Node) http.HandlerFunc {
 			http.Error(w, "invalid JSON body", http.StatusBadRequest)
 			return
 		}
+		body.Name = strings.TrimSpace(body.Name)
 		if body.Name == "" {
 			http.Error(w, "name is required", http.StatusBadRequest)
 			return

--- a/internal/web/handlers_entity_types.go
+++ b/internal/web/handlers_entity_types.go
@@ -1,0 +1,69 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/k8nstantin/OpenPraxis/internal/entity"
+	"github.com/k8nstantin/OpenPraxis/internal/node"
+)
+
+// apiEntityTypesList handles GET /api/entity-types.
+// Returns all current entity types as {"types": [...]}.
+func apiEntityTypesList(n *node.Node) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		types, err := n.EntityTypes.List(r.Context())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if types == nil {
+			types = []entity.EntityType{}
+		}
+		writeJSON(w, map[string]any{"types": types})
+	}
+}
+
+// apiEntityTypesCreate handles POST /api/entity-types.
+// Accepts {"name", "display_name", "description", "color", "icon"} and creates a new type.
+func apiEntityTypesCreate(n *node.Node) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Name        string `json:"name"`
+			DisplayName string `json:"display_name"`
+			Description string `json:"description"`
+			Color       string `json:"color"`
+			Icon        string `json:"icon"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid JSON body", http.StatusBadRequest)
+			return
+		}
+		if body.Name == "" {
+			http.Error(w, "name is required", http.StatusBadRequest)
+			return
+		}
+		if body.DisplayName == "" {
+			body.DisplayName = body.Name
+		}
+
+		// Check types table first — do not allow duplicate type names.
+		exists, err := n.EntityTypes.Exists(r.Context(), body.Name)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if exists {
+			http.Error(w, "entity type '"+body.Name+"' already exists", http.StatusConflict)
+			return
+		}
+
+		et, err := n.EntityTypes.Create(r.Context(), body.Name, body.DisplayName, body.Description, body.Color, body.Icon, "operator")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		writeJSON(w, et)
+	}
+}

--- a/internal/web/handlers_entity_types.go
+++ b/internal/web/handlers_entity_types.go
@@ -117,6 +117,18 @@ func apiEntityTypesUpdate(n *node.Node) http.HandlerFunc {
 		targetName := name
 		if body.NewName != "" {
 			targetName = strings.TrimSpace(body.NewName)
+			// Reject rename if new_name already exists as a different type.
+			if targetName != name {
+				collision, cerr := n.EntityTypes.Exists(r.Context(), targetName)
+				if cerr != nil {
+					http.Error(w, cerr.Error(), http.StatusInternalServerError)
+					return
+				}
+				if collision {
+					http.Error(w, "entity type '"+targetName+"' already exists", http.StatusConflict)
+					return
+				}
+			}
 		}
 		et, err := n.EntityTypes.Rename(r.Context(), name, targetName, body.DisplayName, body.Description, body.Color, body.Icon, "operator")
 		if err != nil {

--- a/internal/web/handlers_recall.go
+++ b/internal/web/handlers_recall.go
@@ -2,7 +2,9 @@ package web
 
 import (
 	"net/http"
+	"sort"
 
+	"github.com/k8nstantin/OpenPraxis/internal/entity"
 	"github.com/k8nstantin/OpenPraxis/internal/node"
 
 	"github.com/gorilla/mux"
@@ -14,7 +16,7 @@ func apiRecall(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		type recallItem struct {
 			ID    string `json:"id"`
-			Type  string `json:"type"` // memory, task
+			Type  string `json:"type"` // memory, <entity-type>
 			Title string `json:"title"`
 		}
 		var items []recallItem
@@ -25,11 +27,33 @@ func apiRecall(n *node.Node) http.HandlerFunc {
 			items = append(items, recallItem{ID: m.ID, Type: "memory", Title: m.L0})
 		}
 
-		// Archived tasks from entities
+		// Archived entities — fetch all types when the EntityTypes registry is
+		// available so dynamic/custom types are included. Fall back to tasks only
+		// when the registry is nil (pre-migration databases).
 		if n.Entities != nil {
-			archived, _ := n.Entities.List("task", "archived", 50)
+			var archived []*entity.Entity
+			if n.EntityTypes != nil {
+				etypes, err := n.EntityTypes.List(r.Context())
+				if err == nil {
+					for _, et := range etypes {
+						items_, _ := n.Entities.List(et.Name, entity.StatusArchived, 50)
+						archived = append(archived, items_...)
+					}
+				} else {
+					archived, _ = n.Entities.List(entity.TypeTask, entity.StatusArchived, 50)
+				}
+			} else {
+				archived, _ = n.Entities.List(entity.TypeTask, entity.StatusArchived, 50)
+			}
+			// Sort combined results by created_at descending and cap at 50.
+			sort.Slice(archived, func(i, j int) bool {
+				return archived[i].CreatedAt > archived[j].CreatedAt
+			})
+			if len(archived) > 50 {
+				archived = archived[:50]
+			}
 			for _, e := range archived {
-				items = append(items, recallItem{ID: e.EntityUID, Type: "task", Title: e.Title})
+				items = append(items, recallItem{ID: e.EntityUID, Type: e.Type, Title: e.Title})
 			}
 		}
 

--- a/internal/web/handlers_recall.go
+++ b/internal/web/handlers_recall.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"net/http"
-	"sort"
 
 	"github.com/k8nstantin/OpenPraxis/internal/entity"
 	"github.com/k8nstantin/OpenPraxis/internal/node"
@@ -27,31 +26,20 @@ func apiRecall(n *node.Node) http.HandlerFunc {
 			items = append(items, recallItem{ID: m.ID, Type: "memory", Title: m.L0})
 		}
 
-		// Archived entities — fetch all types when the EntityTypes registry is
-		// available so dynamic/custom types are included. Fall back to tasks only
-		// when the registry is nil (pre-migration databases).
+		// Archived entities — single ListByTypes call across all known types so
+		// dynamic/custom types are included without N+1 queries.
 		if n.Entities != nil {
-			var archived []*entity.Entity
+			typeNames := []string{entity.TypeTask}
 			if n.EntityTypes != nil {
-				etypes, err := n.EntityTypes.List(r.Context())
-				if err == nil {
+				if etypes, err := n.EntityTypes.List(r.Context()); err == nil && len(etypes) > 0 {
+					typeNames = make([]string, 0, len(etypes))
 					for _, et := range etypes {
-						items_, _ := n.Entities.List(et.Name, entity.StatusArchived, 50)
-						archived = append(archived, items_...)
+						typeNames = append(typeNames, et.Name)
 					}
-				} else {
-					archived, _ = n.Entities.List(entity.TypeTask, entity.StatusArchived, 50)
 				}
-			} else {
-				archived, _ = n.Entities.List(entity.TypeTask, entity.StatusArchived, 50)
 			}
-			// Sort combined results by created_at descending and cap at 50.
-			sort.Slice(archived, func(i, j int) bool {
-				return archived[i].CreatedAt > archived[j].CreatedAt
-			})
-			if len(archived) > 50 {
-				archived = archived[:50]
-			}
+			archived, _ := n.Entities.ListByTypes(typeNames, entity.StatusArchived, 50)
+			// Results are already sorted DESC by created_at (store ORDER BY).
 			for _, e := range archived {
 				items = append(items, recallItem{ID: e.EntityUID, Type: e.Type, Title: e.Title})
 			}
@@ -69,15 +57,21 @@ func apiRestore(n *node.Node) http.HandlerFunc {
 		switch itemType {
 		case "memory":
 			err = n.Index.Restore(id)
-		case "task":
-			if n.Entities != nil {
-				_, err = n.Entities.Get(id)
-				if err == nil {
-					err = n.Entities.Update(id, "", "active", nil, "recall", "restored from archived")
-				}
-			}
 		default:
-			http.Error(w, "unknown type: "+itemType, 400)
+			if n.Entities != nil {
+				e, getErr := n.Entities.Get(id)
+				if getErr != nil || e == nil {
+					http.Error(w, "not found: "+id, http.StatusNotFound)
+					return
+				}
+				if err = n.Entities.Update(id, e.Title, entity.StatusActive, e.Tags, "operator", "restored from archive"); err != nil {
+					writeError(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				writeJSON(w, map[string]any{"ok": true, "id": id, "type": itemType})
+				return
+			}
+			http.Error(w, "unknown type: "+itemType, http.StatusBadRequest)
 			return
 		}
 		if err != nil {

--- a/internal/web/handlers_template.go
+++ b/internal/web/handlers_template.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/k8nstantin/OpenPraxis/internal/node"
+	"github.com/k8nstantin/OpenPraxis/internal/relationships"
 	"github.com/k8nstantin/OpenPraxis/internal/templates"
 )
 
@@ -258,9 +259,11 @@ func apiTemplatePreview(n *node.Node) http.HandlerFunc {
 				}
 				// Look up manifest via relationships (owns edge pointing to this task)
 				if n.Relationships != nil {
-					if edges, err := n.Relationships.ListIncoming(r.Context(), tk.EntityUID, "owns"); err == nil {
+					if edges, err := n.Relationships.ListIncoming(r.Context(), tk.EntityUID, relationships.EdgeOwns); err == nil {
+						// Accept the first owner regardless of type — any entity that
+						// owns a task can act as the "manifest" context for template rendering.
 						for _, edge := range edges {
-							if e, err2 := n.Entities.Get(edge.SrcID); err2 == nil && e != nil && e.Type == "manifest" {
+							if e, err2 := n.Entities.Get(edge.SrcID); err2 == nil && e != nil {
 								data.Manifest = templates.ManifestView{
 									ID:    e.EntityUID,
 									Title: e.Title,

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,7 +49,7 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-sbwS3ssH.js"></script>
+    <script type="module" crossorigin src="/assets/index-BR2QAaMW.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/redirect-X9XGZzhz.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-BCEqhk7D.js">

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,11 +49,11 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-USMJccg1.js"></script>
+    <script type="module" crossorigin src="/assets/index-7vBSm2-2.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/redirect-X9XGZzhz.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-BCEqhk7D.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-BWoESLF-.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-CRPG6hEr.css">
   </head>
 
   <body>

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,7 +49,7 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-7vBSm2-2.js"></script>
+    <script type="module" crossorigin src="/assets/index-sbwS3ssH.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/redirect-X9XGZzhz.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-BCEqhk7D.js">

--- a/internal/web/ui/dashboard-v2/src/features/entity/add-entity-dialog.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/add-entity-dialog.tsx
@@ -17,9 +17,10 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Skeleton } from '@/components/ui/skeleton'
+import { useQueryClient } from '@tanstack/react-query'
 import { useEntityTypes } from '@/lib/queries/entity-types'
 import { useCreateEntity } from '@/lib/queries/entity'
-import type { EntityKind } from '@/lib/queries/entity'
+import type { AnyEntityKind } from '@/lib/queries/entity'
 import type { Entity } from '@/lib/types'
 
 interface AddEntityDialogProps {
@@ -38,6 +39,7 @@ export function AddEntityDialog({
   onOpenChange,
   onCreated,
 }: AddEntityDialogProps) {
+  const qc = useQueryClient()
   const { data: entityTypes, isLoading: typesLoading } = useEntityTypes()
   const [selectedType, setSelectedType] = useState<string>('')
   const [title, setTitle] = useState('')
@@ -45,16 +47,19 @@ export function AddEntityDialog({
   // useCreateEntity requires the kind up front; we update it dynamically
   // as the user picks a type. Fallback to 'task' to satisfy the hook's
   // type requirement while no type is selected.
-  const create = useCreateEntity((selectedType || 'task') as EntityKind)
+  const create = useCreateEntity((selectedType || 'task') as AnyEntityKind)
 
   const handleSubmit = async () => {
     if (!selectedType || !title.trim()) return
     try {
       const entity = await create.mutateAsync({
-        type: selectedType as EntityKind,
+        type: selectedType as AnyEntityKind,
         title: title.trim(),
         status: 'draft',
       })
+      // Invalidate the entity-types cache so sidebar and other consumers
+      // reflect any newly registered type without waiting for staleTime.
+      qc.invalidateQueries({ queryKey: ['entity-types'] })
       setTitle('')
       setSelectedType('')
       onOpenChange(false)

--- a/internal/web/ui/dashboard-v2/src/features/entity/add-entity-dialog.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/add-entity-dialog.tsx
@@ -1,0 +1,133 @@
+import { useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Skeleton } from '@/components/ui/skeleton'
+import { useEntityTypes } from '@/lib/queries/entity-types'
+import { useCreateEntity } from '@/lib/queries/entity'
+import type { EntityKind } from '@/lib/queries/entity'
+import type { Entity } from '@/lib/types'
+
+interface AddEntityDialogProps {
+  open: boolean
+  onOpenChange: (next: boolean) => void
+  onCreated?: (entity: Entity) => void
+}
+
+// AddEntityDialog is a generic "create entity" dialog that sources
+// the available type options from the DB-driven /api/entity-types
+// endpoint rather than a hardcoded array. While the types are loading
+// the Select trigger shows a skeleton. The created entity is forwarded
+// via onCreated so callers can navigate or update local state.
+export function AddEntityDialog({
+  open,
+  onOpenChange,
+  onCreated,
+}: AddEntityDialogProps) {
+  const { data: entityTypes, isLoading: typesLoading } = useEntityTypes()
+  const [selectedType, setSelectedType] = useState<string>('')
+  const [title, setTitle] = useState('')
+
+  // useCreateEntity requires the kind up front; we update it dynamically
+  // as the user picks a type. Fallback to 'task' to satisfy the hook's
+  // type requirement while no type is selected.
+  const create = useCreateEntity((selectedType || 'task') as EntityKind)
+
+  const handleSubmit = async () => {
+    if (!selectedType || !title.trim()) return
+    try {
+      const entity = await create.mutateAsync({
+        type: selectedType as EntityKind,
+        title: title.trim(),
+        status: 'draft',
+      })
+      setTitle('')
+      setSelectedType('')
+      onOpenChange(false)
+      onCreated?.(entity)
+    } catch {
+      // create.isError surfaces the error in the UI
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='sm:max-w-[400px]'>
+        <DialogHeader>
+          <DialogTitle>New entity</DialogTitle>
+        </DialogHeader>
+
+        <div className='space-y-4 py-2'>
+          <div className='space-y-1.5'>
+            <Label htmlFor='entity-type' className='text-xs'>
+              Type
+            </Label>
+            {typesLoading ? (
+              <Skeleton className='h-9 w-full' />
+            ) : (
+              <Select value={selectedType} onValueChange={setSelectedType}>
+                <SelectTrigger id='entity-type' className='h-9 text-sm'>
+                  <SelectValue placeholder='Select a type…' />
+                </SelectTrigger>
+                <SelectContent>
+                  {(entityTypes ?? []).map((et) => (
+                    <SelectItem key={et.name} value={et.name}>
+                      {et.display_name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          </div>
+
+          <div className='space-y-1.5'>
+            <Label htmlFor='entity-title' className='text-xs'>
+              Title
+            </Label>
+            <Input
+              id='entity-title'
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleSubmit()
+                if (e.key === 'Escape') onOpenChange(false)
+              }}
+              placeholder='Title…'
+              className='h-9 text-sm'
+              autoFocus
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant='ghost'
+            onClick={() => onOpenChange(false)}
+            className='text-sm'>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={!selectedType || !title.trim() || create.isPending}
+            className='text-sm'>
+            {create.isPending ? 'Creating…' : 'Create'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/internal/web/ui/dashboard-v2/src/features/entity/detail-pane.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/detail-pane.tsx
@@ -1,5 +1,7 @@
+import { useMemo } from 'react'
 import { useEntity, type EntityKind } from '@/lib/queries/entity'
-import { Boxes, CheckSquare, FileText } from 'lucide-react'
+import { useEntityTypes } from '@/lib/queries/entity-types'
+import { Boxes, CheckSquare, Database, FileText } from 'lucide-react'
 import { CopyButton } from '@/components/copy-button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -37,16 +39,22 @@ export function EntityDetailPane({
   onTabChange: (tab: EntityTabId) => void
 }) {
   const entity = useEntity(kind, entityId)
+  const { data: entityTypes } = useEntityTypes()
+
+  // Static icon map for built-in kinds; unknown/custom kinds fall back to Database.
   const iconMap: Record<string, React.ElementType> = {
     product: Boxes, task: CheckSquare, manifest: FileText,
     skill: FileText, idea: FileText,
   }
-  const nounMap: Record<string, string> = {
-    product: 'product', manifest: 'manifest', task: 'task',
-    skill: 'skill', idea: 'idea',
-  }
-  const Icon = iconMap[kind] ?? FileText
-  const noun = nounMap[kind] ?? kind
+
+  // noun: prefer display_name from entity_types; fall back to built-in map then kind itself.
+  const noun = useMemo(() => {
+    const et = entityTypes?.find((t) => t.name === kind)
+    if (et) return et.display_name.toLowerCase()
+    return kind
+  }, [entityTypes, kind])
+
+  const Icon = iconMap[kind] ?? Database
 
   if (!entityId) {
     return (

--- a/internal/web/ui/dashboard-v2/src/features/entity/list-pane.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/list-pane.tsx
@@ -6,6 +6,7 @@ import {
   useLiveRuns,
   type EntityKind,
 } from '@/lib/queries/entity'
+import { useEntityTypes } from '@/lib/queries/entity-types'
 import type { Entity } from '@/lib/types'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -20,9 +21,10 @@ const STATUS_DOT: Record<string, string> = {
   archived: 'bg-zinc-600',
 }
 
-const KIND_LABEL: Record<string, string> = {
+// Fallback labels for built-in kinds while entity_types loads.
+const KIND_LABEL_FALLBACK: Record<string, string> = {
   product: 'Products', manifest: 'Manifests', task: 'Tasks',
-  idea: 'Ideas', skill: 'Skills',
+  idea: 'Ideas', skill: 'Skills', RAG: 'RAG',
 }
 
 interface ListRow { id: string; title: string; status: string; tags?: string[] }
@@ -39,6 +41,7 @@ export function EntityListPane({
   const list = useEntityList(kind)
   const create = useCreateEntity(kind)
   const { data: liveRuns } = useLiveRuns()
+  const { data: entityTypes } = useEntityTypes()
   const runningIds = useMemo(
     () => new Set((liveRuns ?? []).map((r) => r.entity_uid)),
     [liveRuns]
@@ -49,7 +52,15 @@ export function EntityListPane({
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE)
   const sentinelRef = useRef<HTMLDivElement>(null)
 
-  const label = KIND_LABEL[kind] ?? kind
+  // Build label from entity_types display_name when loaded; fall back to
+  // static map for built-in kinds, then capitalize the kind name.
+  const label = useMemo(() => {
+    const et = entityTypes?.find((t) => t.name === kind)
+    if (et) return et.display_name + 's'
+    const fallback = KIND_LABEL_FALLBACK[kind]
+    if (fallback) return fallback
+    return kind.charAt(0).toUpperCase() + kind.slice(1) + 's'
+  }, [entityTypes, kind])
 
   // Flat chronological list — newest first (API returns newest first by default)
   const rows: ListRow[] = useMemo(() => {

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/dag.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/dag.tsx
@@ -7,6 +7,7 @@ import {
   type GraphNode,
   type GraphEdge,
 } from '@/lib/queries/entity'
+import { useEntityTypes } from '@/lib/queries/entity-types'
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 
@@ -45,6 +46,8 @@ const KIND_COLOR: Record<string, string> = {
   product:  '#3b82f6', // blue-500
   manifest: '#a78bfa', // violet-400
   task:     '#10b981', // emerald-500
+  // fallback for unknown/custom entity types
+  _default: '#6366f1', // indigo-500
 }
 
 const KIND_SYMBOL: Record<string, string> = {
@@ -52,6 +55,8 @@ const KIND_SYMBOL: Record<string, string> = {
   product:  'roundRect',
   manifest: 'diamond',
   task:     'circle',
+  // fallback for unknown/custom entity types
+  _default: 'diamond',
 }
 
 const KIND_SIZE: Record<string, number> = {
@@ -59,6 +64,8 @@ const KIND_SIZE: Record<string, number> = {
   product:  32,
   manifest: 26,
   task:     18,
+  // fallback for unknown/custom entity types
+  _default: 20,
 }
 
 interface ChartNode {
@@ -86,10 +93,21 @@ interface ChartLink {
 function build(
   rootId: string,
   nodes: GraphNode[],
-  edges: GraphEdge[]
+  edges: GraphEdge[],
+  apiKindColor: Record<string, string>
 ): { data: ChartNode[]; links: ChartLink[]; categories: { name: string }[] } {
-  const categories = [{ name: 'skill' }, { name: 'product' }, { name: 'manifest' }, { name: 'task' }]
-  const catIndex: Record<string, number> = { skill: 0, product: 1, manifest: 2, task: 3 }
+  // Build categories dynamically from the node kinds present in this graph.
+  const seenKinds: string[] = []
+  const seenSet = new Set<string>()
+  for (const n of nodes) {
+    if (!seenSet.has(n.kind)) {
+      seenSet.add(n.kind)
+      seenKinds.push(n.kind)
+    }
+  }
+  const categories = seenKinds.map((k) => ({ name: k }))
+  const catIndex: Record<string, number> = {}
+  seenKinds.forEach((k, i) => { catIndex[k] = i })
   // Per-node radial-gradient fill. ECharts accepts {type:'radial',
   // colorStops:[]} on itemStyle.color directly. Center bright →
   // periphery deeper; gives each node a soft "glow from within" look.
@@ -104,19 +122,23 @@ function build(
       { offset: 1, color: hex + '60' },
     ],
   })
-  const data: ChartNode[] = nodes.map((n) => ({
+  const data: ChartNode[] = nodes.map((n) => {
+    const color = apiKindColor[n.kind] ?? KIND_COLOR[n.kind] ?? KIND_COLOR._default
+    const symbol = KIND_SYMBOL[n.kind] ?? KIND_SYMBOL._default
+    const size = KIND_SIZE[n.kind] ?? KIND_SIZE._default
+    return ({
     id: n.id,
     name: n.title,
-    symbol: KIND_SYMBOL[n.kind] ?? 'circle',
-    symbolSize: n.id === rootId ? KIND_SIZE[n.kind] + 12 : KIND_SIZE[n.kind],
+    symbol,
+    symbolSize: n.id === rootId ? size + 12 : size,
     category: catIndex[n.kind] ?? 0,
     itemStyle: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      color: grad(KIND_COLOR[n.kind] ?? '#3b82f6') as any,
+      color: grad(color) as any,
       borderColor: STATUS_BORDER[n.status] ?? '#71717a',
       borderWidth: n.id === rootId ? 3 : 1.5,
       shadowBlur: n.id === rootId ? 24 : 8,
-      shadowColor: KIND_COLOR[n.kind] ?? '#3b82f6',
+      shadowColor: color,
       shadowOffsetX: 0,
       shadowOffsetY: 0,
     },
@@ -125,7 +147,7 @@ function build(
     },
     _kind: n.kind,
     _status: n.status,
-  }))
+  })})
   const links: ChartLink[] = edges.map((e) => {
     const isOwns = e.kind === 'owns'
     return {
@@ -148,11 +170,22 @@ function build(
 export function DAGTab({ kind, entityId }: DAGTabProps) {
   const graph = useEntityGraph(kind, entityId, 10)
   const navigate = useNavigate()
+  const entityTypes = useEntityTypes()
+
+  // Build a color map from the API data so custom entity types get their
+  // configured colors. Falls back to KIND_COLOR for any missing entry.
+  const apiKindColor = useMemo(() => {
+    const m: Record<string, string> = {}
+    for (const et of entityTypes.data ?? []) {
+      if (et.color) m[et.name] = et.color
+    }
+    return m
+  }, [entityTypes.data])
 
   const built = useMemo(() => {
     if (!graph.data) return null
-    return build(entityId, graph.data.nodes, graph.data.edges)
-  }, [graph.data, entityId])
+    return build(entityId, graph.data.nodes, graph.data.edges, apiKindColor)
+  }, [graph.data, entityId, apiKindColor])
 
   if (graph.isLoading) {
     return (
@@ -255,17 +288,11 @@ export function DAGTab({ kind, entityId }: DAGTabProps) {
                 if (p.dataType !== 'node' || !p.data) return
                 const d = p.data
                 if (d.id === entityId) return
-                const target =
-                  d._kind === 'product'
-                    ? '/products'
-                    : d._kind === 'manifest'
-                      ? '/manifests'
-                      : '/tasks'
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 navigate({
-                  to: target,
-                  search: { id: d.id, tab: 'dag' },
-                } as any)
+                  to: '/entities/$uid',
+                  params: { uid: d.id },
+                  search: { kind: d._kind, tab: 'dag' },
+                })
               },
             }}
           />

--- a/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useDeferredValue } from 'react'
-import { Search } from 'lucide-react'
+import { Plus, Search } from 'lucide-react'
 import { Tree } from 'react-arborist'
 import type { NodeApi } from 'react-arborist'
 import { useNavigate } from '@tanstack/react-router'
+import { AddEntityDialog } from '@/features/entity/add-entity-dialog'
 import { useLiveRuns } from '@/lib/queries/entity'
 import {
   TreeStatus,
@@ -99,6 +100,7 @@ export function EntityTree() {
   const navigate = useNavigate()
   const [filterInput, setFilterInput] = useState('')
   const filter = useDeferredValue(filterInput)
+  const [dialogOpen, setDialogOpen] = useState(false)
 
   const liveIds = new Set(
     (liveRuns ?? [])
@@ -190,6 +192,18 @@ export function EntityTree() {
 
   return (
     <div className='flex flex-col flex-1 min-h-0 w-full'>
+      {/* Create Entity button */}
+      <div className='flex items-center px-2 pt-1 pb-0 shrink-0'>
+        <button
+          type='button'
+          onClick={() => setDialogOpen(true)}
+          className='flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-white/10 hover:text-foreground transition-colors'
+        >
+          <Plus className='h-3.5 w-3.5' />
+          Create Entity
+        </button>
+        <AddEntityDialog open={dialogOpen} onOpenChange={setDialogOpen} />
+      </div>
       {/* Filter input — VS Code style search in tree */}
       <div className='relative px-2 py-1 shrink-0'>
         <Search className='absolute left-4 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground' />

--- a/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, useDeferredValue } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, useDeferredValue } from 'react'
 import { Search } from 'lucide-react'
 import { Tree } from 'react-arborist'
 import type { NodeApi } from 'react-arborist'
@@ -10,6 +10,7 @@ import {
   useEntityTree,
   type TreeNode,
 } from '@/lib/queries/entity-tree'
+import { useEntityTypes } from '@/lib/queries/entity-types'
 import { Skeleton } from '@/components/ui/skeleton'
 import { EntityTreeNode } from './EntityTreeNode'
 
@@ -22,7 +23,10 @@ const GROUP_TASKS = '__tasks__'
 const GROUP_PRODUCTS = '__products__'
 const GROUP_IDEAS = '__ideas__'
 const GROUP_PAGES = '__pages__'
-const GROUP_IDS: ReadonlySet<string> = new Set([GROUP_ENTITIES, GROUP_SKILLS, GROUP_RAG, GROUP_MANIFESTS, GROUP_TASKS, GROUP_PRODUCTS, GROUP_IDEAS, GROUP_PAGES])
+
+// BASE_GROUP_IDS covers the built-in groups. Dynamic groups are added
+// per-render based on extra_types from the entity tree response.
+const BASE_GROUP_IDS: ReadonlySet<string> = new Set([GROUP_ENTITIES, GROUP_SKILLS, GROUP_RAG, GROUP_MANIFESTS, GROUP_TASKS, GROUP_PRODUCTS, GROUP_IDEAS, GROUP_PAGES])
 
 // Page nav nodes injected into the tree so ALL navigation goes through arborist.
 const PAGE_URLS: Record<string, string> = {
@@ -90,6 +94,7 @@ function useElementSize<T extends HTMLElement>() {
 export function EntityTree() {
   const { ref, width, height } = useElementSize<HTMLDivElement>()
   const { data: rawTree, isLoading } = useEntityTree()
+  const { data: entityTypes } = useEntityTypes()
   const { data: liveRuns } = useLiveRuns()
   const navigate = useNavigate()
   const [filterInput, setFilterInput] = useState('')
@@ -102,8 +107,41 @@ export function EntityTree() {
   )
   const overlaid = rawTree ? overlayLiveStatus(rawTree, liveIds) : null
 
+  // Build display name map from entity_types for extra/dynamic groups.
+  const typeDisplayName = useMemo(() => {
+    const m: Record<string, string> = {}
+    for (const et of entityTypes ?? []) {
+      m[et.name] = et.display_name
+    }
+    return m
+  }, [entityTypes])
+
+  // Extra type group ids (prefixed to avoid collisions with real entity ids).
+  const extraGroupIds = useMemo(() => {
+    if (!overlaid?.extra_types) return new Set<string>()
+    return new Set(Object.keys(overlaid.extra_types).map((k) => `__type_${k}__`))
+  }, [overlaid?.extra_types])
+
+  // Full set of group ids: built-in + dynamic.
+  const groupIds = useMemo(
+    () => new Set([...BASE_GROUP_IDS, ...extraGroupIds]),
+    [extraGroupIds],
+  )
+
   const products = overlaid?.lifecycle.filter((n) => n.kind === 'product') ?? []
   const ideas = overlaid?.lifecycle.filter((n) => n.kind === 'idea') ?? []
+
+  // Extra group children for dynamic entity types from the entity_types table.
+  const extraTypeGroups: TreeNode[] = useMemo(() => {
+    if (!overlaid?.extra_types) return []
+    return Object.entries(overlaid.extra_types).map(([typeName, nodes]) => ({
+      id: `__type_${typeName}__`,
+      name: typeDisplayName[typeName] ?? typeName,
+      kind: '__group__',
+      status: '',
+      children: nodes,
+    }))
+  }, [overlaid?.extra_types, typeDisplayName])
 
   const treeData: TreeNode[] = [
     {
@@ -117,6 +155,7 @@ export function EntityTree() {
             { id: GROUP_RAG,       name: 'RAG',       kind: '__group__', status: '', children: overlaid.rags },
             { id: GROUP_IDEAS,     name: 'Ideas',     kind: '__group__', status: '', children: ideas },
             { id: GROUP_PRODUCTS,  name: 'Products',  kind: '__group__', status: '', children: products },
+            ...extraTypeGroups,
             { id: GROUP_MANIFESTS, name: 'Manifests', kind: '__group__', status: '', children: overlaid.manifests },
             { id: GROUP_TASKS,     name: 'Tasks',     kind: '__group__', status: '', children: overlaid.tasks },
           ]
@@ -134,7 +173,7 @@ export function EntityTree() {
   const onSelect = useCallback(
     (nodes: NodeApi<TreeNode>[]) => {
       const node = nodes[0]
-      if (!node || GROUP_IDS.has(node.id)) return
+      if (!node || groupIds.has(node.id)) return
       const url = PAGE_URLS[node.id]
       if (url) {
         navigate({ to: url })
@@ -146,7 +185,7 @@ export function EntityTree() {
         })
       }
     },
-    [navigate],
+    [navigate, groupIds],
   )
 
   return (
@@ -179,7 +218,7 @@ export function EntityTree() {
             overscanCount={8}
             onSelect={onSelect}
             openByDefault={false}
-            initialOpenState={{ [GROUP_ENTITIES]: true, [GROUP_PAGES]: true }}
+            initialOpenState={{ [GROUP_ENTITIES]: true, [GROUP_PAGES]: true, [GROUP_PRODUCTS]: true }}
             searchTerm={filter}
             searchMatch={(node, term) => {
               const t = term.toLowerCase()

--- a/internal/web/ui/dashboard-v2/src/lib/queries/entity-tree.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/queries/entity-tree.ts
@@ -19,6 +19,8 @@ export interface EntityTreePayload {
   manifests: TreeNode[]
   tasks: TreeNode[]
   rags: TreeNode[]
+  // extra_types: any entity types beyond the six built-in kinds, keyed by name.
+  extra_types: Record<string, TreeNode[]>
 }
 
 async function fetchEntityTree(): Promise<EntityTreePayload> {
@@ -31,6 +33,7 @@ async function fetchEntityTree(): Promise<EntityTreePayload> {
     manifests: data.manifests ?? [],
     tasks: data.tasks ?? [],
     rags: data.rags ?? [],
+    extra_types: data.extra_types ?? {},
   }
 }
 
@@ -71,12 +74,17 @@ export function overlayLiveStatus(
     }
     return live ? { ...n, status: TreeStatus.Running } : n
   }
+  const walkedExtra: Record<string, TreeNode[]> = {}
+  for (const [k, nodes] of Object.entries(tree.extra_types)) {
+    walkedExtra[k] = nodes.map(walk)
+  }
   return {
     skills: tree.skills.map(walk),
     lifecycle: tree.lifecycle.map(walk),
     manifests: tree.manifests.map(walk),
     tasks: tree.tasks.map(walk),
     rags: tree.rags.map(walk),
+    extra_types: walkedExtra,
   }
 }
 

--- a/internal/web/ui/dashboard-v2/src/lib/queries/entity-types.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/queries/entity-types.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query'
+
+export interface EntityType {
+  type_uid: string
+  name: string
+  display_name: string
+  description: string
+  color: string
+  icon: string
+}
+
+export function useEntityTypes() {
+  return useQuery({
+    queryKey: ['entity-types'],
+    queryFn: () =>
+      fetch('/api/entity-types')
+        .then((r) => r.json())
+        .then((d) => (d.types ?? []) as EntityType[]),
+    staleTime: 60_000,
+  })
+}

--- a/internal/web/ui/dashboard-v2/src/lib/queries/entity-types.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/queries/entity-types.ts
@@ -16,6 +16,7 @@ export function useEntityTypes() {
       fetch('/api/entity-types')
         .then((r) => r.json())
         .then((d) => (d.types ?? []) as EntityType[]),
+    // 60 s stale time; types are invalidated on create via add-entity-dialog mutation.
     staleTime: 60_000,
   })
 }

--- a/internal/web/ui/dashboard-v2/src/lib/queries/entity.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/queries/entity.ts
@@ -50,6 +50,12 @@ export const KIND = {
 
 export type EntityKind = (typeof KIND)[keyof typeof KIND]
 
+// AnyEntityKind accepts the 6 known built-in kinds (with full autocomplete)
+// plus any arbitrary string for DB-driven dynamic types. Use this wherever
+// custom/user-defined kinds may flow through instead of EntityKind.
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type AnyEntityKind = EntityKind | (string & {})
+
 // EntityRecord is the unified entity shape returned by /api/entities.
 export type EntityRecord = Entity
 
@@ -320,11 +326,12 @@ export function useExecutionOutput(runUid: string | undefined, isLive = true) {
 // ── Mutations ─────────────────────────────────────────────────────────
 
 // Create a new entity of any type. Returns the created entity so the
-// caller can immediately navigate to it.
-export function useCreateEntity(kind: EntityKind) {
+// caller can immediately navigate to it. Accepts AnyEntityKind so
+// DB-driven dynamic types are not rejected at the call site.
+export function useCreateEntity(kind: AnyEntityKind) {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: async (payload: { type: EntityKind; title: string; status?: string; tags?: string[] }) => {
+    mutationFn: async (payload: { type: AnyEntityKind; title: string; status?: string; tags?: string[] }) => {
       const res = await fetch('/api/entities', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -334,7 +341,10 @@ export function useCreateEntity(kind: EntityKind) {
       return (await res.json()) as Entity
     },
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: entityKeys.list(kind) })
+      // Invalidate the list for this kind if it is a known EntityKind.
+      // For dynamic kinds the query key still matches the string value so
+      // callers that used entityKeys.list() for the same kind will refresh.
+      qc.invalidateQueries({ queryKey: [kind, 'list'] })
     },
   })
 }

--- a/internal/web/ui/dashboard-v2/src/lib/queries/entity.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/queries/entity.ts
@@ -103,7 +103,7 @@ async function fetchJSON<T>(path: string): Promise<T> {
 // GET /api/relationships/graph?root_id=&root_kind=&depth=&edge_kinds=
 export interface GraphNode {
   id: string
-  kind: 'product' | 'manifest' | 'task'
+  kind: AnyEntityKind
   title: string
   status: string
 }
@@ -111,7 +111,7 @@ export interface GraphEdge {
   id: string
   source: string
   target: string
-  kind: 'owns' | 'depends_on' | 'reviews' | 'links_to'
+  kind: 'owns' | 'depends_on'
 }
 export interface GraphPayload {
   nodes: GraphNode[]


### PR DESCRIPTION
## Summary

Entity types are now stored in the `entity_types` table (SCD-2). Adding a new type is one INSERT — the DAG and sidebar menu auto-reflect it. No code changes needed.

## What changed

### New table
```sql
entity_types(type_uid UUID7, name TEXT, display_name TEXT, description TEXT, 
             color TEXT, icon TEXT, valid_from, valid_to, ...)
```
Seeded on startup with: skill, product, manifest, task, idea, RAG (each with correct color + icon).

### API
- `GET /api/entity-types` → list all current types with color/icon
- `POST /api/entity-types {name, display_name, description, color, icon}` → add type, **409 if already exists**

### Dynamic behavior
- **Sidebar menu**: fetches kinds from entity_types on load, auto-creates groups for new types
- **DAG**: node colors read from `/api/entity-types`, `_default` fallback for unknown types
- **DAG click**: all entity types navigate via `/entities/$uid` generic route
- **Add Entity dialog**: type dropdown built from API, not hardcoded

### Execution fixes (new types work with runner)
- `dispatchAtomicTasks`: generic recursive `owns` walk — works for any entity type
- `schedule/store.go`: accepts any non-empty type string (no `ErrInvalidKind`)
- `schedule/runner.go`: `"*"` wildcard dispatcher for unknown types
- `handlers_entity.go`: parent ownership wiring on create is type-agnostic
- `handlers_template.go`: any entity type can be a template context

## Test plan
- [ ] `GET /api/entity-types` returns 6 built-in types with correct colors/icons
- [ ] `POST /api/entity-types {name: "pipeline", ...}` creates new type
- [ ] `POST /api/entity-types {name: "skill", ...}` returns 409 Conflict
- [ ] New type appears in sidebar tree group automatically
- [ ] New type node appears in DAG with its color
- [ ] Schedule a `pipeline` entity — fires without error
- [ ] Create Entity dialog shows all types from API

🤖 Generated with [Claude Code](https://claude.com/claude-code)