### PR TITLE
leiden(M2/T1): local-move, refinement, aggregation phases

### DIFF
--- a/leiden/aggregation.go
+++ b/leiden/aggregation.go
@@ -1,0 +1,110 @@
+package leiden
+
+// aggregateNetwork builds the next coarsening level of the Leiden algorithm.
+//
+// Each cluster of `refined` becomes one node in the returned network:
+//
+//   - The new node's weight is the sum of [CompactNetwork.NodeWeight] over its
+//     members.
+//   - Edges between original nodes within the same refined cluster contribute
+//     to a self-loop on the corresponding new node, preserving the cluster's
+//     internal edge weight (each undirected edge counted once).
+//   - Edges between original nodes in different refined clusters become a
+//     weighted edge between the corresponding new nodes; multi-edges are
+//     summed.
+//
+// `aggInit` is the initial clustering for the next algorithm iteration: two
+// new nodes (refined clusters) are placed in the same bucket iff their
+// original members were in the same cluster of `parent`. This is the
+// invariant that distinguishes Leiden from Louvain — the next local-move
+// phase resumes from the (pre-refinement) partition.
+//
+// `refined` is normalized (cluster IDs renumbered into a contiguous range)
+// as a side effect.
+//
+// With this construction, the CPM quality of `parent` on `net` equals the CPM
+// quality of `aggInit` on the returned aggNet, so the algorithm's monotone
+// improvement property holds across coarsening levels.
+//
+// Errors:
+//   - [ErrInvalidNodeCount] if `refined` or `net` is nil or has zero nodes.
+func aggregateNetwork(net *CompactNetwork, refined, parent *Clustering) (aggNet *CompactNetwork, aggInit *Clustering, err error) {
+	if net == nil || refined == nil || parent == nil {
+		return nil, nil, ErrInvalidNodeCount
+	}
+	if net.nNodes == 0 || refined.nNodes == 0 || parent.nNodes == 0 {
+		return nil, nil, ErrInvalidNodeCount
+	}
+	refined.Normalize()
+	k := refined.nClusters
+
+	newWeights := make([]float64, k)
+	for u := 0; u < net.nNodes; u++ {
+		newWeights[refined.assignment[u]] += net.nodeWeights[u]
+	}
+
+	// Accumulators. Each undirected edge in the original network is stored
+	// twice in CSR (once on each endpoint), so we count only the src <= dst
+	// direction. Self-loops appear once (src == dst) and naturally fall in
+	// the same-cluster branch.
+	selfLoop := make([]float64, k)
+	type pair struct{ i, j int }
+	cross := make(map[pair]float64)
+
+	for src := 0; src < net.nNodes; src++ {
+		i := refined.assignment[src]
+		nbrs := net.Neighbors(src)
+		ws := net.NeighborWeights(src)
+		for idx, dst := range nbrs {
+			if src > dst {
+				continue
+			}
+			j := refined.assignment[dst]
+			w := ws[idx]
+			if i == j {
+				selfLoop[i] += w
+				continue
+			}
+			a, b := i, j
+			if a > b {
+				a, b = b, a
+			}
+			cross[pair{a, b}] += w
+		}
+	}
+
+	edges := make([]Edge, 0, len(cross)+k)
+	for i, w := range selfLoop {
+		if w > 0 {
+			edges = append(edges, Edge{From: i, To: i, Weight: w})
+		}
+	}
+	for p, w := range cross {
+		edges = append(edges, Edge{From: p.i, To: p.j, Weight: w})
+	}
+
+	aggNet, err = NewCompactNetworkWithNodeWeights(k, newWeights, edges)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// New-node i (refined cluster i) inherits its parent cluster ID. All
+	// members of a refined cluster share the same parent cluster — refinement
+	// only merges within a parent cluster — so taking the first-seen member
+	// is well-defined.
+	aggAssign := make([]int, k)
+	seen := make([]bool, k)
+	for u := 0; u < net.nNodes; u++ {
+		ri := refined.assignment[u]
+		if seen[ri] {
+			continue
+		}
+		seen[ri] = true
+		aggAssign[ri] = parent.assignment[u]
+	}
+	aggInit, err = NewClusteringFromAssignment(aggAssign)
+	if err != nil {
+		return nil, nil, err
+	}
+	return aggNet, aggInit, nil
+}

--- a/leiden/aggregation_test.go
+++ b/leiden/aggregation_test.go
@@ -1,0 +1,195 @@
+package leiden
+
+import (
+	"errors"
+	"sort"
+	"testing"
+)
+
+func TestAggregate_SingletonRefinement_PreservesGraph(t *testing.T) {
+	// Refinement is the identity (singletons → singletons): the aggregated
+	// network must be structurally equivalent to the input, with each node
+	// keeping its parent cluster ID.
+	edges := []Edge{
+		{0, 1, 1}, {1, 2, 2}, {0, 2, 3},
+	}
+	net := mustNetwork(t, 3, edges)
+	refined, _ := NewSingletonClustering(3)
+	parent, _ := NewClusteringFromAssignment([]int{0, 0, 1})
+
+	agg, init, err := aggregateNetwork(net, refined, parent)
+	if err != nil {
+		t.Fatalf("aggregateNetwork: %v", err)
+	}
+	if agg.NumNodes() != 3 {
+		t.Errorf("agg.NumNodes=%d, want 3", agg.NumNodes())
+	}
+	if init.NumClusters() != 2 {
+		t.Errorf("init.NumClusters=%d, want 2", init.NumClusters())
+	}
+	if got, want := agg.TotalEdgeWeight(), 6.0; !floatEq(got, want) {
+		t.Errorf("agg.TotalEdgeWeight=%g, want %g", got, want)
+	}
+	// Node weights unchanged.
+	for i := 0; i < 3; i++ {
+		if w := agg.NodeWeight(i); w != 1.0 {
+			t.Errorf("agg.NodeWeight(%d)=%g, want 1", i, w)
+		}
+	}
+}
+
+func TestAggregate_TriangleCollapsedToOneNode(t *testing.T) {
+	// Triangle 0-1-2 (unit weights), refinement collapses everything into
+	// cluster 0. Expected: 1 new node, self-loop weight = 3 (the three
+	// internal edges), node weight = 3.
+	edges := []Edge{
+		{0, 1, 1}, {1, 2, 1}, {0, 2, 1},
+	}
+	net := mustNetwork(t, 3, edges)
+	refined, _ := NewClustering(3) // all in cluster 0
+	parent, _ := NewClustering(3)
+
+	agg, init, err := aggregateNetwork(net, refined, parent)
+	if err != nil {
+		t.Fatalf("aggregateNetwork: %v", err)
+	}
+	if agg.NumNodes() != 1 {
+		t.Fatalf("agg.NumNodes=%d, want 1", agg.NumNodes())
+	}
+	if w := agg.NodeWeight(0); w != 3 {
+		t.Errorf("agg.NodeWeight(0)=%g, want 3", w)
+	}
+	if w := agg.TotalEdgeWeight(); w != 3 {
+		t.Errorf("agg.TotalEdgeWeight=%g, want 3", w)
+	}
+	// Single self-loop edge, weight 3.
+	nbrs := agg.Neighbors(0)
+	ws := agg.NeighborWeights(0)
+	if len(nbrs) != 1 || nbrs[0] != 0 || ws[0] != 3 {
+		t.Errorf("agg neighbours=%v weights=%v, want self-loop weight 3", nbrs, ws)
+	}
+	if init.NumNodes() != 1 || init.Cluster(0) != 0 {
+		t.Errorf("init clustering wrong: %+v", init.Assignment())
+	}
+}
+
+func TestAggregate_PreservesCPMQuality(t *testing.T) {
+	// CPM quality of a partition on the original network must equal the CPM
+	// quality of the corresponding (initial) partition on the aggregated
+	// network. This is the invariant that lets the algorithm iterate.
+	//
+	// Graph: two triangles bridged by one edge.
+	edges := []Edge{
+		{0, 1, 1}, {1, 2, 1}, {0, 2, 1},
+		{3, 4, 1}, {4, 5, 1}, {3, 5, 1},
+		{2, 3, 1},
+	}
+	net := mustNetwork(t, 6, edges)
+	parent, _ := NewClusteringFromAssignment([]int{0, 0, 0, 1, 1, 1})
+	// Refinement coincides with parent (one R-cluster per parent cluster).
+	refined, _ := NewClusteringFromAssignment([]int{0, 0, 0, 1, 1, 1})
+	q := cpmQuality{Gamma: 0.3}
+
+	want := q.value(net, parent)
+	agg, init, err := aggregateNetwork(net, refined, parent)
+	if err != nil {
+		t.Fatalf("aggregateNetwork: %v", err)
+	}
+	got := q.value(agg, init)
+	if !floatEq(got, want) {
+		t.Errorf("aggregated quality %g != original %g", got, want)
+	}
+}
+
+func TestAggregate_PreservesQuality_RefinementSubdividesParent(t *testing.T) {
+	// Same graph, but refinement subdivides each parent cluster into two
+	// sub-clusters. Quality must still be preserved.
+	edges := []Edge{
+		{0, 1, 1}, {1, 2, 1}, {0, 2, 1},
+		{3, 4, 1}, {4, 5, 1}, {3, 5, 1},
+		{2, 3, 1},
+	}
+	net := mustNetwork(t, 6, edges)
+	parent, _ := NewClusteringFromAssignment([]int{0, 0, 0, 1, 1, 1})
+	refined, _ := NewClusteringFromAssignment([]int{0, 0, 2, 3, 3, 5})
+	q := cpmQuality{Gamma: 0.3}
+
+	want := q.value(net, parent)
+	agg, init, err := aggregateNetwork(net, refined, parent)
+	if err != nil {
+		t.Fatalf("aggregateNetwork: %v", err)
+	}
+	got := q.value(agg, init)
+	if !floatEq(got, want) {
+		t.Errorf("aggregated quality %g != original %g", got, want)
+	}
+	// Sanity: aggregated network has 4 new nodes (one per refined cluster).
+	if agg.NumNodes() != 4 {
+		t.Errorf("agg.NumNodes=%d, want 4", agg.NumNodes())
+	}
+}
+
+func TestAggregate_PreservesTotalEdgeWeight(t *testing.T) {
+	// Sum of input edge weights is invariant under aggregation regardless of
+	// the refined clustering used.
+	edges := []Edge{
+		{0, 1, 0.5}, {1, 2, 1.5}, {2, 3, 2.0}, {0, 3, 0.25},
+		{1, 1, 0.7}, // self-loop
+	}
+	net := mustNetwork(t, 4, edges)
+	parent, _ := NewClustering(4)
+	refined, _ := NewClusteringFromAssignment([]int{0, 0, 1, 1})
+
+	agg, _, err := aggregateNetwork(net, refined, parent)
+	if err != nil {
+		t.Fatalf("aggregateNetwork: %v", err)
+	}
+	if !floatEq(agg.TotalEdgeWeight(), net.TotalEdgeWeight()) {
+		t.Errorf("TotalEdgeWeight: agg=%g, orig=%g", agg.TotalEdgeWeight(), net.TotalEdgeWeight())
+	}
+}
+
+func TestAggregate_NormalisesRefinedClusters(t *testing.T) {
+	// Refined cluster IDs need not be contiguous; aggregateNetwork should
+	// normalize them transparently.
+	edges := []Edge{{0, 1, 1}, {1, 2, 1}}
+	net := mustNetwork(t, 3, edges)
+	parent, _ := NewClustering(3)
+	refined, _ := NewClusteringFromAssignment([]int{7, 7, 99})
+	agg, init, err := aggregateNetwork(net, refined, parent)
+	if err != nil {
+		t.Fatalf("aggregateNetwork: %v", err)
+	}
+	if agg.NumNodes() != 2 {
+		t.Errorf("agg.NumNodes=%d, want 2", agg.NumNodes())
+	}
+	if init.NumNodes() != 2 {
+		t.Errorf("init.NumNodes=%d, want 2", init.NumNodes())
+	}
+	// Both new nodes inherited parent cluster 0.
+	got := init.Assignment()
+	sort.Ints(got)
+	if got[0] != 0 || got[1] != 0 {
+		t.Errorf("init assignment=%v, want [0,0]", got)
+	}
+}
+
+func TestAggregate_NilInputs_Error(t *testing.T) {
+	cl, _ := NewSingletonClustering(2)
+	net := mustNetwork(t, 2, nil)
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{"nil network", func() error { _, _, e := aggregateNetwork(nil, cl, cl); return e }},
+		{"nil refined", func() error { _, _, e := aggregateNetwork(net, nil, cl); return e }},
+		{"nil parent", func() error { _, _, e := aggregateNetwork(net, cl, nil); return e }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.fn(); !errors.Is(err, ErrInvalidNodeCount) {
+				t.Errorf("got %v, want errors.Is %v", err, ErrInvalidNodeCount)
+			}
+		})
+	}
+}

--- a/leiden/algorithm_loop_test.go
+++ b/leiden/algorithm_loop_test.go
@@ -1,0 +1,110 @@
+package leiden
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// TestAlgorithmLoop_ThreePhasesCompose drives the local-move →
+// refinement → aggregation pipeline end-to-end and verifies the
+// across-level invariants that future milestones will rely on:
+//
+//   - Refinement never breaks parent-cluster boundaries.
+//   - Aggregation preserves CPM quality between levels.
+//   - One full iteration on a known graph reaches the expected
+//     two-community partition for moderately-connected planted clusters.
+func TestAlgorithmLoop_ThreePhasesCompose(t *testing.T) {
+	// Two 4-cliques bridged by a single edge (3—4).
+	var edges []Edge
+	for i := 0; i < 4; i++ {
+		for j := i + 1; j < 4; j++ {
+			edges = append(edges, Edge{From: i, To: j, Weight: 1})
+		}
+	}
+	for i := 4; i < 8; i++ {
+		for j := i + 1; j < 8; j++ {
+			edges = append(edges, Edge{From: i, To: j, Weight: 1})
+		}
+	}
+	edges = append(edges, Edge{From: 3, To: 4, Weight: 1})
+	net := mustNetwork(t, 8, edges)
+
+	q := cpmQuality{Gamma: 0.5}
+	rng := rand.New(rand.NewSource(42))
+
+	// Phase 1: local-move from singletons.
+	parent, _ := NewSingletonClustering(8)
+	qBefore := q.value(net, parent)
+	runLocalMove(net, parent, q, rng)
+	qAfterLocalMove := q.value(net, parent)
+	if qAfterLocalMove+floatTol < qBefore {
+		t.Fatalf("local-move decreased quality: %g → %g", qBefore, qAfterLocalMove)
+	}
+
+	// Phase 2: refinement.
+	refined := runRefinement(net, parent, q, 0, rng)
+	for u := 0; u < net.NumNodes(); u++ {
+		for v := u + 1; v < net.NumNodes(); v++ {
+			if refined.Cluster(u) == refined.Cluster(v) && parent.Cluster(u) != parent.Cluster(v) {
+				t.Errorf("refined cluster crosses parent boundary: nodes %d,%d", u, v)
+			}
+		}
+	}
+
+	// Phase 3: aggregation.
+	agg, init, err := aggregateNetwork(net, refined, parent)
+	if err != nil {
+		t.Fatalf("aggregateNetwork: %v", err)
+	}
+	qAgg := q.value(agg, init)
+	// CPM-quality invariant: H(parent on net) == H(init on agg).
+	if !floatEq(qAgg, qAfterLocalMove) {
+		t.Errorf("aggregated quality %g != original %g", qAgg, qAfterLocalMove)
+	}
+
+	// Expected partition (parent): two communities split at the bridge.
+	want := [][]int{{0, 1, 2, 3}, {4, 5, 6, 7}}
+	got := clusterMembership(parent)
+	if len(got) != len(want) {
+		t.Fatalf("partition = %v, want %v", got, want)
+	}
+	for i := range want {
+		if len(got[i]) != len(want[i]) {
+			t.Errorf("cluster %d: got %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestAlgorithmLoop_AggregatedNextIteration_Stable(t *testing.T) {
+	// After one full iteration the aggregated network's local-move pass
+	// should make no further moves: the partition is at a local optimum.
+	var edges []Edge
+	for i := 0; i < 4; i++ {
+		for j := i + 1; j < 4; j++ {
+			edges = append(edges, Edge{From: i, To: j, Weight: 1})
+		}
+	}
+	for i := 4; i < 8; i++ {
+		for j := i + 1; j < 8; j++ {
+			edges = append(edges, Edge{From: i, To: j, Weight: 1})
+		}
+	}
+	edges = append(edges, Edge{From: 3, To: 4, Weight: 1})
+	net := mustNetwork(t, 8, edges)
+
+	q := cpmQuality{Gamma: 0.5}
+	rng := rand.New(rand.NewSource(42))
+
+	parent, _ := NewSingletonClustering(8)
+	runLocalMove(net, parent, q, rng)
+	refined := runRefinement(net, parent, q, 0, rng)
+	agg, init, err := aggregateNetwork(net, refined, parent)
+	if err != nil {
+		t.Fatalf("aggregateNetwork: %v", err)
+	}
+
+	moves := runLocalMove(agg, init, q, rng)
+	if moves != 0 {
+		t.Errorf("local-move on aggregated network made %d moves; expected 0 at local optimum", moves)
+	}
+}

--- a/leiden/clustering.go
+++ b/leiden/clustering.go
@@ -1,0 +1,194 @@
+package leiden
+
+import "fmt"
+
+// Clustering is a partition of nodes into clusters.
+//
+// Cluster IDs are non-negative integers. Cluster IDs are not required to be
+// contiguous (i.e. a Clustering with nodes assigned to clusters 0, 2, 5 is
+// valid); use [Clustering.Normalize] to renumber them into [0, k).
+//
+// The zero value of Clustering is not usable; construct one via
+// [NewClustering], [NewSingletonClustering], or
+// [NewClusteringFromAssignment].
+type Clustering struct {
+	nNodes     int
+	nClusters  int
+	assignment []int
+}
+
+// NewClustering returns a clustering with every node in cluster 0.
+//
+// Returns an error if nNodes is non-positive.
+func NewClustering(nNodes int) (*Clustering, error) {
+	if nNodes <= 0 {
+		return nil, fmt.Errorf("%w: got %d", ErrInvalidNodeCount, nNodes)
+	}
+	return &Clustering{
+		nNodes:     nNodes,
+		nClusters:  1,
+		assignment: make([]int, nNodes),
+	}, nil
+}
+
+// NewSingletonClustering returns a clustering with each node in its own
+// cluster: node i is assigned to cluster i.
+//
+// Returns an error if nNodes is non-positive.
+func NewSingletonClustering(nNodes int) (*Clustering, error) {
+	if nNodes <= 0 {
+		return nil, fmt.Errorf("%w: got %d", ErrInvalidNodeCount, nNodes)
+	}
+	a := make([]int, nNodes)
+	for i := range a {
+		a[i] = i
+	}
+	return &Clustering{
+		nNodes:     nNodes,
+		nClusters:  nNodes,
+		assignment: a,
+	}, nil
+}
+
+// NewClusteringFromAssignment returns a clustering from an explicit
+// node-to-cluster assignment. The returned clustering owns a copy of the
+// input slice; the caller may safely mutate the original.
+//
+// Returns an error if the assignment is empty or contains a negative ID.
+func NewClusteringFromAssignment(assignment []int) (*Clustering, error) {
+	if len(assignment) == 0 {
+		return nil, fmt.Errorf("%w: got 0", ErrInvalidNodeCount)
+	}
+	maxID := -1
+	for i, c := range assignment {
+		if c < 0 {
+			return nil, fmt.Errorf("%w: node %d assigned to %d", ErrNegativeClusterID, i, c)
+		}
+		if c > maxID {
+			maxID = c
+		}
+	}
+	a := make([]int, len(assignment))
+	copy(a, assignment)
+	return &Clustering{
+		nNodes:     len(assignment),
+		nClusters:  maxID + 1,
+		assignment: a,
+	}, nil
+}
+
+// NumNodes returns the number of nodes in the clustering.
+func (c *Clustering) NumNodes() int { return c.nNodes }
+
+// NumClusters returns the cluster count: max(assignment)+1. Clusters in the
+// range [0, NumClusters()) may be empty if [Clustering.Normalize] has not
+// been called.
+func (c *Clustering) NumClusters() int { return c.nClusters }
+
+// Cluster returns the cluster ID assigned to the given node. The caller is
+// responsible for ensuring 0 <= node < NumNodes().
+func (c *Clustering) Cluster(node int) int { return c.assignment[node] }
+
+// SetCluster assigns node to the given cluster, growing NumClusters if
+// needed. Returns an error if the cluster ID is negative or the node is
+// out of range.
+func (c *Clustering) SetCluster(node, cluster int) error {
+	if node < 0 || node >= c.nNodes {
+		return fmt.Errorf("%w: node=%d, nNodes=%d", ErrNodeOutOfRange, node, c.nNodes)
+	}
+	if cluster < 0 {
+		return fmt.Errorf("%w: cluster=%d", ErrNegativeClusterID, cluster)
+	}
+	c.assignment[node] = cluster
+	if cluster+1 > c.nClusters {
+		c.nClusters = cluster + 1
+	}
+	return nil
+}
+
+// Assignment returns a copy of the node-to-cluster assignment. The returned
+// slice is owned by the caller and safe to mutate.
+func (c *Clustering) Assignment() []int {
+	out := make([]int, c.nNodes)
+	copy(out, c.assignment)
+	return out
+}
+
+// Sizes returns a copy of the per-cluster node counts. The returned slice
+// has length [Clustering.NumClusters] and is owned by the caller.
+func (c *Clustering) Sizes() []int {
+	out := make([]int, c.nClusters)
+	for _, cl := range c.assignment {
+		out[cl]++
+	}
+	return out
+}
+
+// Nodes returns the node IDs assigned to the given cluster, in ascending
+// order. The returned slice is owned by the caller. Returns an empty slice
+// if the cluster ID is out of range or contains no nodes.
+func (c *Clustering) Nodes(cluster int) []int {
+	if cluster < 0 || cluster >= c.nClusters {
+		return []int{}
+	}
+	var out []int
+	for node, cl := range c.assignment {
+		if cl == cluster {
+			out = append(out, node)
+		}
+	}
+	return out
+}
+
+// Normalize renumbers cluster IDs so they form a contiguous range [0, k),
+// preserving the relative order of first appearance in the assignment.
+// After normalization, [Clustering.NumClusters] equals the number of
+// non-empty clusters.
+func (c *Clustering) Normalize() {
+	remap := make(map[int]int, c.nClusters)
+	next := 0
+	for i, cl := range c.assignment {
+		newID, ok := remap[cl]
+		if !ok {
+			newID = next
+			remap[cl] = newID
+			next++
+		}
+		c.assignment[i] = newID
+	}
+	c.nClusters = next
+}
+
+// MergeClusters reassigns every node in cluster b to cluster a. Both IDs
+// must be non-negative. Cluster b becomes empty but [Clustering.NumClusters]
+// is not reduced until [Clustering.Normalize] is called.
+//
+// Returns an error if either ID is negative.
+func (c *Clustering) MergeClusters(a, b int) error {
+	if a < 0 || b < 0 {
+		return fmt.Errorf("%w: a=%d, b=%d", ErrNegativeClusterID, a, b)
+	}
+	if a == b {
+		return nil
+	}
+	for i, cl := range c.assignment {
+		if cl == b {
+			c.assignment[i] = a
+		}
+	}
+	if a+1 > c.nClusters {
+		c.nClusters = a + 1
+	}
+	return nil
+}
+
+// Clone returns an independent deep copy of the clustering.
+func (c *Clustering) Clone() *Clustering {
+	a := make([]int, c.nNodes)
+	copy(a, c.assignment)
+	return &Clustering{
+		nNodes:     c.nNodes,
+		nClusters:  c.nClusters,
+		assignment: a,
+	}
+}

--- a/leiden/clustering_test.go
+++ b/leiden/clustering_test.go
@@ -1,0 +1,209 @@
+package leiden
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestNewClustering_AllZero(t *testing.T) {
+	c, err := NewClustering(4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.NumNodes() != 4 {
+		t.Errorf("NumNodes=%d, want 4", c.NumNodes())
+	}
+	if c.NumClusters() != 1 {
+		t.Errorf("NumClusters=%d, want 1", c.NumClusters())
+	}
+	for i := 0; i < 4; i++ {
+		if c.Cluster(i) != 0 {
+			t.Errorf("Cluster(%d)=%d, want 0", i, c.Cluster(i))
+		}
+	}
+}
+
+func TestNewSingletonClustering(t *testing.T) {
+	c, err := NewSingletonClustering(3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.NumClusters() != 3 {
+		t.Errorf("NumClusters=%d, want 3", c.NumClusters())
+	}
+	for i := 0; i < 3; i++ {
+		if c.Cluster(i) != i {
+			t.Errorf("Cluster(%d)=%d, want %d", i, c.Cluster(i), i)
+		}
+	}
+}
+
+func TestNewClusteringFromAssignment(t *testing.T) {
+	in := []int{0, 0, 2, 1, 2}
+	c, err := NewClusteringFromAssignment(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.NumNodes() != 5 {
+		t.Errorf("NumNodes=%d", c.NumNodes())
+	}
+	if c.NumClusters() != 3 {
+		t.Errorf("NumClusters=%d, want 3 (max+1)", c.NumClusters())
+	}
+	// Caller mutating input must not affect clustering.
+	in[0] = 99
+	if c.Cluster(0) != 0 {
+		t.Errorf("clustering shared input slice: Cluster(0)=%d", c.Cluster(0))
+	}
+}
+
+func TestNewClustering_Errors(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func() error
+		want error
+	}{
+		{
+			name: "zero nodes",
+			fn:   func() error { _, e := NewClustering(0); return e },
+			want: ErrInvalidNodeCount,
+		},
+		{
+			name: "negative nodes singleton",
+			fn:   func() error { _, e := NewSingletonClustering(-1); return e },
+			want: ErrInvalidNodeCount,
+		},
+		{
+			name: "empty assignment",
+			fn:   func() error { _, e := NewClusteringFromAssignment(nil); return e },
+			want: ErrInvalidNodeCount,
+		},
+		{
+			name: "negative cluster id",
+			fn:   func() error { _, e := NewClusteringFromAssignment([]int{0, -1}); return e },
+			want: ErrNegativeClusterID,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.fn(); !errors.Is(err, tt.want) {
+				t.Fatalf("got %v, want errors.Is %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestClustering_SetCluster(t *testing.T) {
+	c, _ := NewClustering(3)
+	if err := c.SetCluster(1, 5); err != nil {
+		t.Fatal(err)
+	}
+	if c.Cluster(1) != 5 {
+		t.Errorf("Cluster(1)=%d, want 5", c.Cluster(1))
+	}
+	if c.NumClusters() != 6 {
+		t.Errorf("NumClusters=%d, want 6", c.NumClusters())
+	}
+
+	if err := c.SetCluster(-1, 0); !errors.Is(err, ErrNodeOutOfRange) {
+		t.Errorf("expected ErrNodeOutOfRange, got %v", err)
+	}
+	if err := c.SetCluster(0, -1); !errors.Is(err, ErrNegativeClusterID) {
+		t.Errorf("expected ErrNegativeClusterID, got %v", err)
+	}
+}
+
+func TestClustering_Assignment_ReturnsCopy(t *testing.T) {
+	c, _ := NewClusteringFromAssignment([]int{0, 1, 0, 1})
+	a := c.Assignment()
+	a[0] = 99
+	if c.Cluster(0) != 0 {
+		t.Errorf("Assignment() shared internal slice; Cluster(0)=%d", c.Cluster(0))
+	}
+}
+
+func TestClustering_Sizes(t *testing.T) {
+	c, _ := NewClusteringFromAssignment([]int{0, 1, 0, 2, 2, 2})
+	sizes := c.Sizes()
+	want := []int{2, 1, 3}
+	if !reflect.DeepEqual(sizes, want) {
+		t.Errorf("Sizes=%v, want %v", sizes, want)
+	}
+}
+
+func TestClustering_Nodes(t *testing.T) {
+	c, _ := NewClusteringFromAssignment([]int{2, 0, 2, 1, 0})
+	if got, want := c.Nodes(0), []int{1, 4}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Nodes(0)=%v, want %v", got, want)
+	}
+	if got, want := c.Nodes(2), []int{0, 2}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Nodes(2)=%v, want %v", got, want)
+	}
+	if got := c.Nodes(99); len(got) != 0 {
+		t.Errorf("Nodes(99) should be empty, got %v", got)
+	}
+	if got := c.Nodes(-1); len(got) != 0 {
+		t.Errorf("Nodes(-1) should be empty, got %v", got)
+	}
+}
+
+func TestClustering_Normalize(t *testing.T) {
+	c, _ := NewClusteringFromAssignment([]int{2, 5, 2, 5, 9})
+	c.Normalize()
+	if c.NumClusters() != 3 {
+		t.Errorf("NumClusters=%d, want 3", c.NumClusters())
+	}
+	// First-appearance order: 2→0, 5→1, 9→2.
+	want := []int{0, 1, 0, 1, 2}
+	got := c.Assignment()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Assignment=%v, want %v", got, want)
+	}
+}
+
+func TestClustering_MergeClusters(t *testing.T) {
+	c, _ := NewClusteringFromAssignment([]int{0, 1, 2, 1, 0})
+	if err := c.MergeClusters(0, 1); err != nil {
+		t.Fatal(err)
+	}
+	want := []int{0, 0, 2, 0, 0}
+	if got := c.Assignment(); !reflect.DeepEqual(got, want) {
+		t.Errorf("after merge: %v, want %v", got, want)
+	}
+	// NumClusters retains the upper bound until Normalize.
+	if c.NumClusters() != 3 {
+		t.Errorf("NumClusters=%d, want 3 (pre-normalize)", c.NumClusters())
+	}
+	c.Normalize()
+	if c.NumClusters() != 2 {
+		t.Errorf("NumClusters=%d, want 2 (post-normalize)", c.NumClusters())
+	}
+
+	if err := c.MergeClusters(-1, 0); !errors.Is(err, ErrNegativeClusterID) {
+		t.Errorf("got %v, want ErrNegativeClusterID", err)
+	}
+
+	// a == b is a no-op.
+	before := c.Assignment()
+	if err := c.MergeClusters(1, 1); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(c.Assignment(), before) {
+		t.Errorf("merging cluster with itself changed assignment")
+	}
+}
+
+func TestClustering_Clone_Independent(t *testing.T) {
+	a, _ := NewClusteringFromAssignment([]int{0, 1, 0, 1})
+	b := a.Clone()
+	if err := b.SetCluster(0, 2); err != nil {
+		t.Fatal(err)
+	}
+	if a.Cluster(0) != 0 {
+		t.Errorf("Clone is not independent: original mutated to %d", a.Cluster(0))
+	}
+	if b.Cluster(0) != 2 {
+		t.Errorf("Clone mutation failed: got %d", b.Cluster(0))
+	}
+}

--- a/leiden/compactnetwork.go
+++ b/leiden/compactnetwork.go
@@ -1,0 +1,191 @@
+package leiden
+
+import "fmt"
+
+// CompactNetwork is an immutable, compressed-sparse-row (CSR) representation
+// of a weighted, undirected graph.
+//
+// The structure is the working graph for the Leiden algorithm: it must be
+// cache-friendly to traverse and cheap to copy by reference. Once
+// constructed, no public method mutates its state.
+//
+// Storage layout:
+//
+//   - Each undirected edge (u, v) with u != v is stored as two directed
+//     entries: v in u's neighbor list and u in v's neighbor list, with the
+//     same weight.
+//   - A self-loop (u, u) is stored as exactly one entry in u's neighbor
+//     list with the edge's weight.
+//   - Neighbors of node i are stored contiguously in the range
+//     [firstNeighborIdx[i], firstNeighborIdx[i+1]).
+//
+// Node weights default to 1.0 when not supplied. Node strength — the sum of
+// weights of incident directed entries — is precomputed on construction.
+type CompactNetwork struct {
+	nNodes           int
+	nEdges           int
+	nodeWeights      []float64
+	nodeStrengths    []float64
+	firstNeighborIdx []int
+	neighbors        []int
+	neighborWeights  []float64
+	totalNodeWeight  float64
+	totalEdgeWeight  float64
+}
+
+// NewCompactNetwork builds a CompactNetwork over nNodes nodes from the given
+// undirected edge list. Each node defaults to unit weight.
+//
+// Returns an error if nNodes is non-positive, if any edge references a node
+// outside [0, nNodes), or if any edge weight is negative.
+//
+// Edges may include duplicate pairs and self-loops; duplicates are summed
+// implicitly because they each produce independent neighbor entries.
+func NewCompactNetwork(nNodes int, edges []Edge) (*CompactNetwork, error) {
+	return NewCompactNetworkWithNodeWeights(nNodes, nil, edges)
+}
+
+// NewCompactNetworkWithNodeWeights builds a CompactNetwork with explicit
+// per-node weights. If nodeWeights is nil, each node defaults to weight 1.0.
+//
+// Returns an error if nNodes is non-positive, if len(nodeWeights) does not
+// match nNodes when supplied, if any node weight is negative, if any edge
+// references an out-of-range node, or if any edge weight is negative.
+func NewCompactNetworkWithNodeWeights(nNodes int, nodeWeights []float64, edges []Edge) (*CompactNetwork, error) {
+	if nNodes <= 0 {
+		return nil, fmt.Errorf("%w: got %d", ErrInvalidNodeCount, nNodes)
+	}
+
+	weights := make([]float64, nNodes)
+	if nodeWeights == nil {
+		for i := range weights {
+			weights[i] = 1.0
+		}
+	} else {
+		if len(nodeWeights) != nNodes {
+			return nil, fmt.Errorf("%w: got %d, want %d", ErrNodeWeightsLength, len(nodeWeights), nNodes)
+		}
+		for i, w := range nodeWeights {
+			if w < 0 {
+				return nil, fmt.Errorf("%w: node %d weight %g", ErrNegativeNodeWeight, i, w)
+			}
+			weights[i] = w
+		}
+	}
+
+	totalNodeWeight := 0.0
+	for _, w := range weights {
+		totalNodeWeight += w
+	}
+
+	// Validate edges and compute degrees in one pass.
+	degree := make([]int, nNodes)
+	for i, e := range edges {
+		if e.From < 0 || e.From >= nNodes {
+			return nil, fmt.Errorf("%w: edge %d From=%d, nNodes=%d", ErrNodeOutOfRange, i, e.From, nNodes)
+		}
+		if e.To < 0 || e.To >= nNodes {
+			return nil, fmt.Errorf("%w: edge %d To=%d, nNodes=%d", ErrNodeOutOfRange, i, e.To, nNodes)
+		}
+		if e.Weight < 0 {
+			return nil, fmt.Errorf("%w: edge %d weight %g", ErrNegativeEdgeWeight, i, e.Weight)
+		}
+		degree[e.From]++
+		if e.From != e.To {
+			degree[e.To]++
+		}
+	}
+
+	// CSR offsets via prefix sum.
+	firstNeighborIdx := make([]int, nNodes+1)
+	for i := 0; i < nNodes; i++ {
+		firstNeighborIdx[i+1] = firstNeighborIdx[i] + degree[i]
+	}
+	totalEntries := firstNeighborIdx[nNodes]
+	neighbors := make([]int, totalEntries)
+	neighborWeights := make([]float64, totalEntries)
+
+	// Per-node write cursor reusing degree as the running offset.
+	cursor := make([]int, nNodes)
+	copy(cursor, firstNeighborIdx[:nNodes])
+
+	totalEdgeWeight := 0.0
+	for _, e := range edges {
+		neighbors[cursor[e.From]] = e.To
+		neighborWeights[cursor[e.From]] = e.Weight
+		cursor[e.From]++
+		if e.From != e.To {
+			neighbors[cursor[e.To]] = e.From
+			neighborWeights[cursor[e.To]] = e.Weight
+			cursor[e.To]++
+		}
+		totalEdgeWeight += e.Weight
+	}
+
+	strengths := make([]float64, nNodes)
+	for i := 0; i < nNodes; i++ {
+		s := 0.0
+		for j := firstNeighborIdx[i]; j < firstNeighborIdx[i+1]; j++ {
+			s += neighborWeights[j]
+		}
+		strengths[i] = s
+	}
+
+	return &CompactNetwork{
+		nNodes:           nNodes,
+		nEdges:           len(edges),
+		nodeWeights:      weights,
+		nodeStrengths:    strengths,
+		firstNeighborIdx: firstNeighborIdx,
+		neighbors:        neighbors,
+		neighborWeights:  neighborWeights,
+		totalNodeWeight:  totalNodeWeight,
+		totalEdgeWeight:  totalEdgeWeight,
+	}, nil
+}
+
+// NumNodes returns the number of nodes in the network.
+func (n *CompactNetwork) NumNodes() int { return n.nNodes }
+
+// NumEdges returns the number of input edges used to construct the network,
+// counting duplicate pairs and self-loops exactly once each.
+func (n *CompactNetwork) NumEdges() int { return n.nEdges }
+
+// NodeWeight returns the weight of the given node. The caller is responsible
+// for ensuring 0 <= node < NumNodes().
+func (n *CompactNetwork) NodeWeight(node int) float64 { return n.nodeWeights[node] }
+
+// NodeStrength returns the sum of incident edge weights for the given node,
+// computed from the neighbor list as stored (self-loops contribute once).
+func (n *CompactNetwork) NodeStrength(node int) float64 { return n.nodeStrengths[node] }
+
+// TotalNodeWeight returns the sum of all node weights.
+func (n *CompactNetwork) TotalNodeWeight() float64 { return n.totalNodeWeight }
+
+// TotalEdgeWeight returns the sum of all input edge weights, counting each
+// undirected edge once.
+func (n *CompactNetwork) TotalEdgeWeight() float64 { return n.totalEdgeWeight }
+
+// Degree returns the number of stored neighbor entries for the given node.
+// This counts each non-self-loop incident edge once and each incident
+// self-loop once.
+func (n *CompactNetwork) Degree(node int) int {
+	return n.firstNeighborIdx[node+1] - n.firstNeighborIdx[node]
+}
+
+// Neighbors returns the neighbor IDs of the given node as a slice view into
+// the network's internal storage. The returned slice MUST NOT be mutated;
+// it remains valid for the lifetime of the CompactNetwork.
+//
+// The slice is suitable for indexed iteration alongside [CompactNetwork.NeighborWeights]
+// for the same node.
+func (n *CompactNetwork) Neighbors(node int) []int {
+	return n.neighbors[n.firstNeighborIdx[node]:n.firstNeighborIdx[node+1]]
+}
+
+// NeighborWeights returns the per-edge weights for the given node's
+// neighbors, parallel to [CompactNetwork.Neighbors]. The returned slice MUST
+// NOT be mutated.
+func (n *CompactNetwork) NeighborWeights(node int) []float64 {
+	return n.neighborWeights[n.firstNeighborIdx[node]:n.firstNeighborIdx[node+1]]
+}

--- a/leiden/compactnetwork_test.go
+++ b/leiden/compactnetwork_test.go
@@ -1,0 +1,274 @@
+package leiden
+
+import (
+	"errors"
+	"math"
+	"sort"
+	"testing"
+)
+
+// neighborSet returns the (neighbor, weight) entries for a node sorted by
+// neighbor ID so tests can compare without depending on input edge order.
+func neighborSet(n *CompactNetwork, node int) []Edge {
+	nbrs := n.Neighbors(node)
+	weights := n.NeighborWeights(node)
+	out := make([]Edge, len(nbrs))
+	for i := range nbrs {
+		out[i] = Edge{From: node, To: nbrs[i], Weight: weights[i]}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].To < out[j].To })
+	return out
+}
+
+func mustNetwork(t *testing.T, nNodes int, edges []Edge) *CompactNetwork {
+	t.Helper()
+	n, err := NewCompactNetwork(nNodes, edges)
+	if err != nil {
+		t.Fatalf("NewCompactNetwork: %v", err)
+	}
+	return n
+}
+
+func TestNewCompactNetwork_Triangle(t *testing.T) {
+	edges := []Edge{
+		{From: 0, To: 1, Weight: 1},
+		{From: 1, To: 2, Weight: 1},
+		{From: 2, To: 0, Weight: 1},
+	}
+	n := mustNetwork(t, 3, edges)
+
+	if got, want := n.NumNodes(), 3; got != want {
+		t.Errorf("NumNodes=%d, want %d", got, want)
+	}
+	if got, want := n.NumEdges(), 3; got != want {
+		t.Errorf("NumEdges=%d, want %d", got, want)
+	}
+	if got, want := n.TotalEdgeWeight(), 3.0; got != want {
+		t.Errorf("TotalEdgeWeight=%g, want %g", got, want)
+	}
+	if got, want := n.TotalNodeWeight(), 3.0; got != want {
+		t.Errorf("TotalNodeWeight=%g, want %g", got, want)
+	}
+
+	for node := 0; node < 3; node++ {
+		if d := n.Degree(node); d != 2 {
+			t.Errorf("Degree(%d)=%d, want 2", node, d)
+		}
+		if s := n.NodeStrength(node); s != 2.0 {
+			t.Errorf("NodeStrength(%d)=%g, want 2", node, s)
+		}
+	}
+
+	want0 := []Edge{{From: 0, To: 1, Weight: 1}, {From: 0, To: 2, Weight: 1}}
+	got0 := neighborSet(n, 0)
+	if len(got0) != len(want0) {
+		t.Fatalf("node 0 neighbors len=%d, want %d", len(got0), len(want0))
+	}
+	for i := range want0 {
+		if got0[i] != want0[i] {
+			t.Errorf("node 0 neighbor %d: got %+v, want %+v", i, got0[i], want0[i])
+		}
+	}
+}
+
+func TestNewCompactNetwork_SelfLoop(t *testing.T) {
+	edges := []Edge{
+		{From: 0, To: 0, Weight: 2.5},
+		{From: 0, To: 1, Weight: 1.0},
+	}
+	n := mustNetwork(t, 2, edges)
+
+	if d := n.Degree(0); d != 2 {
+		t.Errorf("Degree(0)=%d, want 2 (self-loop + edge to 1)", d)
+	}
+	if d := n.Degree(1); d != 1 {
+		t.Errorf("Degree(1)=%d, want 1", d)
+	}
+	if got, want := n.NodeStrength(0), 3.5; got != want {
+		t.Errorf("NodeStrength(0)=%g, want %g", got, want)
+	}
+	if got, want := n.NodeStrength(1), 1.0; got != want {
+		t.Errorf("NodeStrength(1)=%g, want %g", got, want)
+	}
+	if got, want := n.TotalEdgeWeight(), 3.5; got != want {
+		t.Errorf("TotalEdgeWeight=%g, want %g", got, want)
+	}
+}
+
+func TestNewCompactNetwork_Isolated(t *testing.T) {
+	n := mustNetwork(t, 5, nil)
+	for i := 0; i < 5; i++ {
+		if d := n.Degree(i); d != 0 {
+			t.Errorf("Degree(%d)=%d, want 0", i, d)
+		}
+		if s := n.NodeStrength(i); s != 0 {
+			t.Errorf("NodeStrength(%d)=%g, want 0", i, s)
+		}
+		if w := n.NodeWeight(i); w != 1.0 {
+			t.Errorf("NodeWeight(%d)=%g, want default 1", i, w)
+		}
+	}
+	if n.TotalEdgeWeight() != 0 {
+		t.Errorf("TotalEdgeWeight=%g, want 0", n.TotalEdgeWeight())
+	}
+	if n.TotalNodeWeight() != 5 {
+		t.Errorf("TotalNodeWeight=%g, want 5", n.TotalNodeWeight())
+	}
+}
+
+func TestNewCompactNetwork_Duplicates(t *testing.T) {
+	edges := []Edge{
+		{From: 0, To: 1, Weight: 0.5},
+		{From: 0, To: 1, Weight: 0.25},
+	}
+	n := mustNetwork(t, 2, edges)
+
+	if got, want := n.NumEdges(), 2; got != want {
+		t.Errorf("NumEdges=%d, want %d", got, want)
+	}
+	if got, want := n.Degree(0), 2; got != want {
+		t.Errorf("Degree(0)=%d, want %d", got, want)
+	}
+	if got, want := n.NodeStrength(0), 0.75; math.Abs(got-want) > 1e-12 {
+		t.Errorf("NodeStrength(0)=%g, want %g", got, want)
+	}
+	if got, want := n.NodeStrength(1), 0.75; math.Abs(got-want) > 1e-12 {
+		t.Errorf("NodeStrength(1)=%g, want %g", got, want)
+	}
+}
+
+func TestNewCompactNetwork_CustomNodeWeights(t *testing.T) {
+	weights := []float64{0.5, 1.5, 3.0}
+	n, err := NewCompactNetworkWithNodeWeights(3, weights, []Edge{{From: 0, To: 1, Weight: 1}})
+	if err != nil {
+		t.Fatalf("ctor: %v", err)
+	}
+	for i, w := range weights {
+		if got := n.NodeWeight(i); got != w {
+			t.Errorf("NodeWeight(%d)=%g, want %g", i, got, w)
+		}
+	}
+	if n.TotalNodeWeight() != 5.0 {
+		t.Errorf("TotalNodeWeight=%g, want 5", n.TotalNodeWeight())
+	}
+}
+
+func TestNewCompactNetwork_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		nNodes  int
+		weights []float64
+		edges   []Edge
+		wantErr error
+	}{
+		{
+			name:    "zero nodes",
+			nNodes:  0,
+			wantErr: ErrInvalidNodeCount,
+		},
+		{
+			name:    "negative nodes",
+			nNodes:  -1,
+			wantErr: ErrInvalidNodeCount,
+		},
+		{
+			name:    "node weights length mismatch",
+			nNodes:  3,
+			weights: []float64{1, 1},
+			wantErr: ErrNodeWeightsLength,
+		},
+		{
+			name:    "negative node weight",
+			nNodes:  2,
+			weights: []float64{1, -0.5},
+			wantErr: ErrNegativeNodeWeight,
+		},
+		{
+			name:    "edge From out of range",
+			nNodes:  2,
+			edges:   []Edge{{From: 2, To: 1, Weight: 1}},
+			wantErr: ErrNodeOutOfRange,
+		},
+		{
+			name:    "edge To out of range",
+			nNodes:  2,
+			edges:   []Edge{{From: 0, To: -1, Weight: 1}},
+			wantErr: ErrNodeOutOfRange,
+		},
+		{
+			name:    "negative edge weight",
+			nNodes:  2,
+			edges:   []Edge{{From: 0, To: 1, Weight: -0.1}},
+			wantErr: ErrNegativeEdgeWeight,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewCompactNetworkWithNodeWeights(tt.nNodes, tt.weights, tt.edges)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err=%v, want errors.Is %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCompactNetwork_NeighborsAndWeights_LineGraph(t *testing.T) {
+	// Line: 0 - 1 - 2 - 3, weights 1, 2, 3.
+	edges := []Edge{
+		{From: 0, To: 1, Weight: 1},
+		{From: 1, To: 2, Weight: 2},
+		{From: 2, To: 3, Weight: 3},
+	}
+	n := mustNetwork(t, 4, edges)
+
+	if got, want := n.NodeStrength(1), 3.0; got != want {
+		t.Errorf("strength(1)=%g, want %g", got, want)
+	}
+	if got, want := n.NodeStrength(2), 5.0; got != want {
+		t.Errorf("strength(2)=%g, want %g", got, want)
+	}
+	want3 := []Edge{{From: 3, To: 2, Weight: 3}}
+	got3 := neighborSet(n, 3)
+	if len(got3) != 1 || got3[0] != want3[0] {
+		t.Errorf("node 3 neighbors=%+v, want %+v", got3, want3)
+	}
+}
+
+func BenchmarkNewCompactNetwork_Ring1k(b *testing.B) {
+	const n = 1000
+	edges := make([]Edge, n)
+	for i := 0; i < n; i++ {
+		edges[i] = Edge{From: i, To: (i + 1) % n, Weight: 1}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := NewCompactNetwork(n, edges); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func FuzzNewCompactNetwork(f *testing.F) {
+	f.Add(4, []byte{0, 1, 1, 2, 2, 3})
+	f.Fuzz(func(t *testing.T, nNodes int, raw []byte) {
+		if nNodes <= 0 || nNodes > 64 {
+			return
+		}
+		edges := make([]Edge, 0, len(raw)/2)
+		for i := 0; i+1 < len(raw); i += 2 {
+			from := int(raw[i]) % nNodes
+			to := int(raw[i+1]) % nNodes
+			edges = append(edges, Edge{From: from, To: to, Weight: 1})
+		}
+		n, err := NewCompactNetwork(nNodes, edges)
+		if err != nil {
+			t.Fatalf("unexpected error on valid input: %v", err)
+		}
+		if n.NumNodes() != nNodes {
+			t.Fatalf("nNodes mismatch")
+		}
+		if n.NumEdges() != len(edges) {
+			t.Fatalf("nEdges mismatch")
+		}
+	})
+}

--- a/leiden/doc.go
+++ b/leiden/doc.go
@@ -1,0 +1,18 @@
+// Package leiden provides a pure-Go implementation of the Leiden algorithm for
+// community detection in weighted, undirected graphs.
+//
+// The Leiden algorithm (Traag, Waltman, van Eck, 2019) refines the Louvain
+// method to guarantee well-connected communities. This package targets the
+// same primitives as the reference implementation in networkanalysis-java
+// (CWTS) and leidenalg (Python), while remaining idiomatic Go with zero
+// external dependencies.
+//
+// The core data structures are:
+//
+//   - [Edge]: an undirected, weighted edge used as input.
+//   - [CompactNetwork]: an immutable CSR-style representation of the graph.
+//   - [Clustering]: a partition of nodes into clusters.
+//
+// Higher-level entry points (the algorithm itself, options, results) are
+// introduced in later milestones and are not part of this milestone.
+package leiden

--- a/leiden/edge.go
+++ b/leiden/edge.go
@@ -1,0 +1,17 @@
+package leiden
+
+// Edge is a weighted, undirected edge between two nodes identified by
+// zero-based integer IDs.
+//
+// Edges are treated as undirected by [CompactNetwork]: the pair (From, To)
+// is equivalent to (To, From). Self-loops (From == To) are permitted and
+// contribute twice their Weight to the incident node's strength, matching
+// the convention used by the Leiden reference implementation.
+//
+// Weight must be non-negative; negative weights are rejected when
+// constructing a [CompactNetwork].
+type Edge struct {
+	From   int
+	To     int
+	Weight float64
+}

--- a/leiden/edge_test.go
+++ b/leiden/edge_test.go
@@ -1,0 +1,17 @@
+package leiden
+
+import "testing"
+
+func TestEdgeZeroValue(t *testing.T) {
+	var e Edge
+	if e.From != 0 || e.To != 0 || e.Weight != 0 {
+		t.Fatalf("zero Edge should be {0,0,0}, got %+v", e)
+	}
+}
+
+func TestEdgeLiteral(t *testing.T) {
+	e := Edge{From: 1, To: 2, Weight: 0.5}
+	if e.From != 1 || e.To != 2 || e.Weight != 0.5 {
+		t.Fatalf("literal mismatch: %+v", e)
+	}
+}

--- a/leiden/errors.go
+++ b/leiden/errors.go
@@ -1,0 +1,32 @@
+package leiden
+
+import "errors"
+
+// Errors returned by constructors in this package. Callers compare with
+// [errors.Is] rather than string matching.
+var (
+	// ErrInvalidNodeCount is returned when a non-positive node count is supplied.
+	ErrInvalidNodeCount = errors.New("leiden: node count must be positive")
+
+	// ErrNodeOutOfRange is returned when an edge or assignment references a
+	// node ID outside [0, nNodes).
+	ErrNodeOutOfRange = errors.New("leiden: node id out of range")
+
+	// ErrNegativeEdgeWeight is returned when an edge weight is negative.
+	ErrNegativeEdgeWeight = errors.New("leiden: edge weight must be non-negative")
+
+	// ErrNegativeNodeWeight is returned when a node weight is negative.
+	ErrNegativeNodeWeight = errors.New("leiden: node weight must be non-negative")
+
+	// ErrNodeWeightsLength is returned when the node-weights slice length does
+	// not match the declared node count.
+	ErrNodeWeightsLength = errors.New("leiden: node weights length does not match node count")
+
+	// ErrAssignmentLength is returned when a cluster assignment slice length
+	// does not match the declared node count.
+	ErrAssignmentLength = errors.New("leiden: assignment length does not match node count")
+
+	// ErrNegativeClusterID is returned when a cluster assignment contains a
+	// negative cluster ID.
+	ErrNegativeClusterID = errors.New("leiden: cluster id must be non-negative")
+)

--- a/leiden/go.mod
+++ b/leiden/go.mod
@@ -1,0 +1,3 @@
+module github.com/k8nstantin/leiden
+
+go 1.22

--- a/leiden/localmove.go
+++ b/leiden/localmove.go
@@ -1,0 +1,111 @@
+package leiden
+
+import "math/rand"
+
+// runLocalMove performs the Louvain-style local-moving phase: nodes are
+// visited in shuffled order, and each is greedily reassigned to the
+// neighbouring cluster offering the largest positive Δquality. When a node
+// moves, its still-pending neighbours are re-enqueued. The loop terminates
+// when the queue is drained — i.e. every node has been visited at least once
+// since its last move and chose not to move.
+//
+// cl is mutated in place; its node-to-cluster assignments are updated but
+// NumClusters never grows (local-move never creates new clusters).
+//
+// Returns the total number of moves performed.
+//
+// Pre-conditions:
+//   - cl.NumNodes() == net.NumNodes()
+//   - cl.NumClusters() correctly covers all cluster IDs that appear in the
+//     assignment (the standard invariant of [NewClusteringFromAssignment]).
+//
+// rng is used only to shuffle the initial visit order; passing
+// rand.New(rand.NewSource(seed)) gives deterministic runs.
+func runLocalMove(net *CompactNetwork, cl *Clustering, q qualityFunction, rng *rand.Rand) int {
+	n := net.nNodes
+	if n == 0 {
+		return 0
+	}
+
+	clusterMass := make([]float64, cl.nClusters)
+	for u := 0; u < n; u++ {
+		clusterMass[cl.assignment[u]] += q.nodeMass(net, u)
+	}
+
+	// Circular FIFO of pending nodes. inQueue dedups so the queue never
+	// exceeds n elements.
+	qbuf := make([]int, n)
+	inQueue := make([]bool, n)
+	perm := rng.Perm(n)
+	copy(qbuf, perm)
+	for _, p := range perm {
+		inQueue[p] = true
+	}
+	head, qsize := 0, n
+
+	// Workspace map: edge weight from u to each neighbouring cluster, keyed
+	// by cluster ID. Reset per node by deletion (cheaper than reallocating
+	// for sparse touches).
+	edgeToCluster := make(map[int]float64)
+
+	moves := 0
+	for qsize > 0 {
+		u := qbuf[head]
+		head = (head + 1) % n
+		qsize--
+		inQueue[u] = false
+
+		for k := range edgeToCluster {
+			delete(edgeToCluster, k)
+		}
+		nbrs := net.Neighbors(u)
+		ws := net.NeighborWeights(u)
+		for i, v := range nbrs {
+			if v == u {
+				continue
+			}
+			edgeToCluster[cl.assignment[v]] += ws[i]
+		}
+
+		curr := cl.assignment[u]
+		wToCurr := edgeToCluster[curr]
+
+		bestCluster := curr
+		bestDelta := 0.0
+		for c, wToC := range edgeToCluster {
+			if c == curr {
+				continue
+			}
+			d := q.moveDelta(net, u, curr, c, wToCurr, wToC, clusterMass)
+			if d > bestDelta {
+				bestDelta = d
+				bestCluster = c
+			}
+		}
+		if bestCluster == curr {
+			continue
+		}
+
+		mu := q.nodeMass(net, u)
+		clusterMass[curr] -= mu
+		clusterMass[bestCluster] += mu
+		cl.assignment[u] = bestCluster
+		moves++
+
+		// Re-enqueue not-already-queued neighbours that are not already in
+		// the new cluster: their best-move evaluation may have changed.
+		for _, v := range nbrs {
+			if v == u || inQueue[v] {
+				continue
+			}
+			if cl.assignment[v] == bestCluster {
+				continue
+			}
+			tail := (head + qsize) % n
+			qbuf[tail] = v
+			qsize++
+			inQueue[v] = true
+		}
+	}
+	return moves
+}

--- a/leiden/localmove_test.go
+++ b/leiden/localmove_test.go
@@ -1,0 +1,129 @@
+package leiden
+
+import (
+	"math/rand"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// clusterMembership returns a sorted slice of cluster IDs and a sorted member
+// list per cluster, so a partition can be compared up to renaming of cluster
+// IDs.
+func clusterMembership(cl *Clustering) [][]int {
+	cl.Normalize()
+	out := make([][]int, cl.NumClusters())
+	for u := 0; u < cl.NumNodes(); u++ {
+		out[cl.Cluster(u)] = append(out[cl.Cluster(u)], u)
+	}
+	for _, m := range out {
+		sort.Ints(m)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if len(out[i]) == 0 || len(out[j]) == 0 {
+			return len(out[i]) < len(out[j])
+		}
+		return out[i][0] < out[j][0]
+	})
+	return out
+}
+
+func TestLocalMove_EmptyNetwork_NoCrash(t *testing.T) {
+	net := mustNetwork(t, 1, nil)
+	cl, _ := NewSingletonClustering(1)
+	q := cpmQuality{Gamma: 0.1}
+	moves := runLocalMove(net, cl, q, rand.New(rand.NewSource(1)))
+	if moves != 0 {
+		t.Errorf("moves=%d, want 0", moves)
+	}
+}
+
+func TestLocalMove_NoBeneficialMove_StaysPut(t *testing.T) {
+	// Two isolated nodes. Starting from singletons: any merge has Δ = 0 − γ·1·1 < 0
+	// (no edge weight). So no moves.
+	net := mustNetwork(t, 2, nil)
+	cl, _ := NewSingletonClustering(2)
+	q := cpmQuality{Gamma: 1.0}
+	moves := runLocalMove(net, cl, q, rand.New(rand.NewSource(1)))
+	if moves != 0 {
+		t.Errorf("moves=%d, want 0", moves)
+	}
+	if cl.Cluster(0) == cl.Cluster(1) {
+		t.Errorf("isolated nodes merged unexpectedly")
+	}
+}
+
+func TestLocalMove_TwoCliquesBridge_SeparatesClusters(t *testing.T) {
+	// Two 4-cliques connected by a single bridge edge. With γ = 0.5, internal
+	// edges (weight 1) inside each clique dominate the penalty, and the bridge
+	// is too weak to glue them together.
+	var edges []Edge
+	for i := 0; i < 4; i++ {
+		for j := i + 1; j < 4; j++ {
+			edges = append(edges, Edge{From: i, To: j, Weight: 1})
+		}
+	}
+	for i := 4; i < 8; i++ {
+		for j := i + 1; j < 8; j++ {
+			edges = append(edges, Edge{From: i, To: j, Weight: 1})
+		}
+	}
+	edges = append(edges, Edge{From: 3, To: 4, Weight: 1}) // bridge
+	net := mustNetwork(t, 8, edges)
+	cl, _ := NewSingletonClustering(8)
+	q := cpmQuality{Gamma: 0.5}
+	rng := rand.New(rand.NewSource(42))
+
+	if moves := runLocalMove(net, cl, q, rng); moves == 0 {
+		t.Fatalf("expected moves; got 0")
+	}
+
+	want := [][]int{{0, 1, 2, 3}, {4, 5, 6, 7}}
+	got := clusterMembership(cl)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("partition = %v, want %v", got, want)
+	}
+}
+
+func TestLocalMove_MonotoneImprovement(t *testing.T) {
+	// On any non-trivial graph, the local-moving phase must never decrease
+	// quality. Use a 6-node graph and a seed-deterministic run.
+	edges := []Edge{
+		{0, 1, 1}, {1, 2, 1}, {0, 2, 1},
+		{3, 4, 1}, {4, 5, 1}, {3, 5, 1},
+		{2, 3, 0.2},
+	}
+	net := mustNetwork(t, 6, edges)
+	cl, _ := NewSingletonClustering(6)
+	q := cpmQuality{Gamma: 0.3}
+	before := q.value(net, cl)
+
+	runLocalMove(net, cl, q, rand.New(rand.NewSource(7)))
+
+	after := q.value(net, cl)
+	if after+floatTol < before {
+		t.Errorf("quality decreased: before=%g, after=%g", before, after)
+	}
+}
+
+func TestLocalMove_DeterministicWithSeed(t *testing.T) {
+	edges := []Edge{
+		{0, 1, 1}, {1, 2, 1}, {0, 2, 1},
+		{3, 4, 1}, {4, 5, 1}, {3, 5, 1},
+		{2, 3, 0.2},
+	}
+	net := mustNetwork(t, 6, edges)
+	q := cpmQuality{Gamma: 0.3}
+
+	run := func(seed int64) []int {
+		cl, _ := NewSingletonClustering(6)
+		runLocalMove(net, cl, q, rand.New(rand.NewSource(seed)))
+		cl.Normalize()
+		return cl.Assignment()
+	}
+	a := run(123)
+	b := run(123)
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("non-deterministic: %v vs %v", a, b)
+	}
+}

--- a/leiden/quality.go
+++ b/leiden/quality.go
@@ -1,0 +1,108 @@
+package leiden
+
+// qualityFunction abstracts the optimisation objective used by the Leiden
+// algorithm phases. Implementations evaluate the absolute quality of a
+// clustering on a network and the change in quality for a proposed single-node
+// move.
+//
+// Positive deltas are improvements; the algorithm only commits moves with
+// delta > 0.
+//
+// All implementations must produce the same value invariant under
+// aggregation: the quality of a partition on the original network equals the
+// quality of the corresponding partition on the aggregated network produced
+// by [aggregateNetwork].
+type qualityFunction interface {
+	// value returns H(P) for clustering cl over net.
+	value(net *CompactNetwork, cl *Clustering) float64
+
+	// moveDelta returns ΔH for moving node u from cluster `from` to cluster
+	// `to`, given precomputed:
+	//
+	//   wToFrom = Σ_{v ∈ from, v ≠ u} A_uv   (edges from u to other from-members)
+	//   wToTo   = Σ_{v ∈ to}          A_uv   (edges from u to to-members; u ∉ to)
+	//
+	// clusterMass[c] is the total nodeMass currently assigned to cluster c,
+	// with u still in `from`. Implementations must not retain references to
+	// clusterMass.
+	moveDelta(net *CompactNetwork, u, from, to int, wToFrom, wToTo float64, clusterMass []float64) float64
+
+	// nodeMass returns the contribution of node u to its cluster's mass for
+	// this quality function. The local-move and refinement phases maintain
+	// clusterMass as the running sum of nodeMass per cluster.
+	nodeMass(net *CompactNetwork, u int) float64
+
+	// resolution returns the γ parameter, used by the refinement phase to
+	// gate well-connectedness of singletons and candidate sub-clusters.
+	resolution() float64
+}
+
+// cpmQuality is the Constant Potts Model (CPM) quality function recommended
+// by Traag et al. for Leiden:
+//
+//	H(P) = Σ_c [ e_c − (γ/2) · w_c² ]
+//
+// where e_c is the total weight of edges with both endpoints in cluster c
+// (each undirected edge counted once; self-loops counted once), and w_c is
+// the sum of node weights in c.
+//
+// γ is the resolution parameter: larger γ favours smaller clusters. The
+// formula is invariant under [aggregateNetwork], so iteration across
+// coarsening levels preserves quality.
+type cpmQuality struct {
+	Gamma float64
+}
+
+func (q cpmQuality) value(net *CompactNetwork, cl *Clustering) float64 {
+	var internal float64
+	for u := 0; u < net.nNodes; u++ {
+		cu := cl.assignment[u]
+		nbrs := net.Neighbors(u)
+		ws := net.NeighborWeights(u)
+		for i, v := range nbrs {
+			if cl.assignment[v] != cu {
+				continue
+			}
+			// Each non-self edge is stored twice in CSR (u→v and v→u); halve
+			// to count once. Self-loops are stored once and counted as-is.
+			if v == u {
+				internal += ws[i]
+			} else {
+				internal += ws[i] / 2.0
+			}
+		}
+	}
+	masses := make([]float64, cl.nClusters)
+	for u := 0; u < net.nNodes; u++ {
+		masses[cl.assignment[u]] += net.nodeWeights[u]
+	}
+	var penalty float64
+	for _, w := range masses {
+		penalty += w * w
+	}
+	return internal - q.Gamma*penalty/2.0
+}
+
+func (q cpmQuality) moveDelta(net *CompactNetwork, u, from, to int, wToFrom, wToTo float64, clusterMass []float64) float64 {
+	if from == to {
+		return 0
+	}
+	wu := net.nodeWeights[u]
+	// Edge term: each side of the inequality counts non-self-loop weights once
+	// (the caller's accumulator is over the directed CSR entries from u, so
+	// the self-loop is excluded by construction and cancels between from/to).
+	deltaEdge := wToTo - wToFrom
+	// Penalty term: Δ(w_from² + w_to²) = 2·w_u·(w_to − w_from + w_u),
+	// scaled by γ/2 gives γ·w_u·(w_to − w_from + w_u). clusterMass[from]
+	// still includes u, clusterMass[to] does not.
+	deltaPenalty := q.Gamma * wu * (clusterMass[to] - clusterMass[from] + wu)
+	return deltaEdge - deltaPenalty
+}
+
+func (q cpmQuality) nodeMass(net *CompactNetwork, u int) float64 {
+	return net.nodeWeights[u]
+}
+
+func (q cpmQuality) resolution() float64 {
+	return q.Gamma
+}

--- a/leiden/quality_test.go
+++ b/leiden/quality_test.go
@@ -1,0 +1,131 @@
+package leiden
+
+import (
+	"math"
+	"testing"
+)
+
+const floatTol = 1e-9
+
+func floatEq(a, b float64) bool {
+	return math.Abs(a-b) <= floatTol
+}
+
+func TestCPMQuality_AllSingletons_NoEdges(t *testing.T) {
+	// 5 isolated nodes, all singletons: e_c = 0, w_c = 1 for each cluster.
+	// H = 0 − γ/2 · 5·1² = −2.5γ
+	net := mustNetwork(t, 5, nil)
+	cl, _ := NewSingletonClustering(5)
+	q := cpmQuality{Gamma: 1.0}
+	got := q.value(net, cl)
+	want := -2.5
+	if !floatEq(got, want) {
+		t.Errorf("value=%g, want %g", got, want)
+	}
+}
+
+func TestCPMQuality_TriangleOneCluster(t *testing.T) {
+	// Triangle 0-1-2 with unit edges; all in one cluster.
+	// e_c = 3, w_c = 3. H = 3 − γ/2 · 9 = 3 − 4.5γ.
+	edges := []Edge{
+		{From: 0, To: 1, Weight: 1},
+		{From: 1, To: 2, Weight: 1},
+		{From: 0, To: 2, Weight: 1},
+	}
+	net := mustNetwork(t, 3, edges)
+	cl, _ := NewClustering(3)
+	for gamma, want := range map[float64]float64{
+		0.0: 3.0,
+		0.5: 0.75,
+		1.0: -1.5,
+	} {
+		q := cpmQuality{Gamma: gamma}
+		got := q.value(net, cl)
+		if !floatEq(got, want) {
+			t.Errorf("γ=%g: value=%g, want %g", gamma, got, want)
+		}
+	}
+}
+
+func TestCPMQuality_SelfLoopCountedOnce(t *testing.T) {
+	// Single node with self-loop w=2.0; one cluster.
+	// e_c = 2.0, w_c = 1. H = 2 − γ/2 = 2 − 0.5γ.
+	net := mustNetwork(t, 1, []Edge{{From: 0, To: 0, Weight: 2.0}})
+	cl, _ := NewClustering(1)
+	q := cpmQuality{Gamma: 1.0}
+	got := q.value(net, cl)
+	want := 1.5
+	if !floatEq(got, want) {
+		t.Errorf("value=%g, want %g", got, want)
+	}
+}
+
+func TestCPMQuality_MoveDeltaMatchesRecompute(t *testing.T) {
+	// Move-delta must equal H(after) - H(before) for any valid move.
+	// Use a 6-node graph with two triangles connected by a single edge.
+	edges := []Edge{
+		{0, 1, 1}, {1, 2, 1}, {0, 2, 1}, // triangle A
+		{3, 4, 1}, {4, 5, 1}, {3, 5, 1}, // triangle B
+		{2, 3, 1}, // bridge
+	}
+	net := mustNetwork(t, 6, edges)
+
+	// Start with two natural clusters: {0,1,2}=0, {3,4,5}=1.
+	cl, _ := NewClusteringFromAssignment([]int{0, 0, 0, 1, 1, 1})
+	q := cpmQuality{Gamma: 0.4}
+
+	before := q.value(net, cl)
+
+	// Compute the helpers required by moveDelta: edges from node 2 to each cluster.
+	u := 2
+	wToFrom := 0.0
+	wToTo := 0.0
+	for i, v := range net.Neighbors(u) {
+		if v == u {
+			continue
+		}
+		w := net.NeighborWeights(u)[i]
+		switch cl.Cluster(v) {
+		case 0:
+			wToFrom += w
+		case 1:
+			wToTo += w
+		}
+	}
+	clusterMass := []float64{3, 3}
+	delta := q.moveDelta(net, u, 0, 1, wToFrom, wToTo, clusterMass)
+
+	// Apply move and recompute.
+	_ = cl.SetCluster(u, 1)
+	after := q.value(net, cl)
+
+	if !floatEq(delta, after-before) {
+		t.Errorf("moveDelta=%g, recomputed=%g", delta, after-before)
+	}
+}
+
+func TestCPMQuality_MoveDeltaSelfTargetZero(t *testing.T) {
+	net := mustNetwork(t, 2, []Edge{{0, 1, 1}})
+	q := cpmQuality{Gamma: 1.0}
+	cm := []float64{1, 1}
+	if d := q.moveDelta(net, 0, 0, 0, 0, 0, cm); d != 0 {
+		t.Errorf("moveDelta(from==to)=%g, want 0", d)
+	}
+}
+
+func TestCPMQuality_NodeMassReturnsNodeWeight(t *testing.T) {
+	net, _ := NewCompactNetworkWithNodeWeights(3, []float64{0.5, 1.0, 2.0}, nil)
+	q := cpmQuality{Gamma: 1.0}
+	for i, want := range []float64{0.5, 1.0, 2.0} {
+		if got := q.nodeMass(net, i); got != want {
+			t.Errorf("nodeMass(%d)=%g, want %g", i, got, want)
+		}
+	}
+}
+
+func TestCPMQuality_ResolutionGetter(t *testing.T) {
+	q := cpmQuality{Gamma: 0.37}
+	if got := q.resolution(); got != 0.37 {
+		t.Errorf("resolution=%g, want 0.37", got)
+	}
+}

--- a/leiden/refinement.go
+++ b/leiden/refinement.go
@@ -1,0 +1,191 @@
+package leiden
+
+import (
+	"math"
+	"math/rand"
+)
+
+// runRefinement performs the Leiden refinement phase on the partition
+// produced by [runLocalMove].
+//
+// The refinement starts from singletons (each node in its own R-cluster)
+// and only merges singleton nodes into existing R-clusters; established
+// R-clusters are never split or relocated. A merge is gated by two
+// well-connectedness conditions (per Traag, Waltman & van Eck, 2019):
+//
+//  1. The singleton u must be well-connected to its parent P-cluster:
+//
+//     Σ_{v ∈ P(u), v ≠ u} A_uv  ≥  γ · w_u · (w_{P(u)} − w_u)
+//
+//  2. The candidate R-cluster t (within the same P-cluster) must itself be
+//     well-connected to the rest of the P-cluster:
+//
+//     Σ_{x ∈ t, y ∈ P(u)\t} A_xy  ≥  γ · w_t · (w_{P(u)} − w_t)
+//
+// Only candidates with ΔH > 0 are considered. Selection among them is
+// controlled by theta:
+//
+//   - theta ≤ 0 : deterministic argmax over ΔH.
+//   - theta > 0 : sample with probability ∝ exp(ΔH / theta) (Traag-style
+//     refinement randomisation; smaller theta sharpens toward argmax).
+//
+// Returns a freshly allocated refined [Clustering]. parent is not mutated.
+//
+// rng is used both to shuffle the visit order and to sample candidates when
+// theta > 0; deterministic seeding yields deterministic output.
+func runRefinement(net *CompactNetwork, parent *Clustering, q qualityFunction, theta float64, rng *rand.Rand) *Clustering {
+	n := net.nNodes
+	gamma := q.resolution()
+
+	// rAssign[u] is u's current R-cluster ID. We use the node ID itself as
+	// the initial singleton ID so an R-cluster has a stable representative
+	// even after dissolution (the singleton key is never reused).
+	rAssign := make([]int, n)
+	for i := range rAssign {
+		rAssign[i] = i
+	}
+
+	// Per-R-cluster mass and external-to-parent-cluster weight.
+	rMass := make([]float64, n)
+	rExt := make([]float64, n)
+
+	// Per-parent-cluster total mass.
+	pMass := make([]float64, parent.nClusters)
+
+	// Per-node weight of edges to other members of the same parent cluster.
+	extToP := make([]float64, n)
+
+	for u := 0; u < n; u++ {
+		m := q.nodeMass(net, u)
+		rMass[u] = m
+		pMass[parent.assignment[u]] += m
+	}
+	for u := 0; u < n; u++ {
+		nbrs := net.Neighbors(u)
+		ws := net.NeighborWeights(u)
+		pu := parent.assignment[u]
+		for i, v := range nbrs {
+			if v == u {
+				continue
+			}
+			if parent.assignment[v] == pu {
+				extToP[u] += ws[i]
+			}
+		}
+		// Singleton: external-to-parent equals the node's parent-internal
+		// neighbour weight.
+		rExt[u] = extToP[u]
+	}
+
+	// Workspace, reused across iterations.
+	edgeToR := make(map[int]float64)
+	var candidates []cand
+
+	perm := rng.Perm(n)
+	for _, u := range perm {
+		// Established (non-singleton) R-clusters are frozen.
+		if rAssign[u] != u {
+			continue
+		}
+		wu := q.nodeMass(net, u)
+		pu := parent.assignment[u]
+		if extToP[u] < gamma*wu*(pMass[pu]-wu) {
+			continue
+		}
+
+		for k := range edgeToR {
+			delete(edgeToR, k)
+		}
+		nbrs := net.Neighbors(u)
+		ws := net.NeighborWeights(u)
+		for i, v := range nbrs {
+			if v == u || parent.assignment[v] != pu {
+				continue
+			}
+			edgeToR[rAssign[v]] += ws[i]
+		}
+
+		candidates = candidates[:0]
+		for t, wToT := range edgeToR {
+			if t == u {
+				continue
+			}
+			if rExt[t] < gamma*rMass[t]*(pMass[pu]-rMass[t]) {
+				continue
+			}
+			// CPM ΔH for merging singleton {u} into R-cluster t (sizes are:
+			// wFrom = wu, wTo = rMass[t], wToFrom = 0):
+			//   ΔH = wToT − γ · wu · rMass[t]
+			d := wToT - gamma*wu*rMass[t]
+			if d <= 0 {
+				continue
+			}
+			candidates = append(candidates, cand{id: t, delta: d, wToT: wToT})
+		}
+		if len(candidates) == 0 {
+			continue
+		}
+
+		var pick cand
+		if theta <= 0 {
+			pick = candidates[0]
+			for _, c := range candidates[1:] {
+				if c.delta > pick.delta {
+					pick = c
+				}
+			}
+		} else {
+			pick = sampleByExp(candidates, theta, rng)
+		}
+
+		rAssign[u] = pick.id
+		rMass[pick.id] += wu
+		rMass[u] = 0
+		// Δ rExt[t] = extToP[u] − 2·wToT : u's edges to nodes in P\t become
+		// either internal-to-t (the wToT going-to-t edges) or external-to-t
+		// from t's perspective (now that u ∈ t). The 2× accounts for the
+		// fact that the wToT edges were also previously counted in t's
+		// external weight from t's side.
+		rExt[pick.id] += extToP[u] - 2*pick.wToT
+		rExt[u] = 0
+	}
+
+	cl, _ := NewClusteringFromAssignment(rAssign)
+	return cl
+}
+
+// sampleByExp picks a candidate with probability proportional to
+// exp(delta / theta), using max-shift for numerical stability so very large
+// deltas don't overflow exp.
+func sampleByExp(cs []cand, theta float64, rng *rand.Rand) cand {
+	maxD := cs[0].delta
+	for _, c := range cs[1:] {
+		if c.delta > maxD {
+			maxD = c.delta
+		}
+	}
+	weights := make([]float64, len(cs))
+	var sum float64
+	for i, c := range cs {
+		weights[i] = math.Exp((c.delta - maxD) / theta)
+		sum += weights[i]
+	}
+	target := rng.Float64() * sum
+	var acc float64
+	for i, c := range cs {
+		acc += weights[i]
+		if target <= acc {
+			return c
+		}
+	}
+	return cs[len(cs)-1]
+}
+
+// cand is the unit of choice for refinement; declared at package scope so
+// sampleByExp can take it by slice without redeclaring the type inside the
+// runRefinement closure.
+type cand struct {
+	id    int
+	delta float64
+	wToT  float64
+}

--- a/leiden/refinement_test.go
+++ b/leiden/refinement_test.go
@@ -1,0 +1,127 @@
+package leiden
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestRefinement_RespectsParentClusterBoundaries(t *testing.T) {
+	// 8-node graph: two cliques bridged once. Parent puts everything in one
+	// cluster; refinement must split the bridge (since the two cliques aren't
+	// well-connected to a combined 8-cluster at γ = 0.5) and never produce a
+	// refined cluster spanning both halves.
+	var edges []Edge
+	for i := 0; i < 4; i++ {
+		for j := i + 1; j < 4; j++ {
+			edges = append(edges, Edge{From: i, To: j, Weight: 1})
+		}
+	}
+	for i := 4; i < 8; i++ {
+		for j := i + 1; j < 8; j++ {
+			edges = append(edges, Edge{From: i, To: j, Weight: 1})
+		}
+	}
+	edges = append(edges, Edge{From: 3, To: 4, Weight: 1})
+	net := mustNetwork(t, 8, edges)
+
+	// Parent: everyone in one cluster.
+	parent, _ := NewClustering(8)
+	q := cpmQuality{Gamma: 0.5}
+	refined := runRefinement(net, parent, q, 0, rand.New(rand.NewSource(1)))
+
+	// Every refined cluster's members must share a parent cluster ID. Parent
+	// is single-cluster so this is trivially true; check the stronger
+	// property that two nodes in different parent clusters never end up in
+	// the same refined cluster, using a mixed parent.
+	parent2, _ := NewClusteringFromAssignment([]int{0, 0, 0, 0, 1, 1, 1, 1})
+	refined2 := runRefinement(net, parent2, q, 0, rand.New(rand.NewSource(1)))
+	for u := 0; u < net.NumNodes(); u++ {
+		for v := 0; v < net.NumNodes(); v++ {
+			if refined2.Cluster(u) == refined2.Cluster(v) && parent2.Cluster(u) != parent2.Cluster(v) {
+				t.Errorf("refined cluster crosses parent boundary: u=%d v=%d", u, v)
+			}
+		}
+	}
+	_ = refined
+}
+
+func TestRefinement_AllSingletonsOnIsolatedNodes(t *testing.T) {
+	// No edges at all → no node can be well-connected to its parent cluster.
+	// Refinement must leave everyone in their singleton.
+	net := mustNetwork(t, 5, nil)
+	parent, _ := NewClustering(5)
+	q := cpmQuality{Gamma: 0.1}
+	refined := runRefinement(net, parent, q, 0, rand.New(rand.NewSource(2)))
+	refined.Normalize()
+	if refined.NumClusters() != 5 {
+		t.Errorf("NumClusters=%d, want 5", refined.NumClusters())
+	}
+}
+
+func TestRefinement_NeverDecreasesQuality(t *testing.T) {
+	edges := []Edge{
+		{0, 1, 1}, {1, 2, 1}, {0, 2, 1},
+		{3, 4, 1}, {4, 5, 1}, {3, 5, 1},
+		{2, 3, 0.2},
+	}
+	net := mustNetwork(t, 6, edges)
+	parent, _ := NewClusteringFromAssignment([]int{0, 0, 0, 1, 1, 1})
+	q := cpmQuality{Gamma: 0.3}
+
+	// Singleton baseline quality is the floor refinement must beat or match.
+	singletons, _ := NewSingletonClustering(6)
+	baseline := q.value(net, singletons)
+
+	refined := runRefinement(net, parent, q, 0, rand.New(rand.NewSource(3)))
+	got := q.value(net, refined)
+	if got+floatTol < baseline {
+		t.Errorf("refinement quality %g below singleton baseline %g", got, baseline)
+	}
+}
+
+func TestRefinement_DeterministicWithSeed(t *testing.T) {
+	edges := []Edge{
+		{0, 1, 1}, {1, 2, 1}, {0, 2, 1},
+		{3, 4, 1}, {4, 5, 1}, {3, 5, 1},
+		{2, 3, 1},
+	}
+	net := mustNetwork(t, 6, edges)
+	parent, _ := NewClustering(6)
+	q := cpmQuality{Gamma: 0.3}
+
+	run := func(seed int64) []int {
+		r := runRefinement(net, parent, q, 0, rand.New(rand.NewSource(seed)))
+		r.Normalize()
+		return r.Assignment()
+	}
+	a := run(99)
+	b := run(99)
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("non-deterministic refinement: %v vs %v", a, b)
+		}
+	}
+}
+
+func TestRefinement_ThetaRandomizationConsumesRNG(t *testing.T) {
+	// With theta > 0 and multiple positive candidates, the picker should
+	// consult the RNG; two distinct seeds must be able to diverge. Set up
+	// a star-ish graph where node 0 sees two equally-attractive candidate
+	// clusters.
+	edges := []Edge{
+		{1, 2, 1}, {1, 3, 1}, {2, 3, 1}, // R-cluster candidate A: {1,2,3}
+		{4, 5, 1}, {4, 6, 1}, {5, 6, 1}, // R-cluster candidate B: {4,5,6}
+		{0, 1, 1}, {0, 2, 1}, {0, 4, 1}, {0, 5, 1}, // 0 connects to both
+	}
+	net := mustNetwork(t, 7, edges)
+	parent, _ := NewClustering(7)
+	q := cpmQuality{Gamma: 0.01}
+
+	// We can't guarantee divergence (the picker may still hit the same
+	// candidate), but we can verify the function runs and produces a valid
+	// partition under theta > 0.
+	r := runRefinement(net, parent, q, 0.5, rand.New(rand.NewSource(11)))
+	if r.NumNodes() != 7 {
+		t.Errorf("NumNodes=%d, want 7", r.NumNodes())
+	}
+}


### PR DESCRIPTION
## Summary
- Implements the three core Leiden phases against the M1 data structures:
  - `runLocalMove` — Louvain-style greedy single-node moves with CWTS FIFO requeue.
  - `runRefinement` — well-connectedness-gated singleton merges; deterministic argmax (theta = 0) or Boltzmann sampling (theta > 0).
  - `aggregateNetwork` — coarsens the network into one node per refined cluster, preserving CPM quality across the level transition.
- Adds the `cpmQuality` quality function (CPM with resolution γ) shared by the three phases.
- All new code lives in the `leiden/` library module; zero external dependencies (stdlib only).
- Phase symbols are unexported on purpose — the public `Run/Options/Result` API lands in later milestones per the design doc.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` passes (M1 tests + 27 new M2 tests)
- [x] CPM `moveDelta` matches recomputed `H(after) − H(before)`
- [x] Local-move separates planted two-clique-with-bridge graph at γ = 0.5
- [x] Local-move quality monotonically non-decreasing; deterministic with fixed seed
- [x] Refinement never crosses parent-cluster boundaries
- [x] Aggregation preserves CPM quality (identity refinement and subdivided refinement) and total edge weight
- [x] End-to-end integration test composes all three phases and confirms quality is preserved across the level transition