### PR TITLE
feat: Entity Types settings page + active status fix

### DIFF
--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,7 +49,7 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-EDXs75JX.js"></script>
+    <script type="module" crossorigin src="/assets/index-CHvLRClT.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/redirect-X9XGZzhz.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-BCEqhk7D.js">

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,11 +49,11 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-Bi4ASYcL.js"></script>
+    <script type="module" crossorigin src="/assets/index-EDXs75JX.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/redirect-X9XGZzhz.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-BCEqhk7D.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-eAvipZNq.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-DQNybLIw.css">
   </head>
 
   <body>

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,7 +49,7 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-CHvLRClT.js"></script>
+    <script type="module" crossorigin src="/assets/index-NHIBVRUp.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/redirect-X9XGZzhz.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-BCEqhk7D.js">

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,11 +49,11 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-BR2QAaMW.js"></script>
+    <script type="module" crossorigin src="/assets/index-P8rF1QZO.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/redirect-X9XGZzhz.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-BCEqhk7D.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-CRPG6hEr.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-8UORR_Bd.css">
   </head>
 
   <body>

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,11 +49,11 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-P8rF1QZO.js"></script>
+    <script type="module" crossorigin src="/assets/index-CZc9sI-J.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/redirect-X9XGZzhz.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-BCEqhk7D.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-8UORR_Bd.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-eAvipZNq.css">
   </head>
 
   <body>

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,7 +49,7 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-CZc9sI-J.js"></script>
+    <script type="module" crossorigin src="/assets/index-Bi4ASYcL.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/redirect-X9XGZzhz.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-BCEqhk7D.js">

--- a/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
@@ -111,12 +111,16 @@ export function EntityTree() {
   )
   const overlaid = rawTree ? overlayLiveStatus(rawTree, liveIds) : null
 
-  // Build display name map from entity_types for extra/dynamic groups.
+  // Build display name + icon name maps from entity_types.
   const typeDisplayName = useMemo(() => {
     const m: Record<string, string> = {}
-    for (const et of entityTypes ?? []) {
-      m[et.name] = et.display_name
-    }
+    for (const et of entityTypes ?? []) m[et.name] = et.display_name
+    return m
+  }, [entityTypes])
+
+  const typeIconName = useMemo(() => {
+    const m: Record<string, string> = {}
+    for (const et of entityTypes ?? []) m[et.name] = et.icon
     return m
   }, [entityTypes])
 
@@ -143,9 +147,9 @@ export function EntityTree() {
       name: typeDisplayName[typeName] ?? typeName,
       kind: '__group__',
       status: '',
-      children: nodes,
+      children: nodes.map(n => ({ ...n, iconName: typeIconName[typeName] })),
     }))
-  }, [overlaid?.extra_types, typeDisplayName])
+  }, [overlaid?.extra_types, typeDisplayName, typeIconName])
 
   const treeData: TreeNode[] = [
     {

--- a/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
@@ -41,6 +41,7 @@ const PAGE_URLS: Record<string, string> = {
   __page_audit__: '/audit',
   __page_activity__: '/activity',
   __page_settings__: '/settings',
+  __page_entity_types__: '/settings/entity-types',
 }
 
 const PAGE_NODES = Object.entries(PAGE_URLS).map(([id, _]) => ({
@@ -56,6 +57,7 @@ const PAGE_NODES = Object.entries(PAGE_URLS).map(([id, _]) => ({
     __page_audit__: 'Audit',
     __page_activity__: 'Activity',
     __page_settings__: 'Settings',
+    __page_entity_types__: 'Entity Types',
   }[id] ?? id,
   kind: 'page',
   status: '',

--- a/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTree.tsx
@@ -238,7 +238,7 @@ export function EntityTree() {
             overscanCount={8}
             onSelect={onSelect}
             openByDefault={false}
-            initialOpenState={{ [GROUP_ENTITIES]: true, [GROUP_PAGES]: true, [GROUP_PRODUCTS]: true }}
+            initialOpenState={{ [GROUP_ENTITIES]: true, [GROUP_PAGES]: true }}
             searchTerm={filter}
             searchMatch={(node, term) => {
               const t = term.toLowerCase()

--- a/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTreeNode.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTreeNode.tsx
@@ -32,6 +32,22 @@ export const KIND_ICON: Record<string, ElementType> = {
   RAG: Database,
 }
 
+// Lucide icons available for dynamic entity types — keyed by the icon
+// name string stored in entity_types.icon. Extend this map when new
+// icon names are used in Settings › Entity Types.
+export const LUCIDE_BY_NAME: Record<string, ElementType> = {
+  Activity, AlertTriangle, BarChart3, Boxes, Brain, CalendarClock,
+  CheckSquare, Database, FileText, GitBranch, Inbox, LayoutDashboard,
+  Lightbulb, ScrollText, Settings, TrendingUp, Wand2,
+}
+
+// Resolve the icon for any entity kind — checks KIND_ICON first,
+// then LUCIDE_BY_NAME (for dynamic types with an icon name from entity_types),
+// then falls back to GitBranch.
+export function kindIcon(kind: string, iconName?: string): ElementType {
+  return KIND_ICON[kind] ?? (iconName ? LUCIDE_BY_NAME[iconName] : undefined) ?? GitBranch
+}
+
 // Icons for synthetic page nav nodes — keyed by node ID.
 const PAGE_NAV_ICON: Record<string, ElementType> = {
   __page_overview__: LayoutDashboard,
@@ -112,7 +128,7 @@ export function EntityTreeNode({ node, style, dragHandle }: NodeRendererProps<Tr
     )
   }
 
-  const Icon = KIND_ICON[node.data.kind] ?? GitBranch
+  const Icon = kindIcon(node.data.kind, node.data.iconName)
   const glyph = STATUS_GLYPH[node.data.status] ?? '○'
   const color = STATUS_COLOR[node.data.status] ?? 'text-muted-foreground'
   const isPulsing = node.data.status === TreeStatus.Running

--- a/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTreeNode.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tree/EntityTreeNode.tsx
@@ -44,6 +44,7 @@ const PAGE_NAV_ICON: Record<string, ElementType> = {
   __page_audit__: AlertTriangle,
   __page_activity__: Activity,
   __page_settings__: Settings,
+  __page_entity_types__: Database,
 }
 
 const STATUS_COLOR: Partial<Record<string, string>> = {
@@ -57,7 +58,7 @@ const STATUS_GLYPH: Partial<Record<string, string>> = {
   [TreeStatus.Running]: '●',
   [TreeStatus.Completed]: '✓',
   [TreeStatus.Failed]: '✗',
-  [TreeStatus.Active]: '⚠',
+  [TreeStatus.Active]: '●',
   [TreeStatus.Draft]: '○',
   [TreeStatus.Closed]: '○',
   [TreeStatus.Archived]: '○',

--- a/internal/web/ui/dashboard-v2/src/features/settings/entity-types.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/settings/entity-types.tsx
@@ -91,25 +91,28 @@ function TypeRow({ et }: { et: EntityType }) {
               <code className='text-xs font-mono font-medium'>{et.name}</code>
               <span className='text-xs text-muted-foreground'>— {et.display_name}</span>
             </div>
-            {et.description && (
-              <div className='mt-1'>
-                <div className='flex gap-2 mb-1'>
-                  <button type='button' onClick={() => setViewSource(false)}
-                    className={`text-[10px] px-1.5 py-0.5 rounded ${!viewSource ? 'bg-white/10 text-foreground' : 'text-muted-foreground hover:text-foreground'}`}>
-                    Rendered
-                  </button>
-                  <button type='button' onClick={() => setViewSource(true)}
-                    className={`text-[10px] px-1.5 py-0.5 rounded ${viewSource ? 'bg-white/10 text-foreground' : 'text-muted-foreground hover:text-foreground'}`}>
-                    Source
-                  </button>
-                </div>
+            <div className='mt-1.5 rounded-lg border bg-card'>
+              <div className='flex items-center gap-2 px-3 py-1.5 border-b border-white/5'>
+                <span className='text-[10px] font-medium text-muted-foreground uppercase tracking-wide flex-1'>Description</span>
+                <button type='button' onClick={() => setViewSource(false)}
+                  className={`text-[10px] px-2 py-0.5 rounded transition-colors ${!viewSource ? 'bg-white/10 text-foreground' : 'text-muted-foreground hover:text-foreground'}`}>
+                  Rendered
+                </button>
+                <button type='button' onClick={() => setViewSource(true)}
+                  className={`text-[10px] px-2 py-0.5 rounded transition-colors ${viewSource ? 'bg-white/10 text-foreground' : 'text-muted-foreground hover:text-foreground'}`}>
+                  Source
+                </button>
+              </div>
+              <div className='px-3 py-2'>
                 {viewSource
-                  ? <pre className='whitespace-pre-wrap text-xs font-mono text-muted-foreground'>{et.description}</pre>
-                  : <BlockNoteReadView markdown={et.description} />
+                  ? <pre className='whitespace-pre-wrap text-xs font-mono text-muted-foreground min-h-[2rem]'>{et.description || '(no description)'}</pre>
+                  : et.description
+                    ? <BlockNoteReadView markdown={et.description} />
+                    : <span className='text-xs text-muted-foreground italic'>No description</span>
                 }
               </div>
-            )}
-            <p className='text-[10px] text-muted-foreground font-mono mt-0.5'>icon: {et.icon} · color: {et.color}</p>
+            </div>
+            <p className='text-[10px] text-muted-foreground font-mono mt-1'>icon: {et.icon} · color: {et.color}</p>
           </div>
         )}
       </div>

--- a/internal/web/ui/dashboard-v2/src/features/settings/entity-types.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/settings/entity-types.tsx
@@ -1,0 +1,178 @@
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Skeleton } from '@/components/ui/skeleton'
+import { useEntityTypes, type EntityType } from '@/lib/queries/entity-types'
+
+async function createEntityType(body: { name: string; display_name: string; description: string; color: string; icon: string }) {
+  const res = await fetch('/api/entity-types', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(text)
+  }
+  return res.json()
+}
+
+async function updateEntityType(name: string, body: { display_name?: string; description?: string; color?: string; icon?: string; new_name?: string }) {
+  const res = await fetch(`/api/entity-types/${encodeURIComponent(name)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(text)
+  }
+  return res.json()
+}
+
+function TypeRow({ et }: { et: EntityType }) {
+  const qc = useQueryClient()
+  const [editing, setEditing] = useState(false)
+  const [displayName, setDisplayName] = useState(et.display_name)
+  const [description, setDescription] = useState(et.description)
+  const [color, setColor] = useState(et.color)
+  const [icon, setIcon] = useState(et.icon)
+
+  const update = useMutation({
+    mutationFn: () => updateEntityType(et.name, { display_name: displayName, description, color, icon }),
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ['entity-types'] }); setEditing(false) },
+  })
+
+  return (
+    <div className='flex items-start gap-3 py-2 border-b border-white/5 last:border-0'>
+      <div
+        className='mt-1 h-4 w-4 rounded-full shrink-0 border border-white/20'
+        style={{ backgroundColor: et.color }}
+      />
+      <div className='flex-1 min-w-0'>
+        {editing ? (
+          <div className='space-y-2'>
+            <div className='grid grid-cols-2 gap-2'>
+              <div>
+                <label className='text-[10px] text-muted-foreground uppercase tracking-wide'>Display Name</label>
+                <Input value={displayName} onChange={e => setDisplayName(e.target.value)} className='h-7 text-xs mt-0.5' />
+              </div>
+              <div>
+                <label className='text-[10px] text-muted-foreground uppercase tracking-wide'>Icon (lucide name)</label>
+                <Input value={icon} onChange={e => setIcon(e.target.value)} className='h-7 text-xs mt-0.5' />
+              </div>
+              <div>
+                <label className='text-[10px] text-muted-foreground uppercase tracking-wide'>Color (hex)</label>
+                <div className='flex items-center gap-1 mt-0.5'>
+                  <input type='color' value={color} onChange={e => setColor(e.target.value)} className='h-7 w-10 rounded cursor-pointer bg-transparent border border-white/20' />
+                  <Input value={color} onChange={e => setColor(e.target.value)} className='h-7 text-xs flex-1 font-mono' />
+                </div>
+              </div>
+              <div>
+                <label className='text-[10px] text-muted-foreground uppercase tracking-wide'>Description</label>
+                <Input value={description} onChange={e => setDescription(e.target.value)} className='h-7 text-xs mt-0.5' />
+              </div>
+            </div>
+            {update.isError && <p className='text-xs text-rose-400'>{String(update.error)}</p>}
+            <div className='flex gap-2'>
+              <Button size='sm' className='h-7 text-xs' onClick={() => update.mutate()} disabled={update.isPending}>
+                {update.isPending ? 'Saving…' : 'Save'}
+              </Button>
+              <Button size='sm' variant='ghost' className='h-7 text-xs' onClick={() => setEditing(false)}>Cancel</Button>
+            </div>
+          </div>
+        ) : (
+          <div>
+            <div className='flex items-center gap-2'>
+              <code className='text-xs font-mono font-medium'>{et.name}</code>
+              <span className='text-xs text-muted-foreground'>— {et.display_name}</span>
+            </div>
+            {et.description && <p className='text-xs text-muted-foreground mt-0.5'>{et.description}</p>}
+            <p className='text-[10px] text-muted-foreground font-mono mt-0.5'>icon: {et.icon} · color: {et.color}</p>
+          </div>
+        )}
+      </div>
+      {!editing && (
+        <Button size='sm' variant='ghost' className='h-7 text-xs shrink-0' onClick={() => setEditing(true)}>Edit</Button>
+      )}
+    </div>
+  )
+}
+
+export function SettingsEntityTypes() {
+  const qc = useQueryClient()
+  const { data: types, isLoading } = useEntityTypes()
+  const [name, setName] = useState('')
+  const [displayName, setDisplayName] = useState('')
+  const [description, setDescription] = useState('')
+  const [color, setColor] = useState('#6366f1')
+  const [icon, setIcon] = useState('Database')
+
+  const create = useMutation({
+    mutationFn: () => createEntityType({ name: name.trim(), display_name: displayName.trim() || name.trim(), description, color, icon }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['entity-types'] })
+      setName(''); setDisplayName(''); setDescription(''); setColor('#6366f1'); setIcon('Database')
+    },
+  })
+
+  return (
+    <div className='space-y-6 w-full'>
+      {/* Existing types */}
+      <Card>
+        <CardHeader className='pb-2'>
+          <CardTitle className='text-sm font-semibold uppercase tracking-wide text-muted-foreground'>Entity Types</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className='space-y-2'>{[1,2,3].map(i => <Skeleton key={i} className='h-8 w-full' />)}</div>
+          ) : (
+            <div>
+              {(types ?? []).map(et => <TypeRow key={et.type_uid} et={et} />)}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Add new type */}
+      <Card>
+        <CardHeader className='pb-2'>
+          <CardTitle className='text-sm font-semibold uppercase tracking-wide text-muted-foreground'>Add Entity Type</CardTitle>
+        </CardHeader>
+        <CardContent className='space-y-3'>
+          <div className='grid grid-cols-2 gap-3'>
+            <div>
+              <label className='text-xs text-muted-foreground'>Name (internal key)</label>
+              <Input value={name} onChange={e => setName(e.target.value)} placeholder='e.g. pipeline' className='mt-1 h-8 text-sm font-mono' />
+            </div>
+            <div>
+              <label className='text-xs text-muted-foreground'>Display Name</label>
+              <Input value={displayName} onChange={e => setDisplayName(e.target.value)} placeholder='e.g. Pipeline' className='mt-1 h-8 text-sm' />
+            </div>
+            <div>
+              <label className='text-xs text-muted-foreground'>Color</label>
+              <div className='flex items-center gap-2 mt-1'>
+                <input type='color' value={color} onChange={e => setColor(e.target.value)} className='h-8 w-10 rounded cursor-pointer bg-transparent border border-white/20' />
+                <Input value={color} onChange={e => setColor(e.target.value)} className='h-8 text-sm font-mono flex-1' />
+              </div>
+            </div>
+            <div>
+              <label className='text-xs text-muted-foreground'>Icon (lucide name)</label>
+              <Input value={icon} onChange={e => setIcon(e.target.value)} placeholder='e.g. GitBranch' className='mt-1 h-8 text-sm' />
+            </div>
+            <div className='col-span-2'>
+              <label className='text-xs text-muted-foreground'>Description</label>
+              <Input value={description} onChange={e => setDescription(e.target.value)} placeholder='What is this type for?' className='mt-1 h-8 text-sm' />
+            </div>
+          </div>
+          {create.isError && <p className='text-xs text-rose-400'>{String(create.error)}</p>}
+          <Button size='sm' onClick={() => create.mutate()} disabled={!name.trim() || create.isPending}>
+            {create.isPending ? 'Creating…' : 'Add Type'}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/internal/web/ui/dashboard-v2/src/features/settings/entity-types.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/settings/entity-types.tsx
@@ -31,6 +31,7 @@ async function updateEntityType(name: string, body: { display_name?: string; des
 function TypeRow({ et }: { et: EntityType }) {
   const qc = useQueryClient()
   const [editing, setEditing] = useState(false)
+  const [viewSource, setViewSource] = useState(false)
   const [displayName, setDisplayName] = useState(et.display_name)
   const [color, setColor] = useState(et.color)
   const [icon, setIcon] = useState(et.icon)
@@ -92,7 +93,20 @@ function TypeRow({ et }: { et: EntityType }) {
             </div>
             {et.description && (
               <div className='mt-1'>
-                <BlockNoteReadView markdown={et.description} />
+                <div className='flex gap-2 mb-1'>
+                  <button type='button' onClick={() => setViewSource(false)}
+                    className={`text-[10px] px-1.5 py-0.5 rounded ${!viewSource ? 'bg-white/10 text-foreground' : 'text-muted-foreground hover:text-foreground'}`}>
+                    Rendered
+                  </button>
+                  <button type='button' onClick={() => setViewSource(true)}
+                    className={`text-[10px] px-1.5 py-0.5 rounded ${viewSource ? 'bg-white/10 text-foreground' : 'text-muted-foreground hover:text-foreground'}`}>
+                    Source
+                  </button>
+                </div>
+                {viewSource
+                  ? <pre className='whitespace-pre-wrap text-xs font-mono text-muted-foreground'>{et.description}</pre>
+                  : <BlockNoteReadView markdown={et.description} />
+                }
               </div>
             )}
             <p className='text-[10px] text-muted-foreground font-mono mt-0.5'>icon: {et.icon} · color: {et.color}</p>

--- a/internal/web/ui/dashboard-v2/src/features/settings/entity-types.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/settings/entity-types.tsx
@@ -1,9 +1,11 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
+import { BlockNoteComposer, type BlockNoteComposerHandle } from '@/components/blocknote-composer'
+import { BlockNoteReadView } from '@/components/blocknote-read-view'
 import { useEntityTypes, type EntityType } from '@/lib/queries/entity-types'
 
 async function createEntityType(body: { name: string; display_name: string; description: string; color: string; icon: string }) {
@@ -12,10 +14,7 @@ async function createEntityType(body: { name: string; display_name: string; desc
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   })
-  if (!res.ok) {
-    const text = await res.text()
-    throw new Error(text)
-  }
+  if (!res.ok) throw new Error(await res.text())
   return res.json()
 }
 
@@ -25,10 +24,7 @@ async function updateEntityType(name: string, body: { display_name?: string; des
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   })
-  if (!res.ok) {
-    const text = await res.text()
-    throw new Error(text)
-  }
+  if (!res.ok) throw new Error(await res.text())
   return res.json()
 }
 
@@ -36,24 +32,27 @@ function TypeRow({ et }: { et: EntityType }) {
   const qc = useQueryClient()
   const [editing, setEditing] = useState(false)
   const [displayName, setDisplayName] = useState(et.display_name)
-  const [description, setDescription] = useState(et.description)
   const [color, setColor] = useState(et.color)
   const [icon, setIcon] = useState(et.icon)
+  const descRef = useRef<BlockNoteComposerHandle>(null)
 
   const update = useMutation({
-    mutationFn: () => updateEntityType(et.name, { display_name: displayName, description, color, icon }),
+    mutationFn: async () => {
+      const description = descRef.current ? (await descRef.current.getMarkdown()).trim() : et.description
+      return updateEntityType(et.name, { display_name: displayName, description, color, icon })
+    },
     onSuccess: () => { qc.invalidateQueries({ queryKey: ['entity-types'] }); setEditing(false) },
   })
 
   return (
-    <div className='flex items-start gap-3 py-2 border-b border-white/5 last:border-0'>
+    <div className='flex items-start gap-3 py-3 border-b border-white/5 last:border-0'>
       <div
         className='mt-1 h-4 w-4 rounded-full shrink-0 border border-white/20'
         style={{ backgroundColor: et.color }}
       />
       <div className='flex-1 min-w-0'>
         {editing ? (
-          <div className='space-y-2'>
+          <div className='space-y-3'>
             <div className='grid grid-cols-2 gap-2'>
               <div>
                 <label className='text-[10px] text-muted-foreground uppercase tracking-wide'>Display Name</label>
@@ -64,15 +63,17 @@ function TypeRow({ et }: { et: EntityType }) {
                 <Input value={icon} onChange={e => setIcon(e.target.value)} className='h-7 text-xs mt-0.5' />
               </div>
               <div>
-                <label className='text-[10px] text-muted-foreground uppercase tracking-wide'>Color (hex)</label>
+                <label className='text-[10px] text-muted-foreground uppercase tracking-wide'>Color</label>
                 <div className='flex items-center gap-1 mt-0.5'>
                   <input type='color' value={color} onChange={e => setColor(e.target.value)} className='h-7 w-10 rounded cursor-pointer bg-transparent border border-white/20' />
                   <Input value={color} onChange={e => setColor(e.target.value)} className='h-7 text-xs flex-1 font-mono' />
                 </div>
               </div>
-              <div>
-                <label className='text-[10px] text-muted-foreground uppercase tracking-wide'>Description</label>
-                <Input value={description} onChange={e => setDescription(e.target.value)} className='h-7 text-xs mt-0.5' />
+            </div>
+            <div>
+              <label className='text-[10px] text-muted-foreground uppercase tracking-wide'>Description</label>
+              <div className='rounded-lg border bg-card mt-0.5'>
+                <BlockNoteComposer ref={descRef} initialMarkdown={et.description ?? ''} />
               </div>
             </div>
             {update.isError && <p className='text-xs text-rose-400'>{String(update.error)}</p>}
@@ -89,7 +90,11 @@ function TypeRow({ et }: { et: EntityType }) {
               <code className='text-xs font-mono font-medium'>{et.name}</code>
               <span className='text-xs text-muted-foreground'>— {et.display_name}</span>
             </div>
-            {et.description && <p className='text-xs text-muted-foreground mt-0.5'>{et.description}</p>}
+            {et.description && (
+              <div className='mt-1'>
+                <BlockNoteReadView markdown={et.description} />
+              </div>
+            )}
             <p className='text-[10px] text-muted-foreground font-mono mt-0.5'>icon: {et.icon} · color: {et.color}</p>
           </div>
         )}
@@ -106,21 +111,24 @@ export function SettingsEntityTypes() {
   const { data: types, isLoading } = useEntityTypes()
   const [name, setName] = useState('')
   const [displayName, setDisplayName] = useState('')
-  const [description, setDescription] = useState('')
   const [color, setColor] = useState('#6366f1')
   const [icon, setIcon] = useState('Database')
+  const newDescRef = useRef<BlockNoteComposerHandle>(null)
 
   const create = useMutation({
-    mutationFn: () => createEntityType({ name: name.trim(), display_name: displayName.trim() || name.trim(), description, color, icon }),
+    mutationFn: async () => {
+      const description = newDescRef.current ? (await newDescRef.current.getMarkdown()).trim() : ''
+      return createEntityType({ name: name.trim(), display_name: displayName.trim() || name.trim(), description, color, icon })
+    },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['entity-types'] })
-      setName(''); setDisplayName(''); setDescription(''); setColor('#6366f1'); setIcon('Database')
+      setName(''); setDisplayName(''); setColor('#6366f1'); setIcon('Database')
+      newDescRef.current?.clear()
     },
   })
 
   return (
     <div className='space-y-6 w-full'>
-      {/* Existing types */}
       <Card>
         <CardHeader className='pb-2'>
           <CardTitle className='text-sm font-semibold uppercase tracking-wide text-muted-foreground'>Entity Types</CardTitle>
@@ -129,14 +137,11 @@ export function SettingsEntityTypes() {
           {isLoading ? (
             <div className='space-y-2'>{[1,2,3].map(i => <Skeleton key={i} className='h-8 w-full' />)}</div>
           ) : (
-            <div>
-              {(types ?? []).map(et => <TypeRow key={et.type_uid} et={et} />)}
-            </div>
+            (types ?? []).map(et => <TypeRow key={et.type_uid} et={et} />)
           )}
         </CardContent>
       </Card>
 
-      {/* Add new type */}
       <Card>
         <CardHeader className='pb-2'>
           <CardTitle className='text-sm font-semibold uppercase tracking-wide text-muted-foreground'>Add Entity Type</CardTitle>
@@ -162,9 +167,11 @@ export function SettingsEntityTypes() {
               <label className='text-xs text-muted-foreground'>Icon (lucide name)</label>
               <Input value={icon} onChange={e => setIcon(e.target.value)} placeholder='e.g. GitBranch' className='mt-1 h-8 text-sm' />
             </div>
-            <div className='col-span-2'>
-              <label className='text-xs text-muted-foreground'>Description</label>
-              <Input value={description} onChange={e => setDescription(e.target.value)} placeholder='What is this type for?' className='mt-1 h-8 text-sm' />
+          </div>
+          <div>
+            <label className='text-xs text-muted-foreground'>Description</label>
+            <div className='rounded-lg border bg-card mt-1'>
+              <BlockNoteComposer ref={newDescRef} initialMarkdown='' />
             </div>
           </div>
           {create.isError && <p className='text-xs text-rose-400'>{String(create.error)}</p>}

--- a/internal/web/ui/dashboard-v2/src/lib/queries/entity-tree.ts
+++ b/internal/web/ui/dashboard-v2/src/lib/queries/entity-tree.ts
@@ -10,6 +10,7 @@ export interface TreeNode {
   name: string
   kind: string  // EntityKind for real entities; 'page' for synthetic nav nodes
   status: string
+  iconName?: string  // lucide icon name for dynamic entity types from entity_types table
   children?: TreeNode[]
 }
 

--- a/internal/web/ui/dashboard-v2/src/routeTree.gen.ts
+++ b/internal/web/ui/dashboard-v2/src/routeTree.gen.ts
@@ -35,6 +35,7 @@ import { Route as AuthenticatedSettingsIndexRouteImport } from './routes/_authen
 import { Route as AuthenticatedEntitiesIndexRouteImport } from './routes/_authenticated/entities/index'
 import { Route as AuthenticatedSettingsSystemRouteImport } from './routes/_authenticated/settings/system'
 import { Route as AuthenticatedSettingsNotificationsRouteImport } from './routes/_authenticated/settings/notifications'
+import { Route as AuthenticatedSettingsEntityTypesRouteImport } from './routes/_authenticated/settings/entity-types'
 import { Route as AuthenticatedSettingsDisplayRouteImport } from './routes/_authenticated/settings/display'
 import { Route as AuthenticatedSettingsAppearanceRouteImport } from './routes/_authenticated/settings/appearance'
 import { Route as AuthenticatedSettingsAccountRouteImport } from './routes/_authenticated/settings/account'
@@ -176,6 +177,12 @@ const AuthenticatedSettingsNotificationsRoute =
     path: '/notifications',
     getParentRoute: () => AuthenticatedSettingsRouteRoute,
   } as any)
+const AuthenticatedSettingsEntityTypesRoute =
+  AuthenticatedSettingsEntityTypesRouteImport.update({
+    id: '/entity-types',
+    path: '/entity-types',
+    getParentRoute: () => AuthenticatedSettingsRouteRoute,
+  } as any)
 const AuthenticatedSettingsDisplayRoute =
   AuthenticatedSettingsDisplayRouteImport.update({
     id: '/display',
@@ -227,6 +234,7 @@ export interface FileRoutesByFullPath {
   '/settings/account': typeof AuthenticatedSettingsAccountRoute
   '/settings/appearance': typeof AuthenticatedSettingsAppearanceRoute
   '/settings/display': typeof AuthenticatedSettingsDisplayRoute
+  '/settings/entity-types': typeof AuthenticatedSettingsEntityTypesRoute
   '/settings/notifications': typeof AuthenticatedSettingsNotificationsRoute
   '/settings/system': typeof AuthenticatedSettingsSystemRoute
   '/entities/': typeof AuthenticatedEntitiesIndexRoute
@@ -256,6 +264,7 @@ export interface FileRoutesByTo {
   '/settings/account': typeof AuthenticatedSettingsAccountRoute
   '/settings/appearance': typeof AuthenticatedSettingsAppearanceRoute
   '/settings/display': typeof AuthenticatedSettingsDisplayRoute
+  '/settings/entity-types': typeof AuthenticatedSettingsEntityTypesRoute
   '/settings/notifications': typeof AuthenticatedSettingsNotificationsRoute
   '/settings/system': typeof AuthenticatedSettingsSystemRoute
   '/entities': typeof AuthenticatedEntitiesIndexRoute
@@ -289,6 +298,7 @@ export interface FileRoutesById {
   '/_authenticated/settings/account': typeof AuthenticatedSettingsAccountRoute
   '/_authenticated/settings/appearance': typeof AuthenticatedSettingsAppearanceRoute
   '/_authenticated/settings/display': typeof AuthenticatedSettingsDisplayRoute
+  '/_authenticated/settings/entity-types': typeof AuthenticatedSettingsEntityTypesRoute
   '/_authenticated/settings/notifications': typeof AuthenticatedSettingsNotificationsRoute
   '/_authenticated/settings/system': typeof AuthenticatedSettingsSystemRoute
   '/_authenticated/entities/': typeof AuthenticatedEntitiesIndexRoute
@@ -322,6 +332,7 @@ export interface FileRouteTypes {
     | '/settings/account'
     | '/settings/appearance'
     | '/settings/display'
+    | '/settings/entity-types'
     | '/settings/notifications'
     | '/settings/system'
     | '/entities/'
@@ -351,6 +362,7 @@ export interface FileRouteTypes {
     | '/settings/account'
     | '/settings/appearance'
     | '/settings/display'
+    | '/settings/entity-types'
     | '/settings/notifications'
     | '/settings/system'
     | '/entities'
@@ -383,6 +395,7 @@ export interface FileRouteTypes {
     | '/_authenticated/settings/account'
     | '/_authenticated/settings/appearance'
     | '/_authenticated/settings/display'
+    | '/_authenticated/settings/entity-types'
     | '/_authenticated/settings/notifications'
     | '/_authenticated/settings/system'
     | '/_authenticated/entities/'
@@ -582,6 +595,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSettingsNotificationsRouteImport
       parentRoute: typeof AuthenticatedSettingsRouteRoute
     }
+    '/_authenticated/settings/entity-types': {
+      id: '/_authenticated/settings/entity-types'
+      path: '/entity-types'
+      fullPath: '/settings/entity-types'
+      preLoaderRoute: typeof AuthenticatedSettingsEntityTypesRouteImport
+      parentRoute: typeof AuthenticatedSettingsRouteRoute
+    }
     '/_authenticated/settings/display': {
       id: '/_authenticated/settings/display'
       path: '/display'
@@ -633,6 +653,7 @@ interface AuthenticatedSettingsRouteRouteChildren {
   AuthenticatedSettingsAccountRoute: typeof AuthenticatedSettingsAccountRoute
   AuthenticatedSettingsAppearanceRoute: typeof AuthenticatedSettingsAppearanceRoute
   AuthenticatedSettingsDisplayRoute: typeof AuthenticatedSettingsDisplayRoute
+  AuthenticatedSettingsEntityTypesRoute: typeof AuthenticatedSettingsEntityTypesRoute
   AuthenticatedSettingsNotificationsRoute: typeof AuthenticatedSettingsNotificationsRoute
   AuthenticatedSettingsSystemRoute: typeof AuthenticatedSettingsSystemRoute
   AuthenticatedSettingsIndexRoute: typeof AuthenticatedSettingsIndexRoute
@@ -643,6 +664,8 @@ const AuthenticatedSettingsRouteRouteChildren: AuthenticatedSettingsRouteRouteCh
     AuthenticatedSettingsAccountRoute: AuthenticatedSettingsAccountRoute,
     AuthenticatedSettingsAppearanceRoute: AuthenticatedSettingsAppearanceRoute,
     AuthenticatedSettingsDisplayRoute: AuthenticatedSettingsDisplayRoute,
+    AuthenticatedSettingsEntityTypesRoute:
+      AuthenticatedSettingsEntityTypesRoute,
     AuthenticatedSettingsNotificationsRoute:
       AuthenticatedSettingsNotificationsRoute,
     AuthenticatedSettingsSystemRoute: AuthenticatedSettingsSystemRoute,

--- a/internal/web/ui/dashboard-v2/src/routes/_authenticated/settings/entity-types.tsx
+++ b/internal/web/ui/dashboard-v2/src/routes/_authenticated/settings/entity-types.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SettingsEntityTypes } from '@/features/settings/entity-types'
+
+export const Route = createFileRoute('/_authenticated/settings/entity-types')({
+  component: SettingsEntityTypes,
+})


### PR DESCRIPTION
## Summary

- **Entity Types settings** at `/settings/entity-types` — list all types with color swatch, edit display name/color/icon inline, add new types with color picker. Accessible via Navigation › Entity Types in the sidebar
- **Active status** `●` instead of `⚠` — amber dot instead of warning triangle (same color, less alarming)

## Test plan
- [ ] Navigation group shows Entity Types item
- [ ] /settings/entity-types lists all types with correct colors
- [ ] Edit a type's display_name/color/icon — saves correctly
- [ ] Add a new type — appears in list + sidebar tree
- [ ] Active status entities show `●` not `⚠`

🤖 Generated with [Claude Code](https://claude.com/claude-code)