### PR TITLE
feat: per-run output replay + per-entity Stats tab

### DIFF
--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -485,6 +485,7 @@ func mountAPI(api *mux.Router, deps ServerDeps) {
 	api.HandleFunc("/entities", apiEntityCreate(n)).Methods("POST")
 	api.HandleFunc("/entities/{id}/history", apiEntityHistory(n)).Methods("GET")
 	api.HandleFunc("/entities/{id}/runs", apiEntityExecutionLog(n)).Methods("GET")
+	api.HandleFunc("/entities/{id}/stats", apiEntityStatsHistory(n)).Methods("GET")
 	api.HandleFunc("/entities/{id}/actions", apiEntityActions(n)).Methods("GET")
 	api.HandleFunc("/entities/{id}/turn-timeline", apiTurnTimeline(n)).Methods("GET")
 	api.HandleFunc("/entities/{id}/turn-tools", apiTurnTools(n)).Methods("GET")

--- a/internal/web/handlers_entity.go
+++ b/internal/web/handlers_entity.go
@@ -865,16 +865,26 @@ func apiEntityActions(n *node.Node) http.HandlerFunc {
 			}
 		}
 
-		// If run_uid provided, filter to actions created at/after run start.
+		// If run_uid provided, filter actions to the run's time window:
+		//   [started_at, terminal_at]   for completed/failed/cancelled runs
+		//   [started_at, ∞)              for in-flight runs (no terminal row yet)
+		// Without the upper bound, expanding an older completed run would
+		// surface actions from every later run of the same task.
 		runUID := r.URL.Query().Get("run_uid")
-		var sinceTime string
+		var sinceTime, untilTime string
 		if runUID != "" && n.ExecutionLog != nil {
 			rows, err := n.ExecutionLog.ListByRun(ctx, runUID)
 			if err == nil {
 				for _, row := range rows {
-					if row.Event == "started" {
-						sinceTime = row.CreatedAt
-						break
+					switch row.Event {
+					case "started":
+						if sinceTime == "" {
+							sinceTime = row.CreatedAt
+						}
+					case "completed", "failed", "cancelled":
+						if row.CreatedAt > untilTime {
+							untilTime = row.CreatedAt
+						}
 					}
 				}
 			}
@@ -890,13 +900,17 @@ func apiEntityActions(n *node.Node) http.HandlerFunc {
 			return
 		}
 
-		// Filter by run start time when run_uid was specified.
-		if sinceTime != "" {
+		if sinceTime != "" || untilTime != "" {
 			filtered := actions[:0]
 			for _, a := range actions {
-				if a.CreatedAt.Format("2006-01-02T15:04:05Z07:00") >= sinceTime {
-					filtered = append(filtered, a)
+				ts := a.CreatedAt.Format("2006-01-02T15:04:05Z07:00")
+				if sinceTime != "" && ts < sinceTime {
+					continue
 				}
+				if untilTime != "" && ts > untilTime {
+					continue
+				}
+				filtered = append(filtered, a)
 			}
 			actions = filtered
 		}

--- a/internal/web/handlers_stats_history.go
+++ b/internal/web/handlers_stats_history.go
@@ -1,10 +1,14 @@
 package web
 
 import (
+	"context"
+	"database/sql"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/k8nstantin/OpenPraxis/internal/node"
+	"github.com/k8nstantin/OpenPraxis/internal/relationships"
 )
 
 // statsHistory is the full history payload for GET /api/stats/history.
@@ -20,10 +24,10 @@ type statsHistory struct {
 	// Daily code productivity
 	Productivity []dayProductivityBucket `json:"productivity"`
 	// Model/agent distribution (all time totals)
-	Models        []labelCount `json:"models"`
-	Agents        []labelCount `json:"agents"`
+	Models          []labelCount `json:"models"`
+	Agents          []labelCount `json:"agents"`
 	TerminalReasons []labelCount `json:"terminal_reasons"`
-	TriggerSplit  []labelCount `json:"trigger_split"`
+	TriggerSplit    []labelCount `json:"trigger_split"`
 	// Tool call breakdown from tool_calls_json aggregated (all time)
 	TopTools []labelCount `json:"top_tools"`
 	// Daily system averages (from system_host_samples)
@@ -33,34 +37,34 @@ type statsHistory struct {
 }
 
 type daySystemBucket struct {
-	Day             string  `json:"day"`
-	AvgCPUPct       float64 `json:"avg_cpu_pct"`
-	AvgNetRxMbps    float64 `json:"avg_net_rx_mbps"`
-	AvgNetTxMbps    float64 `json:"avg_net_tx_mbps"`
-	AvgDiskReadMBps float64 `json:"avg_disk_read_mbps"`
+	Day              string  `json:"day"`
+	AvgCPUPct        float64 `json:"avg_cpu_pct"`
+	AvgNetRxMbps     float64 `json:"avg_net_rx_mbps"`
+	AvgNetTxMbps     float64 `json:"avg_net_tx_mbps"`
+	AvgDiskReadMBps  float64 `json:"avg_disk_read_mbps"`
 	AvgDiskWriteMBps float64 `json:"avg_disk_write_mbps"`
 }
 
 type dayRunBucket struct {
-	Day        string  `json:"day"`
-	Completed  int     `json:"completed"`
-	Failed     int     `json:"failed"`
-	AvgDurSec  float64 `json:"avg_dur_sec"`
-	MaxDurSec  float64 `json:"max_dur_sec"`
-	AvgRunNum  float64 `json:"avg_run_number"` // retry indicator
+	Day       string  `json:"day"`
+	Completed int     `json:"completed"`
+	Failed    int     `json:"failed"`
+	AvgDurSec float64 `json:"avg_dur_sec"`
+	MaxDurSec float64 `json:"max_dur_sec"`
+	AvgRunNum float64 `json:"avg_run_number"` // retry indicator
 }
 
 type dayEfficiencyBucket struct {
-	Day              string  `json:"day"`
-	AvgTurns         float64 `json:"avg_turns"`
-	AvgActions       float64 `json:"avg_actions"`
+	Day               string  `json:"day"`
+	AvgTurns          float64 `json:"avg_turns"`
+	AvgActions        float64 `json:"avg_actions"`
 	AvgActionsPerTurn float64 `json:"avg_actions_per_turn"`
-	AvgContextPct    float64 `json:"avg_context_pct"`
-	AvgTokensPerTurn float64 `json:"avg_tokens_per_turn"`
-	AvgCacheHitPct   float64 `json:"avg_cache_hit_pct"`
-	TotalCompactions int64   `json:"total_compactions"`
-	TotalErrors      int64   `json:"total_errors"`
-	AvgTTFBMs        float64 `json:"avg_ttfb_ms"`
+	AvgContextPct     float64 `json:"avg_context_pct"`
+	AvgTokensPerTurn  float64 `json:"avg_tokens_per_turn"`
+	AvgCacheHitPct    float64 `json:"avg_cache_hit_pct"`
+	TotalCompactions  int64   `json:"total_compactions"`
+	TotalErrors       int64   `json:"total_errors"`
+	AvgTTFBMs         float64 `json:"avg_ttfb_ms"`
 }
 
 type dayTokenBucket struct {
@@ -91,27 +95,263 @@ type labelCount struct {
 }
 
 type statsTotals struct {
-	TotalRuns        int     `json:"total_runs"`
-	TotalFailed      int     `json:"total_failed"`
-	TotalTurns       int64   `json:"total_turns"`
-	TotalActions     int64   `json:"total_actions"`
-	TotalCompactions int64   `json:"total_compactions"`
-	TotalErrors      int64   `json:"total_errors"`
-	TotalInputTok    int64   `json:"total_input_tokens"`
-	TotalOutputTok   int64   `json:"total_output_tokens"`
-	TotalCacheRead   int64   `json:"total_cache_read_tokens"`
-	TotalCacheCreate int64   `json:"total_cache_create_tokens"`
-	TotalLinesAdded  int64   `json:"total_lines_added"`
-	TotalLinesRemoved int64  `json:"total_lines_removed"`
-	TotalFilesChanged int64  `json:"total_files_changed"`
-	TotalCommits     int64   `json:"total_commits"`
-	TotalTestsRun    int64   `json:"total_tests_run"`
-	TotalTestsPassed int64   `json:"total_tests_passed"`
-	TotalTestsFailed int64   `json:"total_tests_failed"`
-	AvgCacheHitPct   float64 `json:"avg_cache_hit_pct"`
-	AvgTurns         float64 `json:"avg_turns"`
-	AvgDurSec        float64 `json:"avg_dur_sec"`
-	AvgContextPct    float64 `json:"avg_context_pct"`
+	TotalRuns         int     `json:"total_runs"`
+	TotalFailed       int     `json:"total_failed"`
+	TotalTurns        int64   `json:"total_turns"`
+	TotalActions      int64   `json:"total_actions"`
+	TotalCompactions  int64   `json:"total_compactions"`
+	TotalErrors       int64   `json:"total_errors"`
+	TotalInputTok     int64   `json:"total_input_tokens"`
+	TotalOutputTok    int64   `json:"total_output_tokens"`
+	TotalCacheRead    int64   `json:"total_cache_read_tokens"`
+	TotalCacheCreate  int64   `json:"total_cache_create_tokens"`
+	TotalLinesAdded   int64   `json:"total_lines_added"`
+	TotalLinesRemoved int64   `json:"total_lines_removed"`
+	TotalFilesChanged int64   `json:"total_files_changed"`
+	TotalCommits      int64   `json:"total_commits"`
+	TotalTestsRun     int64   `json:"total_tests_run"`
+	TotalTestsPassed  int64   `json:"total_tests_passed"`
+	TotalTestsFailed  int64   `json:"total_tests_failed"`
+	AvgCacheHitPct    float64 `json:"avg_cache_hit_pct"`
+	AvgTurns          float64 `json:"avg_turns"`
+	AvgDurSec         float64 `json:"avg_dur_sec"`
+	AvgContextPct     float64 `json:"avg_context_pct"`
+}
+
+// buildStatsWhereClause builds the WHERE fragment + arg slice for the given
+// scope. since is the days-back filter (empty for all time). entityUIDs, when
+// non-nil, restricts to rows where entity_uid IN (...). For the system sample
+// query (event='sample'), pass terminalEvents=false; otherwise true.
+func buildStatsWhereClause(since string, entityUIDs []string, terminalEvents bool) (string, []any) {
+	var clauses []string
+	var args []any
+
+	if terminalEvents {
+		clauses = append(clauses, "event IN ('completed','failed')")
+	} else {
+		clauses = append(clauses, "event = 'sample'")
+	}
+
+	if since != "" {
+		if terminalEvents {
+			clauses = append(clauses, "(CASE WHEN started_at>0 THEN datetime(started_at/1000,'unixepoch') ELSE created_at END) >= datetime('now', '-"+since+" days')")
+		} else {
+			clauses = append(clauses, "date(created_at) >= date('now', '-"+since+" days')")
+		}
+	}
+
+	if entityUIDs != nil {
+		if len(entityUIDs) == 0 {
+			// Empty allow-list — match nothing.
+			clauses = append(clauses, "1=0")
+		} else {
+			placeholders := make([]string, len(entityUIDs))
+			for i, uid := range entityUIDs {
+				placeholders[i] = "?"
+				args = append(args, uid)
+			}
+			clauses = append(clauses, "entity_uid IN ("+strings.Join(placeholders, ",")+")")
+		}
+	}
+
+	return strings.Join(clauses, " AND "), args
+}
+
+// computeStatsHistory runs every aggregation query for the given scope and
+// returns the assembled statsHistory. entityUIDs=nil means "global" (no entity
+// filter); entityUIDs=[]string{} means "explicit empty set, return zeros."
+func computeStatsHistory(ctx context.Context, db *sql.DB, since string, entityUIDs []string) statsHistory {
+	var h statsHistory
+	whereClause, args := buildStatsWhereClause(since, entityUIDs, true)
+
+	// ── Daily run activity ─────────────────────────────────────────────
+	if rows, err := db.QueryContext(ctx, `
+		SELECT date(datetime(CASE WHEN started_at>0 THEN started_at/1000 ELSE strftime('%s', created_at) END, 'unixepoch')) as day,
+		       SUM(CASE WHEN event='completed' THEN 1 ELSE 0 END),
+		       SUM(CASE WHEN event='failed' THEN 1 ELSE 0 END),
+		       COALESCE(AVG(CASE WHEN duration_ms>0 THEN duration_ms/1000.0 END),0),
+		       COALESCE(MAX(duration_ms)/1000.0,0),
+		       COALESCE(AVG(CASE WHEN run_number>0 THEN run_number END),0)
+		FROM execution_log WHERE `+whereClause+`
+		GROUP BY day ORDER BY day ASC`, args...); err == nil {
+		defer rows.Close()
+		for rows.Next() {
+			var b dayRunBucket
+			rows.Scan(&b.Day, &b.Completed, &b.Failed, &b.AvgDurSec, &b.MaxDurSec, &b.AvgRunNum)
+			h.Runs = append(h.Runs, b)
+		}
+	}
+
+	// ── Daily efficiency ───────────────────────────────────────────────
+	if rows, err := db.QueryContext(ctx, `
+		SELECT date(datetime(CASE WHEN started_at>0 THEN started_at/1000 ELSE strftime('%s', created_at) END, 'unixepoch')) as day,
+		       COALESCE(SUM(turns),0),
+		       COALESCE(SUM(actions),0),
+		       COALESCE(AVG(CASE WHEN turns>0 AND actions>0 THEN CAST(actions AS REAL)/turns END),0),
+		       COALESCE(AVG(CASE WHEN context_window_pct>0 THEN context_window_pct END),0),
+		       COALESCE(AVG(CASE WHEN tokens_per_turn>0 THEN tokens_per_turn END),0),
+		       COALESCE(AVG(CASE WHEN cache_hit_rate_pct>0 THEN cache_hit_rate_pct END),0),
+		       COALESCE(SUM(compactions),0),
+		       COALESCE(SUM(errors),0),
+		       COALESCE(AVG(CASE WHEN ttfb_ms>0 THEN ttfb_ms END),0)
+		FROM execution_log WHERE `+whereClause+`
+		GROUP BY day ORDER BY day ASC`, args...); err == nil {
+		defer rows.Close()
+		for rows.Next() {
+			var b dayEfficiencyBucket
+			rows.Scan(&b.Day, &b.AvgTurns, &b.AvgActions, &b.AvgActionsPerTurn,
+				&b.AvgContextPct, &b.AvgTokensPerTurn, &b.AvgCacheHitPct,
+				&b.TotalCompactions, &b.TotalErrors, &b.AvgTTFBMs)
+			h.Efficiency = append(h.Efficiency, b)
+		}
+	}
+
+	// ── Daily tokens ───────────────────────────────────────────────────
+	if rows, err := db.QueryContext(ctx, `
+		SELECT date(datetime(CASE WHEN started_at>0 THEN started_at/1000 ELSE strftime('%s', created_at) END, 'unixepoch')) as day,
+		       COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
+		       COALESCE(SUM(cache_read_tokens),0), COALESCE(SUM(cache_create_tokens),0),
+		       COALESCE(SUM(reasoning_tokens),0), COALESCE(SUM(tool_use_tokens),0)
+		FROM execution_log WHERE `+whereClause+`
+		GROUP BY day ORDER BY day ASC`, args...); err == nil {
+		defer rows.Close()
+		for rows.Next() {
+			var b dayTokenBucket
+			rows.Scan(&b.Day, &b.InputTokens, &b.OutputTokens,
+				&b.CacheReadTokens, &b.CacheCreateTokens,
+				&b.ReasoningTokens, &b.ToolUseTokens)
+			h.Tokens = append(h.Tokens, b)
+		}
+	}
+
+	// ── Daily productivity ─────────────────────────────────────────────
+	if rows, err := db.QueryContext(ctx, `
+		SELECT date(datetime(CASE WHEN started_at>0 THEN started_at/1000 ELSE strftime('%s', created_at) END, 'unixepoch')) as day,
+		       COALESCE(SUM(lines_added),0), COALESCE(SUM(lines_removed),0),
+		       COALESCE(SUM(files_changed),0), COALESCE(SUM(commits),0),
+		       COALESCE(SUM(tests_run),0), COALESCE(SUM(tests_passed),0),
+		       COALESCE(SUM(tests_failed),0),
+		       COUNT(DISTINCT CASE WHEN pr_number>0 THEN pr_number END)
+		FROM execution_log WHERE `+whereClause+`
+		GROUP BY day ORDER BY day ASC`, args...); err == nil {
+		defer rows.Close()
+		for rows.Next() {
+			var b dayProductivityBucket
+			rows.Scan(&b.Day, &b.LinesAdded, &b.LinesRemoved, &b.FilesChanged, &b.Commits,
+				&b.TestsRun, &b.TestsPassed, &b.TestsFailed, &b.PRsOpened)
+			h.Productivity = append(h.Productivity, b)
+		}
+	}
+
+	// ── Models ─────────────────────────────────────────────────────────
+	if rows, _ := db.QueryContext(ctx, `
+		SELECT COALESCE(NULLIF(model,''),'unknown') as label, COUNT(*) as cnt
+		FROM execution_log WHERE `+whereClause+` GROUP BY label ORDER BY cnt DESC`, args...); rows != nil {
+		defer rows.Close()
+		for rows.Next() {
+			var lc labelCount
+			rows.Scan(&lc.Label, &lc.Count)
+			h.Models = append(h.Models, lc)
+		}
+	}
+
+	// ── Agent runtimes ─────────────────────────────────────────────────
+	if rows, _ := db.QueryContext(ctx, `
+		SELECT COALESCE(NULLIF(agent_runtime,''),'unknown') as label, COUNT(*) as cnt
+		FROM execution_log WHERE `+whereClause+` GROUP BY label ORDER BY cnt DESC`, args...); rows != nil {
+		defer rows.Close()
+		for rows.Next() {
+			var lc labelCount
+			rows.Scan(&lc.Label, &lc.Count)
+			h.Agents = append(h.Agents, lc)
+		}
+	}
+
+	// ── Terminal reasons ───────────────────────────────────────────────
+	if rows, _ := db.QueryContext(ctx, `
+		SELECT COALESCE(NULLIF(terminal_reason,''),'success') as label, COUNT(*) as cnt
+		FROM execution_log WHERE `+whereClause+` GROUP BY label ORDER BY cnt DESC`, args...); rows != nil {
+		defer rows.Close()
+		for rows.Next() {
+			var lc labelCount
+			rows.Scan(&lc.Label, &lc.Count)
+			h.TerminalReasons = append(h.TerminalReasons, lc)
+		}
+	}
+
+	// ── Trigger split ──────────────────────────────────────────────────
+	if rows, _ := db.QueryContext(ctx, `
+		SELECT COALESCE(NULLIF(trigger,''),'unknown') as label, COUNT(*) as cnt
+		FROM execution_log WHERE `+whereClause+` GROUP BY label ORDER BY cnt DESC`, args...); rows != nil {
+		defer rows.Close()
+		for rows.Next() {
+			var lc labelCount
+			rows.Scan(&lc.Label, &lc.Count)
+			h.TriggerSplit = append(h.TriggerSplit, lc)
+		}
+	}
+
+	// ── Totals ─────────────────────────────────────────────────────────
+	db.QueryRowContext(ctx, `
+		SELECT
+		  SUM(CASE WHEN event='completed' THEN 1 ELSE 0 END),
+		  SUM(CASE WHEN event='failed' THEN 1 ELSE 0 END),
+		  COALESCE(SUM(turns),0), COALESCE(SUM(actions),0),
+		  COALESCE(SUM(compactions),0), COALESCE(SUM(errors),0),
+		  COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
+		  COALESCE(SUM(cache_read_tokens),0), COALESCE(SUM(cache_create_tokens),0),
+		  COALESCE(SUM(lines_added),0), COALESCE(SUM(lines_removed),0),
+		  COALESCE(SUM(files_changed),0), COALESCE(SUM(commits),0),
+		  COALESCE(SUM(tests_run),0), COALESCE(SUM(tests_passed),0), COALESCE(SUM(tests_failed),0),
+		  COALESCE(AVG(CASE WHEN cache_hit_rate_pct>0 THEN cache_hit_rate_pct END),0),
+		  COALESCE(AVG(CASE WHEN turns>0 THEN turns END),0),
+		  COALESCE(AVG(CASE WHEN duration_ms>0 THEN duration_ms/1000.0 END),0),
+		  COALESCE(AVG(CASE WHEN context_window_pct>0 THEN context_window_pct END),0)
+		FROM execution_log WHERE `+whereClause, args...).
+		Scan(&h.Totals.TotalRuns, &h.Totals.TotalFailed,
+			&h.Totals.TotalTurns, &h.Totals.TotalActions,
+			&h.Totals.TotalCompactions, &h.Totals.TotalErrors,
+			&h.Totals.TotalInputTok, &h.Totals.TotalOutputTok,
+			&h.Totals.TotalCacheRead, &h.Totals.TotalCacheCreate,
+			&h.Totals.TotalLinesAdded, &h.Totals.TotalLinesRemoved,
+			&h.Totals.TotalFilesChanged, &h.Totals.TotalCommits,
+			&h.Totals.TotalTestsRun, &h.Totals.TotalTestsPassed, &h.Totals.TotalTestsFailed,
+			&h.Totals.AvgCacheHitPct, &h.Totals.AvgTurns,
+			&h.Totals.AvgDurSec, &h.Totals.AvgContextPct)
+
+	// ── Daily system averages ─────────────────────────────────────────
+	// Source: execution_log sample rows (system_host_samples was dropped
+	// in commit 79a8ca5). System samples are not entity-scoped, so when
+	// an entity filter is in effect we skip this series entirely.
+	if entityUIDs == nil {
+		sysWhere, sysArgs := buildStatsWhereClause(since, nil, false)
+		if rows, _ := db.QueryContext(ctx, `
+			SELECT date(created_at) as day,
+			       AVG(cpu_pct), AVG(net_rx_mbps), AVG(net_tx_mbps),
+			       AVG(disk_read_mbps), AVG(disk_write_mbps)
+			FROM execution_log WHERE `+sysWhere+`
+			GROUP BY day ORDER BY day ASC`, sysArgs...); rows != nil {
+			defer rows.Close()
+			for rows.Next() {
+				var b daySystemBucket
+				if rows.Scan(&b.Day, &b.AvgCPUPct, &b.AvgNetRxMbps, &b.AvgNetTxMbps,
+					&b.AvgDiskReadMBps, &b.AvgDiskWriteMBps) == nil {
+					h.SystemDaily = append(h.SystemDaily, b)
+				}
+			}
+		}
+	}
+
+	return h
+}
+
+func parseSinceDays(r *http.Request) string {
+	if d := r.URL.Query().Get("days"); d != "" {
+		if days, err := strconv.Atoi(d); err == nil && days > 0 {
+			return strconv.Itoa(days)
+		}
+	}
+	return ""
 }
 
 // apiStatsHistory handles GET /api/stats/history?days=90
@@ -119,209 +359,75 @@ type statsTotals struct {
 // so operators see the full picture from day one.
 func apiStatsHistory(n *node.Node) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var since string
-		if d := r.URL.Query().Get("days"); d != "" {
-			if days, err := strconv.Atoi(d); err == nil && days > 0 {
-				since = strconv.Itoa(days)
-			}
-		}
-		// Use started_at (real run timestamp) for date filtering when available.
-		// Fall back to created_at for rows without started_at.
-		whereClause := "event IN ('completed','failed')"
-		if since != "" {
-			whereClause += " AND (CASE WHEN started_at>0 THEN datetime(started_at/1000,'unixepoch') ELSE created_at END) >= datetime('now', '-" + since + " days')"
-		}
-
-		var h statsHistory
-		db := n.DB()
-
-		// ── Daily run activity ─────────────────────────────────────────────
-		rows, err := db.QueryContext(r.Context(), `
-			SELECT date(datetime(CASE WHEN started_at>0 THEN started_at/1000 ELSE strftime('%s', created_at) END, 'unixepoch')) as day,
-			       SUM(CASE WHEN event='completed' THEN 1 ELSE 0 END),
-			       SUM(CASE WHEN event='failed' THEN 1 ELSE 0 END),
-			       COALESCE(AVG(CASE WHEN duration_ms>0 THEN duration_ms/1000.0 END),0),
-			       COALESCE(MAX(duration_ms)/1000.0,0),
-			       COALESCE(AVG(CASE WHEN run_number>0 THEN run_number END),0)
-			FROM execution_log WHERE `+whereClause+`
-			GROUP BY day ORDER BY day ASC`)
-		if err == nil {
-			defer rows.Close()
-			for rows.Next() {
-				var b dayRunBucket
-				rows.Scan(&b.Day, &b.Completed, &b.Failed, &b.AvgDurSec, &b.MaxDurSec, &b.AvgRunNum)
-				h.Runs = append(h.Runs, b)
-			}
-		}
-
-		// ── Daily efficiency ───────────────────────────────────────────────
-		rows2, err := db.QueryContext(r.Context(), `
-			SELECT date(datetime(CASE WHEN started_at>0 THEN started_at/1000 ELSE strftime('%s', created_at) END, 'unixepoch')) as day,
-			       COALESCE(SUM(turns),0),
-			       COALESCE(SUM(actions),0),
-			       COALESCE(AVG(CASE WHEN turns>0 AND actions>0 THEN CAST(actions AS REAL)/turns END),0),
-			       COALESCE(AVG(CASE WHEN context_window_pct>0 THEN context_window_pct END),0),
-			       COALESCE(AVG(CASE WHEN tokens_per_turn>0 THEN tokens_per_turn END),0),
-			       COALESCE(AVG(CASE WHEN cache_hit_rate_pct>0 THEN cache_hit_rate_pct END),0),
-			       COALESCE(SUM(compactions),0),
-			       COALESCE(SUM(errors),0),
-			       COALESCE(AVG(CASE WHEN ttfb_ms>0 THEN ttfb_ms END),0)
-			FROM execution_log WHERE `+whereClause+`
-			GROUP BY day ORDER BY day ASC`)
-		if err == nil {
-			defer rows2.Close()
-			for rows2.Next() {
-				var b dayEfficiencyBucket
-				rows2.Scan(&b.Day, &b.AvgTurns, &b.AvgActions, &b.AvgActionsPerTurn,
-					&b.AvgContextPct, &b.AvgTokensPerTurn, &b.AvgCacheHitPct,
-					&b.TotalCompactions, &b.TotalErrors, &b.AvgTTFBMs)
-				h.Efficiency = append(h.Efficiency, b)
-			}
-		}
-
-		// ── Daily tokens ───────────────────────────────────────────────────
-		rows3, err := db.QueryContext(r.Context(), `
-			SELECT date(datetime(CASE WHEN started_at>0 THEN started_at/1000 ELSE strftime('%s', created_at) END, 'unixepoch')) as day,
-			       COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
-			       COALESCE(SUM(cache_read_tokens),0), COALESCE(SUM(cache_create_tokens),0),
-			       COALESCE(SUM(reasoning_tokens),0), COALESCE(SUM(tool_use_tokens),0)
-			FROM execution_log WHERE `+whereClause+`
-			GROUP BY day ORDER BY day ASC`)
-		if err == nil {
-			defer rows3.Close()
-			for rows3.Next() {
-				var b dayTokenBucket
-				rows3.Scan(&b.Day, &b.InputTokens, &b.OutputTokens,
-					&b.CacheReadTokens, &b.CacheCreateTokens,
-					&b.ReasoningTokens, &b.ToolUseTokens)
-				h.Tokens = append(h.Tokens, b)
-			}
-		}
-
-		// ── Daily productivity ─────────────────────────────────────────────
-		rows4, err := db.QueryContext(r.Context(), `
-			SELECT date(datetime(CASE WHEN started_at>0 THEN started_at/1000 ELSE strftime('%s', created_at) END, 'unixepoch')) as day,
-			       COALESCE(SUM(lines_added),0), COALESCE(SUM(lines_removed),0),
-			       COALESCE(SUM(files_changed),0), COALESCE(SUM(commits),0),
-			       COALESCE(SUM(tests_run),0), COALESCE(SUM(tests_passed),0),
-			       COALESCE(SUM(tests_failed),0),
-			       COUNT(DISTINCT CASE WHEN pr_number>0 THEN pr_number END)
-			FROM execution_log WHERE `+whereClause+`
-			GROUP BY day ORDER BY day ASC`)
-		if err == nil {
-			defer rows4.Close()
-			for rows4.Next() {
-				var b dayProductivityBucket
-				rows4.Scan(&b.Day, &b.LinesAdded, &b.LinesRemoved, &b.FilesChanged, &b.Commits,
-					&b.TestsRun, &b.TestsPassed, &b.TestsFailed, &b.PRsOpened)
-				h.Productivity = append(h.Productivity, b)
-			}
-		}
-
-		// ── Models ─────────────────────────────────────────────────────────
-		rows5, _ := db.QueryContext(r.Context(), `
-			SELECT COALESCE(NULLIF(model,''),'unknown') as label, COUNT(*) as cnt
-			FROM execution_log WHERE `+whereClause+` GROUP BY label ORDER BY cnt DESC`)
-		if rows5 != nil {
-			defer rows5.Close()
-			for rows5.Next() {
-				var lc labelCount
-				rows5.Scan(&lc.Label, &lc.Count)
-				h.Models = append(h.Models, lc)
-			}
-		}
-
-		// ── Agent runtimes ─────────────────────────────────────────────────
-		rows6, _ := db.QueryContext(r.Context(), `
-			SELECT COALESCE(NULLIF(agent_runtime,''),'unknown') as label, COUNT(*) as cnt
-			FROM execution_log WHERE `+whereClause+` GROUP BY label ORDER BY cnt DESC`)
-		if rows6 != nil {
-			defer rows6.Close()
-			for rows6.Next() {
-				var lc labelCount
-				rows6.Scan(&lc.Label, &lc.Count)
-				h.Agents = append(h.Agents, lc)
-			}
-		}
-
-		// ── Terminal reasons ───────────────────────────────────────────────
-		rows7, _ := db.QueryContext(r.Context(), `
-			SELECT COALESCE(NULLIF(terminal_reason,''),'success') as label, COUNT(*) as cnt
-			FROM execution_log WHERE `+whereClause+` GROUP BY label ORDER BY cnt DESC`)
-		if rows7 != nil {
-			defer rows7.Close()
-			for rows7.Next() {
-				var lc labelCount
-				rows7.Scan(&lc.Label, &lc.Count)
-				h.TerminalReasons = append(h.TerminalReasons, lc)
-			}
-		}
-
-		// ── Trigger split ──────────────────────────────────────────────────
-		rows8, _ := db.QueryContext(r.Context(), `
-			SELECT COALESCE(NULLIF(trigger,''),'unknown') as label, COUNT(*) as cnt
-			FROM execution_log WHERE `+whereClause+` GROUP BY label ORDER BY cnt DESC`)
-		if rows8 != nil {
-			defer rows8.Close()
-			for rows8.Next() {
-				var lc labelCount
-				rows8.Scan(&lc.Label, &lc.Count)
-				h.TriggerSplit = append(h.TriggerSplit, lc)
-			}
-		}
-
-		// ── Totals ─────────────────────────────────────────────────────────
-		db.QueryRowContext(r.Context(), `
-			SELECT
-			  SUM(CASE WHEN event='completed' THEN 1 ELSE 0 END),
-			  SUM(CASE WHEN event='failed' THEN 1 ELSE 0 END),
-			  COALESCE(SUM(turns),0), COALESCE(SUM(actions),0),
-			  COALESCE(SUM(compactions),0), COALESCE(SUM(errors),0),
-			  COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
-			  COALESCE(SUM(cache_read_tokens),0), COALESCE(SUM(cache_create_tokens),0),
-			  COALESCE(SUM(lines_added),0), COALESCE(SUM(lines_removed),0),
-			  COALESCE(SUM(files_changed),0), COALESCE(SUM(commits),0),
-			  COALESCE(SUM(tests_run),0), COALESCE(SUM(tests_passed),0), COALESCE(SUM(tests_failed),0),
-			  COALESCE(AVG(CASE WHEN cache_hit_rate_pct>0 THEN cache_hit_rate_pct END),0),
-			  COALESCE(AVG(CASE WHEN turns>0 THEN turns END),0),
-			  COALESCE(AVG(CASE WHEN duration_ms>0 THEN duration_ms/1000.0 END),0),
-			  COALESCE(AVG(CASE WHEN context_window_pct>0 THEN context_window_pct END),0)
-			FROM execution_log WHERE `+whereClause).
-			Scan(&h.Totals.TotalRuns, &h.Totals.TotalFailed,
-				&h.Totals.TotalTurns, &h.Totals.TotalActions,
-				&h.Totals.TotalCompactions, &h.Totals.TotalErrors,
-				&h.Totals.TotalInputTok, &h.Totals.TotalOutputTok,
-				&h.Totals.TotalCacheRead, &h.Totals.TotalCacheCreate,
-				&h.Totals.TotalLinesAdded, &h.Totals.TotalLinesRemoved,
-				&h.Totals.TotalFilesChanged, &h.Totals.TotalCommits,
-				&h.Totals.TotalTestsRun, &h.Totals.TotalTestsPassed, &h.Totals.TotalTestsFailed,
-				&h.Totals.AvgCacheHitPct, &h.Totals.AvgTurns,
-				&h.Totals.AvgDurSec, &h.Totals.AvgContextPct)
-
-		// ── Daily system averages ─────────────────────────────────────────
-		// Source: execution_log sample rows (system_host_samples was dropped
-		// in commit 79a8ca5).
-		sysWhere := "event = 'sample'"
-		if since != "" {
-			sysWhere += " AND date(created_at) >= date('now', '-" + since + " days')"
-		}
-		sysRows, _ := db.QueryContext(r.Context(), `
-			SELECT date(created_at) as day,
-			       AVG(cpu_pct), AVG(net_rx_mbps), AVG(net_tx_mbps),
-			       AVG(disk_read_mbps), AVG(disk_write_mbps)
-			FROM execution_log WHERE `+sysWhere+`
-			GROUP BY day ORDER BY day ASC`)
-		if sysRows != nil {
-			defer sysRows.Close()
-			for sysRows.Next() {
-				var b daySystemBucket
-				if sysRows.Scan(&b.Day, &b.AvgCPUPct, &b.AvgNetRxMbps, &b.AvgNetTxMbps,
-					&b.AvgDiskReadMBps, &b.AvgDiskWriteMBps) == nil {
-					h.SystemDaily = append(h.SystemDaily, b)
-				}
-			}
-		}
-
+		since := parseSinceDays(r)
+		h := computeStatsHistory(r.Context(), n.DB(), since, nil)
 		writeJSON(w, h)
 	}
+}
+
+// apiEntityStatsHistory handles GET /api/entities/{id}/stats?days=90
+// Returns the same statsHistory shape as /api/stats/history, scoped to:
+//   - task entity:     just this task's runs
+//   - manifest entity: all linked tasks' runs (owns edges)
+//   - product/other:   all descendant tasks' runs (two-hop owns walk)
+func apiEntityStatsHistory(n *node.Node) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		id, ok := entityID(w, r)
+		if !ok {
+			return
+		}
+		since := parseSinceDays(r)
+
+		uids := resolveEntityTaskUIDs(ctx, n, id)
+		h := computeStatsHistory(ctx, n.DB(), since, uids)
+		writeJSON(w, h)
+	}
+}
+
+// resolveEntityTaskUIDs returns the set of entity_uids whose runs roll up to
+// the given entity. Mirrors apiEntityExecutionLog's walk:
+//   - task / unknown-no-relationships: just [id]
+//   - manifest:                        owned tasks (1-hop owns walk)
+//   - product / other:                 owned manifests' owned tasks (2-hop owns walk)
+//                                      + the entity itself if it has direct runs
+func resolveEntityTaskUIDs(ctx context.Context, n *node.Node, id string) []string {
+	e, _ := n.Entities.Get(id)
+	if e == nil || n.Relationships == nil {
+		return []string{id}
+	}
+	if e.Type == relationships.KindTask {
+		return []string{id}
+	}
+
+	if e.Type == relationships.KindManifest {
+		edges, _ := n.Relationships.ListOutgoing(ctx, id, relationships.EdgeOwns)
+		uids := []string{id}
+		for _, edge := range edges {
+			if edge.DstKind == relationships.KindTask {
+				uids = append(uids, edge.DstID)
+			}
+		}
+		return uids
+	}
+
+	// product or unknown kind: walk owned non-task entities, collect their
+	// owned tasks. Include the entity itself in case it has direct runs.
+	manifEdges, _ := n.Relationships.ListOutgoing(ctx, id, relationships.EdgeOwns)
+	uids := []string{id}
+	for _, me := range manifEdges {
+		if me.DstKind == relationships.KindTask {
+			uids = append(uids, me.DstID)
+			continue
+		}
+		// non-task child — also count its own runs and walk its children.
+		uids = append(uids, me.DstID)
+		tEdges, _ := n.Relationships.ListOutgoing(ctx, me.DstID, relationships.EdgeOwns)
+		for _, te := range tEdges {
+			if te.DstKind == relationships.KindTask {
+				uids = append(uids, te.DstID)
+			}
+		}
+	}
+	return uids
 }

--- a/internal/web/ui/dashboard-v2/dist/index.html
+++ b/internal/web/ui/dashboard-v2/dist/index.html
@@ -49,11 +49,11 @@
     />
 
     <meta name="theme-color" content="#fff" />
-    <script type="module" crossorigin src="/assets/index-NHIBVRUp.js"></script>
+    <script type="module" crossorigin src="/assets/index-Dr2M7Poz.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-S-ySWqyJ.js">
     <link rel="modulepreload" crossorigin href="/assets/redirect-X9XGZzhz.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-BCEqhk7D.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-DQNybLIw.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-B9xEvKhI.css">
   </head>
 
   <body>

--- a/internal/web/ui/dashboard-v2/src/features/entity/detail-pane.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/detail-pane.tsx
@@ -14,12 +14,14 @@ import { DependenciesTab } from './tabs/dependencies'
 import { ExecutionTab } from './tabs/execution'
 import { MainTab } from './tabs/main'
 import { RunsTab } from './tabs/runs'
+import { StatsTab } from './tabs/stats'
 
-// Tabs: Main · Execution · Runs · Comments · Dependencies · DAG
+// Tabs: Main · Execution · Runs · Stats · Comments · Dependencies · DAG
 const TAB_IDS = [
   'main',
   'execution',
   'runs',
+  'stats',
   'comments',
   'dependencies',
   'dag',
@@ -114,6 +116,7 @@ export function EntityDetailPane({
               <TabsTrigger value='main'>Main</TabsTrigger>
               <TabsTrigger value='execution'>Execution</TabsTrigger>
               <TabsTrigger value='runs'>Runs</TabsTrigger>
+              <TabsTrigger value='stats'>Stats</TabsTrigger>
               <TabsTrigger value='comments'>Comments</TabsTrigger>
               <TabsTrigger value='dependencies'>Dependencies</TabsTrigger>
               <TabsTrigger value='dag'>DAG</TabsTrigger>
@@ -127,6 +130,9 @@ export function EntityDetailPane({
             </TabsContent>
             <TabsContent value='runs'>
               <RunsTab kind={kind} entityId={entityId} />
+            </TabsContent>
+            <TabsContent value='stats'>
+              <StatsTab kind={kind} entityId={entityId} />
             </TabsContent>
             <TabsContent value='comments'>
               <CommentsTab kind={kind} entityId={entityId} />

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/runs.tsx
@@ -37,21 +37,21 @@ function exportJSON(data: ActionRow[], runUid: string) {
   URL.revokeObjectURL(url)
 }
 
-function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) {
-  const { data, isLoading } = useEntityActions(entityId, runUid, true)
+function RunOutput({ entityId, runUid, isLive }: { entityId: string; runUid: string; isLive: boolean }) {
+  const { data, isLoading } = useEntityActions(entityId, runUid, isLive)
   const bottomRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
-  const [autoScroll, setAutoScroll] = useState(true)
+  // Only auto-scroll for live runs — replay should let the user scroll freely.
+  const [autoScroll, setAutoScroll] = useState(isLive)
 
-  // Auto-scroll to bottom when new rows arrive (unless user scrolled up).
-  // Use scrollTop directly — scrollIntoView scrolls the page, not the container.
   useEffect(() => {
-    if (autoScroll && containerRef.current) {
+    if (isLive && autoScroll && containerRef.current) {
       containerRef.current.scrollTop = containerRef.current.scrollHeight
     }
-  }, [data?.length, autoScroll])
+  }, [data?.length, autoScroll, isLive])
 
   const handleScroll = () => {
+    if (!isLive) return
     const el = containerRef.current
     if (!el) return
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40
@@ -59,7 +59,11 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
   }
 
   if (isLoading) return <div className='text-muted-foreground p-3 text-xs'>Loading…</div>
-  if (!data?.length) return <div className='text-muted-foreground p-3 text-xs animate-pulse'>Waiting for agent output…</div>
+  if (!data?.length) return (
+    <div className={`text-muted-foreground p-3 text-xs ${isLive ? 'animate-pulse' : ''}`}>
+      {isLive ? 'Waiting for agent output…' : 'No actions captured for this run.'}
+    </div>
+  )
 
   return (
     <div>
@@ -107,7 +111,7 @@ function LiveOutput({ entityId, runUid }: { entityId: string; runUid: string }) 
         </div>
       ))}
       <div ref={bottomRef} />
-      {!autoScroll && (
+      {isLive && !autoScroll && (
         <button
           type='button'
           onClick={() => { setAutoScroll(true); if (containerRef.current) containerRef.current.scrollTop = containerRef.current.scrollHeight }}
@@ -131,6 +135,76 @@ function fmtCost(usd: number) {
 function fmtTime(v: string | number) {
   const ms = typeof v === 'number' ? v * 1000 : Date.parse(v)
   return isFinite(ms) ? new Date(ms).toLocaleString() : '—'
+}
+function fmtNum(n: number) {
+  if (!n) return '0'
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M'
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k'
+  return String(n)
+}
+function fmtDur(ms: number) {
+  if (!ms) return '—'
+  const s = ms / 1000
+  if (s < 60) return `${s.toFixed(1)}s`
+  const m = Math.floor(s / 60)
+  const rem = (s - m * 60).toFixed(0)
+  return `${m}m ${rem}s`
+}
+
+function Kpi({ label, value, sub, accent }: { label: string; value: string; sub?: string; accent?: string }) {
+  return (
+    <div className='rounded border bg-card/40 px-2 py-1.5'>
+      <div className='text-muted-foreground text-[9px] uppercase tracking-wider'>{label}</div>
+      <div className={`font-mono text-sm font-semibold tabular-nums ${accent ?? ''}`}>{value}</div>
+      {sub && <div className='text-muted-foreground text-[9px]'>{sub}</div>}
+    </div>
+  )
+}
+
+function RunStatsStrip({ run }: { run: ExecutionRow }) {
+  const totalTok = (run.input_tokens || 0) + (run.output_tokens || 0) + (run.cache_read_tokens || 0) + (run.cache_create_tokens || 0)
+  return (
+    <div className='space-y-2'>
+      <div className='grid grid-cols-3 gap-1.5 md:grid-cols-6 lg:grid-cols-9'>
+        <Kpi label='Status' value={run.event} accent={
+          run.event === 'completed' ? 'text-emerald-400' :
+          run.event === 'failed' ? 'text-rose-400' : 'text-amber-400'
+        } sub={run.terminal_reason || undefined} />
+        <Kpi label='Duration' value={fmtDur(run.duration_ms)} sub={run.ttfb_ms ? `${fmtDur(run.ttfb_ms)} ttfb` : undefined} />
+        <Kpi label='Cost' value={fmtCost(run.cost_usd)} sub={run.cost_per_turn ? `${fmtCost(run.cost_per_turn)}/turn` : undefined} />
+        <Kpi label='Turns' value={String(run.turns || 0)} sub={run.tokens_per_turn ? `${fmtNum(run.tokens_per_turn)} tok/turn` : undefined} />
+        <Kpi label='Actions' value={String(run.actions || 0)} sub={run.cost_per_action ? `${fmtCost(run.cost_per_action)}/act` : undefined} />
+        <Kpi label='Errors' value={String(run.errors || 0)} accent={run.errors > 0 ? 'text-rose-400' : undefined} />
+        <Kpi label='Compactions' value={String(run.compactions || 0)} accent={run.compactions > 0 ? 'text-amber-400' : undefined} />
+        <Kpi label='Cache hit' value={`${(run.cache_hit_rate_pct || 0).toFixed(0)}%`} accent='text-emerald-400' />
+        <Kpi label='Ctx window' value={`${(run.context_window_pct || 0).toFixed(0)}%`} accent={run.context_window_pct > 80 ? 'text-amber-400' : undefined} />
+      </div>
+      <div className='grid grid-cols-3 gap-1.5 md:grid-cols-6 lg:grid-cols-9'>
+        <Kpi label='Input tok' value={fmtNum(run.input_tokens)} accent='text-sky-400' />
+        <Kpi label='Output tok' value={fmtNum(run.output_tokens)} accent='text-violet-400' />
+        <Kpi label='Cache read' value={fmtNum(run.cache_read_tokens)} accent='text-emerald-400' />
+        <Kpi label='Cache write' value={fmtNum(run.cache_create_tokens)} accent='text-amber-400' />
+        <Kpi label='Reasoning tok' value={fmtNum(run.reasoning_tokens)} accent={run.reasoning_tokens > 0 ? 'text-rose-400' : undefined} />
+        <Kpi label='Total tok' value={fmtNum(totalTok)} />
+        <Kpi label='Lines +/−' value={`${fmtNum(run.lines_added)} / ${fmtNum(run.lines_removed)}`}
+          accent={run.lines_added > 0 || run.lines_removed > 0 ? 'text-emerald-400' : undefined} />
+        <Kpi label='Files / commits' value={`${run.files_changed || 0} / ${run.commits || 0}`} />
+        <Kpi label='Tests p/f' value={`${run.tests_passed || 0} / ${run.tests_failed || 0}`}
+          accent={run.tests_failed > 0 ? 'text-rose-400' : run.tests_passed > 0 ? 'text-emerald-400' : undefined} />
+      </div>
+      {(run.peak_cpu_pct > 0 || run.peak_rss_mb > 0 || run.model || run.agent_runtime) && (
+        <div className='grid grid-cols-3 gap-1.5 md:grid-cols-6 lg:grid-cols-9'>
+          {run.peak_cpu_pct > 0 && <Kpi label='Peak CPU' value={`${run.peak_cpu_pct.toFixed(0)}%`} sub={run.avg_cpu_pct ? `${run.avg_cpu_pct.toFixed(0)}% avg` : undefined} />}
+          {run.peak_rss_mb > 0 && <Kpi label='Peak RSS' value={`${fmtNum(run.peak_rss_mb)} MB`} sub={run.avg_rss_mb ? `${fmtNum(run.avg_rss_mb)} avg` : undefined} />}
+          {run.model && <Kpi label='Model' value={run.model} sub={run.provider || undefined} />}
+          {run.agent_runtime && <Kpi label='Agent' value={run.agent_runtime} sub={run.agent_version || undefined} />}
+          {run.trigger && <Kpi label='Trigger' value={run.trigger} />}
+          {run.branch && <Kpi label='Branch' value={run.branch.length > 24 ? run.branch.slice(0, 22) + '…' : run.branch}
+            sub={run.commit_sha ? run.commit_sha.slice(0, 7) : undefined} />}
+        </div>
+      )}
+    </div>
+  )
 }
 
 const thCls = 'text-muted-foreground px-3 py-2 text-left text-[11px] font-medium uppercase tracking-wide'
@@ -165,7 +239,18 @@ function RunRow({ run, entityId, selectedRunUid, onSelect, onSelectHistory }: {
       </tr>
       {expanded && (
         <tr><td colSpan={7} className='border-b bg-white/3 px-4 py-3'>
-          <TurnAnalyticsBlock entityId={entityId} runUid={run.run_uid} />
+          <div className='space-y-4'>
+            <RunStatsStrip run={run} />
+            <div>
+              <div className='text-muted-foreground mb-1 text-[10px] uppercase tracking-wider'>
+                Output replay
+              </div>
+              <div className='rounded border bg-card/40'>
+                <RunOutput entityId={entityId} runUid={run.run_uid} isLive={false} />
+              </div>
+            </div>
+            <TurnAnalyticsBlock entityId={entityId} runUid={run.run_uid} />
+          </div>
         </td></tr>
       )}
     </Fragment>
@@ -248,9 +333,9 @@ export function RunsTab({ kind, entityId, onSelectLive, onSelectHistory }: RunsT
               <CopyButton text={liveRun.run_uid} />
             </span>
           </div>
-          {/* Live output — polls actions every 3s */}
+          {/* Live output — polls actions every 2s */}
           <div className='border-t border-emerald-500/20'>
-            <LiveOutput entityId={liveRun.entity_uid} runUid={liveRun.run_uid} />
+            <RunOutput entityId={liveRun.entity_uid} runUid={liveRun.run_uid} isLive={true} />
           </div>
         </div>
       )}

--- a/internal/web/ui/dashboard-v2/src/features/entity/tabs/stats.tsx
+++ b/internal/web/ui/dashboard-v2/src/features/entity/tabs/stats.tsx
@@ -1,0 +1,511 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Card, CardContent } from '@/components/ui/card'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { EChart } from '@/components/echart'
+import { LineChart, toMs } from '@/components/charts'
+import { cn } from '@/lib/utils'
+import type { EntityKind } from '@/lib/queries/entity'
+
+// Entity-scoped Stats tab — mirrors the global /stats page, scoped to one
+// entity. Data source: GET /api/entities/{id}/stats?days=N. The backend
+// returns the same StatsHistory shape /api/stats/history returns, restricted
+// to:
+//   task     → just this task's runs
+//   manifest → all linked tasks' runs (1-hop owns walk)
+//   product  → all descendant tasks' runs (2-hop owns walk)
+//
+// One range selector at the top drives one fetch; all panels render from
+// the shared response. No per-chart range selectors (that's a /stats-page
+// convenience that isn't needed when comparing within a single entity).
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+interface DayRun { day: string; completed: number; failed: number; avg_dur_sec: number; max_dur_sec: number; avg_run_number: number }
+interface DayEfficiency { day: string; avg_turns: number; avg_actions: number; avg_actions_per_turn: number; avg_context_pct: number; avg_tokens_per_turn: number; avg_cache_hit_pct: number; total_compactions: number; total_errors: number; avg_ttfb_ms: number }
+interface DayTokens { day: string; input_tokens: number; output_tokens: number; cache_read_tokens: number; cache_create_tokens: number; reasoning_tokens: number; tool_use_tokens: number }
+interface DayProductivity { day: string; lines_added: number; lines_removed: number; files_changed: number; commits: number; tests_run: number; tests_passed: number; tests_failed: number; prs_opened: number }
+interface LabelCount { label: string; count: number }
+interface Totals {
+  total_runs: number; total_failed: number; total_turns: number; total_actions: number
+  total_compactions: number; total_errors: number
+  total_input_tokens: number; total_output_tokens: number
+  total_cache_read_tokens: number; total_cache_create_tokens: number
+  total_lines_added: number; total_lines_removed: number
+  total_files_changed: number; total_commits: number
+  total_tests_run: number; total_tests_passed: number; total_tests_failed: number
+  avg_cache_hit_pct: number; avg_turns: number; avg_dur_sec: number; avg_context_pct: number
+}
+interface EntityStatsHistory {
+  runs: DayRun[]
+  efficiency: DayEfficiency[]
+  tokens: DayTokens[]
+  productivity: DayProductivity[]
+  models: LabelCount[]
+  agents: LabelCount[]
+  terminal_reasons: LabelCount[]
+  trigger_split: LabelCount[]
+  totals: Totals
+}
+
+// ── Range selector ────────────────────────────────────────────────────────
+
+const RANGES = [
+  { label: '1d',  days: 1 },
+  { label: '2d',  days: 2 },
+  { label: '3d',  days: 3 },
+  { label: '1w',  days: 7 },
+  { label: '2w',  days: 14 },
+  { label: '1m',  days: 30 },
+  { label: '3m',  days: 90 },
+  { label: 'All', days: 0 },
+] as const
+type RangeDays = typeof RANGES[number]['days']
+
+const dayMs = (day: string) => toMs(day)
+
+function useEntityStatsHistory(entityId: string, days: RangeDays) {
+  const url = days > 0
+    ? `/api/entities/${entityId}/stats?days=${days}`
+    : `/api/entities/${entityId}/stats`
+  return useQuery({
+    queryKey: ['entity-stats', entityId, days],
+    queryFn: () => fetch(url).then(r => r.json()) as Promise<EntityStatsHistory>,
+    enabled: !!entityId,
+    staleTime: 30_000,
+  })
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function padDays<T extends { day: string }>(data: T[], empty: (day: string) => T): T[] {
+  if (!data.length) return data
+  const map = new Map(data.map(d => [d.day, d]))
+  const start = new Date(data[0].day + 'T00:00:00Z')
+  const end = new Date(data[data.length - 1].day + 'T00:00:00Z')
+  const out: T[] = []
+  for (let d = new Date(start); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
+    const key = d.toISOString().slice(0, 10)
+    out.push(map.get(key) ?? empty(key))
+  }
+  return out
+}
+
+function fmt(n: number, dec = 0) {
+  if (!n) return '0'
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M'
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k'
+  return n.toFixed(dec)
+}
+
+function Kpi({ label, value, sub, accent }: { label: string; value: string; sub?: string; accent?: string }) {
+  return (
+    <div className='space-y-0.5'>
+      <div className='text-muted-foreground text-[10px] uppercase tracking-wider'>{label}</div>
+      <div className={cn('font-mono text-xl font-semibold tabular-nums', accent)}>{value}</div>
+      {sub && <div className='text-muted-foreground text-[10px]'>{sub}</div>}
+    </div>
+  )
+}
+
+function Empty() {
+  return <div className='h-[180px] flex items-center justify-center text-xs text-muted-foreground'>No data yet</div>
+}
+
+function ChartFrame({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <Card>
+      <CardContent className='pt-3 pb-3'>
+        <div className='text-xs text-muted-foreground uppercase tracking-wider truncate mb-2'>{title}</div>
+        {children}
+      </CardContent>
+    </Card>
+  )
+}
+
+// ── Runs panel ────────────────────────────────────────────────────────────
+
+function RunsPanel({ data }: { data: EntityStatsHistory }) {
+  const t = data.totals
+  const runs = padDays(data.runs, d => ({ day: d, completed: 0, failed: 0, avg_dur_sec: 0, max_dur_sec: 0, avg_run_number: 0 }))
+  const days = runs.map(d => d.day.slice(5))
+  const successPct = t.total_runs + t.total_failed > 0
+    ? ((t.total_runs / (t.total_runs + t.total_failed)) * 100).toFixed(0)
+    : '0'
+
+  return (
+    <div className='space-y-4'>
+      <div className='grid grid-cols-2 gap-3 md:grid-cols-5'>
+        <Card><CardContent className='pt-4'><Kpi label='Total runs' value={String(t.total_runs + t.total_failed)} sub={`${t.total_failed} failed`} /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='Success rate' value={`${successPct}%`} accent='text-emerald-400' /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='Avg duration' value={`${t.avg_dur_sec.toFixed(0)}s`} sub={`${(t.avg_dur_sec / 60).toFixed(1)} min`} /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='Avg turns' value={t.avg_turns.toFixed(1)} /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='Errors' value={String(t.total_errors)} accent={t.total_errors > 0 ? 'text-rose-400' : undefined} /></CardContent></Card>
+      </div>
+
+      <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+        <ChartFrame title='Daily runs — completed vs failed'>
+          {runs.length === 0 ? <Empty /> : (
+            <EChart height={180} option={{
+              grid: { left: 32, right: 16, top: 8, bottom: 24 },
+              tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+              xAxis: { type: 'category', data: days, axisLabel: { fontSize: 9 }, boundaryGap: false },
+              yAxis: { type: 'value', axisLabel: { fontSize: 9 }, minInterval: 1 },
+              series: [
+                { name: 'completed', type: 'bar', stack: 'r', data: runs.map(d => d.completed), itemStyle: { color: '#10b981' } },
+                { name: 'failed',    type: 'bar', stack: 'r', data: runs.map(d => d.failed),    itemStyle: { color: '#f43f5e' } },
+              ],
+            }} />
+          )}
+        </ChartFrame>
+
+        <ChartFrame title='Avg duration per day (seconds)'>
+          {runs.length === 0 ? <Empty /> : (
+            <LineChart series={[{ name: 'avg dur', data: runs.map(d => [dayMs(d.day), +d.avg_dur_sec.toFixed(1)] as [number, number]), color: '#a78bfa', area: true }]} yLeft={{ unit: 's' }} />
+          )}
+        </ChartFrame>
+
+        <ChartFrame title='Terminal reasons'>
+          {data.terminal_reasons.length === 0 ? <Empty /> : (
+            <EChart height={180} option={{
+              tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+              legend: { bottom: 0, itemWidth: 8, itemHeight: 8, textStyle: { fontSize: 9, color: '#a1a1aa' } },
+              series: [{
+                type: 'pie', radius: ['40%', '65%'], center: ['50%', '42%'],
+                data: data.terminal_reasons.map(d => ({
+                  name: d.label || 'success',
+                  value: d.count,
+                  itemStyle: {
+                    color: d.label === 'success' || d.label === '' ? '#10b981'
+                      : d.label === 'max_turns' ? '#f59e0b' : '#f43f5e',
+                  },
+                })),
+                label: { show: false },
+              }],
+            }} />
+          )}
+        </ChartFrame>
+
+        <ChartFrame title='Avg retry number (run_number) — higher = more retries'>
+          {runs.length === 0 ? <Empty /> : (
+            <EChart height={180} option={{
+              grid: { left: 32, right: 16, top: 8, bottom: 24 },
+              tooltip: { trigger: 'axis' },
+              xAxis: { type: 'category', data: days, axisLabel: { fontSize: 9 }, boundaryGap: false },
+              yAxis: { type: 'value', axisLabel: { fontSize: 9 } },
+              series: [{ type: 'bar', data: runs.map(d => +d.avg_run_number.toFixed(1)), itemStyle: { color: '#6366f1' } }],
+            }} />
+          )}
+        </ChartFrame>
+      </div>
+    </div>
+  )
+}
+
+// ── Efficiency panel ──────────────────────────────────────────────────────
+
+function EfficiencyPanel({ data }: { data: EntityStatsHistory }) {
+  const t = data.totals
+  const eff = padDays(data.efficiency, d => ({ day: d, avg_turns: 0, avg_actions: 0, avg_actions_per_turn: 0, avg_context_pct: 0, avg_tokens_per_turn: 0, avg_cache_hit_pct: 0, total_compactions: 0, total_errors: 0, avg_ttfb_ms: 0 }))
+  const days = eff.map(d => d.day.slice(5))
+
+  return (
+    <div className='space-y-4'>
+      <div className='grid grid-cols-2 gap-3 md:grid-cols-5'>
+        <Card><CardContent className='pt-4'><Kpi label='Avg turns/run' value={t.avg_turns.toFixed(1)} /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='Cache hit' value={`${t.avg_cache_hit_pct.toFixed(0)}%`} accent='text-emerald-400' /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='Avg context %' value={`${t.avg_context_pct.toFixed(0)}%`} accent={t.avg_context_pct > 80 ? 'text-amber-400' : undefined} /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='Compactions' value={String(t.total_compactions)} sub='context resets' accent={t.total_compactions > 0 ? 'text-amber-400' : undefined} /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='Total errors' value={String(t.total_errors)} accent={t.total_errors > 10 ? 'text-rose-400' : undefined} /></CardContent></Card>
+      </div>
+
+      <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+        <ChartFrame title='Avg turns per run'>
+          {eff.length === 0 ? <Empty /> : <LineChart series={[{ name: 'avg turns', data: eff.map(d => [dayMs(d.day), +d.avg_turns.toFixed(1)] as [number, number]), color: '#a78bfa', area: true }]} />}
+        </ChartFrame>
+        <ChartFrame title='Cache hit rate %'>
+          {eff.length === 0 ? <Empty /> : <LineChart series={[{ name: 'cache hit', data: eff.map(d => [dayMs(d.day), +d.avg_cache_hit_pct.toFixed(1)] as [number, number]), color: '#10b981', area: true }]} yLeft={{ min: 0, max: 100, unit: '%' }} />}
+        </ChartFrame>
+        <ChartFrame title='Avg context window used %'>
+          {eff.length === 0 ? <Empty /> : <LineChart series={[{ name: 'ctx window', data: eff.map(d => [dayMs(d.day), +d.avg_context_pct.toFixed(1)] as [number, number]), color: '#f59e0b', area: true }]} yLeft={{ min: 0, max: 100, unit: '%' }} />}
+        </ChartFrame>
+        <ChartFrame title='Avg tokens per turn'>
+          {eff.length === 0 ? <Empty /> : <LineChart series={[{ name: 'tok/turn', data: eff.map(d => [dayMs(d.day), +d.avg_tokens_per_turn.toFixed(0)] as [number, number]), color: '#38bdf8' }]} />}
+        </ChartFrame>
+        <ChartFrame title='Actions per turn (higher = less deliberation)'>
+          {eff.length === 0 ? <Empty /> : <LineChart series={[{ name: 'actions/turn', data: eff.map(d => [dayMs(d.day), +d.avg_actions_per_turn.toFixed(2)] as [number, number]), color: '#6366f1' }]} />}
+        </ChartFrame>
+        <ChartFrame title='Compactions per day (context resets — 0 is best)'>
+          {eff.length === 0 ? <Empty /> : (
+            <EChart height={180} option={{
+              grid: { left: 32, right: 16, top: 8, bottom: 24 },
+              tooltip: { trigger: 'axis' },
+              xAxis: { type: 'category', data: days, axisLabel: { fontSize: 9 }, boundaryGap: false },
+              yAxis: { type: 'value', axisLabel: { fontSize: 9 }, minInterval: 1 },
+              series: [{ type: 'bar', data: eff.map(d => d.total_compactions), itemStyle: { color: '#f59e0b' } }],
+            }} />
+          )}
+        </ChartFrame>
+      </div>
+    </div>
+  )
+}
+
+// ── Tokens panel ──────────────────────────────────────────────────────────
+
+function TokensPanel({ data }: { data: EntityStatsHistory }) {
+  const t = data.totals
+  const totalAll = t.total_input_tokens + t.total_output_tokens + t.total_cache_read_tokens + t.total_cache_create_tokens
+  const tok = padDays(data.tokens, d => ({ day: d, input_tokens: 0, output_tokens: 0, cache_read_tokens: 0, cache_create_tokens: 0, reasoning_tokens: 0, tool_use_tokens: 0 }))
+  const days = tok.map(d => d.day.slice(5))
+
+  return (
+    <div className='space-y-4'>
+      <div className='grid grid-cols-2 gap-3 md:grid-cols-5'>
+        <Card><CardContent className='pt-4'><Kpi label='Input tokens'  value={fmt(t.total_input_tokens)}  accent='text-sky-400' /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='Output tokens' value={fmt(t.total_output_tokens)} accent='text-violet-400' /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='Cache read'    value={fmt(t.total_cache_read_tokens)} sub='reused' accent='text-emerald-400' /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='Cache write'   value={fmt(t.total_cache_create_tokens)} sub='written' accent='text-amber-400' /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='Total tokens'  value={fmt(totalAll)} /></CardContent></Card>
+      </div>
+
+      <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+        <ChartFrame title='Daily token volumes (stacked)'>
+          {tok.length === 0 ? <Empty /> : (
+            <EChart height={180} option={{
+              grid: { left: 40, right: 16, top: 8, bottom: 24 },
+              tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+              xAxis: { type: 'category', data: days, axisLabel: { fontSize: 9 }, boundaryGap: false },
+              yAxis: { type: 'value', axisLabel: { fontSize: 9, formatter: (v: number) => v >= 1e6 ? (v/1e6).toFixed(1)+'M' : v >= 1e3 ? (v/1e3).toFixed(0)+'k' : String(v) } },
+              series: [
+                { name: 'cache read',  type: 'bar', stack: 'tok', data: tok.map(d => d.cache_read_tokens),   itemStyle: { color: '#10b981' } },
+                { name: 'input',       type: 'bar', stack: 'tok', data: tok.map(d => d.input_tokens),        itemStyle: { color: '#38bdf8' } },
+                { name: 'output',      type: 'bar', stack: 'tok', data: tok.map(d => d.output_tokens),       itemStyle: { color: '#a78bfa' } },
+                { name: 'cache write', type: 'bar', stack: 'tok', data: tok.map(d => d.cache_create_tokens), itemStyle: { color: '#f59e0b' } },
+              ],
+            }} />
+          )}
+        </ChartFrame>
+
+        <ChartFrame title='Cache read/write ratio (higher = better cache compounding)'>
+          {tok.length === 0 ? <Empty /> : (
+            <LineChart series={[{
+              name: 'cache reuse',
+              data: tok.map(d => {
+                const total = d.cache_read_tokens + d.cache_create_tokens
+                return [dayMs(d.day), total > 0 ? +((d.cache_read_tokens / total) * 100).toFixed(1) : 0] as [number, number]
+              }),
+              color: '#10b981', area: true,
+            }]} yLeft={{ min: 0, max: 100, unit: '%' }} />
+          )}
+        </ChartFrame>
+
+        <ChartFrame title='Output tokens per day'>
+          {tok.length === 0 ? <Empty /> : (
+            <EChart height={180} option={{
+              grid: { left: 40, right: 16, top: 8, bottom: 24 },
+              tooltip: { trigger: 'axis' },
+              xAxis: { type: 'category', data: days, axisLabel: { fontSize: 9 }, boundaryGap: false },
+              yAxis: { type: 'value', axisLabel: { fontSize: 9, formatter: (v: number) => v >= 1e3 ? (v/1e3).toFixed(0)+'k' : String(v) } },
+              series: [{ type: 'bar', data: tok.map(d => d.output_tokens), itemStyle: { color: '#a78bfa' } }],
+            }} />
+          )}
+        </ChartFrame>
+
+        <ChartFrame title='Reasoning tokens per day (extended thinking)'>
+          {tok.length === 0 || !tok.some(d => d.reasoning_tokens > 0) ? (
+            <div className='h-[180px] flex items-center justify-center text-xs text-muted-foreground'>No reasoning tokens yet</div>
+          ) : (
+            <EChart height={180} option={{
+              grid: { left: 40, right: 16, top: 8, bottom: 24 },
+              tooltip: { trigger: 'axis' },
+              xAxis: { type: 'category', data: days, axisLabel: { fontSize: 9 }, boundaryGap: false },
+              yAxis: { type: 'value', axisLabel: { fontSize: 9 } },
+              series: [{ type: 'bar', data: tok.map(d => d.reasoning_tokens), itemStyle: { color: '#f43f5e' } }],
+            }} />
+          )}
+        </ChartFrame>
+      </div>
+    </div>
+  )
+}
+
+// ── Productivity panel ────────────────────────────────────────────────────
+
+function ProductivityPanel({ data }: { data: EntityStatsHistory }) {
+  const t = data.totals
+  const prod = padDays(data.productivity, d => ({ day: d, lines_added: 0, lines_removed: 0, files_changed: 0, commits: 0, tests_run: 0, tests_passed: 0, tests_failed: 0, prs_opened: 0 }))
+  const days = prod.map(d => d.day.slice(5))
+  const hasData = prod.some(d => d.lines_added > 0 || d.commits > 0 || d.tests_run > 0)
+
+  return (
+    <div className='space-y-4'>
+      <div className='grid grid-cols-2 gap-3 md:grid-cols-4 lg:grid-cols-8'>
+        <Card><CardContent className='pt-4'><Kpi label='Lines added'   value={fmt(t.total_lines_added)}   accent='text-emerald-400' /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='Lines removed' value={fmt(t.total_lines_removed)} accent='text-rose-400' /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='Files changed' value={fmt(t.total_files_changed)} /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='Commits'       value={String(t.total_commits)} accent='text-blue-400' /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='PRs opened'    value={String(prod.reduce((a, d) => a + d.prs_opened, 0))} accent='text-violet-400' /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='Tests run'     value={String(t.total_tests_run)} /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='Tests passed'  value={String(t.total_tests_passed)} accent='text-emerald-400' /></CardContent></Card>
+        <Card><CardContent className='pt-4'><Kpi label='Tests failed'  value={String(t.total_tests_failed)} accent={t.total_tests_failed > 0 ? 'text-rose-400' : undefined} /></CardContent></Card>
+      </div>
+
+      <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+        <ChartFrame title='Lines added / removed per day'>
+          {!hasData ? <Empty /> : (
+            <EChart height={180} option={{
+              grid: { left: 40, right: 16, top: 8, bottom: 24 },
+              tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+              xAxis: { type: 'category', data: days, axisLabel: { fontSize: 9 }, boundaryGap: false },
+              yAxis: { type: 'value', axisLabel: { fontSize: 9 } },
+              series: [
+                { name: 'added',   type: 'bar', data: prod.map(d => d.lines_added),    itemStyle: { color: '#10b981' }, stack: 'lines' },
+                { name: 'removed', type: 'bar', data: prod.map(d => -d.lines_removed), itemStyle: { color: '#f43f5e' }, stack: 'lines' },
+              ],
+            }} />
+          )}
+        </ChartFrame>
+
+        <ChartFrame title='Commits + files changed per day'>
+          {!hasData ? <Empty /> : (
+            <EChart height={180} option={{
+              grid: { left: 32, right: 16, top: 8, bottom: 24 },
+              tooltip: { trigger: 'axis' },
+              xAxis: { type: 'category', data: days, axisLabel: { fontSize: 9 }, boundaryGap: false },
+              yAxis: { type: 'value', axisLabel: { fontSize: 9 }, minInterval: 1 },
+              series: [
+                { name: 'commits', type: 'bar', data: prod.map(d => d.commits),       itemStyle: { color: '#6366f1' } },
+                { name: 'files',   type: 'bar', data: prod.map(d => d.files_changed), itemStyle: { color: '#38bdf8' } },
+              ],
+            }} />
+          )}
+        </ChartFrame>
+
+        <ChartFrame title='Tests passed / failed per day'>
+          {!hasData ? <Empty /> : (
+            <EChart height={180} option={{
+              grid: { left: 32, right: 16, top: 8, bottom: 24 },
+              tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+              xAxis: { type: 'category', data: days, axisLabel: { fontSize: 9 }, boundaryGap: false },
+              yAxis: { type: 'value', axisLabel: { fontSize: 9 }, minInterval: 1 },
+              series: [
+                { name: 'passed', type: 'bar', stack: 't', data: prod.map(d => d.tests_passed), itemStyle: { color: '#10b981' } },
+                { name: 'failed', type: 'bar', stack: 't', data: prod.map(d => d.tests_failed), itemStyle: { color: '#f43f5e' } },
+              ],
+            }} />
+          )}
+        </ChartFrame>
+      </div>
+    </div>
+  )
+}
+
+// ── Agents panel ──────────────────────────────────────────────────────────
+
+function AgentsPanel({ data }: { data: EntityStatsHistory }) {
+  const modelColors: Record<string, string> = {
+    'claude-opus-4-7': '#f43f5e', 'claude-sonnet-4-6': '#a78bfa',
+    'claude-haiku-4-5': '#38bdf8', 'unknown': '#71717a',
+  }
+
+  return (
+    <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3'>
+      <ChartFrame title='Runs by model'>
+        {data.models.length === 0 ? <Empty /> : (
+          <EChart height={180} option={{
+            tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+            legend: { bottom: 0, itemWidth: 8, itemHeight: 8, textStyle: { fontSize: 9, color: '#a1a1aa' } },
+            series: [{
+              type: 'pie', radius: ['40%', '65%'], center: ['50%', '42%'],
+              data: data.models.map(d => ({ name: d.label, value: d.count, itemStyle: { color: modelColors[d.label] ?? '#71717a' } })),
+              label: { show: false },
+            }],
+          }} />
+        )}
+      </ChartFrame>
+
+      <ChartFrame title='Runs by agent runtime'>
+        {data.agents.length === 0 ? <Empty /> : (
+          <EChart height={180} option={{
+            tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+            legend: { bottom: 0, itemWidth: 8, itemHeight: 8, textStyle: { fontSize: 9, color: '#a1a1aa' } },
+            series: [{
+              type: 'pie', radius: ['40%', '65%'], center: ['50%', '42%'],
+              data: data.agents.map(d => ({ name: d.label, value: d.count })),
+              label: { show: false },
+            }],
+          }} />
+        )}
+      </ChartFrame>
+
+      <ChartFrame title='Interactive vs autonomous'>
+        {data.trigger_split.length === 0 ? <Empty /> : (
+          <EChart height={180} option={{
+            tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+            legend: { bottom: 0, itemWidth: 8, itemHeight: 8, textStyle: { fontSize: 9, color: '#a1a1aa' } },
+            series: [{
+              type: 'pie', radius: ['40%', '65%'], center: ['50%', '42%'],
+              data: data.trigger_split.map(d => ({
+                name: d.label, value: d.count,
+                itemStyle: { color: d.label === 'interactive' ? '#38bdf8' : d.label === 'manual' ? '#10b981' : '#a78bfa' },
+              })),
+              label: { show: false },
+            }],
+          }} />
+        )}
+      </ChartFrame>
+    </div>
+  )
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────
+
+export function StatsTab({ kind: _kind, entityId }: { kind: EntityKind; entityId: string }) {
+  const [range, setRange] = useState<RangeDays>(7)
+  const { data, isLoading, isError, error } = useEntityStatsHistory(entityId, range)
+
+  return (
+    <div className='space-y-3'>
+      <div className='flex items-center justify-between'>
+        <div className='text-muted-foreground text-xs'>
+          Scope: this entity's run set (descendants included for manifest / product).
+        </div>
+        <div className='inline-flex rounded-md border bg-card p-0.5 text-xs'>
+          {RANGES.map(r => (
+            <button key={r.days} type='button'
+              onClick={() => setRange(r.days)}
+              className={cn('rounded px-3 py-1 transition-colors',
+                range === r.days
+                  ? 'bg-primary/15 text-foreground font-semibold'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}>
+              {r.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className='text-muted-foreground p-6 text-center text-sm'>Loading entity stats…</div>
+      ) : isError ? (
+        <div className='p-4 text-sm text-rose-400'>Failed to load: {String(error)}</div>
+      ) : data ? (
+        <Tabs defaultValue='runs'>
+          <TabsList>
+            <TabsTrigger value='runs'>Runs</TabsTrigger>
+            <TabsTrigger value='efficiency'>Efficiency</TabsTrigger>
+            <TabsTrigger value='tokens'>Tokens</TabsTrigger>
+            <TabsTrigger value='productivity'>Productivity</TabsTrigger>
+            <TabsTrigger value='agents'>Agents</TabsTrigger>
+          </TabsList>
+          <TabsContent value='runs'         className='mt-4'><RunsPanel         data={data} /></TabsContent>
+          <TabsContent value='efficiency'   className='mt-4'><EfficiencyPanel   data={data} /></TabsContent>
+          <TabsContent value='tokens'       className='mt-4'><TokensPanel       data={data} /></TabsContent>
+          <TabsContent value='productivity' className='mt-4'><ProductivityPanel data={data} /></TabsContent>
+          <TabsContent value='agents'       className='mt-4'><AgentsPanel       data={data} /></TabsContent>
+        </Tabs>
+      ) : null}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Two related additions to the entity detail view:

**Runs tab — per-run replay + per-run KPIs**
- Expanded run row now shows the same action timeline the live-run pane uses, scoped to that run alone (replay).
- Per-run KPI strip surfaces every metric already on \`ExecutionRow\`: cost, tokens (input/output/cache read/write/reasoning), cache hit %, ctx %, turns, actions, errors, compactions, lines +/−, files, commits, peak CPU/RSS, model, agent runtime, trigger, branch/commit.
- \`apiEntityActions\` gains an upper bound (run's \`completed_at\` / \`cancelled_at\`) so expanding an older completed run no longer surfaces actions from later runs of the same task.

**Stats tab — entity-scoped /stats parity**
- New entity-detail tab backed by \`GET /api/entities/{id}/stats?days=N\`.
- Returns the same \`StatsHistory\` shape as the global \`/api/stats/history\`, restricted to the entity's run set:
  - task     → just this task's runs
  - manifest → linked tasks (1-hop owns walk)
  - product  → descendant tasks (2-hop owns walk)
- Mirrors the \`/stats\` page's inner tabs — **Runs / Efficiency / Tokens / Productivity / Agents** — so per-entity comparison uses the identical KPIs and charts as the global view.

**Backend refactor:** \`handlers_stats_history.go\` extracts \`computeStatsHistory(ctx, db, since, entityUIDs)\` so the global and entity endpoints share aggregation. Entity scoping is a parameterised \`entity_uid IN (...)\` clause — no SQL duplication.

## Test plan

- [ ] Open a task entity → Runs tab → expand a completed run: per-run KPIs visible, action timeline replays bounded to that run only.
- [ ] Run the task again, expand both runs: actions for the older run don't include the newer run's tool calls.
- [ ] Task entity → Stats tab: 5 inner tabs render, KPIs and charts match the per-entity data.
- [ ] Manifest entity → Stats tab: rollup sums match the union of linked tasks' runs.
- [ ] Product entity → Stats tab: rollup sums match the union of all descendant tasks' runs.
- [ ] Global \`/stats\` page unchanged (same charts, same per-chart range selectors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)