### PR TITLE
fix: hierarchy renderer skips archived and closed entities

### DIFF
--- a/internal/web/handlers_entity.go
+++ b/internal/web/handlers_entity.go
@@ -825,6 +825,13 @@ func buildHierarchy(r *http.Request, n *node.Node, entityID string, depth int) *
 		if err != nil || child == nil {
 			continue
 		}
+		// Skip archived and closed entities from the rendered hierarchy.
+		// They remain in the database (SCD-2 history) but are not part of the
+		// live tree. Status filtering is data-driven: the entities table is
+		// the source of truth for what is currently live; the renderer respects it.
+		if child.Status == "archived" || child.Status == "closed" {
+			continue
+		}
 		sub := buildHierarchy(r, n, child.EntityUID, depth+1)
 		if sub == nil {
 			continue


### PR DESCRIPTION
## Why

buildHierarchy walks outgoing owns edges generically (since PR #413) but did not filter destination entities by status. Archived and closed entities continued to appear in product hierarchy views (e.g. archived legacy manifests rendering alongside their replacements).

## What

Adds a status filter inside the recursion: children with `status='archived'` or `status='closed'` are skipped. They remain in the SCD-2 history; they are not part of the live tree.

## Validation

go-graphify product and OpenPraxis API redesign product should both render only live (non-archived, non-closed) descendants after this lands.